### PR TITLE
Revise menu link text to change Postgres to the official product name…

### DIFF
--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -67,7 +67,7 @@ export default {
           to: LINKS.docs,
         },
         {
-          text: 'Postgres docs',
+          text: 'PostgreSQL docs',
           to: LINKS.postgresDocs,
         },
         {
@@ -75,7 +75,7 @@ export default {
           to: LINKS.security,
         },
         {
-          text: 'Postgres mailing lists',
+          text: 'PostgreSQL mailing lists',
           to: LINKS.postgresList,
         },
       ],


### PR DESCRIPTION
… "PostgreSQL".

Revise menu link text to change "Postgres" to the official product name, "PostgreSQL".  The docs will use the official name.