### PR TITLE
docs: symphony => symfony

### DIFF
--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -26,8 +26,8 @@
       slug: quickstart/node
     - title: Run a Vercel and Next.js app
       slug: quickstart/vercel
-    - title: Run a Symphony app
-      slug: quickstart/symphony
+    - title: Run a Symfony app
+      slug: quickstart/symfony
     - title: Run a Java app
       slug: quickstart/java
     - title: Run a Go app


### PR DESCRIPTION
Hey guys @hlinnaka @kelvich @stepashka @nikitashamgunov!

Bumped on a typo today that caused a redirect to the homepage when you try to open [/docs/quickstart/symphony/](https://neon.tech/docs/quickstart/symphony/)

Also, page seems like a draft, in order to hide it in production, you can use `isDraft` flag:

```mdx
---
title: Run a Symfony app
isDraft: true
---
```