### PR TITLE
Update SNI info for Elixir Postgrex client

### DIFF
--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -85,11 +85,11 @@ Native client libraries:
 | npgsql            | C#          | yes                                                      |
 | Postmodern        | Common Lisp |                                                          |
 | crystal-pg        | Crystal     |                                                          |
-| Postgrex          | Elixir      |                                                          |
+| Postgrex          | Elixir      | yes ([configure ssl_opts with server_name_indication](https://hexdocs.pm/postgrex/Postgrex.html#start_link/1-ssl-client-authentication)) |
 | epgsql            | Erlang      |                                                          |
 | pgo               | Erlang      |                                                          |
 | github.com/lib/pq | Go          | no (SNI support is in review)                            |
-| pgx               | Go          | no (SNI support is merged, not released yet)              |
+| pgx               | Go          | no (SNI support is merged, not released yet)             |
 | go-pg             | Go          | no (except verify-full mode)                             |
 | JDBC              | Java        | yes                                                      |
 | R2DBC             | Java        |                                                          |


### PR DESCRIPTION
Clarified that Postgrex supports SNI, and also added a link to the official documentation which shows how it can be done.