### PR TITLE
[ON HOLD] Create chatgpt-plugins.md

### DIFF
--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -1,13 +1,11 @@
 ---
 title: Set up the ChatGPT Retrieval Plugin with Neon  
-subtitle: Learn how to use Neon as a vector database for the ChatGPT Retrieval Plugin
+subtitle: Learn how to set up and run the ChatGPT Retrieval Plugin with Neon as a vector database
 enableTableOfContents: true
 isDraft: false
 ---
 
-This guide describes how to set up and run the [ChatGPT Retrieval Plugin](https://github.com/openai/chatgpt-retrieval-plugin) with Neon as the vector database.
-
-The ChatGPT Retrieval Plugin enables enables semantic search and retrieval of personal or organizational documents using natural language queries. It allows users to obtain the most relevant document snippets from their data sources, such as files, notes, or emails, by asking questions or expressing needs in natural language. Enterprises can make their internal documents available to their employees through ChatGPT using this plugin.
+The [ChatGPT Retrieval Plugin](https://github.com/openai/chatgpt-retrieval-plugin) enables enables semantic search and retrieval of personal or organizational documents using natural language queries. It allows users to obtain the most relevant document snippets from their data sources, such as files, notes, or emails, by asking questions or expressing needs in natural language. Enterprises can make their internal documents available to their employees through ChatGPT using this plugin.
 
 Follow the steps below to get started.
 

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -1,5 +1,5 @@
 ---
-title: Set up the ChatGPT Retrieval Plugin with Neon as the vector database  
+title: Set up the ChatGPT Retrieval Plugin with Neon  
 subtitle: Learn how to use Neon as a vector database for the ChatGPT Retrieval Plugin
 enableTableOfContents: true
 isDraft: false
@@ -7,7 +7,7 @@ isDraft: false
 
 This guide describes how to set up and run the [ChatGPT Retrieval Plugin](https://github.com/openai/chatgpt-retrieval-plugin) with Neon as the vector database.
 
-The ChatGPT Retrieval Plugin enables search and retrieval of personal or organizational documents using natural language queries.
+The ChatGPT Retrieval Plugin enables enables semantic search and retrieval of personal or organizational documents using natural language queries. It allows users to obtain the most relevant document snippets from their data sources, such as files, notes, or emails, by asking questions or expressing needs in natural language. Enterprises can make their internal documents available to their employees through ChatGPT using this plugin.
 
 Follow the steps below to get started.
 
@@ -60,7 +60,7 @@ Install the `pgvector` extension on Neon:
 1. Select your Neon project.
 1. Select **SQL Editor** from the sidebar.
 1. Select the branch and database that you will use.
-1. Run the following statement to install the `pgvector` extension.
+1. Run the following statement to install the `pgvector` extension:
 
 ```sql
 CREATE EXTENSION pgvector
@@ -70,12 +70,11 @@ CREATE EXTENSION pgvector
 
 Set the required environment variables:
 
-1. Set the environment variables for PostgreSQL and Neon as the vector database:
-
 ```bash
 export DATASTORE=<your_datastore>
 export BEARER_TOKEN=<your_bearer_token>
 export OPENAI_API_KEY=<your_openai_api_key>
+export DATABASE_URL=<connection_string>
 ```
 
 where:
@@ -83,19 +82,11 @@ where:
 - `DATASTORE`: This specifies the vector database provider you want to use to store and query embeddings. Set this value to `postgresql`.
 - `BEARER_TOKEN`: This is the secret token that you need to authenticate your requests to the API. You can generate one using any tool or method you prefer, such as [jwt.io](https://jwt.io/).
 - `OPEN_API_KEY`: This is your OpenAI API key that you need to generate embeddings using the text-embedding-ada-002 model. You can get an API key by creating an account on [OpenAI](https://openai.com/). See [API keys](https://platform.openai.com/account/api-keys), in the _OpenAI documentation_.
+- `DATABASE_URL`: This is the Neon PostgreSQL connection string for the database that you will use to store embeddings. You can obtain a connection string from the **Connection Details** widget on th Neon **Dashboard**. For instructions, see [Connect from any application](/docs/connect/connect-from-any-app). It will look similar to the following:
 
-
-2. Set the `DATABASE_URL` environment variable to your Neon PostgreSQL connection string:
-
-```bash
-export DATABASE_URL=<connection_string>
-```
-
-You can obtain a connection string from the **Connection Details** widget on th Neon **Dashboard**. For instructions, see [Connect from any application](/docs/connect/connect-from-any-app). It will look similar to the following:
-
-```text
-postgres://daniel:<password>@ep-aged-silence-344434.us-east-2.aws.neon.tech/neondb
-```
+    ```text
+    postgres://daniel:<password>@ep-aged-silence-344434.us-east-2.aws.neon.tech/neondb
+    ```
 
 ### Run the API Locally
 
@@ -107,8 +98,8 @@ poetry run start
 
 Access the API documentation at [http://0.0.0.0:8000/docs](http://0.0.0.0:8000/docs) and test the API endpoints (make sure to add your bearer token).
 
-For more detailed information on setting up, developing, and deploying a ChatGPT Retrieval Plugin, refer to the full [Development](https://github.com/openai/chatgpt-retrieval-plugin#development) section in the `openai/chatgpt-retrieval-plugin`  repository.
+For more detailed information on setting up, developing, and deploying the ChatGPT Retrieval Plugin, refer to the full [Development](https://github.com/openai/chatgpt-retrieval-plugin#development) section in the `openai/chatgpt-retrieval-plugin`  repository.
 
 ## Conclusion
 
-By enabling Neon PostgreSQL as a vector database option for ChatGPT plugins, we provide developers with more choice and flexibility in creating powerful chatbot applications. We encourage you to give it a try and experience the benefits of using Neon as your vector database for ChatGPT Retrieval Plugins.
+By enabling Neon PostgreSQL as a vector database option for ChatGPT plugins, we provide developers with more choice and flexibility in creating powerful chatbot applications. We encourage you to give it a try and experience the benefits of using Neon as your vector database for the ChatGPT Retrieval Plugin.

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -86,7 +86,7 @@ where:
     postgres://daniel:<password>@ep-aged-silence-344434.us-east-2.aws.neon.tech/neondb
     ```
 
-## Run the API Locally
+## Run the API locally
 
 Run the API locally.
 

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -94,10 +94,10 @@ Run the API locally.
 poetry run start
 ```
 
-Access the API documentation at [http://0.0.0.0:8000/docs](http://0.0.0.0:8000/docs) and test the API endpoints (make sure to add your bearer token).
+You can access the API documentation at [http://0.0.0.0:8000/docs](http://0.0.0.0:8000/docs) and test the API endpoints (make sure to add your bearer token).
 
-For more detailed information on setting up, developing, and deploying the ChatGPT Retrieval Plugin, refer to the full [Development](https://github.com/openai/chatgpt-retrieval-plugin#development) section in the `openai/chatgpt-retrieval-plugin`  repository.
+For more information on setting up, developing, and deploying the ChatGPT Retrieval Plugin, refer to the full [Development](https://github.com/openai/chatgpt-retrieval-plugin#development) section in the `openai/chatgpt-retrieval-plugin`  repository.
 
 ## Conclusion
 
-By enabling Neon PostgreSQL as a vector database option for ChatGPT plugins, we provide developers with more choice and flexibility in creating powerful chatbot applications. We encourage you to give it a try and experience the benefits of using Neon as your vector database for the ChatGPT Retrieval Plugin.
+By enabling Neon as a vector database option for ChatGPT plugins, we provide developers with more choice and flexibility in creating powerful chatbot applications. We encourage you to give it a try and experience the benefits of using Neon as the vector  database for the ChatGPT Retrieval Plugin.

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -77,7 +77,7 @@ export DATABASE_URL=<connection_string>
 
 where:
 
-- `DATASTORE`: This specifies the vector database provider you want to use to store and query embeddings. Set this value to `postgresql`.
+- `DATASTORE`: This specifies the vector database provider you want to use to store and query embeddings. Set this value to `postgres`.
 - `BEARER_TOKEN`: This is the secret token that you need to authenticate your requests to the API. You can generate one using any tool or method you prefer, such as [jwt.io](https://jwt.io/).
 - `OPEN_API_KEY`: This is your OpenAI API key that you need to generate embeddings using the text-embedding-ada-002 model. You can get an API key by creating an account on [OpenAI](https://openai.com/). See [API keys](https://platform.openai.com/account/api-keys), in the _OpenAI documentation_.
 - `DATABASE_URL`: This is the Neon PostgreSQL connection string for the database that you will use to store embeddings. You can obtain a connection string from the **Connection Details** widget on th Neon **Dashboard**. For instructions, see [Connect from any application](/docs/connect/connect-from-any-app). It will look similar to the following:

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -1,6 +1,6 @@
 ---
 title: ChatGPT plugins  
-subtitle: Learn how to use Neon PostgreSQL as a vector database for your ChatGPT Retrieval Plugin
+subtitle: Learn how to use Neon PostgreSQL as a vector database for your ChatGPT retrieval plugin
 enableTableOfContents: true
 isDraft: false
 ---
@@ -11,46 +11,48 @@ Follow the steps below to get started.
 
 ## Install dependencies
 
-1. Install Python 3.10, if not already installed. For instructions, see [Getting and installing the latest version of Python](https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python).
-2. Clone the repository.
+Install the following dependencies:
 
-  ```bash
-   git clone https://github.com/openai/chatgpt-retrieval-plugin.git
-   ```
+1. Install Python 3.10, if not already installed. For instructions, see [Getting and installing the latest version of Python](https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python), in the _Python documentation_.
+2. Clone the ChatGPT Retrieval Plugin repository:
 
-3. Navigate to the cloned repository directory.
+    ```bash
+    git clone https://github.com/openai/chatgpt-retrieval-plugin.git
+    ```
 
-  ```bash
-  cd /path/to/chatgpt-retrieval-plugin
-  ```
+3. Navigate to the cloned repository directory:
 
-4. Install poetry.
+    ```bash
+    cd /path/to/chatgpt-retrieval-plugin
+    ```
 
-  ```bash
-  pip install poetry
-  ```
+4. Install [poetry](https://python-poetry.org/docs/). It's required for dependency management and packaging in Python.
 
-5. Create a new virtual environment with Python 3.10: `poetry env use python3.10`
+    ```bash
+    pip install poetry
+    ```
 
-```bash
-poetry env use python3.10
-```
+5. Create a new virtual environment with Python 3.10:
 
-6. Activate the virtual environment.
+    ```bash
+    poetry env use python3.10
+    ```
 
-  ```bash
-  poetry shell
-  ```
+6. Activate the virtual environment:
 
-7. Install app dependencies.
+    ```bash
+    poetry shell
+    ```
 
-  ```bash
-  poetry install
-  ```
+7. Install application dependencies:
+
+    ```bash
+    poetry install
+    ```
 
 ## Set Environment Variables
 
-Set the required environment variables for your chosen datastore and vector database:
+Set the required environment variables for PostgreSQL and Neon as the vector database:
 
 ```bash
 export DATASTORE=<your_datastore>
@@ -65,6 +67,8 @@ export DATABASE_URL=<connection_string>
 ```
 
 You can obtain a connection string from the **Connection Details** widget on th Neon **Dashboard**. For instructions, see [Connect from any application](/docs/connect/connect-from-any-app).
+
+
 
 ### Run the API Locally
 

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -1,11 +1,13 @@
 ---
-title: ChatGPT plugins  
-subtitle: Learn how to use Neon PostgreSQL as a vector database for your ChatGPT retrieval plugin
+title: Set up the ChatGPT Retrieval Plugin with Neon as the vector database  
+subtitle: Learn how to use Neon as a vector database for the ChatGPT Retrieval Plugin
 enableTableOfContents: true
 isDraft: false
 ---
 
-This guide describes how to set up and run a [ChatGPT Retrieval Plugin](https://github.com/openai/chatgpt-retrieval-plugin) with Neon as the vector database.
+This guide describes how to set up and run the [ChatGPT Retrieval Plugin](https://github.com/openai/chatgpt-retrieval-plugin) with Neon as the vector database.
+
+The ChatGPT Retrieval Plugin enables search and retrieval of personal or organizational documents using natural language queries.
 
 Follow the steps below to get started.
 
@@ -49,6 +51,20 @@ Install the following dependencies:
     ```bash
     poetry install
     ```
+
+## Install the pgvector extension on Neon
+
+Install the `pgvector` extension on Neon:
+
+1. Navigate to the Neon Console.
+1. Select your Neon project.
+1. Select **SQL Editor** from the sidebar.
+1. Select the branch and database that you will use.
+1. Run the following statement to install the `pgvector` extension.
+
+```sql
+CREATE EXTENSION pgvector
+```
 
 ## Set Environment Variables
 

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -88,7 +88,7 @@ where:
     postgres://daniel:<password>@ep-aged-silence-344434.us-east-2.aws.neon.tech/neondb
     ```
 
-### Run the API Locally
+## Run the API Locally
 
 Run the API locally.
 

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -1,0 +1,83 @@
+---
+title: ChatGPT plugins  
+subtitle: Learn how to use Neon PostgreSQL as a vector database for your ChatGPT Retrieval Plugin
+enableTableOfContents: true
+isDraft: false
+---
+
+This guide describes how to set up and run a [ChatGPT Retrieval Plugin](https://github.com/openai/chatgpt-retrieval-plugin) with Neon as the vector database.
+
+Follow the steps below to get started.
+
+## Install dependencies
+
+1. Install Python 3.10, if not already installed. For instructions, see [Getting and installing the latest version of Python](https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python).
+2. Clone the repository.
+
+  ```bash
+   git clone https://github.com/openai/chatgpt-retrieval-plugin.git
+   ```
+
+3. Navigate to the cloned repository directory.
+
+  ```bash
+  cd /path/to/chatgpt-retrieval-plugin
+  ```
+
+4. Install poetry.
+
+  ```bash
+  pip install poetry
+  ```
+
+5. Create a new virtual environment with Python 3.10: `poetry env use python3.10`
+
+```bash
+poetry env use python3.10
+```
+
+6. Activate the virtual environment.
+
+  ```bash
+  poetry shell
+  ```
+
+7. Install app dependencies.
+
+  ```bash
+  poetry install
+  ```
+
+## Set Environment Variables
+
+Set the required environment variables for your chosen datastore and vector database:
+
+```bash
+export DATASTORE=<your_datastore>
+export BEARER_TOKEN=<your_bearer_token>
+export OPENAI_API_KEY=<your_openai_api_key>
+```
+
+Set the `DATABASE_URL` environment variable to your Neon PostgreSQL connection string:
+
+```bash
+export DATABASE_URL=<connection_string>
+```
+
+You can obtain a connection string from the **Connection Details** widget on th Neon **Dashboard**. For instructions, see [Connect from any application](/docs/connect/connect-from-any-app).
+
+### Run the API Locally
+
+Run the API locally.
+
+```bash
+poetry run start
+```
+
+Access the API documentation at [http://0.0.0.0:8000/docs](http://0.0.0.0:8000/docs) and test the API endpoints (make sure to add your bearer token).
+
+For more detailed information on setting up, developing, and deploying a ChatGPT Retrieval Plugin, refer to the full [Development](https://github.com/openai/chatgpt-retrieval-plugin#development) section in the `openai/chatgpt-retrieval-plugin`  repository.
+
+## Conclusion
+
+By enabling Neon PostgreSQL as a vector database option for ChatGPT plugins, we provide developers with more choice and flexibility in creating powerful chatbot applications. We encourage you to give it a try and experience the benefits of using Neon as your vector database for ChatGPT Retrieval Plugins.

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -64,9 +64,9 @@ Install the `pgvector` extension on Neon:
 CREATE EXTENSION pgvector
 ```
 
-## Set Environment Variables
+## Set local environment variables
 
-Set the required environment variables:
+Set the required local environment variables for the ChatGPT Retrieval Plugin.
 
 ```bash
 export DATASTORE=<your_datastore>
@@ -96,7 +96,7 @@ poetry run start
 
 You can access the API documentation at [http://0.0.0.0:8000/docs](http://0.0.0.0:8000/docs) and test the API endpoints (make sure to add your bearer token).
 
-For more information on setting up, developing, and deploying the ChatGPT Retrieval Plugin, refer to the full [Development](https://github.com/openai/chatgpt-retrieval-plugin#development) section in the `openai/chatgpt-retrieval-plugin`  repository.
+For more information on setting up, developing, and deploying the ChatGPT Retrieval Plugin, refer to the [Development](https://github.com/openai/chatgpt-retrieval-plugin#development) section in the `openai/chatgpt-retrieval-plugin` repository.
 
 ## Conclusion
 

--- a/content/docs/guides/chatgpt-plugins.md
+++ b/content/docs/guides/chatgpt-plugins.md
@@ -26,7 +26,7 @@ Install the following dependencies:
     cd /path/to/chatgpt-retrieval-plugin
     ```
 
-4. Install [poetry](https://python-poetry.org/docs/). It's required for dependency management and packaging in Python.
+4. Install [poetry](https://python-poetry.org/docs/). It's required for dependency management.
 
     ```bash
     pip install poetry
@@ -52,7 +52,9 @@ Install the following dependencies:
 
 ## Set Environment Variables
 
-Set the required environment variables for PostgreSQL and Neon as the vector database:
+Set the required environment variables:
+
+1. Set the environment variables for PostgreSQL and Neon as the vector database:
 
 ```bash
 export DATASTORE=<your_datastore>
@@ -60,15 +62,24 @@ export BEARER_TOKEN=<your_bearer_token>
 export OPENAI_API_KEY=<your_openai_api_key>
 ```
 
-Set the `DATABASE_URL` environment variable to your Neon PostgreSQL connection string:
+where:
+
+- `DATASTORE`: This specifies the vector database provider you want to use to store and query embeddings. Set this value to `postgresql`.
+- `BEARER_TOKEN`: This is the secret token that you need to authenticate your requests to the API. You can generate one using any tool or method you prefer, such as [jwt.io](https://jwt.io/).
+- `OPEN_API_KEY`: This is your OpenAI API key that you need to generate embeddings using the text-embedding-ada-002 model. You can get an API key by creating an account on [OpenAI](https://openai.com/). See [API keys](https://platform.openai.com/account/api-keys), in the _OpenAI documentation_.
+
+
+2. Set the `DATABASE_URL` environment variable to your Neon PostgreSQL connection string:
 
 ```bash
 export DATABASE_URL=<connection_string>
 ```
 
-You can obtain a connection string from the **Connection Details** widget on th Neon **Dashboard**. For instructions, see [Connect from any application](/docs/connect/connect-from-any-app).
+You can obtain a connection string from the **Connection Details** widget on th Neon **Dashboard**. For instructions, see [Connect from any application](/docs/connect/connect-from-any-app). It will look similar to the following:
 
-
+```text
+postgres://daniel:<password>@ep-aged-silence-344434.us-east-2.aws.neon.tech/neondb
+```
 
 ### Run the API Locally
 


### PR DESCRIPTION
Preview:
https://neon-next-git-dprice-chatgpt-retrieval-plugin-docs-neondatabase.vercel.app/docs/guides/chatgpt-plugins
(steps not tested yet)
Waiting on:
https://github.com/openai/chatgpt-retrieval-plugin/pull/65/files
Looks like we closed it when "Postgres" was added.
Maybe a PR to have Neon added here:
https://github.com/openai/chatgpt-retrieval-plugin/blob/main/docs/providers/postgres/setup.md