### PR TITLE
chore: added id to subscribe section

### DIFF
--- a/src/components/shared/subscribe/subscribe.jsx
+++ b/src/components/shared/subscribe/subscribe.jsx
@@ -32,7 +32,10 @@ const links = [
 ];
 
 const Subscribe = () => (
-  <section className="safe-paddings my-48 3xl:my-44 2xl:my-40 xl:my-32 lg:my-24 md:my-20">
+  <section
+    id="subscribe"
+    className="safe-paddings my-48 3xl:my-44 2xl:my-40 xl:my-32 lg:my-24 md:my-20"
+  >
     <Container className="flex items-center justify-between lg:block" size="md">
       <StaticImage
         className="max-w-[800px] 3xl:max-w-[660px] 2xl:max-w-[550px] xl:max-w-[430px] lg:!hidden"


### PR DESCRIPTION
This PR adds `id` attribute for `Subscribe` section so that we can generate proper QR link to be used in Subscribe CTA conference flyers