### PR TITLE
docs: updates branches and branching 

### DIFF
--- a/content/docs/conceptual-guides/branching.md
+++ b/content/docs/conceptual-guides/branching.md
@@ -1,5 +1,7 @@
 ---
-title: Branches
+title: Branching
+redirectFrom:
+  - docs/conceptual-guides/branches
 ---
 
 <a id="branches-coming-soon/"></a>

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -7,7 +7,7 @@ redirectFrom:
 
 <a id="branches-coming-soon/"></a>
 
-## Branches
+## Branch
 
 _Neon Branching capabilities are not publicly available yet. If you would like to try out this feature, reach out to iwantbranching@neon.tech describing your use case and request to enable branching capabilities for your account._
 

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -72,8 +72,8 @@
       slug: conceptual-guides/architecture-overview
     - title: Compute Lifecycle
       slug: conceptual-guides/compute-lifecycle
-    - title: Branches
-      slug: conceptual-guides/branches
+    - title: Branching
+      slug: conceptual-guides/branching
 
 - title: Security
   items:


### PR DESCRIPTION
This updates the glossary from `Branches` to `Branch` and renames the concept guide to `Branching`