### PR TITLE
Update api-reference.md

### DIFF
--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -1,5 +1,6 @@
 ---
 title: Neon API
+enableTableOfContents: true
 redirectFrom:
   - /docs/reference/about
   - /docs/api/about

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -44,4 +44,4 @@ https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}
 
 You can use the the [Neon API v2 reference](https://neon.tech/api-reference/v2) to construct and execute Neon API requests. Click **Authorize** to add your API key token, and for each method, click **Try it out** and supply the required parameters and request body attributes. Click **Execute** to create and submit the request.
 
-The [Neon API v2 reference](https://neon.tech/api-reference/v2) also provides request and response body examples that you can reference when constructing your own requests. For branching API examples, you can also refer to examples provided in [Branching with the Neon API](../../manage/manage/branches/#branching-using-the-neon-api).
+The [Neon API v2 reference](https://neon.tech/api-reference/v2) also provides request and response body examples that you can reference when constructing your own requests. For branching API examples, you can also refer to examples provided in [Branching with the Neon API](../../manage/branches/#branching-with-the-neon-api).


### PR DESCRIPTION
- Fix branching with API link
- Enable TOC for the page
-https://websitemain62807-dpricefixbranchingwithapilink.gatsbyjs.io/docs/reference/api-reference/#using-the-neon-api-reference-to-construct-and-execute-requests