### PR TITLE
Add data-at-rest content

### DIFF
--- a/content/docs/introduction/architecture-overview.md
+++ b/content/docs/introduction/architecture-overview.md
@@ -18,6 +18,6 @@ PostgreSQL streams [Write-Ahead Log (WAL)](../reference/glossary#wal) to the Saf
 
 Pageservers are responsible for serving read requests. To do that, Pageservers process the incoming WAL stream into a custom storage format that makes all [page](../reference/glossary#page) versions easily accessible. Pageservers also upload data to cloud object storage, and download the data on demand.
 
-Neon uses cloud object storage, such as S3, Azure Blob Storage, or Google Cloud Storage, for long-term data storage.
+Neon uses cloud object storage such as S3 for long-term data storage. Stored data is [encrypted at rest](../reference/glossary#data-at-rest-encryption).
 
 Safekeepers can be thought of as an ultra reliable write buffer that holds the latest data until it is processed and uploaded to cloud storage. Safekeepers implement the Paxos protocol for reliability. Pageservers also function as a read cache for cloud storage, providing fast random access to data pages.

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -124,6 +124,10 @@ A Neon Control Plane operation that creates a branch in a Neon project. For rela
 
 A Neon Control Plane operation that creates a project with a primary branch. See [Operations](../manage/operations) for more information.
 
+### Data-at-rest encryption
+
+A method of storing inactive data that converts plaintext data into a coded form or cipher text, making it unreadable without an encryption key. Neon stores inactive data in [NVMe SSD volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html#nvme-ssd-volumes). The data on NVMe instance storage is encrypted using an XTS-AES-256 block cipher implemented in a hardware module on the instance.
+
 ### Data transfer
 
 A billing metric that measures the amount of data transferred out of Neon (egress). See [Data transfer](../introduction/billing#data-transfer).


### PR DESCRIPTION
- Add Data-at-rest encryption glossary entry, explaining that Neon encrypts data at rest.
https://neon-next-git-dprice-data-at-rest-doc-neondatabase.vercel.app/docs/reference/glossary#data-at-rest-encryption
- Reference the glossary entry from our Architecture page (just a "encrypted at rest" link).
https://neon-next-git-dprice-data-at-rest-doc-neondatabase.vercel.app/docs/introduction/architecture-overview