### PR TITLE
Minor style fix for an input

### DIFF
--- a/src/components/pages/early-access/hero/hero.jsx
+++ b/src/components/pages/early-access/hero/hero.jsx
@@ -140,7 +140,7 @@ const Hero = () => {
             <div className="relative">
               <input
                 className={clsx(
-                  'remove-autocomplete-styles h-11 w-full rounded border border-[#c7ccd1] px-3.5 transition-colors duration-200',
+                  'remove-autocomplete-styles h-11 w-full appearance-none rounded border border-[#c7ccd1] px-3.5 transition-colors duration-200',
                   errorMessage && 'border-[#FF4C79]'
                 )}
                 name="email"


### PR DESCRIPTION
This PR adds an appearance-none class to an input on the Get Early Access page to disable default safari styles.
[Preview](https://websitemain62807-inputfix.gtsb.io/early-access/)