### PR TITLE
docs: updated cloud integrations to deployments

### DIFF
--- a/content/docs/integrations/integrations-list.md
+++ b/content/docs/integrations/integrations-list.md
@@ -2,7 +2,7 @@
 title: Integrations
 ---
 
-To see **Cloud Integrations**,
+To see **Cloud Deployments**,
 
 - Run a Hasura App
 - Run a Next.js and Vercel App

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -16,7 +16,7 @@
           slug: get-started-with-neon/query-with-psql-editor
 - title: Integrations
   items:
-    - title: Cloud Integrations
+    - title: Cloud Deployments
       items:
       - title: Run a Hasura app
         slug: integrations/hasura


### PR DESCRIPTION
Small change, this updates the name of "cloud integrations" to "cloud deployments"