### PR TITLE
fix: jumping releaes notes date relative to user agent

### DIFF
--- a/src/utils/get-release-notes-date-from-slug.js
+++ b/src/utils/get-release-notes-date-from-slug.js
@@ -1,7 +1,6 @@
 export default function getReleaseNotesDateFromSlug(slug) {
-  return new Date(slug.slice(0, 10)).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  const date = new Date(slug.slice(0, 10));
+  const options = { year: 'numeric', month: 'short', day: 'numeric' };
+  const formatter = new Intl.DateTimeFormat('en-US', options);
+  return formatter.format(date);
 }


### PR DESCRIPTION
**Describe the changes**
This PR brings the fix for release notes dates, that sometimes do jump. Presumably, it has been happening to due `toLocaleDateString`, whose output is relative to user agent.