### PR TITLE
docs: fixes broken link to getting started

### DIFF
--- a/content/docs/cloud/about.md
+++ b/content/docs/cloud/about.md
@@ -1,6 +1,5 @@
 ---
 title: About Neon
-
 ---
 
 Neon is a fully managed serverless Postgres with a generous free tier.
@@ -20,7 +19,7 @@ In fact, branches are so cheap that you can create a branch for every code deplo
 
 ## Fully managed
 
-Neon cloud service provides high availability without any administrative, maintenance, or scaling burden. Check [our documentation](../getting_started) for Neon users.
+Neon cloud service provides high availability without any administrative, maintenance, or scaling burden. Check [our documentation](../get-started-with-neon/signing-up) for Neon users.
 
 ## Bottomless Storage
 

--- a/content/docs/cloud/about.md
+++ b/content/docs/cloud/about.md
@@ -19,7 +19,7 @@ In fact, branches are so cheap that you can create a branch for every code deplo
 
 ## Fully managed
 
-Neon cloud service provides high availability without any administrative, maintenance, or scaling burden. Check [our documentation](../get-started-with-neon/signing-up) for Neon users.
+Neon cloud service provides high availability without any administrative, maintenance, or scaling burden. Check [our documentation](/docs/get-started-with-neon/signing-up) for Neon users.
 
 ## Bottomless Storage
 

--- a/content/docs/get-started-with-neon/signing-up.md
+++ b/content/docs/get-started-with-neon/signing-up.md
@@ -3,6 +3,7 @@ title: Signing Up
 redirectFrom:
   - docs/quickstart/console/
   - docs/cloud/getting-started/
+  - docs/cloud/getting_started/
 ---
 
 In order to launch Neon projects, you need to sign up on <https://console.neon.tech> and click on the New Project button.


### PR DESCRIPTION
This PR is a small fix to a broken link in the docs. It adds a redirect in case the broken link has been shared anywhere and updates the documentation page to an existing link.