### PR TITLE
Fix: return next docs/release-notes page

### DIFF
--- a/next/content/docs/release-notes.md
+++ b/next/content/docs/release-notes.md
@@ -1,4 +1,4 @@
 ---
 title: 'Release notes'
-isDraft: true
+isDraft: false
 ---

--- a/next/src/constants/links.js
+++ b/next/src/constants/links.js
@@ -4,7 +4,7 @@ export default {
   careers: '/careers/',
   blog: '/blog/',
   signup: 'https://console.neon.tech/sign_in',
-  security: '/docs/security/',
+  security: '/docs/security/security/',
   releaseNotes: '/docs/release-notes/',
   discord: 'https://discord.gg/YKY4CBXZT2',
   discussions: 'https://github.com/neondatabase/neon/discussions',


### PR DESCRIPTION
So far, the vercel-bot has fallen 