### PR TITLE
Dprice add sequelize instructions

### DIFF
--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -1,0 +1,115 @@
+---
+title: Connect from Sequelize to Neon
+subtitle: Set up a Neon project in seconds and connect from Sequelize
+enableTableOfContents: true
+---
+
+Sequelize is a promise-based Node.js Object-Relational Mapping (ORM) library for SQL databases such as PostgreSQL. It provides a high-level abstraction for working with SQL databases and allows developers to interact with databases using JavaScript instead of writing SQL queries. It supports various features like transactions, relations, read replication, and more.
+
+This guide provides a simple example showing how to set up Sequelize and connect to a Neon database.
+
+## Prerequisites
+
+- A Neon project. See [Create a Neon project](../manage/projects#create-a-project).
+- Sequelize is a Node.js module, so you will need to have Node.js and npm (node package manager) installed on your machine. For instructions for your operating system, refer to the [npm Docs](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+  On Debian-based system including Ubuntu, you can install Node.js and npm using `apt`.
+
+  ```bash
+  sudo apt update
+  sudo apt install nodejs npm
+  ```
+
+  You can verify your installation by checking the versions of Node.js and npm:
+
+  ```bash
+  node -v
+  npm -v
+  ```
+
+## Retrieve your Neon connection string
+
+A database connection string is required to connect to your Neon database. To retrieve the connection string for your database:
+
+1. Navigate to the Neon **Dashboard**.
+2. Copy the connection string for your database from the **Connection Details** widget. The connection string should appear similar to the following:
+
+    ```text
+    postgres://<user>:<password>@ep-crimson-wildflower-999999.eu-central-1.aws.neon.tech/neondb
+    ```
+
+## Initialize a new Node.js project
+
+Create a new directory for your project, navigate into it, and initialize a new Node.js project:
+
+```bash
+mkdir sequelize_test
+cd sequelize_test
+npm init -y
+```
+
+The `npm init -y` command initializes a new Node.js project with default settings.
+
+## Install Sequelize and the PostgreSQL driver
+
+In your project directory, install Sequelize and the PostgreSQL driver (`pg` and `pg-hstore`) using npm:
+
+```bash
+npm install --save sequelize pg pg-hstore
+```
+
+## Create a new JavaScript file to test the connection
+
+1. In your project directory, create a new file (for example, `dbTest.js`) and open it in your favorite text editor.
+
+    ```bash
+    touch dbTest.js
+    nano dbTest.js
+    ```
+
+2. In the `dbTest.js` file, add the following code. Replace 'your_connection_string' with your Neon connection string.
+
+    Neon requires a secure SSL connection. The `require: true` option tells Sequelize to attempt to connect over SSL.
+
+    ```js
+    const { Sequelize } = require('sequelize');
+
+    const sequelize = new Sequelize('postgres://<user>:<password>@ep-crimson-wildflower-123456.eu-central-1.aws.neon.tech/neondb', {
+    dialectOptions: {
+        ssl: {
+        require: true,
+        rejectUnauthorized: false // added for TLS/SSL connection
+        }
+    }
+    });
+
+    sequelize.authenticate()
+    .then(() => {
+        console.log('Connection has been established successfully.');
+    })
+    .catch(err => {
+        console.error('Unable to connect to the database:', err);
+    });
+    ```
+
+<Admonition type="info">
+The `rejectUnauthorized: false` option in the script above tells Sequelize to ignore any issues with the SSL certificate, but this option can leave you vulnerable to "man in the middle" attacks. Therefore, it is recommended to use this setting only for local testing or if your PostgreSQL server uses a self-signed certificate. For production use, you should use a valid certificate and remove the `rejectUnauthorized: false` option.
+</Admonition>
+
+## Run the script to test the connection
+
+Save your file and exit the text editor. Then, run your script with Node.
+
+```bash
+node dbTest.js
+```
+
+If everything is set up correctly, you should see "Connection has been established successfully." If not, the error message should give you a clue about what's going wrong.
+
+<Admonition type="important">
+Remember to handle your connection string securely, as it contains sensitive information. In a real project, you would not hardcode this into your application; instead, you would use environment variables or some other secure configuration method.
+</Admonition>
+
+## Need help?
+
+Send a request to [support@neon.tech](mailto:support@neon.tech), or join the [Neon community forum](https://community.neon.tech/).

--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -4,9 +4,9 @@ subtitle: Set up a Neon project in seconds and connect from Sequelize
 enableTableOfContents: true
 ---
 
-Sequelize is a promise-based Node.js Object-Relational Mapping (ORM) library for SQL databases such as PostgreSQL. It provides a high-level abstraction for working with SQL databases and allows developers to interact with databases using JavaScript instead of writing SQL queries. It supports various features like transactions, relations, read replication, and more.
+[Sequelize](https://sequelize.org/) is a promise-based Node.js and TypeScript Object-Relational Mapping (ORM) library for SQL databases such as PostgreSQL. It provides a high-level abstraction for working with SQL databases and allows developers to interact with databases using JavaScript or TypeScript instead of writing SQL queries. It supports various features like transactions, relations, read replication, and more.
 
-This guide provides a simple example showing how to set up Sequelize and connect to a Neon database.
+This guide provides a simple example showing how to set up Sequelize and connect to a Neon database. For more more information about using Sequelize, please refer to the [Sequelize documentation]().
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ This guide provides a simple example showing how to set up Sequelize and connect
 
 ## Retrieve your Neon connection string
 
-A database connection string is required to connect to your Neon database. To retrieve the connection string for your database:
+A database connection string is required to connect to your Neon database. To retrieve a connection string for your database:
 
 1. Navigate to the Neon **Dashboard**.
 2. Copy the connection string for your database from the **Connection Details** widget. The connection string should appear similar to the following:
@@ -67,7 +67,7 @@ npm install --save sequelize pg pg-hstore
     nano dbTest.js
     ```
 
-2. In the `dbTest.js` file, add the following code. Replace 'your_connection_string' with your Neon connection string.
+2. In the `dbTest.js` file, add the following code. Replace the connection string with your own Neon connection string.
 
     Neon requires a secure SSL connection. The `require: true` option tells Sequelize to attempt to connect over SSL.
 
@@ -92,9 +92,9 @@ npm install --save sequelize pg pg-hstore
     });
     ```
 
-<Admonition type="info">
-The `rejectUnauthorized: false` option in the script above tells Sequelize to ignore any issues with the SSL certificate, but this option can leave you vulnerable to "man in the middle" attacks. Therefore, it is recommended to use this setting only for local testing or if your PostgreSQL server uses a self-signed certificate. For production use, you should use a valid certificate and remove the `rejectUnauthorized: false` option.
-</Admonition>
+    <Admonition type="info">
+    The `rejectUnauthorized: false` option in the script above tells Sequelize to ignore any issues with the SSL certificate, but this option can leave you vulnerable to "man in the middle" attacks. Therefore, it is recommended to use this setting only for local testing or if your PostgreSQL server uses a self-signed certificate. For production use, you should use a valid certificate and remove the `rejectUnauthorized: false` option.
+    </Admonition>
 
 ## Run the script to test the connection
 
@@ -107,7 +107,7 @@ node dbTest.js
 If everything is set up correctly, you should see "Connection has been established successfully." If not, the error message should give you a clue about what's going wrong.
 
 <Admonition type="important">
-Remember to handle your connection string securely, as it contains sensitive information. In a real project, you would not hardcode this into your application; instead, you would use environment variables or some other secure configuration method.
+Remember to handle your connection string securely, as it contains sensitive information. In a real project, you would not hardcode the connection string into your application; instead, you would use environment variables or some other secure configuration method.
 </Admonition>
 
 ## Need help?

--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 [Sequelize](https://sequelize.org/) is a promise-based Node.js Object-Relational Mapping (ORM) library for SQL databases such as PostgreSQL. It provides a high-level abstraction for working with SQL databases and allows developers to interact with databases using JavaScript or TypeScript instead of writing SQL queries. It supports various features like transactions, relations, read replication, and more.
 
-This guide provides a simple example showing how to set up Sequelize and connect to a Neon database. For more more information about using Sequelize, please refer to the [Sequelize documentation](https://sequelize.org/docs/v6/).
+This guide provides a simple example showing how to set up Sequelize and connect to a Neon database. For more information about using Sequelize, please refer to the [Sequelize documentation](https://sequelize.org/docs/v6/).
 
 ## Prerequisites
 

--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -4,9 +4,9 @@ subtitle: Set up a Neon project in seconds and connect from Sequelize
 enableTableOfContents: true
 ---
 
-[Sequelize](https://sequelize.org/) is a promise-based Node.js and TypeScript Object-Relational Mapping (ORM) library for SQL databases such as PostgreSQL. It provides a high-level abstraction for working with SQL databases and allows developers to interact with databases using JavaScript or TypeScript instead of writing SQL queries. It supports various features like transactions, relations, read replication, and more.
+[Sequelize](https://sequelize.org/) is a promise-based Node.js Object-Relational Mapping (ORM) library for SQL databases such as PostgreSQL. It provides a high-level abstraction for working with SQL databases and allows developers to interact with databases using JavaScript or TypeScript instead of writing SQL queries. It supports various features like transactions, relations, read replication, and more.
 
-This guide provides a simple example showing how to set up Sequelize and connect to a Neon database. For more more information about using Sequelize, please refer to the [Sequelize documentation]().
+This guide provides a simple example showing how to set up Sequelize and connect to a Neon database. For more more information about using Sequelize, please refer to the [Sequelize documentation](https://sequelize.org/docs/v6/).
 
 ## Prerequisites
 
@@ -69,16 +69,17 @@ npm install --save sequelize pg pg-hstore
 
 2. In the `dbTest.js` file, add the following code. Replace the connection string with your own Neon connection string.
 
-    Neon requires a secure SSL connection. The `require: true` option tells Sequelize to attempt to connect over SSL.
+    <Admonition type="note">
+    Neon requires a secure SSL connection. The `require: true` option tells Sequelize to connect over SSL.
+    </Admonition>
 
     ```js
     const { Sequelize } = require('sequelize');
 
-    const sequelize = new Sequelize('postgres://<user>:<password>@ep-crimson-wildflower-123456.eu-central-1.aws.neon.tech/neondb', {
+    const sequelize = new Sequelize('postgres://<user>:<password>@ep-crimson-wildflower-999999.eu-central-1.aws.neon.tech/neondb', {
     dialectOptions: {
         ssl: {
-        require: true,
-        rejectUnauthorized: false // added for TLS/SSL connection
+        require: true
         }
     }
     });
@@ -86,15 +87,20 @@ npm install --save sequelize pg pg-hstore
     sequelize.authenticate()
     .then(() => {
         console.log('Connection has been established successfully.');
+
+        // Query the PostgreSQL version
+        sequelize.query("SELECT version();")
+        .then(results => {
+            console.log('PostgreSQL Version:', results[0][0].version);
+        })
+        .catch(err => {
+            console.error('Unable to retrieve PostgreSQL version:', err);
+        });
     })
     .catch(err => {
         console.error('Unable to connect to the database:', err);
     });
     ```
-
-    <Admonition type="info">
-    The `rejectUnauthorized: false` option in the script above tells Sequelize to ignore any issues with the SSL certificate, but this option can leave you vulnerable to "man in the middle" attacks. Therefore, it is recommended to use this setting only for local testing or if your PostgreSQL server uses a self-signed certificate. For production use, you should use a valid certificate and remove the `rejectUnauthorized: false` option.
-    </Admonition>
 
 ## Run the script to test the connection
 
@@ -104,7 +110,7 @@ Save your file and exit the text editor. Then, run your script with Node.
 node dbTest.js
 ```
 
-If everything is set up correctly, you should see "Connection has been established successfully." If not, the error message should give you a clue about what's going wrong.
+If everything is set up correctly, you should see "Connection has been established successfully", and the PostgreSQL version you are connecting to should be returned.
 
 <Admonition type="important">
 Remember to handle your connection string securely, as it contains sensitive information. In a real project, you would not hardcode the connection string into your application; instead, you would use environment variables or some other secure configuration method.

--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -60,7 +60,7 @@ npm install --save sequelize pg pg-hstore
 
 ## Create a new JavaScript file to test the connection
 
-1. In your project directory, create a new file (for example, `dbTest.js`) and open it in your favorite text editor.
+1. In your project directory, create a new file (for example, `dbTest.js`) and open it in your favorite editor.
 
     ```bash
     touch dbTest.js
@@ -122,13 +122,13 @@ npm install --save sequelize pg pg-hstore
     });
     ```
 
-    <Admonition type="note"> 
+    <Admonition type="note">
      Keep in mind that using `rejectUnauthorized: false` disables certificate verification, potentially leaving your connection susceptible to "man-in-the-middle" attacks. Use with caution.
     </Admonition>
 
-## Run the script to test the connection
+## Test the connection
 
-Save your file and exit the text editor. Then, run your script with Node.
+Save your file and exit the editor, and then run your script to test the connection.
 
 ```bash
 node dbTest.js

--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 [Sequelize](https://sequelize.org/) is a promise-based Node.js Object-Relational Mapping (ORM) library for SQL databases such as PostgreSQL. It provides a high-level abstraction for working with SQL databases and allows developers to interact with databases using JavaScript or TypeScript instead of writing SQL queries. It supports various features like transactions, relations, read replication, and more.
 
-This guide provides a simple example showing how to set up Sequelize and connect to a Neon database. For more information about using Sequelize, please refer to the [Sequelize documentation](https://sequelize.org/docs/v6/).
+This guide provides a simple example showing how to connect from Sequelize to a Neon database. For more information about using Sequelize, please refer to the [Sequelize documentation](https://sequelize.org/docs/v6/).
 
 ## Prerequisites
 
@@ -70,16 +70,21 @@ npm install --save sequelize pg pg-hstore
 2. In the `dbTest.js` file, add the following code. Replace the connection string with your own Neon connection string.
 
     <Admonition type="note">
-    Neon requires a secure SSL connection. The `require: true` option tells Sequelize to connect over SSL.
+    The `require: true` option tells Sequelize to connect over SSL. The `ca: rootCert` setting provides the path to a system root certificate file. For root certificate locations, see [Location of system root certificates](https://neon.tech/docs/connect/connect-securely#location-of-system-root-certificates).
     </Admonition>
 
     ```js
     const { Sequelize } = require('sequelize');
+    const fs = require('fs');
 
-    const sequelize = new Sequelize('postgres://<user>:<password>@ep-crimson-wildflower-999999.eu-central-1.aws.neon.tech/neondb', {
+    // Read the certificate file (use the correct path for your certificate file)
+    const rootCert = fs.readFileSync('/etc/ssl/certs/ca-certificates.crt');
+
+    const sequelize = new Sequelize('postgres://<user>:<password>@ep-snowy-unit-123456.us-east-2.aws.neon.tech/neondb', {
     dialectOptions: {
         ssl: {
-        require: true
+        require: true,
+        ca: rootCert, // Use the root certificate
         }
     }
     });
@@ -101,6 +106,25 @@ npm install --save sequelize pg pg-hstore
         console.error('Unable to connect to the database:', err);
     });
     ```
+
+     If you are working in a development environment or do not require certificate verification for some other reason, you can use this connection configuration in place of the one defined above:
+
+     ```js
+    const { Sequelize } = require('sequelize');
+
+    const sequelize = new Sequelize('postgres://<user>:<password>@ep-crimson-wildflower-999999.eu-central-1.aws.neon.tech/neondb', {
+    dialectOptions: {
+        ssl: {
+        require: true,
+        rejectUnauthorized: false, 
+        }
+    }
+    });
+    ```
+
+    <Admonition type="note"> 
+     Keep in mind that using `rejectUnauthorized: false` disables certificate verification, potentially leaving your connection susceptible to "man-in-the-middle" attacks. Use with caution.
+    </Admonition>
 
 ## Run the script to test the connection
 

--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -1,6 +1,6 @@
 ---
 title: Connect from Sequelize to Neon
-subtitle: Set up a Neon project in seconds and connect from Sequelize
+subtitle: Learn how to connect to a Neon database from Sequelize
 enableTableOfContents: true
 ---
 

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -106,6 +106,8 @@
           slug: guides/prisma-migrate
     - title: Rust
       slug: guides/rust
+    - title: Sequelize
+      slug: guides/sequelize
     - title: SQLAlchemy
       slug: guides/sqlalchemy
     - title: StepZen


### PR DESCRIPTION
Add instructions for connecting from Sequelize. Users get stuck on a require ssl error. This guide addresses that. 
https://neon-next-git-dprice-add-sequelize-instructions-neondatabase.vercel.app/docs/guides/sequelize