### PR TITLE
feat: add CTA component for blog posts

### DIFF
--- a/src/components/pages/blog-post/cta/cta.jsx
+++ b/src/components/pages/blog-post/cta/cta.jsx
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Button from 'components/shared/button';
+
+import background from './images/background.svg';
+
+const CTA = ({ title, buttonText, buttonUrl }) => (
+  <div className="relative my-5">
+    <img
+      src={background}
+      alt=""
+      className="absolute inset-0 -z-10 m-0 h-full w-full bg-black object-cover md:m-0"
+      aria-hidden
+    />
+    <div className="flex items-center justify-between space-x-20 py-4 px-8  sm:flex-col sm:space-x-0">
+      <h2 className="my-0 max-w-lg text-[22px] font-semibold text-white md:my-0 sm:text-center sm:text-lg sm:leading-tight">
+        {title}
+      </h2>
+      <Button className="!text-sm sm:mt-3 xs:w-full" theme="primary" size="xs" to={buttonUrl}>
+        {buttonText}
+      </Button>
+    </div>
+  </div>
+);
+
+CTA.propTypes = {
+  title: PropTypes.string.isRequired,
+  buttonText: PropTypes.string.isRequired,
+  buttonUrl: PropTypes.string.isRequired,
+};
+
+export default CTA;

--- a/src/components/pages/blog-post/cta/cta.jsx
+++ b/src/components/pages/blog-post/cta/cta.jsx
@@ -7,13 +7,7 @@ import background from './images/background.svg';
 
 const CTA = ({ title, buttonText, buttonUrl }) => (
   <div className="relative my-5">
-    <img
-      src={background}
-      alt=""
-      className="absolute inset-0 -z-10 m-0 h-full w-full bg-black object-cover md:m-0"
-      aria-hidden
-    />
-    <div className="flex items-center justify-between space-x-20 py-4 px-8  sm:flex-col sm:space-x-0">
+    <div className="flex items-center justify-between space-x-20 py-4 px-8 sm:flex-col sm:space-x-0">
       <h2 className="my-0 max-w-lg text-[22px] font-semibold text-white md:my-0 sm:text-center sm:text-lg sm:leading-tight">
         {title}
       </h2>
@@ -21,6 +15,12 @@ const CTA = ({ title, buttonText, buttonUrl }) => (
         {buttonText}
       </Button>
     </div>
+    <img
+      className="absolute inset-0 -z-10 m-0 h-full w-full bg-black object-cover md:m-0"
+      src={background}
+      alt=""
+      aria-hidden
+    />
   </div>
 );
 

--- a/src/components/pages/blog-post/cta/images/background.svg
+++ b/src/components/pages/blog-post/cta/images/background.svg
@@ -1,0 +1,24 @@
+<svg width="860" height="75" viewBox="0 0 860 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect y="0.00488281" width="860" height="74" fill="#1A1A1A"/>
+<mask id="mask0_7908_12121" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="860" height="75">
+<rect y="0.00488281" width="860" height="74" fill="#1A1A1A"/>
+</mask>
+<g mask="url(#mask0_7908_12121)">
+<path d="M537.974 57C537.454 67.0286 529.158 75 519 75H400V57H537.974Z" stroke="#262626" stroke-width="2"/>
+<path d="M819.011 15C819.535 37.9539 838.046 56.4648 861 56.9886V15H819.011Z" stroke="#262626" stroke-width="2"/>
+<path d="M119 15L430 -22" stroke="#262626" stroke-width="2"/>
+</g>
+<line y1="57.0049" x2="860" y2="57.0049" stroke="#262626" stroke-width="2"/>
+<line y1="15.0049" x2="860" y2="15.0049" stroke="#262626" stroke-width="2"/>
+<path d="M538 15L661 57" stroke="#262626" stroke-width="2"/>
+<line x1="661" y1="74.0049" x2="661" y2="0.00488281" stroke="#262626" stroke-width="2"/>
+<line x1="819" y1="74.0049" x2="819" y2="0.00488281" stroke="#262626" stroke-width="2"/>
+<path d="M538 51L538 26" stroke="#262626" stroke-width="3" stroke-linecap="round" stroke-dasharray="0.01 8"/>
+<path d="M400 45L400 21" stroke="#262626" stroke-width="3" stroke-linecap="round" stroke-dasharray="0.01 8"/>
+<circle cx="400" cy="57" r="5" fill="#1A1A1A" stroke="#262626" stroke-width="2"/>
+<circle cx="400" cy="57.0002" r="1.66667" fill="#262626"/>
+<path d="M430 56L430 -4.17233e-07" stroke="#262626" stroke-width="2"/>
+<line x1="39" y1="74.0049" x2="39" y2="0.00488281" stroke="#262626" stroke-width="2"/>
+<line x1="119" y1="16" x2="119" y2="-4.37114e-08" stroke="#262626" stroke-width="2"/>
+<line x1="269" y1="74" x2="269" y2="58" stroke="#262626" stroke-width="2"/>
+</svg>

--- a/src/components/pages/blog-post/cta/index.js
+++ b/src/components/pages/blog-post/cta/index.js
@@ -1,0 +1,3 @@
+import CTA from './cta';
+
+export default CTA;

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import Content from 'components/pages/blog-post/content';
+import CTA from 'components/pages/blog-post/cta';
 import Hero from 'components/pages/blog-post/hero';
 import SocialShare from 'components/pages/blog-post/social-share';
 import CodeBlock from 'components/shared/code-block';
@@ -23,6 +24,7 @@ const BlogPostTemplate = ({
     content,
     {
       blogpostcode: CodeBlock,
+      blogpostcta: CTA,
     },
     true
   );


### PR DESCRIPTION
This pull request brings the CTA lazy block for blog posts, this block was integrated with WP.
Preview: https://websitemain62807-ctacomponent.gtsb.io/blog/neon-at-percona-live-2022/