### PR TITLE
fix: set time zone for release notes date

### DIFF
--- a/src/utils/get-release-notes-date-from-slug.js
+++ b/src/utils/get-release-notes-date-from-slug.js
@@ -3,5 +3,6 @@ export default function getReleaseNotesDateFromSlug(slug) {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }


### PR DESCRIPTION
This PR brings sets the time zone UTC for release notes date.