### PR TITLE
Update api-reference.md

### DIFF
--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -44,4 +44,4 @@ https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}
 
 You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and run the request.
 
-The [Neon API v2 reference](https://neon.tech/api-reference/v2) also includes request and response body examples that you can reference when constructing your own requests. For branching API request and response examples, you can also refer to examples provided in [Branching with the Neon API](../../manage/manage/branches/#branching-using-the-neon-api).
+The [Neon API v2 reference](https://neon.tech/api-reference/v2) also provides request and response body examples that you can reference when constructing your own requests. For branching API examples, you can also refer to examples provided in [Branching with the Neon API](../../manage/manage/branches/#branching-using-the-neon-api).

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -44,3 +44,5 @@ https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}
 
 You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and run the request.
 
+The [Neon API v2 reference](https://neon.tech/api-reference/v2) also includes request and response body examples that you can reference when constructing your own requests. For branching API request and response examples, you can also refer to examples provided in [}(../../manage/branches/#branching-using-the-neon-api).
+

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -42,6 +42,6 @@ https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}
 
 ## Using the Neon API reference to construct and execute requests
 
-You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and run the request.
+You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and submit the request.
 
 The [Neon API v2 reference](https://neon.tech/api-reference/v2) also provides request and response body examples that you can reference when constructing your own requests. For branching API examples, you can also refer to examples provided in [Branching with the Neon API](../../manage/manage/branches/#branching-using-the-neon-api).

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -5,10 +5,41 @@ redirectFrom:
   - /docs/api/about
 ---
 
-The Neon API allows you to manage projects programmatically, which is helpful when using Neon as a part of a CI/CD pipeline.
+The Neon API allows you to manage projects your Neon projects programmatically.
 
-Refer to the [Neon API V1 reference](https://neon.tech/api-reference) for supported methods.
+Refer to the [Neon API v2 reference](https://neon.tech/api-reference/v2) for supported methods.
 
-The next version of the Neon API is currently in preview. It is partially implemented and intended for review purposes only. To try this version of the Neon API, refer to the [Neon API V2 reference](https://neon.tech/api-reference/v2). If you encounter issues using the Neon API V2 preview, please contact [Neon Support](mailto:support@neon.tech).  
+<Admonition type="warning">
+The [Neon API v1 reference](https://neon.tech/api-reference) is deprecated. Support for it will be removed in a future release.
+</Admonition>
 
-Accessing the Neon API requires an API key. To obtain an API key, refer to the instructions in [Using API keys](/docs/get-started-with-neon/using-api-keys/).
+The Neon API is a REST API. It provides resource-oriented URLs, accepts form-encoded request bodies, returns JSON-encoded responses, and supports standard HTTP response codes, authentication, and verbs.
+
+## Authentication
+
+The Neon API uses API keys to authenticate requests. You can view and manage API keys for your account in the Neon Console. For instructions, refer to [API keys](../../manage/api-keys).
+
+The client must send an API key in the Authorization header when making requests, using the bearer authentication scheme. For example:
+
+```curl
+curl -X GET -H "Authorization: Bearer $NEON_API_KEY" "accept: application/json"
+"https://console.neon.tech/api/v2/projects"
+```
+
+## Neon API base URL
+
+The base URL for a Neon API request is:
+
+```text
+https://console.neon.tech/api/v2/
+```
+
+Append a Neon API method path to the base URL to construct the full URL for a request. For example:
+
+```text
+https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}
+```
+
+## Using the Neon API reference create requests
+
+You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and run the request.

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -40,6 +40,7 @@ Append a Neon API method path to the base URL to construct the full URL for a re
 https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}
 ```
 
-## Using the Neon API reference create requests
+## Using the Neon API reference to construct and execute requests
 
 You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and run the request.
+

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -44,5 +44,4 @@ https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}
 
 You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and run the request.
 
-The [Neon API v2 reference](https://neon.tech/api-reference/v2) also includes request and response body examples that you can reference when constructing your own requests. For branching API request and response examples, you can also refer to examples provided in [}(../../manage/branches/#branching-using-the-neon-api).
-
+The [Neon API v2 reference](https://neon.tech/api-reference/v2) also includes request and response body examples that you can reference when constructing your own requests. For branching API request and response examples, you can also refer to examples provided in [Branching with the Neon API](../../manage/manage/branches/#branching-using-the-neon-api).


### PR DESCRIPTION
Revise API topic for the switch to v2 as the primary Neon API.
https://websitemain62807-dpriceupdateapirefpage.gatsbyjs.io/docs/reference/api-reference/
- Expanded content a bit. More to come in future iterations.
- Added a reference to branching API examples in the docs (to be merged)
