### PR TITLE
feat: add target blank for blog post author url

### DIFF
--- a/src/components/shared/blog-post-author/blog-post-author.jsx
+++ b/src/components/shared/blog-post-author/blog-post-author.jsx
@@ -40,7 +40,12 @@ const BlogPostAuthors = ({ authors, isBlogPost }) =>
   authors?.map(({ author }, index) => (
     <Fragment key={index}>
       {author.postAuthor.url ? (
-        <Link className="group" to={author.postAuthor.url}>
+        <Link
+          className="group"
+          to={author.postAuthor.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Author author={author} isBlogPost={isBlogPost} />
         </Link>
       ) : (


### PR DESCRIPTION
This pull request brings the target `_blank` for the blog post author Link.