### PR TITLE
feat: enable GTM only on production

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -124,13 +124,7 @@ module.exports = {
         ],
       },
     },
-    {
-      resolve: 'gatsby-plugin-google-tagmanager',
-      options: {
-        id: 'GTM-MJLTK6F',
-      },
-    },
-    ...(process.env.NODE_ENV === 'production'
+    ...(process.env.IS_PRODUCTION === 'true'
       ? [
           {
             resolve: 'gatsby-plugin-algolia-search',
@@ -143,6 +137,12 @@ module.exports = {
               queries: require('./src/utils/algolia-queries'),
               matchFields: ['title', 'excerpt'],
               chunkSize: 10000, // default: 1000
+            },
+          },
+          {
+            resolve: 'gatsby-plugin-google-tagmanager',
+            options: {
+              id: 'GTM-MJLTK6F',
             },
           },
         ]

--- a/gatsby/constants.js
+++ b/gatsby/constants.js
@@ -1,5 +1,4 @@
-const IS_PRODUCTION = process.env.NODE_ENV === 'production';
-const DRAFT_FILTER = IS_PRODUCTION && process.env.BRANCH === 'main' ? [false] : [true, false];
+const DRAFT_FILTER = process.env.IS_PRODUCTION === 'true' ? [false] : [true, false];
 
 const POST_REQUIRED_FIELDS = ['title', 'description', 'author'];
 const STATIC_PAGE_REQUIRED_FIELDS = ['title'];
@@ -7,7 +6,6 @@ const DOC_REQUIRED_FIELDS = ['title'];
 const RELEASE_NOTES_REQUIRED_FIELDS = ['label'];
 
 module.exports = {
-  IS_PRODUCTION,
   DRAFT_FILTER,
   POST_REQUIRED_FIELDS,
   STATIC_PAGE_REQUIRED_FIELDS,

--- a/src/components/shared/layout/layout.jsx
+++ b/src/components/shared/layout/layout.jsx
@@ -99,7 +99,7 @@ const Layout = ({
 
 Layout.propTypes = {
   headerTheme: PropTypes.oneOf(['white', 'black']).isRequired,
-  footerTheme: PropTypes.oneOf(['white', 'black']).isRequired,
+  footerTheme: PropTypes.oneOf(['white', 'black']),
   withOverflowHidden: PropTypes.bool,
   children: PropTypes.node.isRequired,
   isSignIn: PropTypes.bool,
@@ -110,6 +110,7 @@ Layout.propTypes = {
 };
 
 Layout.defaultProps = {
+  footerTheme: 'white',
   withOverflowHidden: false,
   isSignIn: false,
   isHeaderSticky: false,


### PR DESCRIPTION
This pull enables Google Tag Manager only on production.

**Additional changes**
- fixed prop types of footer
- updated condition of the draft filter using env variable `IS_PRODUCTION`