### PR TITLE
fix: add padding left for ol in content

### DIFF
--- a/src/components/pages/doc/previous-and-next-links/previous-and-next-links.jsx
+++ b/src/components/pages/doc/previous-and-next-links/previous-and-next-links.jsx
@@ -5,13 +5,13 @@ import Link from 'components/shared/link';
 import { DOCS_BASE_PATH } from 'constants/docs';
 
 const PreviousAndNextLinks = ({ previousLink, nextLink }) => (
-  <div className="mt-16 flex w-full">
+  <div className="mt-16 flex w-full space-x-4">
     {previousLink && (
       <Link
         to={`${DOCS_BASE_PATH}${previousLink.slug}`}
         size="md"
         theme="black-primary-1"
-        className="mr-auto"
+        className="mr-auto xs:!leading-tight"
       >
         {previousLink.title}
       </Link>
@@ -21,7 +21,7 @@ const PreviousAndNextLinks = ({ previousLink, nextLink }) => (
         to={`${DOCS_BASE_PATH}${nextLink.slug}`}
         size="md"
         theme="black-primary-1"
-        className="ml-auto"
+        className="ml-auto text-right xs:!leading-tight"
       >
         {nextLink.title}
       </Link>

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -35,7 +35,7 @@
 
     ol {
       counter-reset: custom-counter;
-      @apply md:pl-0;
+      @apply pl-10 md:pl-4 sm:pl-0;
 
       > li {
         counter-increment: custom-counter;

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -35,7 +35,7 @@
 
     ol {
       counter-reset: custom-counter;
-      @apply pl-10 md:pl-4 sm:pl-0;
+      @apply pl-10 md:pl-4;
 
       > li {
         counter-increment: custom-counter;


### PR DESCRIPTION
This pull request adds padding-left to an ordered list for content block.
Preview: https://websitemain62807-contentstyles.gtsb.io/docs/get-started-with-neon/query-with-neon-sql-editor/