### PR TITLE
docs: missing redirect for architecture overview

### DIFF
--- a/content/docs/conceptual-guides/architecture-overview.md
+++ b/content/docs/conceptual-guides/architecture-overview.md
@@ -1,5 +1,7 @@
 ---
 title: Overview
+redirectFrom:
+  - docs/storage-engine/architecture-overview
 ---
 
 ### Introduction


### PR DESCRIPTION
This fixes a redirect for the architecture overview page