### PR TITLE
Revise TOC headings and topic titles

### DIFF
--- a/content/docs/get-started-with-neon/connection-pooling.md
+++ b/content/docs/get-started-with-neon/connection-pooling.md
@@ -1,5 +1,6 @@
 ---
 title: Connection pooling
+enableTableOfContents: true
 ---
 
 ## PostgreSQL connection limits

--- a/content/docs/get-started-with-neon/query-with-neon-sql-editor.md
+++ b/content/docs/get-started-with-neon/query-with-neon-sql-editor.md
@@ -1,5 +1,6 @@
 ---
 title: Query with Neon's SQL Editor
+enableTableOfContents: true
 redirectFrom:
   - /docs/get-started-with-neon/tutorials
 ---

--- a/content/docs/how-to-guides/connectivity-issues.md
+++ b/content/docs/how-to-guides/connectivity-issues.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting with older clients
+enableTableOfContents: true
 ---
 
 ## Overview

--- a/content/docs/integrations/django.md
+++ b/content/docs/integrations/django.md
@@ -1,17 +1,17 @@
 ---
-title: Run a Django App
+title: Connect a Django application to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/django/
   - /docs/cloud/integrations/
 ---
 
-This topic describes how to create a Neon project and connect to it from a Django project.
+This guide describes how to create a Neon project and connect to it from a Django application.
 
-To connect to Neon from a Django project:
+To connect to Neon from a Django application:
 
 1. [Create a Neon project](#create-a-neon-project)
-2. [Configure Django project connection settings](#configure-django-project-connection-settings)
+2. [Configure Django connection settings](#configure-django-connection-settings)
 
 ## Create a Neon project
 
@@ -25,7 +25,7 @@ To create a Neon project:
 
 For additional information about creating projects, see [Setting up a project](/docs/get-started-with-neon/setting-up-a-project).
 
-## Configure Django project connection settings
+## Configure Django connection settings
 
 Connecting to Neon requires configuring database connection settings in your Django project's `settings.py` file.
 

--- a/content/docs/integrations/go.md
+++ b/content/docs/integrations/go.md
@@ -1,20 +1,20 @@
 ---
-title: Run a Go app
+title: Connect a Go application to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/go
 ---
 
-This topic describes how to create a Neon project and connect to it from a Go project.
+This topic describes how to create a Neon project and connect to it from a Go application.
 
-To connect to Neon from a Go project:
+To connect to Neon from a Go application:
 
 1. [Create a Neon project](#create-a-neon-project)
 2. [Configure Go project connection settings](#configure-go-project-connection-settings)
 
 ## Create a Neon project
 
-When creating a Neon project, take note of your user name, password, database name, and project ID. This information is required when defining connection settings in your Go project.
+When creating a Neon project, take note of your user name, password, database name, and project ID. This information is required when defining connection settings in your Go application.
 
 To create a Neon project:
 
@@ -24,7 +24,7 @@ To create a Neon project:
 
 For additional information about creating projects, see [Setting up a project](/docs/get-started-with-neon/setting-up-a-project).
 
-## Configure Go project connection settings
+## Configure Go application connection settings
 
 Connecting to Neon requires configuring connection settings in your Go project's `.go` file.
 

--- a/content/docs/integrations/hasura.md
+++ b/content/docs/integrations/hasura.md
@@ -1,5 +1,5 @@
 ---
-title: Run a Hasura App
+title: Connect from Hasura Cloud to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/hasura
@@ -7,7 +7,7 @@ redirectFrom:
 
 Hasura Cloud is an open source GraphQL engine that provides a scalable, highly available, globally distributed, secure GraphQL API for your data sources.
 
-The following instructions describe how to connect a Hasura Cloud project to a new or existing Neon database.
+This guide describe how to connect a Hasura Cloud project to a new or existing Neon database.
 
 ## Connecting to a new Neon database
 

--- a/content/docs/integrations/java.md
+++ b/content/docs/integrations/java.md
@@ -1,11 +1,11 @@
 ---
-title: Run a Java app
+title: Connect a Java application to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/java
 ---
 
-This topic describes how to create a Neon project and connect to it with Java Database Connectivity (JDBC) or from a Spring Data project that uses JDBC.
+This guide describes how to create a Neon project and connect to it with Java Database Connectivity (JDBC) or from a Spring Data project that uses JDBC.
 
 The JDBC API is a Java API for relational databases. PostgreSQL has a well-supported open-source JDBC driver which can be used to access Neon. All popular Java frameworks use JDBC internally. To connect to Neon, you are only required to provide a connection URL.
 

--- a/content/docs/integrations/node.md
+++ b/content/docs/integrations/node.md
@@ -1,15 +1,15 @@
 ---
-title: Run a Node.js app
+title: Connect a Node.js application to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/node
 ---
 
-This topic describes how to create a Neon project and connect to it from a NodeJS project.
+This guide describes how to create a Neon project and connect to it from a Node.js application.
 
 _**Note**_: The same configuration steps can be used for Express and Next.js applications.
 
-To connect to Neon from a NodeJS project:
+To connect to Neon from a Node.js application:
 
 1. [Create a Neon Project](#create-a-neon-project)
 2. [Create a NodeJS project and add dependencies](#create-a-nodejs-project-and-add-dependencies)

--- a/content/docs/integrations/prisma.md
+++ b/content/docs/integrations/prisma.md
@@ -1,11 +1,11 @@
 ---
-title: Run a Prisma App
+title: Connect from Prisma to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/prisma
 ---
 
-Prisma is an open-source, next-generation ORM that allows you to easily manage and interact with your database. This topic describes how to create a Neon project, connect to it from Prisma, and optionally configure a shadow database for Prisma Migrate.
+Prisma is an open-source, next-generation ORM that allows you to easily manage and interact with your database. This guide describes how to create a Neon project, connect to it from Prisma, and optionally configure a shadow database for Prisma Migrate.
 
 To create a Neon project and connect to it from Prisma:
 

--- a/content/docs/integrations/rust.md
+++ b/content/docs/integrations/rust.md
@@ -1,10 +1,10 @@
 ---
-title: Getting Started with Rust
+title: Connect a Rust application to Neon
 redirectFrom:
   - /docs/quickstart/rust
 ---
 
-This topic describes how to create a Neon project and connect to it from a Rust app.
+This guide describes how to create a Neon project and connect to it from a Rust application.
 
 1. [Create a Neon project](#create-a-neon-project)
 2. [Configure the connection](#configure-the-connection)

--- a/content/docs/integrations/sqlalchemy.md
+++ b/content/docs/integrations/sqlalchemy.md
@@ -1,11 +1,11 @@
 ---
-title: Run a SQL Alchemy App
+title: Connect an SQLAlchemy application to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/sqlalchemy
 ---
 
-SQLAlchemy is a Python SQL toolkit and Object Relational Mapper (ORM) that provides application developers with the full power and flexibility of SQL. This topic describes how to create a Neon project and connect to it from SQLAlchemy.
+SQLAlchemy is a Python SQL toolkit and Object Relational Mapper (ORM) that provides application developers with the full power and flexibility of SQL. This guide describes how to create a Neon project and connect to it from SQLAlchemy.
 
 **Prerequisites:**
 

--- a/content/docs/integrations/symfony.md
+++ b/content/docs/integrations/symfony.md
@@ -1,5 +1,5 @@
 ---
-title: Run a Symfony app
+title: Connect from Symfony with Doctrine to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/symfony

--- a/content/docs/integrations/vercel.md
+++ b/content/docs/integrations/vercel.md
@@ -1,13 +1,13 @@
 ---
-title: Run a Next.js app
+title: Connect a Next.js application to Neon
 enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
 ---
 
-Next.js by Vercel is an open-source web development framework that enables React-based web applications. This topic describes how to create a Neon project and access it from a Next.js app.
+Next.js by Vercel is an open-source web development framework that enables React-based web applications. This topic describes how to create a Neon project and access it from a Next.js application.
 
-To create a Neon project and access it from a Next.js app:
+To create a Neon project and access it from a Next.js application:
 
 1. [Create a Neon project](#create-a-neon-project)
 2. [Create a Next.js project](#create-a-nextjs-project)

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -28,24 +28,22 @@
       slug: how-to-guides/connectivity-issues
     - title: Connection pooling
       slug: get-started-with-neon/connection-pooling
-- title: Integrations
-  items:
-    - title: Hasura
-      slug: integrations/hasura
-    - title: Prisma
-      slug: integrations/prisma
-- title: Develop
+- title: Guides
   items:
     - title: Django
       slug: integrations/django
     - title: Go
       slug: integrations/go
+    - title: Hasura
+      slug: integrations/hasura
     - title: Java
       slug: integrations/java
     - title: Next.js
       slug: integrations/vercel
     - title: Node.js
       slug: integrations/node
+    - title: Prisma
+      slug: integrations/prisma
     - title: Rust
       slug: integrations/rust
     - title: SQLAlchemy


### PR DESCRIPTION
https://websitemain62807-dpricecreateguidesheadingintoc.gtsb.io/docs/cloud/about/
- Dropped "Integrations" and "Develop" headings from TOC. Replaced with "Guides".
- Adjusted topic titles.
- Enabled TOC for a few other files