### PR TITLE
add redirect for serverless driver docs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,6 +58,11 @@ module.exports = {
         destination: '/',
         permanent: true,
       },
+      {
+        source: '/driver',
+        destination: '/docs/serverless/serverless-driver',
+        permanent: false,
+      },
       ...docsRedirects,
     ];
   },


### PR DESCRIPTION
Adds a redirect from https://neon.tech/driver to https://neon.tech/docs/serverless/serverless-driver to make it easier to share