### PR TITLE
chore: update team member position

### DIFF
--- a/src/components/pages/team/team/team.jsx
+++ b/src/components/pages/team/team/team.jsx
@@ -248,7 +248,7 @@ const members = [
   {
     photo: <StaticImage src="./images/joonas-koivunen-photo.jpg" alt="Joonas Koivunen" />,
     name: 'Joonas Koivunen',
-    position: 'SSE (Storage)',
+    position: 'Software Engineer',
     githubUrl: 'https://www.github.com/koivunej',
     linkedinUrl: 'https://www.linkedin.com/in/joonas-koivunen-70273412/',
   },


### PR DESCRIPTION
This pull request brings a minor fix to the About us page
- update the team member role