### PR TITLE
Fix naming inconsistencies

### DIFF
--- a/content/changelog/2022-07-19-storage-release/index.md
+++ b/content/changelog/2022-07-19-storage-release/index.md
@@ -9,8 +9,8 @@ label: 'Storage'
 - Safekeeper: Switched to etcd subscriptions to keep pageservers up to date regarding safekeeper status.
 - Safekeeper: Implemented JWT authentication in the Safekeeper HTTP API.
 - Proxy: Added support for propagating SASL/SCRAM PostgreSQL authentication errors to clients.
-- Postgres Compute: Updated the PostgreSQL version to 14.4.
-- Postgres Compute: Renamed the following custom configuration parameters:
+- Compute: Updated the PostgreSQL version to 14.4.
+- Compute: Renamed the following custom configuration parameters:
   - `zenith.page_server_connstring` to `neon.pageserver_connstring`
   - `zenith.zenith_tenant` to `neon.tenant_id`
   - `zenith.zenith_timeline` to `neon.timeline_id`
@@ -26,7 +26,7 @@ label: 'Storage'
 
 ### Bug fixes
 
-- Postgres Compute: Fixed `CREATE EXTENSION` for users that are not database owners.
+- Compute: Fixed `CREATE EXTENSION` for users that are not database owners.
 - Safekeeper: Fixed the walreceiver connection selection mechanism:
   - Reconnecting to safekeeper immediately after it fails is now avoided by limiting candidates to those with fewest connection attempts.
   - Increased the `max_lsn_wal_lag` default setting to avoid constant reconnections during normal work.

--- a/content/changelog/2022-08-02-storage-release/index.md
+++ b/content/changelog/2022-08-02-storage-release/index.md
@@ -4,8 +4,8 @@ label: 'Storage'
 
 ### What's new
 
-- Postgres Compute: Installed the 'uuid-ossp' extension binaries. `CREATE EXTENSION "uuid-ossp"` now works.
-- Postgres Compute: Added logging for compute node initialization failure during the 'basebackup' stage.
+- Compute: Installed the 'uuid-ossp' extension binaries. `CREATE EXTENSION "uuid-ossp"` now works.
+- Compute: Added logging for compute node initialization failure during the 'basebackup' stage.
 - Pageserver: Avoided busy looping when deletion from cloud storage is skipped due to failed upload tasks.
 - Pageserver: Merged the 'wal_receiver' endpoint with 'timeline_detail', in the internal management API.
 - Pageserver: Added reporting of the physical size with the tenant status, in the internal management API.

--- a/content/changelog/2022-08-31-console-release/index.md
+++ b/content/changelog/2022-08-31-console-release/index.md
@@ -4,7 +4,7 @@ label: 'Console'
 
 ### What's new
 
-- Control plane: Implemented OAuth backend and OAuth consent screens. OAuth applications are granted permissions to create projects on behalf of the user. To integrate your product with Neon, please contact us.
+- Control Plane: Implemented OAuth backend and OAuth consent screens. OAuth applications are granted permissions to create projects on behalf of the user. To integrate your product with Neon, please contact us.
 
 ### Bug fixes
 

--- a/content/changelog/2022-09-01-storage-release/index.md
+++ b/content/changelog/2022-09-01-storage-release/index.md
@@ -4,7 +4,7 @@ label: 'Storage'
 
 ### What's new
 
-- Postgres Compute: Updated the PostgreSQL version to 14.5.
-- Postgres Compute: Added support for the `PostGIS` extension, version 3.3.0.
+- Compute: Updated the PostgreSQL version to 14.5.
+- Compute: Added support for the `PostGIS` extension, version 3.3.0.
 - Pageserver: Changed basebackup import panics to plain errors.
 - Proxy: Added support for forwarding the `options`, `application_name`, and `replication` connection parameters to compute nodes.

--- a/content/changelog/2022-09-02-console-release/index.md
+++ b/content/changelog/2022-09-02-console-release/index.md
@@ -10,4 +10,4 @@ label: 'Console'
 
 - UI: Fixed the title on the 'Sign in' page.
 - UI: Changed the PostgreSQL version displayed on the project dashboard to 14.5.
-- Control plane: Fixed authentication of concurrent proxy connections to the idle compute node.
+- Control Plane: Fixed authentication of concurrent proxy connections to the idle compute node.

--- a/content/docs/conceptual-guides/branching.md
+++ b/content/docs/conceptual-guides/branching.md
@@ -6,7 +6,7 @@ redirectFrom:
 
 <a id="branches-coming-soon/"></a>
 
-_Neon Branching capabilities are not yet publicly available yet. If you would like to try this feature, reach out to [iwantbranching@neon.tech](iwantbranching@neon.tech) describing your use case and requesting that Neon  enable branching capabilities for your account.
+Neon Branching capabilities are not yet publicly available. If you would like to try this feature, reach out to [iwantbranching@neon.tech](iwantbranching@neon.tech) describing your use case and requesting that Neon enable branching capabilities for your account.
 
 A branch is a copy of the project data created from the current state or any past state that is still available. A branch can be independently modified from its originating project data.
 

--- a/content/docs/get-started-with-neon/using-api-keys.md
+++ b/content/docs/get-started-with-neon/using-api-keys.md
@@ -9,7 +9,7 @@ A Neon user is identified by their email address.
 
 A user registers and authenticates in Neon Web UI with their GitHub or Google account. More authentication methods are coming soon.
 
-Once authenticated, a user can create and access Projects and [query Project data](../tutorials#query-via-ui). You can also manage [Postgres Users](../../reference/glossary/#postgres-users) and [Databases](../../reference/glossary/#postgres-databases) in each Project.
+Once authenticated, a user can create and access Projects and [query Project data](../tutorials#query-via-ui). You can also manage [PostgreSQL Users](../../reference/glossary/#postgres-users) and [Databases](../../reference/glossary/#postgres-databases) in each Project.
 
 ## Using API keys as a Neon User
 

--- a/content/docs/how-to-guides/connectivity-issues.md
+++ b/content/docs/how-to-guides/connectivity-issues.md
@@ -4,7 +4,7 @@ title: Connecting with older clients
 
 ## Overview
 
-In most cases, copy-pasting `Connection string` from the project's dashboard and using it in your project should work as is. However, with older clients and some native Postgres clients, you may receive the following error:
+In most cases, copy-pasting `Connection string` from the project's dashboard and using it in your project should work as is. However, with older clients and some native PostgreSQL clients, you may receive the following error:
 
 ```txt
 ERROR: The project ID is not specified. Either upgrade the PostgreSQL client library (libpq) for SNI support or pass the project ID (the first part of the domain name) as a parameter: '&options=project%3D'. See https://neon.tech/sni for more information.
@@ -14,7 +14,7 @@ In most cases, this happens if your client library or app does not support the s
 
 ## Details
 
-To route incoming connections, we use different domain names for different projects, e.g., to connect to the project `mute-recipe-239816`, we ask you to connect to _**mute-recipe-239816.cloud.neon.tech**_. However, the Postgres wire protocol does not transfer the server domain name, so we rely on the so-called **SNI (Server Name Indication)** extension of the `TLS` protocol, which allows a client to indicate what domain name it is attempting to connect to. That is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. `SNI` support was added to the `libpq` (an official Postgres client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if `libpq` in the system has a version >= 14.
+To route incoming connections, we use different domain names for different projects, e.g., to connect to the project `mute-recipe-239816`, we ask you to connect to _**mute-recipe-239816.cloud.neon.tech**_. However, the PostgreSQL wire protocol does not transfer the server domain name, so we rely on the so-called **SNI (Server Name Indication)** extension of the `TLS` protocol, which allows a client to indicate what domain name it is attempting to connect to. That is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. `SNI` support was added to the `libpq` (an official PostgreSQL client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if `libpq` in the system has a version >= 14.
 
 ## Workarounds
 
@@ -52,7 +52,7 @@ This option is expected to work with all libpq-based apps.
 
 ### C. Set verify-full for golang-based clients
 
-If your application or service uses golang Postgres clients like `pgx` and `lib/pg` you can set `sslmode=verify-full,` which will cause `SNI` info to be sent. Most likely, this was not intentional but happened inadvertently due to the golang's TLS library API design.
+If your application or service uses golang PostgreSQL clients like `pgx` and `lib/pg` you can set `sslmode=verify-full,` which will cause `SNI` info to be sent. Most likely, this was not intentional but happened inadvertently due to the golang's TLS library API design.
 
 ### D. Specify the project ID in the password field
 

--- a/content/docs/integrations/go.md
+++ b/content/docs/integrations/go.md
@@ -4,7 +4,7 @@ redirectFrom:
   - /docs/quickstart/go
 ---
 
-Neon is fully compatible with sql/db package and common Postgres drivers ie. lib/pq, pgx etc.
+Neon is fully compatible with sql/db package and common PostgreSQL drivers ie. lib/pq, pgx etc.
 
 ```go
 package main

--- a/content/docs/integrations/postgres.md
+++ b/content/docs/integrations/postgres.md
@@ -4,10 +4,10 @@ redirectFrom:
   - /docs/quickstart/postgres
 ---
 
-Since Neon compute is regular Postgres, any Postgres app will run out of the box.
+Since Neon compute is regular PostgreSQL, any PostgreSQL app will run out of the box.
 You can also use all the standard client utilities like `psql` and `pg_dump`, client libraries and drivers to connect.
 
-All connections to Postgres are done via an endpoint hosted at `pg.neon.tech`.
+All connections to PostgreSQL are via an endpoint hosted at `pg.neon.tech`.
 
 Try connecting to `pg.neon.tech` using the following command in your terminal:
 

--- a/content/docs/integrations/sqlalchemy.md
+++ b/content/docs/integrations/sqlalchemy.md
@@ -19,9 +19,9 @@ To complete this section, you will need to already have the following:
 
 ## Using from Python + psycopg2
 
-Psycopg2 is the most popular python library for running raw postgres queries. This quickstart covers how to use pscycopg2 with SQLAlchemy, if you are interested in an alternative higher-level ORM on top of psycopg2, see our guide on [Django](../django).
+Psycopg2 is the most popular python library for running raw PostgreSQL queries. This quickstart covers how to use pscycopg2 with SQLAlchemy, if you are interested in an alternative higher-level ORM on top of psycopg2, see our guide on [Django](../django).
 
-This step will cover how to get started with writing postgres queries against Neon via psycopg2.
+This step will cover how to get started with writing PostgreSQL queries against Neon via psycopg2.
 
 First, register on the Neon cloud service and create a Project.
 
@@ -80,8 +80,8 @@ engine = create_engine(CONNSTR)
 - [Establishing Connectivity - the Engine](https://docs.sqlalchemy.org/en/14/tutorial/engine.html)
 - [Connecting to PostgreSQL with SQLAlchemy](https://docs.sqlalchemy.org/en/14/core/engines.html#postgresql)
 
-Now, build great things with Neon! Any Postgres tutorial will be able to guide you on the syntax.
+Now, build great things with Neon! Any PostgreSQL tutorial will be able to guide you on the syntax.
 
 ## Conclusion
 
-In this section, you have learned how to create SQLAlchemy engine that points to your Neon Project and write Postgres queries using psycopg2.
+In this section, you have learned how to create SQLAlchemy engine that points to your Neon Project and write PostgreSQL queries using psycopg2.

--- a/content/docs/integrations/vercel.md
+++ b/content/docs/integrations/vercel.md
@@ -17,9 +17,9 @@ First, [Create a next.js project](https://nextjs.org/learn/basics/create-nextjs-
 
 Next, create a Neon Project for your app. You can configure your database schema from Neon Console or using tools like Prisma.
 
-## Add Postgres client
+## Add PostgreSQL client
 
-Add Postgres client to your app. In this example we used [postgres.js](https://www.npmjs.com/package/postgres), but feel free to choose another one.
+Add PostgreSQL client to your app. In this example we used [postgres.js](https://www.npmjs.com/package/postgres), but feel free to choose another one.
 
 ## Add Neon credentials
 
@@ -35,9 +35,9 @@ NEON_PORT=...
 
 You can use either a connection string or connection options separately.
 
-## Connect to the Database with Postgres client and Neon Credentials
+## Connect to the Database with a PostgreSQL client and Neon Credentials
 
-Connect to the database with postgres client and your Neon credentials from your api handlers or server functions.
+Connect to the database with PostgreSQL client and your Neon credentials from your api handlers or server functions.
 
 ```javascript pages/api/hello_worlds.js
 import postgres from 'postgres';

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -30,30 +30,30 @@ A Neon user is identified by their email address.
 
 A user registers and authenticates in Neon Web UI with their GitHub or Google account. More authentication methods are coming soon.
 
-Once authenticated, a user can create and access [Projects](#project) and [query Project data](../../get-started-with-neon/tutorials#query-via-ui). You can also manage [Postgres Users](#postgres-users) and [Databases](#postgres-databases) in each Project.
+Once authenticated, a user can create and access [Projects](#project) and [query Project data](../../get-started-with-neon/tutorials#query-via-ui). You can also manage [PostgreSQL Users](#postgres-users) and [Databases](#postgres-databases) in each Project.
 
-## Postgres
+## PostgreSQL
 
 - WAL: PostgreSQL uses a [Write Ahead Log (WAL)](https://www.postgresql.org/docs/current/wal-intro.html) for durability and replication. In Neon, we additionally rely on this WAL to separate storage from compute.
 - LSN: [Log Sequence Number](https://www.postgresql.org/docs/current/datatype-pg-lsn.html), a byte offset into a location inside the entire WAL stream.
-- Page: An 8KB chunk of data, which is the smallest unit of storage that Postgres uses for storing relations and indexes on disk. In Neon, a page is also the smallest unit of data the Pageserver can be queried for. See [Postgres Database Page Layout](https://www.postgresql.org/docs/current/storage-page-layout.html).
+- Page: An 8KB chunk of data, which is the smallest unit of storage that PostgreSQL uses for storing relations and indexes on disk. In Neon, a page is also the smallest unit of data the Pageserver can be queried for. See [PostgreSQL Database Page Layout](https://www.postgresql.org/docs/current/storage-page-layout.html).
 
-## Postgres users
+## PostgreSQL users
 
-Postgres users are created as a part of your Neon Project and can be managed via the Neon web UI. A system user `web-access` is used for the SQL Editor in Neon UI and for link authentication for psql. This user cannot be removed or used for authenticating in other scenarios.
+PostgreSQL users are created as a part of your Neon Project and can be managed via the Neon web UI. A system user `web-access` is used for the SQL Editor in Neon UI and for link authentication for psql. This user cannot be removed or used for authenticating in other scenarios.
 
 The second user is created for client access. The credentials for that user can be managed, this user's credentials can be used for password-based psql authentication too.
 
-More Postgres users can be created in Neon UI.
+More PostgreSQL users can be created in Neon UI.
 
-## Postgres databases
+## PostgreSQL databases
 
 When a Project is created, a default database for storing data is created along with it, the name of the database is "main". A Neon user can create more databases inside a Project in the Neon UI. Neon users cannot manipulate system databases, such as `postgres`, `template0`, or `template1`.
 
 ## Project
 
-A Project is a collection of Postgres databases, Postgres users and other settings on Neon cloud service.
+A Project is a collection of PostgreSQL databases, PostgreSQL users and other settings on Neon cloud service.
 
-A Project contains a virtual instance with a Postgres server, also called Compute, as well as the storage used to store the Project data. The amount of virtual resources available for the Project is subject to limits defined by the [Technical Preview Free Tier](../technical-preview-free-tier).
+A Project contains a virtual instance with a PostgreSQL server, also called Compute, as well as the storage used to store the Project data. The amount of virtual resources available for the Project is subject to limits defined by the [Technical Preview Free Tier](../technical-preview-free-tier).
 
 Compute is stateless and can be automatically activated and suspended due to user activity.


### PR DESCRIPTION
- Postgres > PostgreSQL (Heikki and Stas have agreed to use the official name "PostgreSQL" in the docs)
- Control plane > Control Plane (Release notes)
- A few other minor edits