### PR TITLE
docs: release notes for storage release 2023-01-31

### DIFF
--- a/next/content/docs/reference/pg-extensions.md
+++ b/next/content/docs/reference/pg-extensions.md
@@ -51,6 +51,7 @@ For information about using the Neon SQL Editor, see [Query with Neon's SQL Edit
 | tsm_system_rows          | [1.0](https://www.postgresql.org/docs/14/tsm-system-rows.html)  | [1.0](https://www.postgresql.org/docs/15/tsm-system-rows.html)   |                                                                                                                    |
 | tsm_system_time          | [1.0](https://www.postgresql.org/docs/14/tsm-system-time.html)  | [1.0](https://www.postgresql.org/docs/15/tsm-system-time.html)   |                                                                                                                    |
 | unaccent                 | [1.1](https://www.postgresql.org/docs/14/unaccent.html)         | [1.1](https://www.postgresql.org/docs/15/unaccent.html)          |                                                                                                                    |
+| unit                     | [7.7](https://github.com/df7cb/postgresql-unit)                 | [7.7](https://github.com/df7cb/postgresql-unit)                  |                                                                                                                    |
 | uuid-ossp                | [1.1](https://www.postgresql.org/docs/14/uuid-ossp.html)        | [1.1](https://www.postgresql.org/docs/15/uuid-ossp.html)         | Double-quote the extension name when installing: `CREATE EXTENSION "uuid-ossp"`                                    |
 
 ## Extension support notes

--- a/next/content/release-notes/2023-01-31.md
+++ b/next/content/release-notes/2023-01-31.md
@@ -4,8 +4,8 @@ label: 'Storage'
 
 ### Features
 
+- Compute: Added support for the the PostgreSQL `unit` extension. For more information about PostgreSQL extensions supported by Neon, see [PostgreSQL extensions](https://neon.tech/docs/reference/pg-extensions/).
+- Compute: Removed logic that updated roles each time a Neon compute instance was restarted. Roles were updated on each restart to address a password-related backward compatibility issue that is no longer relevant.
 - Pageserver: Reimplemented the layer map used to track the data layers in a branch. The layer map now uses an immutable binary search tree (BST) data structure, which improves data layer lookup performance over the previous R-tree implementation. The data required to reconstruct page versions is stored as data layers in Neon Pageservers.
 - Pageserver: Changed the garbage collection (`gc`) interval from 100 seconds to 60 minutes. This change reduces the frequency of layer map locks.
 - Pageserver: Implemented an asynchronous pipe for communication with the Write Ahead Log (WAL) redo process, which helps improves OLAP query performance.
-- Compute: Added support for the the PostgreSQL `unit` extension. For more information about PostgreSQL extensions supported by Neon, see [PostgreSQL extensions](https://neon.tech/docs/reference/pg-extensions/).
-- Compute: Removed logic that updated roles each time a Neon compute instance was restarted. Roles were updated on each restart to address a password-related backward compatibility issue that is no longer relevant.

--- a/next/content/release-notes/2023-01-31.md
+++ b/next/content/release-notes/2023-01-31.md
@@ -4,8 +4,8 @@ label: 'Storage'
 
 ### Features
 
-- Pageserver: Immutable data structure is used to find layers faster
-- Pageserver: Implemented asynchronous pipe for communication with WAL redo process to improve the performance
-- Pageserver: Run GC on hourly basis
-- Compute: `unit` extension was added
-- Compute: Roles will not be updated on each compute start
+- Pageserver: Reimplemented the layer map used to track the data layers in a branch. The layer map now uses an immutable binary search tree (BST) data structure, which improves data layer lookup performance over the previous R-tree implementation. The data required to reconstruct page versions is stored as data layers in Neon Pageservers.
+- Pageserver: Changed the garbage collection (`gc`) interval from 100 seconds to 60 minutes. This change reduces the frequency of layer map locks.
+- Pageserver: Implemented an asynchronous pipe for communication with the Write Ahead Log (WAL) redo process, which helps improves OLAP query performance.
+- Compute: Added support for the the PostgreSQL `unit` extension. For more information about PostgreSQL extensions supported by Neon, see [PostgreSQL extensions](https://neon.tech/docs/reference/pg-extensions/).
+- Compute: Removed logic that updated roles each time a Neon compute instance was restarted. Roles were updated on each restart to address a password-related backward compatibility issue that is no longer relevant.

--- a/next/content/release-notes/2023-01-31.md
+++ b/next/content/release-notes/2023-01-31.md
@@ -1,0 +1,11 @@
+---
+label: 'Storage'
+---
+
+### Features
+
+- Pageserver: Immutable data structure is used to find layers faster
+- Pageserver: Implemented asynchronous pipe for communication with WAL redo process to improve the performance
+- Pageserver: Run GC on hourly basis
+- Compute: `unit` extension was added
+- Compute: Roles will not be updated on each compute start


### PR DESCRIPTION
Preview:
https://neon-next-git-vk-storagerelease20230131-neondatabase.vercel.app/docs/release-notes