### PR TITLE
feat: add social preview flag to docs

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -258,10 +258,10 @@ Example file structure:
 ```md
 ├── content
 │ ├── docs
-│ ├── conceptual-guides
-│ ├── architecture-overview.md
-│ ├── images
-│ ├── neon_architecture_2.png // put images in the same directory as your .md file
+│   ├── conceptual-guides
+│     ├── architecture-overview.md
+│     ├── images
+│       ├── neon_architecture_2.png // put images in the same directory as your .md file
 ```
 
 Example content in `architecture-overview.md`:
@@ -279,7 +279,7 @@ Custom `mdx` component that makes possible using [extended markdown syntax for d
 The usage is pretty [straightforward](https://github.com/neondatabase/website/pull/231/commits/8f795eaf700c31794a2267fc5978c22bfc649a0c):
 
 ```md
-{/_ other content here _/}
+{/* other content here */}
 
 <DefinitionList>
 {/* required new line */}
@@ -299,10 +299,10 @@ Another term for smoke test
 [Stress test](/)
 : First and **only** definition for both terms with additional markup <br/> Read more: [link](/)
 
-{/_ other content here _/}
+{/* other content here */}
 </DefinitionList>
 
-{/_ other content here _/}
+{/* other content here */}
 ```
 
 ### Acceptable markup for term

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -40,6 +40,7 @@ Right now Markdown files accept 2 fields:
 2. `redirectFrom` — array of strings with paths to redirect from to the page, should start and end with a slash, e.g. `/docs/old-path/`
 3. `isDraft` — flag that says the page is not ready yet. It won't appear in production but will appear in the development mode.
 4. `enableTableOfContents` — flag that turns on the display of the outline for the page. The outline gets built out of second and third-level headings ([`h2`, `h3`]), thus appears as two-level nested max.
+5. `ogImage` - the social preview image of the page.
 
 > ⚠️ Please note that the project won't build if at least one of the Markdown files is missing a required field.
 
@@ -232,7 +233,6 @@ You may also specify an optional title with prop `title`.
 Example:
 
 ```md
-
 <Admonition type="note" title="Your title">
   The branch creation process does not increase load on the originating project. You can create a branch at any time without worrying about downtime or performance degradation.
 </Admonition>
@@ -240,7 +240,6 @@ Example:
 <Admonition type="info">
   The branch creation process does not increase load on the originating project. You can create a branch at any time without worrying about downtime or performance degradation.
 </Admonition>
-
 ```
 
 <details>
@@ -259,10 +258,10 @@ Example file structure:
 ```md
 ├── content
 │ ├── docs
-│   ├── conceptual-guides
-│     ├── architecture-overview.md
-│     ├── images
-│       ├── neon_architecture_2.png // put images in the same directory as your .md file
+│ ├── conceptual-guides
+│ ├── architecture-overview.md
+│ ├── images
+│ ├── neon_architecture_2.png // put images in the same directory as your .md file
 ```
 
 Example content in `architecture-overview.md`:
@@ -280,7 +279,7 @@ Custom `mdx` component that makes possible using [extended markdown syntax for d
 The usage is pretty [straightforward](https://github.com/neondatabase/website/pull/231/commits/8f795eaf700c31794a2267fc5978c22bfc649a0c):
 
 ```md
-{/* other content here */}
+{/_ other content here _/}
 
 <DefinitionList>
 {/* required new line */}
@@ -300,10 +299,10 @@ Another term for smoke test
 [Stress test](/)
 : First and **only** definition for both terms with additional markup <br/> Read more: [link](/)
 
-{/* other content here */}
+{/_ other content here _/}
 </DefinitionList>
 
-{/* other content here */}
+{/_ other content here _/}
 ```
 
 ### Acceptable markup for term

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,2 +1,3 @@
 exports.createPages = require('./gatsby/create-pages');
 exports.onCreateNode = require('./gatsby/on-create-node');
+exports.createSchemaCustomization = require('./gatsby/create-schema-customization');

--- a/gatsby/create-schema-customization.js
+++ b/gatsby/create-schema-customization.js
@@ -1,0 +1,12 @@
+module.exports = ({ actions }) => {
+  const { createTypes } = actions;
+  const typeDefs = `
+    type Mdx implements Node {
+      frontmatter: Frontmatter
+    }
+    type Frontmatter {
+      ogImage: File @fileByRelativePath
+    }
+  `;
+  createTypes(typeDefs);
+};

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -111,6 +111,11 @@ export const query = graphql`
       excerpt(pruneLength: 160)
       frontmatter {
         title
+        ogImage {
+          childImageSharp {
+            gatsbyImageData(layout: FIXED, width: 1200, height: 630, formats: JPG)
+          }
+        }
         enableTableOfContents
       }
     }
@@ -143,7 +148,9 @@ export const Head = ({
   data: {
     mdx: {
       excerpt,
-      frontmatter: { title },
+      frontmatter: { title, ogImage },
     },
   },
-}) => <SEO pathname={pathname} {...SEO_DATA.doc({ title, description: excerpt })} />;
+}) => (
+  <SEO pathname={pathname} {...SEO_DATA.doc({ title, description: excerpt })} ogImage={ogImage} />
+);


### PR DESCRIPTION
This pull request brings the ability to add a social preview for the docs page by adding `ogImage` in the md `frontmatter`.

Example:  
```md
---
title: Neon architecture
ogImage: ./images/neon_architecture_2.png
redirectFrom:
  - /docs/storage-engine/architecture-overview
---
```