### PR TITLE
feat: enable code block wrapping

### DIFF
--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -68,13 +68,16 @@
 
       code {
         text-shadow: unset;
+        white-space: break-spaces !important;
 
-        @apply highlighted-code !font-mono !text-base !text-black;
+        @apply highlighted-code !max-w-full !break-words !font-mono !text-base !text-black;
       }
     }
 
     :not(pre) > code {
-      @apply !rounded-sm !border !border-[#E5E5E5] bg-[#FBFBFB] !px-1.5 !py-0.5 !font-mono !font-normal !text-black;
+      white-space: break-spaces !important;
+
+      @apply !max-w-full !break-words !rounded-sm !border !border-[#E5E5E5] bg-[#FBFBFB] !px-1.5 !py-0.5 !font-mono !font-normal !text-black;
 
       &::before,
       &::after {

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -20,7 +20,7 @@
     }
 
     h2 {
-      @apply mt-10 mb-3;
+      @apply mb-3 mt-10;
     }
 
     p {
@@ -110,12 +110,12 @@
       code {
         text-shadow: unset;
 
-        @apply highlighted-code !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
+        @apply highlighted-code block !max-w-full !whitespace-break-spaces !break-words !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
       }
     }
 
     :not(pre) > code {
-      @apply !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
+      @apply block !max-w-full !whitespace-break-spaces !break-words !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
 
       &::before,
       &::after {

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -109,13 +109,16 @@
 
       code {
         text-shadow: unset;
+        white-space: break-spaces !important;
 
-        @apply highlighted-code block !max-w-full !whitespace-break-spaces !break-words !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
+        @apply highlighted-code block !max-w-full !break-words !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
       }
     }
 
     :not(pre) > code {
-      @apply block !max-w-full !whitespace-break-spaces !break-words !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
+      white-space: break-spaces !important;
+
+      @apply block !max-w-full !break-words !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
 
       &::before,
       &::after {

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -111,14 +111,14 @@
         text-shadow: unset;
         white-space: break-spaces !important;
 
-        @apply highlighted-code block !max-w-full !break-words !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
+        @apply highlighted-code !max-w-full !break-words !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
       }
     }
 
     :not(pre) > code {
       white-space: break-spaces !important;
 
-      @apply block !max-w-full !break-words !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
+      @apply !max-w-full !break-words !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
 
       &::before,
       &::after {


### PR DESCRIPTION
This PR enables code block wrapping instead of scroll

for example:
[doc page](https://neon-next-git-code-block-wrap-neondatabase.vercel.app/docs/manage/databases)
[blog post](https://neon-next-git-code-block-wrap-neondatabase.vercel.app/blog/sql-template-tags)