### PR TITLE
Update 2022-11-04.md

### DIFF
--- a/content/release-notes/2022-11-04.md
+++ b/content/release-notes/2022-11-04.md
@@ -16,6 +16,13 @@ label: 'Console'
 
   _Neon Branching capabilities are not yet publicly available. If you would like to try this feature, contact us at  [iwantbranching@neon.tech](mailto:iwantbranching@neon.tech), describing your use case and requesting that Neon enable branching for your account._
 
+- UI: With the addition of support for new regions and updates to Neon's branching capabilities, changes were made to the hostname in Neon connection strings.
+  - Previously, a hostname had this format: `{PROJECT_ID}.cloud.neon.tech`.
+  - With the introduction of new regions, a region slug and platform value were added for projects created in newly supported regions: `{PROJECT_ID}.{REGION_SLUG}.{PLATFORM}.neon.tech`
+  - With the update to branching capabilities, `{PROJECT_ID}` was replaced by `{ENDPOINT_ID}` for new and existing projects. An endpoint is the compute instance associated with root branch or child branch of a Neon project.
+  - Currently:
+    - Projects created in the original Neon region, US West (Oregon), now have this hostname format: `{ENDPOINT_ID}.cloud.neon.tech`.
+    - Projects created in a newly supported region, US East (Ohio), Europe (Frankfurt), or Asia Pacific (Singapore), now have this hostname format: `{ENDPOINT_ID}.{REGION_SLUG}.{PLATFORM}.neon.tech`.
 - UI: Added highlighting support for [PostgreSQL 15 SQL Keywords](https://www.postgresql.org/docs/15/sql-keywords-appendix.html) to Neon's SQL Editor. Keywords are highlighted when entered in the SQL Editor.
 - UI: Added the ability to display the navigation bar at the top of the Neon Console as a side drawer menu on small screens.
 

--- a/content/release-notes/2022-11-04.md
+++ b/content/release-notes/2022-11-04.md
@@ -16,13 +16,11 @@ label: 'Console'
 
   _Neon Branching capabilities are not yet publicly available. If you would like to try this feature, contact us at  [iwantbranching@neon.tech](mailto:iwantbranching@neon.tech), describing your use case and requesting that Neon enable branching for your account._
 
-- UI: With the addition of support for new regions and updates to Neon's branching capabilities, changes were made to the hostname in Neon connection strings.
-  - Previously, a hostname had this format: `<project_id>.cloud.neon.tech`.
-  - With the introduction of new regions, a region slug and platform value were added for projects created in newly supported regions: `<project_id>.<region_slug>.<platform>.neon.tech`
-  - With the update to branching capabilities, `<project_id>` was replaced by `<endpoint_id>` for new and existing projects. An endpoint is the compute instance associated with root branch or child branch of a Neon project.
-  - Currently:
-    - Projects created in the original Neon region, US West (Oregon), now have this hostname format: `<endpoint_id>.cloud.neon.tech`.
-    - Projects created in a newly supported region, US East (Ohio), Europe (Frankfurt), or Asia Pacific (Singapore), now have this hostname format: `<endpoint_id>.<region_slug>.<platform>.neon.tech`.
+- UI: With the addition of support for new regions and updates to Neon's branching capabilities, changes were made to the hostname in Neon connection strings. Previously, a hostname had this format: `<project_id>.cloud.neon.tech`. With the introduction of new regions, a `<region_slug>` and `<platform>` value were added to the hostname for projects created in newly supported regions. And with the update to branching capabilities, `<project_id>` was replaced by `<endpoint_id>`. An endpoint is the compute instance associated with root branch or child branch of a Neon project. As a result of these changes:
+  - Projects created in the original Neon region, US West (Oregon), have this hostname format: `<endpoint_id>.cloud.neon.tech`.
+  - Projects created in the newly supported regions, have this hostname format: `<endpoint_id>.<region_slug>.<platform>.neon.tech`.
+
+  For projects created before these changes were introduced, the old hostname format continues to be supported.
 - UI: Added highlighting support for [PostgreSQL 15 SQL Keywords](https://www.postgresql.org/docs/15/sql-keywords-appendix.html) to Neon's SQL Editor. Keywords are highlighted when entered in the SQL Editor.
 - UI: Added the ability to display the navigation bar at the top of the Neon Console as a side drawer menu on small screens.
 

--- a/content/release-notes/2022-11-04.md
+++ b/content/release-notes/2022-11-04.md
@@ -19,7 +19,7 @@ label: 'Console'
 - UI: With the addition of support for new regions and updates to Neon's branching capabilities, changes were made to the hostname in Neon connection strings.
   - Previously, a hostname had this format: `<project_id>.cloud.neon.tech`.
   - With the introduction of new regions, a region slug and platform value were added for projects created in newly supported regions: `<project_id>.<region_slug>.<platform>.neon.tech`
-  - With the update to branching capabilities, ``<project_id>` was replaced by `<endpoint_id>` for new and existing projects. An endpoint is the compute instance associated with root branch or child branch of a Neon project.
+  - With the update to branching capabilities, `<project_id>` was replaced by `<endpoint_id>` for new and existing projects. An endpoint is the compute instance associated with root branch or child branch of a Neon project.
   - Currently:
     - Projects created in the original Neon region, US West (Oregon), now have this hostname format: `<endpoint_id>.cloud.neon.tech`.
     - Projects created in a newly supported region, US East (Ohio), Europe (Frankfurt), or Asia Pacific (Singapore), now have this hostname format: `<endpoint_id>.<region_slug>.<platform>.neon.tech`.

--- a/content/release-notes/2022-11-04.md
+++ b/content/release-notes/2022-11-04.md
@@ -17,12 +17,12 @@ label: 'Console'
   _Neon Branching capabilities are not yet publicly available. If you would like to try this feature, contact us at  [iwantbranching@neon.tech](mailto:iwantbranching@neon.tech), describing your use case and requesting that Neon enable branching for your account._
 
 - UI: With the addition of support for new regions and updates to Neon's branching capabilities, changes were made to the hostname in Neon connection strings.
-  - Previously, a hostname had this format: `{PROJECT_ID}.cloud.neon.tech`.
-  - With the introduction of new regions, a region slug and platform value were added for projects created in newly supported regions: `{PROJECT_ID}.{REGION_SLUG}.{PLATFORM}.neon.tech`
-  - With the update to branching capabilities, `{PROJECT_ID}` was replaced by `{ENDPOINT_ID}` for new and existing projects. An endpoint is the compute instance associated with root branch or child branch of a Neon project.
+  - Previously, a hostname had this format: `<project_id>.cloud.neon.tech`.
+  - With the introduction of new regions, a region slug and platform value were added for projects created in newly supported regions: `<project_id>.<region_slug>.<platform>.neon.tech`
+  - With the update to branching capabilities, ``<project_id>` was replaced by `<endpoint_id>` for new and existing projects. An endpoint is the compute instance associated with root branch or child branch of a Neon project.
   - Currently:
-    - Projects created in the original Neon region, US West (Oregon), now have this hostname format: `{ENDPOINT_ID}.cloud.neon.tech`.
-    - Projects created in a newly supported region, US East (Ohio), Europe (Frankfurt), or Asia Pacific (Singapore), now have this hostname format: `{ENDPOINT_ID}.{REGION_SLUG}.{PLATFORM}.neon.tech`.
+    - Projects created in the original Neon region, US West (Oregon), now have this hostname format: `<endpoint_id>.cloud.neon.tech`.
+    - Projects created in a newly supported region, US East (Ohio), Europe (Frankfurt), or Asia Pacific (Singapore), now have this hostname format: `<endpoint_id>.<region_slug>.<platform>.neon.tech`.
 - UI: Added highlighting support for [PostgreSQL 15 SQL Keywords](https://www.postgresql.org/docs/15/sql-keywords-appendix.html) to Neon's SQL Editor. Keywords are highlighted when entered in the SQL Editor.
 - UI: Added the ability to display the navigation bar at the top of the Neon Console as a side drawer menu on small screens.
 

--- a/content/release-notes/2022-11-04.md
+++ b/content/release-notes/2022-11-04.md
@@ -16,11 +16,11 @@ label: 'Console'
 
   _Neon Branching capabilities are not yet publicly available. If you would like to try this feature, contact us at  [iwantbranching@neon.tech](mailto:iwantbranching@neon.tech), describing your use case and requesting that Neon enable branching for your account._
 
-- UI: With the addition of support for new regions and updates to Neon's branching capabilities, changes were made to the hostname in Neon connection strings. Previously, a hostname had this format: `<project_id>.cloud.neon.tech`. With the introduction of new regions, a `<region_slug>` and `<platform>` value were added to the hostname for projects created in newly supported regions. And with the update to branching capabilities, `<project_id>` was replaced by `<endpoint_id>`. An endpoint is the compute instance associated with root branch or child branch of a Neon project. As a result of these changes:
+- UI: With the addition of support for new regions and updates to Neon's branching capabilities, changes were made to the hostname in Neon connection strings. Previously, a hostname had this format: `<project_id>.cloud.neon.tech`. With the introduction of new regions, a `<region_slug>` and `<platform>` value were added to the hostname for projects created in newly supported regions. With the update to branching capabilities, `<project_id>` was replaced by `<endpoint_id>`. As a result of these changes:
   - Projects created in the original Neon region, US West (Oregon), have this hostname format: `<endpoint_id>.cloud.neon.tech`.
   - Projects created in the newly supported regions, have this hostname format: `<endpoint_id>.<region_slug>.<platform>.neon.tech`.
 
-  For projects created before these changes were introduced, the old hostname format continues to be supported.
+  The old hostname format continues to be supported for projects created before these changes were introduced.
 - UI: Added highlighting support for [PostgreSQL 15 SQL Keywords](https://www.postgresql.org/docs/15/sql-keywords-appendix.html) to Neon's SQL Editor. Keywords are highlighted when entered in the SQL Editor.
 - UI: Added the ability to display the navigation bar at the top of the Neon Console as a side drawer menu on small screens.
 


### PR DESCRIPTION
Update release notes to describe changes to the hostname used in Neon connection strings.
https://websitemain62807-dpricereleasenotesupdatesconne.gatsbyjs.io/docs/release-notes/2022-11-04/
Note: There will be a later update to this entry to add a link to a connection string topic to explain the parts of a Neon connection string and hostname.