### PR TITLE
Fix: update release-notes Algolia title

### DIFF
--- a/src/scripts/build-algolia-search.js
+++ b/src/scripts/build-algolia-search.js
@@ -20,12 +20,13 @@ const transformPostsToSearchObjects = async (posts, releaseNotes) => {
 
   const transformedReleaseNotes = await releaseNotes.map(({ slug, content }) => {
     const contentPlainText = getExcerpt(content);
+    const slugDatePiece = slug.slice(0, 10);
     const category = slug.slice(slug.lastIndexOf('-') + 1);
     const capitalisedCategory = category.charAt(0).toUpperCase() + category.slice(1);
 
     return {
       objectID: `${capitalisedCategory} release - ${slug}`,
-      title: `${capitalisedCategory} release - ${slug}`,
+      title: `${capitalisedCategory} release - ${slugDatePiece}`,
       slug: generateReleaseNotePath(slug),
       excerpt: contentPlainText,
     };


### PR DESCRIPTION
This PR updates Algolia release-notes title from `Storage release - 2023-03-21-storage` to `Storage release - 2023-03-28`