### PR TITLE
Dprice passwordless connect update

### DIFF
--- a/content/docs/connect/passwordless-connect.md
+++ b/content/docs/connect/passwordless-connect.md
@@ -35,7 +35,7 @@ To connect using Neon's `psql` passwordless connect feature:
    casey=>
    ```
 
-   **_Note_**: When using passwordless connect, the `psql` prompt shows your local terminal user name. However, you are logged in as the Neon `web_access` user, which you can verify by running this query:
+   When using passwordless connect, the `psql` prompt shows your local terminal user name. However, you are logged in as the Neon `web_access` user, which you can verify by running this query:
 
    ```sql
    SELECT current_user;
@@ -44,7 +44,7 @@ To connect using Neon's `psql` passwordless connect feature:
     web_access
    ```
 
-   To check the database you are connected to, issue this query:
+   The passwordless connect feature connects to the first database created in the branch. To check the database you are connected to, issue this query:
 
    ```sql
    SELECT current_database();
@@ -52,6 +52,8 @@ To connect using Neon's `psql` passwordless connect feature:
    ------------------
     neondb
     ```
+
+    Switching databases from the `psql` prompt (using `\c <database_name>`, for example) after you have authenticated restarts the passwordless connect authentication process to authenticate a connection to the new database.
 
 ## Running queries
 

--- a/content/docs/connect/passwordless-connect.md
+++ b/content/docs/connect/passwordless-connect.md
@@ -23,7 +23,7 @@ To connect using Neon's `psql` passwordless connect feature:
        https://console.neon.tech/psql_session/6d32af5ef8215b62
    ```
 
-2. In your browser, navigate to the provided link where you are asked to select a Neon project and an endpoint to connect with. An endpoint is the compute instance associated with a  branch. A project can have multiple endpoints. Select the endpoint that is associated with the branch you want to connect to.
+2. In your browser, navigate to the provided link where you are asked to select a Neon project to connect to. If your project has more than one endpoint, you are asked to select the endpoint to connect with. An endpoint is the compute instance associated with a branch. Select the endpoint that is associated with the branch you want to connect to.
 
 <Admonition type="note">
 You can determine which endpoint is associated with a branch by selecting the branch on the **Branches** page in the Neon console. The branch details include the name of the associated endpoint, which has an `ep-` prefix. For example: `ep-summer-sun-985942`

--- a/content/docs/connect/passwordless-connect.md
+++ b/content/docs/connect/passwordless-connect.md
@@ -23,7 +23,7 @@ To connect using Neon's `psql` passwordless connect feature:
        https://console.neon.tech/psql_session/6d32af5ef8215b62
    ```
 
-2. In your browser, navigate to the provided link where you are asked to select a Neon project to connect to. If your project has more than one endpoint, you are asked to select the endpoint to connect with. An endpoint is the compute instance associated with a branch. Select the endpoint that is associated with the branch you want to connect to.
+2. In your browser, navigate to the provided link where you are asked to select a Neon project to connect to. If your project has more than one endpoint, you are also asked to select the endpoint. An endpoint is the compute instance associated with a branch. Select the endpoint that is associated with the branch you want to connect to.
 
 <Admonition type="note">
 You can determine which endpoint is associated with a branch by selecting the branch on the **Branches** page in the Neon console. The branch details include the name of the associated endpoint, which has an `ep-` prefix. For example: `ep-summer-sun-985942`

--- a/content/docs/connect/passwordless-connect.md
+++ b/content/docs/connect/passwordless-connect.md
@@ -25,10 +25,6 @@ To connect using Neon's `psql` passwordless connect feature:
 
 2. In your browser, navigate to the provided link where you are asked to select a Neon project to connect to. If your project has more than one endpoint, you are also asked to select the endpoint. An endpoint is the compute instance associated with a branch. Select the endpoint that is associated with the branch you want to connect to.
 
-<Admonition type="note">
-You can determine which endpoint is associated with a branch by selecting the branch on the **Branches** page in the Neon console. The branch details include the name of the associated endpoint, which has an `ep-` prefix. For example: `ep-summer-sun-985942`
-</Admonition>
-
    After making your selection, you are directed to check the terminal where information similar to the following is displayed:
 
    ```bash
@@ -55,7 +51,7 @@ You can determine which endpoint is associated with a branch by selecting the br
     current_database
    ------------------
     neondb
-    ``` 
+    ```
 
 ## Running queries
 

--- a/content/docs/connect/passwordless-connect.md
+++ b/content/docs/connect/passwordless-connect.md
@@ -39,7 +39,7 @@ You can determine which endpoint is associated with a branch by selecting the br
    casey=>
    ```
 
-   **_Note_**: When using _`psql` passwordless connect_, the `psql` prompt shows your local terminal user name. However, you are logged in as the Neon `web_access` user, which you can verify by running this query:
+   **_Note_**: When using passwordless connect, the `psql` prompt shows your local terminal user name. However, you are logged in as the Neon `web_access` user, which you can verify by running this query:
 
    ```sql
    SELECT current_user;


### PR DESCRIPTION
- Passwordless connect no longer requires selecting an endpoint for projects with a single endpoint.
- Mentioned that the connection is to the first database created in the branch
- Mentioned that switching databases restarts the passwordless auth process
https://websitemain62807-dpricepasswordlessconnectupdat.gatsbyjs.io/docs/connect/passwordless-connect/