### PR TITLE
Update connectivity-issues.md

### DIFF
--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -8,7 +8,7 @@ redirectFrom:
 In most cases, copying a connection string from the Neon **Dashboard** and using it in your project should work as is. However, with older clients and some native PostgreSQL clients, you may receive the following error:
 
 ```txt
-ERROR: The project ID is not specified. Either upgrade the PostgreSQL client library (libpq) for SNI support or pass the project ID (the first part of the domain name) as a parameter: '&options=project%3D'. See [https://neon.tech/sni](https://neon.tech/sni) for more information.
+ERROR: The endpoint ID is not specified. Either upgrade the PostgreSQL client library (libpq) for SNI support or pass the endpoint ID (the first part of the domain name) as a parameter: '&options=project%3D'. See [https://neon.tech/sni](https://neon.tech/sni) for more information.
 ```
 
 In most cases, this happens if your client library or application does not support the **SNI (Server Name Indication)** mechanism in TLS. See [Details](#details) for more context and [Workarounds](#workarounds) for a list of ways to work around this issue.

--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -97,9 +97,9 @@ Native client libraries:
 | postgres.js       | JavaScript  | no                                                       |
 | pgmoon            | Lua         |                                                          |
 | asyncpg           | Python      | yes                                                      |
-| pg8000            | Python      | [depends](https://github.com/neondatabase/neon/pull/2008) |
+| pg8000            | Python      | yes (as of pg8000 v1.29.3)                               |
 | rust-postgres     | Rust        |                                                          |
-| PostgresClientKit | Swift       | yes                                                      |
+| PostgresClientKit | Swift       | no                                                       |
 | PostgresNIO       | Swift       |                                                          |
 | postgresql-client | TypeScript  | yes                                                      |
 

--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -97,7 +97,7 @@ Native client libraries:
 | postgres.js       | JavaScript  | no                                                       |
 | pgmoon            | Lua         |                                                          |
 | asyncpg           | Python      | yes                                                      |
-| pg8000            | Python      | yes (as of pg8000 v1.29.3)                               |
+| pg8000            | Python      | yes (requires [scramp >= v1.4.3](https://pypi.org/project/scramp/), which is included in [pg8000 v1.29.3](https://pypi.org/project/scramp/) and higher)  |
 | rust-postgres     | Rust        |                                                          |
 | PostgresClientKit | Swift       | no                                                       |
 | PostgresNIO       | Swift       |                                                          |

--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -97,7 +97,7 @@ Native client libraries:
 | postgres.js       | JavaScript  | no                                                       |
 | pgmoon            | Lua         |                                                          |
 | asyncpg           | Python      | yes                                                      |
-| pg8000            | Python      | yes (requires [scramp >= v1.4.3](https://pypi.org/project/scramp/), which is included in [pg8000 v1.29.3](https://pypi.org/project/scramp/) and higher)  |
+| pg8000            | Python      | yes (requires [scramp >= v1.4.3](https://pypi.org/project/scramp/), which is included in [pg8000 v1.29.3](https://pypi.org/project/pg8000/) and higher)  |
 | rust-postgres     | Rust        |                                                          |
 | PostgresClientKit | Swift       | no                                                       |
 | PostgresNIO       | Swift       |                                                          |


### PR DESCRIPTION
- Update SNI error message to say "Endpoint ID" instead of "Project ID", since we tell users to connect via the Endpoint ID now. The error message was changed by this PR: https://github.com/neondatabase/neon/pull/3349.
https://websitemain62807-dpriceupdatesnierrormessage.gatsbyjs.io/docs/connect/connectivity-issues/
- Update table of drivers that shows SNI support.
  - pg8000 is now supported
  - PostgresClientKit actually does not support SNI (we incorrectly documented that it does support SNI)