### PR TITLE
Support pg15

### DIFF
--- a/content/docs/cloud/about.md
+++ b/content/docs/cloud/about.md
@@ -36,4 +36,4 @@ You can find [neondatabase](https://github.com/neondatabase/neon) on GitHub. We 
 
 ## Compatibility
 
-Neon compute is the latest version of [PostgreSQL](https://www.postgresql.org/docs/14/release-14.html). Currently, we use PostgreSQL 14. It is 100% compatible with any application that uses the official release of PostgreSQL.
+Neon compute is the latest version of PostgreSQL. It is 100% compatible with any application that uses the official release of PostgreSQL. Currently, we support [PostgreSQL 14](https://www.postgresql.org/docs/14/release-14.html). and [PostgreSQL 15](https://www.postgresql.org/docs/15/release-15.html). For details refer to [compatibility](/docs/conceptual-guides/compatibility) page.

--- a/content/docs/cloud/about.md
+++ b/content/docs/cloud/about.md
@@ -36,4 +36,4 @@ You can find [neondatabase](https://github.com/neondatabase/neon) on GitHub. We 
 
 ## Compatibility
 
-Neon compute is the latest version of PostgreSQL. It is 100% compatible with any application that uses the official release of PostgreSQL. Currently, we support [PostgreSQL 14](https://www.postgresql.org/docs/14/release-14.html). and [PostgreSQL 15](https://www.postgresql.org/docs/15/release-15.html). For details refer to [compatibility](/docs/conceptual-guides/compatibility) page.
+Neon compute is the latest version of PostgreSQL. It is 100% compatible with any application that uses the official release of PostgreSQL. Currently, we support [PostgreSQL 14](https://www.postgresql.org/docs/14/release-14.html) and [PostgreSQL 15](https://www.postgresql.org/docs/15/release-15.html). For details refer to [compatibility](/docs/conceptual-guides/compatibility) page.

--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -9,7 +9,7 @@ Neon is protocol and application-compatible with PostgreSQL. However, when using
 
 ## PostgreSQL versions
 
-Neon cloud service is currently only compatible with PostgreSQL v14.
+Neon cloud service is currently compatible with PostgreSQL 14 and PostgreSQL 15.
 
 ## Permissions
 

--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -38,6 +38,7 @@ During the Technical Preview, Neon permits installing the following PostgreSQL e
 | [pg_trgm](https://www.postgresql.org/docs/14/pgtrgm.html)                     |     1.6 |                                                                                                                |
 | [pgcrypto](https://www.postgresql.org/docs/14/pgcrypto.html)                  |     1.3 |                                                                                                                |
 | [plpgsql](https://www.postgresql.org/docs/14/plpgsql.html)                    |     1.0 | Pre-installed with PostgreSQL                                                                                  |
+| [plv8](https://plv8.github.io/)                                               |   3.1.4 |                                                                                                                |
 | [postgis](https://postgis.net/)                                               |   3.3.0 |                                                                                                                |
 | [postgis_raster](https://postgis.net/docs/RT_reference.html)                  |   3.3.0 |                                                                                                                |
 | [postgis_tiger_geocoder](https://postgis.net/docs/Extras.html#Tiger_Geocoder) |   3.3.0 | Cannot be installed using the Neon web UI. Use your `psql` user credentials to install this extension instead. |


### PR DESCRIPTION
Extensions table can be improved, because some extensions' versions differ in v14 and v15.
We could change table from `Extension | Version | Note` to `Extension | Version (pg 14) | Version (pg 15) | Note`