### PR TITLE
fix: update SNI doc

### DIFF
--- a/content/docs/how-to-guides/connectivity-issues.md
+++ b/content/docs/how-to-guides/connectivity-issues.md
@@ -7,7 +7,7 @@ title: Connecting with old clients
 In most cases, copy-pasting `Connection string` from the project's dashboard and using it in your project should work as is. However, with older clients and some native Postgres clients, you may receive the following error:
 
 ```txt
-ERROR: Project ID is not specified. Either please upgrade the postgres client library (libpq) for SNI support or pass the project ID (first part of the domain name) as a parameter: '&options=project%3D<project-id>'. See more at https://neon.tech/sni
+ERROR: The project ID is not specified. Either upgrade the PostgreSQL client library (libpq) for SNI support or pass the project ID (the first part of the domain name) as a parameter: '&options=project%3D'. See https://neon.tech/sni for more information.
 ```
 
 In most cases, this happens if your client library or app does not support the so-called **SNI (Server Name Indication)** mechanism in TLS. See [#Details](Details) for more context and [#Workarounds](Workarounds) for a list of ways to get around this issue.

--- a/content/docs/how-to-guides/connectivity-issues.md
+++ b/content/docs/how-to-guides/connectivity-issues.md
@@ -56,7 +56,7 @@ If your application or service uses golang Postgres clients like `pgx` and `lib/
 
 ### D. Specify the project ID in the password field
 
-You can specify the project ID in the password field as a last resort. So instead of your actual password (let it be 'my-pass'), you can set the following string, consisting of the project ID and the password:
+You can specify the project ID in the password field as a last resort. So, instead of your actual password (for example, 'my-pass'), you can set the following string, consisting of the project ID and the password:
 
 ```txt
 project=mute-recipe-239816;my-pass

--- a/content/docs/how-to-guides/connectivity-issues.md
+++ b/content/docs/how-to-guides/connectivity-issues.md
@@ -7,20 +7,20 @@ title: Connecting with old clients
 In most cases, copy-pasting `Connection string` from the project's dashboard and using it in your project should work as is. However, with older clients and some native Postgres clients, you may receive the following error:
 
 ```txt
-ERROR: Project name is not specified. Either please upgrade the postgres client library (libpq) for SNI support or pass the project name as a parameter: '&options=project%3D<project-name>'. See more at https://neon.tech/sni
+ERROR: Project ID is not specified. Either please upgrade the postgres client library (libpq) for SNI support or pass the project ID (first part of the domain name) as a parameter: '&options=project%3D<project-id>'. See more at https://neon.tech/sni
 ```
 
 In most cases, this happens if your client library or app does not support the so-called **SNI (Server Name Indication)** mechanism in TLS. See [#Details](Details) for more context and [#Workarounds](Workarounds) for a list of ways to get around this issue.
 
 ## Details
 
-To route incoming connections, we use different domain names for different projects, e.g., to connect to the project named `mute-recipe-239816`, we ask you to connect to _**mute-recipe-239816.cloud.neon.tech**_. However, the Postgres wire protocol does not transfer the server domain name, so we always use only encrypted connections and rely on the so-called **SNI (Server Name Indication)** extension of the `TLS` protocol, which allows a client to indicate what domain name it is attempting to connect to. That is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. `SNI` support was added to the `libpq` (an official Postgres client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if `libpq` in the system has a version >= 14.
+To route incoming connections, we use different domain names for different projects, e.g., to connect to the project `mute-recipe-239816`, we ask you to connect to _**mute-recipe-239816.cloud.neon.tech**_. However, the Postgres wire protocol does not transfer the server domain name, so we rely on the so-called **SNI (Server Name Indication)** extension of the `TLS` protocol, which allows a client to indicate what domain name it is attempting to connect to. That is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. `SNI` support was added to the `libpq` (an official Postgres client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if `libpq` in the system has a version >= 14.
 
 ## Workarounds
 
-If you face a `Project name is not specified` error and library/application upgrade does not help, we provide several fallback options. When `SNI` domain name info is missing, we need to get it via other means.
+If you face a `Project ID is not specified` error and library/application upgrade does not help, we provide several fallback options. When `SNI` domain name info is missing, we need to get it via other means.
 
-### A. Pass project name in options
+### A. Pass project ID in options
 
 We support a special connection option named `project,` which you can set to identify the cluster you are connecting to. More specifically, you can set pass `options=project%3Dmy-project-123` as a GET parameter in the connection string. `%3D` here is an url-encoded `=`.
 
@@ -43,7 +43,7 @@ This option is expected to always work if your app/library allow to set. But not
 If your app or client is `libpq` based and you can't easily upgrade the library (e.g., when the library is compiled inside of some pre-build application), you can use the fact that libpq can expand the database name to different options. So instead of the database name, you can specify:
 
 ```txt
-dbname=main options=project=<project name>
+dbname=main options=project=<project ID>
 ```
 
 in the database field.
@@ -54,9 +54,9 @@ This option is expected to work with all libpq-based apps.
 
 If your application or service uses golang Postgres clients like `pgx` and `lib/pg` you can set `sslmode=verify-full,` which will cause `SNI` info to be sent. Most likely, this was not intentional but happened inadvertently due to the golang's TLS library API design.
 
-### D. Specify the project name in the password field
+### D. Specify the project ID in the password field
 
-You can specify the project name in the password field as a last resort. So instead of your actual password (let it be 'my-pass'), you can set the following string, consisting of the project name and the password:
+You can specify the project ID in the password field as a last resort. So instead of your actual password (let it be 'my-pass'), you can set the following string, consisting of the project ID and the password:
 
 ```txt
 project=mute-recipe-239816;my-pass
@@ -89,8 +89,8 @@ List of native client libraries:
 | Postgrex          | Elixir      |                                                          |
 | epgsql            | Erlang      |                                                          |
 | pgo               | Erlang      |                                                          |
-| github.com/lib/pq | Go          | no (except verify-full mode)                             |
-| pgx               | Go          | no (except verify-full mode)                             |
+| github.com/lib/pq | Go          | no (SNI support is in review)                            |
+| pgx               | Go          | no (SNI support is merged, not relesed yet)              |
 | go-pg             | Go          | no (except verify-full mode)                             |
 | JDBC              | Java        | yes                                                      |
 | R2DBC             | Java        |                                                          |

--- a/content/docs/how-to-guides/connectivity-issues.md
+++ b/content/docs/how-to-guides/connectivity-issues.md
@@ -18,7 +18,7 @@ To route incoming connections, we use different domain names for different proje
 
 ## Workarounds
 
-If you face a `Project ID is not specified` error and library/application upgrade does not help, we provide several fallback options. When `SNI` domain name info is missing, we need to get it via other means.
+If you encounter a Project ID is not specified error and a library or application upgrade does not help, we provide several fallback options. When SNI domain name information is missing, we need to obtain this information through other means.
 
 ### A. Pass project ID in options
 


### PR DESCRIPTION
Be more strict with project id/name difference. In passing fix awkward
wording and update status for golang drivers.