### PR TITLE
Highlight Prisma connection timeout instructions

### DIFF
--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -36,9 +36,7 @@ To establish a basic connection from Prisma to Neon, perform the following steps
 
 3. Add a `DATABASE_URL` variable to your `.env` file and set it to the Neon connection string that you copied in the previous step. Your setting will appear similar to the following:
 
-   ```text
-   DATABASE_URL="postgres://daniel:<password>@ep-restless-rice-862380.us-east-2.aws.neon.tech/neondb"
-   ```
+   `DATABASE_URL="postgres://daniel:<password>@ep-restless-rice-862380.us-east-2.aws.neon.tech/neondb"`
 
 <Admonition type="important">
 If you are using Prisma Client from a serverless function, see [Connect from serverless functions](#connect-from-serverless-functions). To adjust your connection string to avoid connection timeouts issues, see [Connection timeouts](#connection-timeouts).
@@ -50,7 +48,7 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b>
+`DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true`
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 
@@ -77,11 +75,11 @@ When you connect to an idle compute from Prisma, Neon automatically activates it
 
 - Add a `connect_timeout` parameter and set it to 0 or a higher value. This parameter defines the maximum number of seconds to wait for a new connection to be opened. The default value is 5 seconds. A setting of 0 means no timeout. A higher setting should provide the time required to avoid connection timeout issues. For example:
 
-  DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb<b>?connect_timeout=10</b>
+  `DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?connect_timeout=10`
   
 - If using a [pooled connection](/docs/connect/connection-pooling), set `pool_timeout` to 0 or a higher value. This setting defines the number of seconds to wait for a new connection from the pool. The default is 10 seconds. A setting of 0 means no timeout. A higher setting should provide the time required to avoid connection timeout issues. For example:
 
-  DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true&<b>pool_timeout=20</b>
+  `DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true&pool_timeout=20`
   
 For additional information about connecting from Prisma, refer to the following resources in the _Prisma documentation_:
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -50,13 +50,7 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-```text
-DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true
-```
-
-`DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true`
-
-`DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380`**-pooler**`.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**`
+DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -52,7 +52,7 @@ To use a pooled connection from Prisma, adjust your Neon connection string by ad
 
 `DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true`
 
-DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**
+DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b>
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -8,7 +8,7 @@ redirectFrom:
   - /docs/guides/prisma-guide
 ---
 
-Prisma is an open-source, next-generation ORM that enables you to manage and interact with your database. This guide explains how to connect Prisma to Neon, establish connections when using Prisma Client in serverless functions, and resolve connection timeout issues.
+Prisma is an open-source, next-generation ORM that enables you to manage and interact with your database. This guide explains how to connect Prisma to Neon, establish connections when using Prisma Client in serverless functions, and resolve [connection timeout](#connection-timeouts) issues.
 
 To configure Prisma Migrate with Neon, see [Use Prisma Migrate with Neon](/docs/guides/prisma-migrate).
 
@@ -40,7 +40,9 @@ To establish a basic connection from Prisma to Neon, perform the following steps
    DATABASE_URL="postgres://daniel:<password>@ep-restless-rice-862380.us-east-2.aws.neon.tech/neondb"
    ```
 
+<Admonition type="important">
 If you are using Prisma Client from a serverless function, see [Connect from serverless functions](#connect-from-serverless-functions). To adjust your connection string to avoid connection timeouts issues, see [Connection timeouts](#connection-timeouts).
+</Admonition>
 
 ## Connect from serverless functions
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -50,7 +50,7 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**
+DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb?pgbouncer=true
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -50,8 +50,6 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-<mark style="background-color: #f0f0f0;">DATABASE_URL=postgres://daniel:&lt;password&gt;@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b></mark>
-
 DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b>
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
@@ -79,16 +77,12 @@ When you connect to an idle compute from Prisma, Neon automatically activates it
 
 - Add a `connect_timeout` parameter and set it to 0 or a higher value. This parameter defines the maximum number of seconds to wait for a new connection to be opened. The default value is 5 seconds. A setting of 0 means no timeout. A higher setting should provide the time required to avoid connection timeout issues. For example:
 
-  ```text
-  DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?connect_timeout=10
-  ```
-
+  DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb<b>?connect_timeout=10</b>
+  
 - If using a [pooled connection](/docs/connect/connection-pooling), set `pool_timeout` to 0 or a higher value. This setting defines the number of seconds to wait for a new connection from the pool. The default is 10 seconds. A setting of 0 means no timeout. A higher setting should provide the time required to avoid connection timeout issues. For example:
 
-  ```text
-  DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true&pool_timeout=20
-  ```
-
+  DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true&<b>pool_timeout=20</b>
+  
 For additional information about connecting from Prisma, refer to the following resources in the _Prisma documentation_:
 
 - [Connection management](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management)

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -51,8 +51,14 @@ Serverless functions typically require a large number of database connections. W
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
 ```text
-DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb?pgbouncer=true
+DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true
 ```
+
+<pre style="background-color:#f8f8f8;border:1px solid #ccc;padding:10px;">
+<code>
+DATABASE_URL=postgres://daniel:&lt;password&gt;@ep-restless-rice-862380<strong>-pooler</strong>.us-east-2.aws.neon.tech/neondb?pgbouncer=true
+</code>
+</pre>
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -50,7 +50,7 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-`DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b>`
+<mark style="background-color: #f0f0f0;">DATABASE_URL=postgres://daniel:&lt;password&gt;@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b></mark>
 
 DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b>
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -51,7 +51,7 @@ Serverless functions typically require a large number of database connections. W
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
 ```text
-DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true
+DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380<bold>-pooler</bold>.us-east-2.aws.neon.tech/neondb?pgbouncer=true
 ```
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -50,7 +50,7 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-`DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true`
+`DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b>`
 
 DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb<b>?pgbouncer=true</b>
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -50,7 +50,9 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-DATABASE_URL=postgres://daniel:&lt;password&gt;@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**
+`DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true`
+
+DATABASE_URL=postgres://daniel:\<password\>@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -54,11 +54,9 @@ To use a pooled connection from Prisma, adjust your Neon connection string by ad
 DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true
 ```
 
-<pre style="background-color:#f8f8f8;border:1px solid #ccc;padding:10px;">
-<code>
-DATABASE_URL=postgres://daniel:&lt;password&gt;@ep-restless-rice-862380<strong>-pooler</strong>.us-east-2.aws.neon.tech/neondb?pgbouncer=true
-</code>
-</pre>
+`DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true`
+
+`DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380`**-pooler**`.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**`
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -50,7 +50,7 @@ Serverless functions typically require a large number of database connections. W
 
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
-DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb?pgbouncer=true
+DATABASE_URL=postgres://daniel:&lt;password&gt;@ep-restless-rice-862380**-pooler**.us-east-2.aws.neon.tech/neondb**?pgbouncer=true**
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -51,7 +51,7 @@ Serverless functions typically require a large number of database connections. W
 To use a pooled connection from Prisma, adjust your Neon connection string by adding a `-pooler` suffix to the endpoint ID and appending the `?pgbouncer=true` flag to the connection string, as shown:
 
 ```text
-DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380<bold>-pooler</bold>.us-east-2.aws.neon.tech/neondb?pgbouncer=true
+DATABASE_URL=postgres://daniel:<password>@ep-restless-rice-862380<b>-pooler</b>.us-east-2.aws.neon.tech/neondb?pgbouncer=true
 ```
 
 The `-pooler` suffix tells Neon to use a pooled connection to the database rather than a direct connection. The `?pgbouncer=true` flag requires that the connection uses PgBouncer.


### PR DESCRIPTION
Update Prisma docs to emphasize adjusting your connection string to avoid timeout issues.
- Add link to connection timeout issues from the intro.
- Add a warning that mentions adjusting the connection string to avoid connection timeout issues.

Preview:
https://neon-next-git-dprice-prisma-connections-update-neondatabase.vercel.app/docs/guides/prisma