### PR TITLE
Update api-reference.md

### DIFF
--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -9,6 +9,6 @@ The Neon API allows you to manage projects programmatically, which is helpful wh
 
 Refer to the [Neon API V1 reference](https://neon.tech/api-reference) for supported methods.
 
-The next version of the Neon API is currently in preview. It is partially implemented and intended for review purposes only. To try this version of the Neon API, refer to the [Neon API V2 reference](https://neon.tech/api-reference). If you encounter issues using the Neon API V2 preview, please contact [Neon Support](mailto:support@neon.tech).  
+The next version of the Neon API is currently in preview. It is partially implemented and intended for review purposes only. To try this version of the Neon API, refer to the [Neon API V2 reference](https://neon.tech/api-reference/v2). If you encounter issues using the Neon API V2 preview, please contact [Neon Support](mailto:support@neon.tech).  
 
 Accessing the Neon API requires an API key. To obtain an API key, refer to the instructions in [Using API keys](/docs/get-started-with-neon/using-api-keys/).

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -7,8 +7,8 @@ redirectFrom:
 
 The Neon API allows you to manage projects programmatically, which is helpful when using Neon as a part of a CI/CD pipeline.
 
-Refer to the the [Neon API V1 reference](https://neon.tech/api-reference) for supported methods.
+Refer to the [Neon API V1 reference](https://neon.tech/api-reference) for supported methods.
 
-The next version of the Neon API is currently in preview. To try this version of the Neon API, refer to the [Neon API V2 reference](https://neon.tech/api-reference). This version of the Neon API is only partially implemented and only intended for review purposes. If you encounter issues using the Neon API V2 preview, please contact [Neon Support](mailto:support@neon.tech).  
+The next version of the Neon API is currently in preview. It is partially implemented and intended for review purposes only. To try this version of the Neon API, refer to the [Neon API V2 reference](https://neon.tech/api-reference). If you encounter issues using the Neon API V2 preview, please contact [Neon Support](mailto:support@neon.tech).  
 
 Accessing the Neon API requires an API key. To obtain an API key, refer to the instructions in [Using API keys](/docs/get-started-with-neon/using-api-keys/).

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -7,4 +7,8 @@ redirectFrom:
 
 The Neon API allows you to manage projects programmatically, which is helpful when using Neon as a part of a CI/CD pipeline.
 
-Refer to the the [API reference](https://neon.tech/api-reference) for available methods. Accessing the Neon API requires an API key. To obtain an API key, refer to the instructions in [Using API keys](/docs/get-started-with-neon/using-api-keys/).
+Refer to the the [Neon API V1 reference](https://neon.tech/api-reference) for supported methods.
+
+The next version of the Neon API is currently in preview. To try this version of the Neon API, refer to the [Neon API V2 reference](https://neon.tech/api-reference). This version of the Neon API is only partially implemented and only intended for review purposes. If you encounter issues using the Neon API V2 preview, please contact [Neon Support](mailto:support@neon.tech).  
+
+Accessing the Neon API requires an API key. To obtain an API key, refer to the instructions in [Using API keys](/docs/get-started-with-neon/using-api-keys/).


### PR DESCRIPTION
Update API docs for the release of the Neon API V2 preview.
https://websitemain62807-dpriceapicontentupdateforv2rel.gtsb.io/docs/reference/api-reference/