### PR TITLE
node-postgres SNI usage

### DIFF
--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -93,7 +93,7 @@ Native client libraries:
 | go-pg             | Go          | no (except verify-full mode)                             |
 | JDBC              | Java        | yes                                                      |
 | R2DBC             | Java        |                                                          |
-| node-postgres     | JavaScript  |                                                          |
+| node-postgres     | JavaScript  | yes when `ssl: {'sslmode': 'require'}` option passed     |
 | postgres.js       | JavaScript  | no                                                       |
 | pgmoon            | Lua         |                                                          |
 | asyncpg           | Python      | yes                                                      |


### PR DESCRIPTION
Works when ssl explicitly enabled
```
const client = new Client({
  user: 'chapson',
  password: 'PASSWORD',
  host: 'ep-hidden-fog-713561.us-east-2.aws.neon.tech',
  database: 'neondb',
  ssl: {
    'sslmode': 'require',
  }
})