### PR TITLE
Terminology fixes

### DIFF
--- a/content/docs/conceptual-guides/architecture-overview.md
+++ b/content/docs/conceptual-guides/architecture-overview.md
@@ -6,7 +6,7 @@ redirectFrom:
 
 Neon architecture is based on the separation of storage and compute and is orchestrated by the Neon Control Plane, which manages cloud resources across both storage and compute.
 
-A Neon Compute runs regular PostgreSQL, and storage is a multi-tenant key-value store for PostgreSQL pages, which is custom-built for the cloud.
+A Neon Compute runs PostgreSQL, and storage is a multi-tenant key-value store for PostgreSQL pages that is custom-built for the cloud.
 
 ![Neon architecture diagram](/docs-images/neon_architecture_2.png)
 

--- a/content/docs/how-to-guides/import-an-existing-database.md
+++ b/content/docs/how-to-guides/import-an-existing-database.md
@@ -25,7 +25,7 @@ You can also configure logical replication to allow Neon to receive a stream of 
 
 Some PostgreSQL features that require access to the local file system are not supported by Neon. For example, tablespaces and large objects are not supported. Please take this into account when importing an existing database to Neon.
 
-In addition to databases, Neon supports importing individual tables. You can do this using the `COPY` command, as you would with regular PostgreSQL. The only requirement is that the data is transferred through a replication stream, which may affect the performance of other queries, including those unrelated to the table you are copying.
+In addition to databases, Neon supports importing individual tables. You can do this using the `COPY` command, as you would with a standalone PostgreSQL installation. The only requirement is that the data is transferred through a replication stream, which may affect the performance of other queries, including those unrelated to the table you are copying.
 
 For information about the commands referred to in this topic, refer to the following topics in the PostgreSQL documentation:
 

--- a/content/docs/how-to-guides/import-an-existing-database.md
+++ b/content/docs/how-to-guides/import-an-existing-database.md
@@ -25,7 +25,7 @@ You can also configure logical replication to allow Neon to receive a stream of 
 
 Some PostgreSQL features that require access to the local file system are not supported by Neon. For example, tablespaces and large objects are not supported. Please take this into account when importing an existing database to Neon.
 
-In addition to databases, Neon supports importing individual tables. You can do this using the `COPY` command, as you would in vanilla PostgreSQL. The only requirement is that the data is transferred through a replication stream, which may affect the performance of other queries, including those unrelated to the table you are copying.
+In addition to databases, Neon supports importing individual tables. You can do this using the `COPY` command, as you would with regular PostgreSQL. The only requirement is that the data is transferred through a replication stream, which may affect the performance of other queries, including those unrelated to the table you are copying.
 
 For information about the commands referred to in this topic, refer to the following topics in the PostgreSQL documentation:
 

--- a/content/docs/integrations/symfony.md
+++ b/content/docs/integrations/symfony.md
@@ -5,7 +5,7 @@ redirectFrom:
   - /docs/quickstart/symfony
 ---
 
-Symfony is a free and open-source PHP web application framework. Symfony uses the Doctrine library for database access. Connecting to Neon from Symfony with Doctrine is the same as connecting to vanilla PostgreSQL from Symfony with Doctrine. Only the connection details differ.
+Symfony is a free and open-source PHP web application framework. Symfony uses the Doctrine library for database access. Connecting to Neon from Symfony with Doctrine is the same as connecting to regular PostgreSQL from Symfony with Doctrine. Only the connection details differ.
 
 To connect to Neon from Symfony with Doctrine:
 

--- a/content/docs/integrations/symfony.md
+++ b/content/docs/integrations/symfony.md
@@ -5,7 +5,7 @@ redirectFrom:
   - /docs/quickstart/symfony
 ---
 
-Symfony is a free and open-source PHP web application framework. Symfony uses the Doctrine library for database access. Connecting to Neon from Symfony with Doctrine is the same as connecting to regular PostgreSQL from Symfony with Doctrine. Only the connection details differ.
+Symfony is a free and open-source PHP web application framework. Symfony uses the Doctrine library for database access. Connecting to Neon from Symfony with Doctrine is the same as connecting to a standalone PostgreSQL installation from Symfony with Doctrine. Only the connection details differ.
 
 To connect to Neon from Symfony with Doctrine:
 

--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -66,7 +66,7 @@ The following table lists Neon PostgreSQL parameter settings that may differ fro
 
 ## Unlogged tables
 
-Unlogged tables are maintained on Neon compute local storage. These tables do not survive compute restart (including when compute becomes idle). This is unlike regular PostgreSQL, where unlogged tables are only truncated in the event of abnormal process termination. Additionally, unlogged tables are limited by compute local storage size.
+Unlogged tables are maintained on Neon compute local storage. These tables do not survive compute restart (including when compute becomes idle). This is unlike a  standalone PostgreSQL installation, where unlogged tables are only truncated in the event of abnormal process termination. Additionally, unlogged tables are limited by compute local storage size.
 
 ## Spill and index build handling
 

--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -66,7 +66,7 @@ The following table lists Neon PostgreSQL parameter settings that may differ fro
 
 ## Unlogged tables
 
-Unlogged tables are maintained on Neon compute local storage. These tables do not survive compute restart (including when compute becomes idle). This is unlike vanilla PostgreSQL, where unlogged tables are only truncated in the event of abnormal process termination. Additionally, unlogged tables are limited by compute local storage size.
+Unlogged tables are maintained on Neon compute local storage. These tables do not survive compute restart (including when compute becomes idle). This is unlike regular PostgreSQL, where unlogged tables are only truncated in the event of abnormal process termination. Additionally, unlogged tables are limited by compute local storage size.
 
 ## Spill and index build handling
 


### PR DESCRIPTION
Use "regular PostgreSQL" instead of "vanilla PostgreSQL". We currently use both. We need to settle on one. I think "regular" is less ambiguous than "vanilla" for users who are not familiar with PostgreSQL lingo.

I will add a glossary definition for "regular PostgreSQL" in a separate PR for the glossary.