### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+/content/docs/ @danieltprice
+/src/ @bolotskydev
+*.js @bolotskydev
+*.jsx @bolotskydev


### PR DESCRIPTION
Add CODEOWNERS file to root of website repo according to GitHub instructions: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

I am not an admin on the website repo, so I am unsure if I will be able to merge this, but we'll see!
Addresses issue: https://github.com/neondatabase/website/issues/211