### PR TITLE
fix: turn doc posts to draft

### DIFF
--- a/content/docs/cloud/getting-started.md
+++ b/content/docs/cloud/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+isDraft: true
 ---
 
 Neon is a fully managed serverless Postgres.

--- a/content/docs/integrations/integrations-list.md
+++ b/content/docs/integrations/integrations-list.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+isDraft: true
 ---
 
 To see **Cloud deployments**,

--- a/content/docs/storage-engine/control-plane.md
+++ b/content/docs/storage-engine/control-plane.md
@@ -1,3 +1,4 @@
 ---
 title: Control Plane
+isDraft: true
 ---

--- a/content/docs/storage-engine/read-path.md
+++ b/content/docs/storage-engine/read-path.md
@@ -1,5 +1,6 @@
 ---
 title: Read Path
+isDraft: true
 ---
 
 PostgreSQL &lt;-- Pageserver &lt;-- Cloud storage

--- a/content/docs/storage-engine/write-path.md
+++ b/content/docs/storage-engine/write-path.md
@@ -1,5 +1,6 @@
 ---
 title: Write Path
+isDraft: true
 ---
 
 PostgreSQL --> Safekeepers --> Pageserver --> Cloud storage


### PR DESCRIPTION
This pull request converts the doc posts, which wasn't included in the sidebar to draft. 

- cloud/getting-started
- integrations/integrations-list
- storage-engine/control-plane
- storage-engine/read-path
- storage-engine/write-path