### PR TITLE
Improve and shorten Go connect example code

### DIFF
--- a/content/docs/guides/go.md
+++ b/content/docs/guides/go.md
@@ -38,7 +38,6 @@ package main
 import (
     "database/sql"
     "fmt"
-    "log"
 
     _ "github.com/lib/pq"
 )
@@ -47,23 +46,15 @@ func main() {
     connStr := "user=<user> password=<password> dbname=neondb host=<hostname>"
     db, err := sql.Open("postgres", connStr)
     if err != nil {
-        log.Fatal(err)
+        panic(err)
     }
     defer db.Close()
-
-    rows, err := db.Query("select version()")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer rows.Close()
-
+    
     var version string
-    for rows.Next() {
-        err := rows.Scan(&version)
-        if err != nil {
-            log.Fatal(err)
-        }
+    if err := db.QueryRow("select version()").Scan(&version); err != nil {
+        panic(err)
     }
+
     fmt.Printf("version=%s\n", version)
 }
 ```


### PR DESCRIPTION
Hopefully this is not too pedantic of a change, but here it is. I updated the sample Go code for connecting to and querying the database to reflect idiomatic code:
- it does not use `log.Fatal` in conjunction with `defer`: `log.Fatal` calls `os.Exit`, which abruptly ends the program without calling any deferred functions
- it uses `QueryRow` instead of `Query`, which should in general be used for querying a single value; the resulting code is much shorter

By having the example shorter, readers can focus better and mainly on the connection part.

BTW, great product and great service! Thank you for creating this.