### PR TITLE
Rename migration guide

### DIFF
--- a/content/docs/how-to-guides/import-an-existing-database.md
+++ b/content/docs/how-to-guides/import-an-existing-database.md
@@ -1,5 +1,5 @@
 ---
-title: Importing a database
+title: Import data from PostgreSQL
 redirectFrom:
   - /docs/cloud/tutorials
 ---
@@ -17,7 +17,7 @@ In the `pg_dump` command shown above, replace `<host>`, `<user>`, and `<dbname>`
 **_Note_**: If you create an archive using `pg_dump` that is in a non-plain-text format, use the `pg_restore` utility instead of `psql` to restore the database to Neon.
 
 Neon is not able to create databases, so you can not use `pg_dumpall` or
-`pg_dump` with the `-C` option. If there are multiple databases in the project that you want to import, you must migrate each database separately.
+`pg_dump` with the `-C` option. If there are multiple databases in the project that you want to import, you must import each database separately.
 
 Because `pg_dump` dumps a single database, it does not include information about roles that are stored in the global `pg_authid` catalog. Also, Neon does not support creating users or roles using `psql`. Those can only be created using the Neon Console. If you do not create roles in Neon before importing a database that has roles, you will receive "role does not exist" errors during the import operation. You can ignore this warning. It does not prevent data from being imported.
 

--- a/content/docs/how-to-guides/import-from-heroku.md
+++ b/content/docs/how-to-guides/import-from-heroku.md
@@ -1,17 +1,19 @@
 ---
-title: Migrating from Heroku
+title: Import data from Heroku
 enableTableOfContents: true
+redirectFrom:
+  - /docs/how-to-guides/hasura-heroku-migration
 ---
 
-This guide describes how to migrate your data from Heroku PostgreSQL to Neon.
+This guide describes how to import data from Heroku PostgreSQL to Neon.
 
 The instructions assume that you have installed the Heroku CLI, which is used to transfer data from Heroku. For installation instructions, see [The Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).
 
-To migrate your data from Heroku to Neon:
+To import your data from Heroku to Neon:
 
 1. [Create a Neon project and copy the connection string](#create-a-neon-project-and-copy-the-connection-string)
 2. [Retrieve your Heroku app name and database name](#retrieve-your-heroku-app-name-and-database-name)
-3. [Migrate your data](#migrate-your-data-to-neon)
+3. [Import your data](#import-your-data-to-neon)
 4. [Verify that your data was transferred to Neon](#verify-that-your-data-was-transferred-to-neon)
 
 
@@ -20,7 +22,7 @@ To migrate your data from Heroku to Neon:
 1. Navigate to the [Projects](https://console.neon.tech/app/projects) page in the Neon Console.
 2. Click **New Project**.
 3. Enter a name for your project and click **Create Project**.
-4. After creating a project, you are directed to the project **Dashboard**, where a connection string with your password is provided under **Connection Details**. The connection string includes your password until you navigate away from the **Dashboard**. Copy the connection string. It is required to migrate your data from Heroku.
+4. After creating a project, you are directed to the project **Dashboard**, where a connection string with your password is provided under **Connection Details**. The connection string includes your password until you navigate away from the **Dashboard**. Copy the connection string. It is required to import your data from Heroku.
 
 The example connection string used the instructions that follow is:
 
@@ -30,7 +32,7 @@ postgres://jsmith:Wij8mIDXoQ8H@lively-voice-223755.cloud.neon.tech:5432/main
 
 ## Retrieve your Heroku app name and database name
 
-1. Log in to [Heroku](https://dashboard.heroku.com/) and select the project you want to migrate data from.
+1. Log in to [Heroku](https://dashboard.heroku.com/) and select the project you want to import data from.
 1. Select **Overview** and copy the name of the Heroku Postgres database, which appears under **Installed add-ons**.
 2. Click **Settings** and copy your Heroku **App Name**.
 
@@ -49,7 +51,7 @@ $ heroku pg:links --app thawing-wave-57227
 === postgresql-trapezoidal-48645
 ```
 
-## Migrate your data to Neon
+## Import your data to Neon
 
 From your terminal, run the following Heroku CLI command:
 

--- a/content/docs/how-to-guides/import-from-heroku.md
+++ b/content/docs/how-to-guides/import-from-heroku.md
@@ -13,8 +13,8 @@ To import your data from Heroku to Neon:
 
 1. [Create a Neon project and copy the connection string](#create-a-neon-project-and-copy-the-connection-string)
 2. [Retrieve your Heroku app name and database name](#retrieve-your-heroku-app-name-and-database-name)
-3. [Import your data](#import-your-data-to-neon)
-4. [Verify that your data was transferred to Neon](#verify-that-your-data-was-transferred-to-neon)
+3. [Import your data](#import-your-data)
+4. [Verify that your data was imported](#verify-that-your-data-was-imported)
 
 
 ## Create a Neon project and copy the connection string
@@ -51,7 +51,7 @@ $ heroku pg:links --app thawing-wave-57227
 === postgresql-trapezoidal-48645
 ```
 
-## Import your data to Neon
+## Import your data
 
 From your terminal, run the following Heroku CLI command:
 
@@ -141,7 +141,7 @@ pg_restore: creating FK CONSTRAINT "public.order order_customer_id_fkey"
 heroku-cli: Pulling complete.
 ```
 
-## Verify that your data was transferred to Neon
+## Verify that your data was imported
 
 1. Log in to the [Neon Console](https://console.neon.tech/app/projects).
 2. Select the Neon project that you transferred data to.

--- a/content/docs/integrations/hasura.md
+++ b/content/docs/integrations/hasura.md
@@ -74,4 +74,4 @@ To view the newly created tables from the Neon Console:
 
 ## Import existing data to Neon
 
-If you are migrating from Hasura with Heroku PostgreSQL to Neon, refer to the [Import data from Heroku](/docs/how-to-guides/import-from-heroku) guide for data import instructions. For general data import instructions, see [Import data from PostgreSQL](/docs/how-to-guides/import-an-extsing-database).
+If you are migrating from Hasura with Heroku PostgreSQL to Neon, refer to the [Import data from Heroku](/docs/how-to-guides/import-from-heroku) guide for data import instructions. For general data import instructions, see [Import data from PostgreSQL](/docs/how-to-guides/import-an-existing-database).

--- a/content/docs/integrations/hasura.md
+++ b/content/docs/integrations/hasura.md
@@ -74,4 +74,4 @@ To view the newly created tables from the Neon Console:
 
 ## Import existing data to Neon
 
-If you are migrating to Neon from Hasura with Heroku PostgreSQL, refer to the [Migrate from Heroku](/docs/how-to-guides/hasura-heroku-migration) guide for data migration instructions. For general data import instructions, see [Importing a database](/docs/how-to-guides/import-an-extsing-database).
+If you are migrating from Hasura with Heroku PostgreSQL to Neon, refer to the [Import data from Heroku](/docs/how-to-guides/import-from-heroku) guide for data import instructions. For general data import instructions, see [Import data from PostgreSQL](/docs/how-to-guides/import-an-extsing-database).

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -54,10 +54,10 @@
       slug: integrations/symfony    
 - title: Import data
   items:
-    - title: Importing a database
+    - title: Import data from PostgreSQL
       slug: how-to-guides/import-an-existing-database
-    - title: Migrating from Heroku
-      slug: how-to-guides/hasura-heroku-migration
+    - title: Import data from Heroku
+      slug: how-to-guides/import-from-heroku
 - title: Security
   slug: security
 - title: Reference


### PR DESCRIPTION
The previous file name included "hasura". The guide is no longer specific to Hasura. Update naming in our data import section to use "Import" instead of "Migrate".

https://websitemain62807-dpricerenameherokufile.gtsb.io/docs/how-to-guides/import-from-heroku/

Previously, headings were:

**Import data**
Importing a database
Migrating from Heroku

Now:

**Import data**
Import data from PostgreSQL
Import data from Heroku