### PR TITLE
Update hero.jsx

### DIFF
--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -32,8 +32,8 @@ const items = [
     description:
       'A usage-based plan for small to medium teams. Unlimited resources with advanced configuration options. Share your projects with anyone. Only pay for what you use with no fixed contract.',
     features: [
-      { title: '20 projects' },
-      { title: 'Unlimited storage and branches' },
+      { title: '20 projects, unlimited branches' },
+      { title: 'Project sharing' },
       { title: 'Configurable compute size' },
       { title: 'Configurable auto-suspend compute', label: 'Coming soon' },
       { title: 'Autoscaling', label: 'Coming soon' },

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -14,10 +14,10 @@ const items = [
       'Essential features to help you get started with Neon. Perfect for prototyping and personal projects.',
     features: [
       { title: '1 project' },
-      { title: '100 active hours /month' },
-      { title: 'Scale to 0' },
-      { title: '1 shared CPU with 1 GB of RAM' },
-      { title: '10 branches, with a limit of 3 GB of data per branch' },
+      { title: '10 branches' },
+      { title: '3 GB of data per branch' },
+      { title: '100 compute hours/month' },
+      { title: 'Auto-suspend compute' },
     ],
     button: {
       url: 'https://console.neon.tech/sign_in',
@@ -32,9 +32,9 @@ const items = [
     description:
       'A usage-based plan for small to medium teams. Unlimited resources with advanced configuration options. Share your projects with anyone. Only pay for what you use with no fixed contract.',
     features: [
+      { title: '20 projects' },
+      { title: 'Unlimited storage and branches' },
       { title: 'Configurable compute size' },
-      { title: 'Always-on compute' },
-      { title: 'Project sharing' },
       { title: 'Configurable auto-suspend compute', label: 'Coming soon' },
       { title: 'Autoscaling', label: 'Coming soon' },
     ],

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -32,7 +32,7 @@ const items = [
     description:
       'A usage-based plan for small to medium teams. Unlimited resources with advanced configuration options. Share your projects with anyone. Only pay for what you use with no fixed contract.',
     features: [
-      { title: '20 projects, unlimited branches' },
+      { title: 'Unlimited resources' },
       { title: 'Project sharing' },
       { title: 'Configurable compute size' },
       { title: 'Configurable auto-suspend compute', label: 'coming soon' },

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -35,8 +35,8 @@ const items = [
       { title: '20 projects, unlimited branches' },
       { title: 'Project sharing' },
       { title: 'Configurable compute size' },
-      { title: 'Configurable auto-suspend compute', label: 'Coming soon' },
-      { title: 'Autoscaling', label: 'Coming soon' },
+      { title: 'Configurable auto-suspend compute', label: 'coming soon' },
+      { title: 'Autoscaling', label: 'coming soon' },
     ],
     button: {
       url: 'https://console.neon.tech/app/projects?show_enroll_to_pro=true',


### PR DESCRIPTION
- Drop Always-on compute from Pro plan list. That's part of Configurable auto-suspend
- Align items in Free and Pro plans more closely with what appears on the Upgrade to Pro page and the Billing page in the docs. Unfortunately, there not room to extend the list on the Pricing page without messing up the graphics. We can ask PP to help if need be.
**Preview**
- https://neon-next-git-dprice-update-pricing-page-neondatabase.vercel.app/pricing

Please compare:

Upgrade to Pro page:
![image](https://user-images.githubusercontent.com/10074684/227320787-4ea39f1d-3365-485c-9b23-c2ce06b9c1ab.png)

Bill page (docs)
![image](https://user-images.githubusercontent.com/10074684/227321115-858f91ea-87ad-408b-9fca-4ca192bf6fda.png)
