### PR TITLE
fix: remove empty lines in docs

### DIFF
--- a/content/docs/get-started-with-neon/query-with-neon-sql-editor.md
+++ b/content/docs/get-started-with-neon/query-with-neon-sql-editor.md
@@ -9,12 +9,9 @@ redirectFrom:
 To use the SQL Editor:
 
 1. Navigate to the [Neon console](https://console.neon.tech/).
-
 2. On the **Dashboard** tab, select your project from project drop-down list.
-
 3. Select the **SQL Editor** tab.
-
-4. Enter a query into the editor and click **Run** to view the results. 
+4. Enter a query into the editor and click **Run** to view the results.
 
 You can use the following queries to try the SQL Editor:
 
@@ -23,7 +20,8 @@ CREATE TABLE t (c int);
 INSERT INTO t SELECT generate_series(1,100);
 SELECT count(*) FROM t;
 ```
-**_Note:_**  Running multiple query statements at once returns a separate result set for each statement. The result sets are displayed in separate tabs, numbered in order of execution.
+
+**_Note:_** Running multiple query statements at once returns a separate result set for each statement. The result sets are displayed in separate tabs, numbered in order of execution.
 
 To clear the editor, click **New Query**.
 
@@ -34,9 +32,7 @@ The SQL Editor allows you to save your queries.
 To save a query:
 
 1. Enter the query into the editor.
-
 2. Click **Save** to open the **SAVE QUERY** dialog.
-
 3. Enter a name for the query and click **Save**.
 
 The query is added to the **Saved** list in the left pane of the SQL Editor. You can rerun a query by selecting it from the **Saved** list.


### PR DESCRIPTION
This pull request prevents line breaks on the docs page. 