### PR TITLE
Update docs to reflect that PG15 is the default

### DIFF
--- a/content/docs/cloud/about.md
+++ b/content/docs/cloud/about.md
@@ -36,4 +36,4 @@ You can find [neondatabase](https://github.com/neondatabase/neon) on GitHub. We 
 
 ## Compatibility
 
-Neon compute is the latest version of PostgreSQL. It is 100% compatible with any application that uses the official release of PostgreSQL. Currently, we support [PostgreSQL 14](https://www.postgresql.org/docs/14/release-14.html) and [PostgreSQL 15](https://www.postgresql.org/docs/15/release-15.html). For details refer to [compatibility](/docs/conceptual-guides/compatibility) page.
+Neon compute is the latest version of PostgreSQL. It is 100% compatible with any application that uses the official release of PostgreSQL. Currently, we support [PostgreSQL 14](https://www.postgresql.org/docs/14/release-14.html) and [PostgreSQL 15](https://www.postgresql.org/docs/15/release-15.html), with PostgreSQL 15 being the default. For details refer to [compatibility](/docs/conceptual-guides/compatibility) page.

--- a/content/docs/get-started-with-neon/connection-pooling.md
+++ b/content/docs/get-started-with-neon/connection-pooling.md
@@ -26,4 +26,4 @@ To enable connection pooling for a Neon project:
 
 ### Limitations
 
-PostgreSQL features such as prepared statements and [LISTEN](https://www.postgresql.org/docs/14/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/14/sql-notify.html) are not supported with connection pooling. For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section, in the [pgbouncer.org Features documentation](https://www.pgbouncer.org/features.html).
+PostgreSQL features such as prepared statements and [LISTEN](https://www.postgresql.org/docs/15/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/15/sql-notify.html) are not supported with connection pooling. For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section, in the [pgbouncer.org Features documentation](https://www.pgbouncer.org/features.html).

--- a/content/docs/get-started-with-neon/query-with-psql-editor.md
+++ b/content/docs/get-started-with-neon/query-with-psql-editor.md
@@ -6,7 +6,7 @@ redirectFrom:
   - /docs/integrations/postgres
 ---
 
-The following instructions require a working installation of [psql](https://www.postgresql.org/download/), an interactive terminal for working with PostgreSQL. For information about `psql`, refer to the [psql reference](https://www.postgresql.org/docs/14/app-psql.html), in the _PostgreSQL Documentation_.
+The following instructions require a working installation of [psql](https://www.postgresql.org/download/), an interactive terminal for working with PostgreSQL. For information about `psql`, refer to the [psql reference](https://www.postgresql.org/docs/15/app-psql.html), in the _PostgreSQL Documentation_.
 
 _**Note**:_ A Neon Compute runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect.
 
@@ -45,10 +45,10 @@ Neon's `psql` passwordless auth feature helps you quickly authenticate a connect
 
    ```bash
    NOTICE:  Connecting to database.
-   psql (14.5 (Ubuntu 14.5-0ubuntu0.22.04.1))
+   psql (15.0 (Ubuntu 15.0-1.pgdg22.04+1))
    Type "help" for help.
 
-   user1=>
+   casey=>
    ```
 
    **_Note_**: When using _`psql` quick auth_ to connect, the `psql` prompt shows your local terminal user name instead of the database name that is shown for the other `psql` connection methods described in this topic. However, you are logged in to the default `main` database as the Neon `web_access` user, which you can verify by running this query:

--- a/content/docs/get-started-with-neon/setting-up-a-project.md
+++ b/content/docs/get-started-with-neon/setting-up-a-project.md
@@ -25,7 +25,7 @@ For information about connecting to Neon using `psql`, see [Querying with psql](
 
 **_Important_**: After navigating away from the Neon Console or refreshing the browser page, the password is no longer accessible. If you forget or misplace your password, your only option is to reset it. You can reset a password on the **User** page, which is found on the **Settings** tab in the Neon Console.
 
-Creating a Neon project automatically creates a Neon compute instance. For the Technical Preview, a Neon compute instance is deployed with PostgreSQL 14.5 by default, 1 vCPU, and 256MB of RAM. Both PostgreSQL 14.5 and 15 are supported. You can select the PostgreSQL version during project creation. For more information about limits associated with the Technical Preview, see [Technical Preview Free Tier](/docs/reference/technical-preview-free-tier).
+Creating a Neon project automatically creates a Neon compute instance. For the Technical Preview, a Neon compute instance is deployed with PostgreSQL 15 by default, 1 vCPU, and 256MB of RAM. Both PostgreSQL 14.5 and 15 are supported. You can select the PostgreSQL version during project creation. For more information about limits associated with the Technical Preview, see [Technical Preview Free Tier](/docs/reference/technical-preview-free-tier).
 
 Each Neon project is created with a default database named `main`. This database and every new database created in Neon contains a `public` schema. As with any standalone PostgreSQL installation, tables and other objects are created in the `public` schema by default. For more information about the `public` schema, refer to [The Public schema](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC), in the _PostgreSQL documentation_.
 

--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -9,7 +9,7 @@ Neon is protocol and application-compatible with PostgreSQL. However, when using
 
 ## PostgreSQL versions
 
-Neon cloud service is currently compatible with PostgreSQL 14 and PostgreSQL 15.
+Neon cloud service is currently compatible with PostgreSQL 14 and PostgreSQL 15, with PostgreSQL 15 being the default version.
 
 ## Permissions
 


### PR DESCRIPTION
To be published when PG15 is made the default on prod.
- Mention that PG15 is the default.
- Update content that implies PG 14 is the default.
- Change links to point to PG 15 docs.