### PR TITLE
Add note about old client connection issue

### DIFF
--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -58,7 +58,7 @@ psql postgres://casey:<password>@ep-polished-water-579720.us-east-2.aws.neon.tec
 ```
 
 <Admonition type="note">
-For information about connecting with `psql`, see [Connect with psql](../query-with-psql-editor). Please be aware that some older `psql` executables are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
+For information about connecting with `psql`, see [Connect with psql](../query-with-psql-editor). Please be aware that some older `psql` executables, libraries, and drivers are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
 </Admonition>
 
 ## Where do I obtain a password?

--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -58,7 +58,7 @@ psql postgres://casey:<password>@ep-polished-water-579720.us-east-2.aws.neon.tec
 ```
 
 <Admonition type="note">
-For information about connecting with `psql`, see [Connect with psql](../query-with-psql-editor). Please be aware that some older `psql` executables, libraries, and drivers are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
+For information about connecting with `psql`, see [Connect with psql](../query-with-psql-editor). Please be aware that some older client libraries and drivers, including older `psql` executables, are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
 </Admonition>
 
 ## Where do I obtain a password?

--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -58,7 +58,7 @@ psql postgres://casey:<password>@ep-polished-water-579720.us-east-2.aws.neon.tec
 ```
 
 <Admonition type="note">
-For information about connecting with `psql`, see [Connect with psql](../query-with-psql-editor).
+For information about connecting with `psql`, see [Connect with psql](../query-with-psql-editor). Please be aware that some older `psql` executables are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
 </Admonition>
 
 ## Where do I obtain a password?

--- a/content/docs/connect/query-with-psql-editor.md
+++ b/content/docs/connect/query-with-psql-editor.md
@@ -10,7 +10,7 @@ redirectFrom:
 The following instructions require a working installation of [psql](https://www.postgresql.org/download/). The `psql` client is the native command-line client for PostgreSQL. It provides an interactive session for sending commands to PostgreSQL and running ad-hoc queries. For more information about `psql`, refer to the [psql reference](https://www.postgresql.org/docs/15/app-psql.html), in the _PostgreSQL Documentation_.
 
 <Admonition type="note">
-A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect.
+A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect. However, please be aware that some older `psql` executables are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
 
 Neon also provide a passwordless connect feature that uses `psql`. For more information, see [Passwordless connect](../passwordless-connect).
 </Admonition>

--- a/content/docs/connect/query-with-psql-editor.md
+++ b/content/docs/connect/query-with-psql-editor.md
@@ -10,7 +10,7 @@ redirectFrom:
 The following instructions require a working installation of [psql](https://www.postgresql.org/download/). The `psql` client is the native command-line client for PostgreSQL. It provides an interactive session for sending commands to PostgreSQL and running ad-hoc queries. For more information about `psql`, refer to the [psql reference](https://www.postgresql.org/docs/15/app-psql.html), in the _PostgreSQL Documentation_.
 
 <Admonition type="note">
-A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect. However, please be aware that some older `psql` executables, libraries, and drivers are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
+A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect. However, please be aware that some older client libraries and drivers, including older `psql` executables, are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
 
 Neon also provide a passwordless connect feature that uses `psql`. For more information, see [Passwordless connect](../passwordless-connect).
 </Admonition>

--- a/content/docs/connect/query-with-psql-editor.md
+++ b/content/docs/connect/query-with-psql-editor.md
@@ -10,7 +10,7 @@ redirectFrom:
 The following instructions require a working installation of [psql](https://www.postgresql.org/download/). The `psql` client is the native command-line client for PostgreSQL. It provides an interactive session for sending commands to PostgreSQL and running ad-hoc queries. For more information about `psql`, refer to the [psql reference](https://www.postgresql.org/docs/15/app-psql.html), in the _PostgreSQL Documentation_.
 
 <Admonition type="note">
-A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect. However, please be aware that some older `psql` executables are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
+A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect. However, please be aware that some older `psql` executables, libraries and drivers are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
 
 Neon also provide a passwordless connect feature that uses `psql`. For more information, see [Passwordless connect](../passwordless-connect).
 </Admonition>

--- a/content/docs/connect/query-with-psql-editor.md
+++ b/content/docs/connect/query-with-psql-editor.md
@@ -10,7 +10,7 @@ redirectFrom:
 The following instructions require a working installation of [psql](https://www.postgresql.org/download/). The `psql` client is the native command-line client for PostgreSQL. It provides an interactive session for sending commands to PostgreSQL and running ad-hoc queries. For more information about `psql`, refer to the [psql reference](https://www.postgresql.org/docs/15/app-psql.html), in the _PostgreSQL Documentation_.
 
 <Admonition type="note">
-A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect. However, please be aware that some older `psql` executables, libraries and drivers are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
+A Neon compute instance runs PostgreSQL, which means that any PostgreSQL application or standard utility such as `psql` is compatible with Neon. You can also use PostgreSQL client libraries and drivers to connect. However, please be aware that some older `psql` executables, libraries, and drivers are built without SNI support and require a workaround. For more information, see [Connecting from older clients](../connectivity-issues).
 
 Neon also provide a passwordless connect feature that uses `psql`. For more information, see [Passwordless connect](../passwordless-connect).
 </Admonition>


### PR DESCRIPTION
Added information about clients without SNI support (search on SNI)
https://websitemain62807-dpriceaddnoteoldclientsniissue.gatsbyjs.io/docs/connect/query-with-psql-editor/
https://websitemain62807-dpriceaddnoteoldclientsniissue.gatsbyjs.io/docs/connect/connect-from-any-app/

Addresses https://github.com/neondatabase/website/issues/333