### PR TITLE
fix: prevent topbar height increase

### DIFF
--- a/src/components/shared/topbar/topbar.jsx
+++ b/src/components/shared/topbar/topbar.jsx
@@ -8,7 +8,7 @@ const TopBar = () => (
     className="safe-paddings relative z-40 flex h-11 w-full items-center justify-center bg-primary-1 px-4 py-3 leading-none transition-colors duration-200 hover:bg-[#1AFFB2] xs:h-auto"
     to="/developer-days-1"
   >
-    <span className="mr-4 border-r border-black border-opacity-20 py-1 pr-4 text-sm font-semibold">
+    <span className="mr-4 truncate border-r border-black border-opacity-20 py-1 pr-4 text-sm font-semibold">
       Register for Neon Developer Days 🚀
     </span>
     <span className="inline-flex items-center text-sm font-bold xs:hidden">


### PR DESCRIPTION
This pull request adds Tailwind class `truncate` to truncate the overflowing text with an ellipsis (…) in case of text in the topbar is longer than 1 line.

<img width="654" alt="image" src="https://user-images.githubusercontent.com/48465000/204517589-297b9edc-7332-4026-9804-1de642a1dc5c.png">
