### PR TITLE
feat: enable code wrapping via flag

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -258,12 +258,12 @@ Example file structure:
 ```md
 ├── public
 │ ├── docs
-│ ├── conceptual-guides
-│ ├── neon_architecture_2.png // put images in a directory with the same name as the .md file
+│   ├── conceptual-guides
+│     ├── neon_architecture_2.png // put images in a directory with the same name as the .md file
 ├── content
 │ ├── docs
-│ ├── conceptual-guides
-│ ├── architecture-overview.md
+│   ├── conceptual-guides
+│     ├── architecture-overview.md
 ```
 
 Example content in `architecture-overview.md`:
@@ -281,7 +281,7 @@ Custom `mdx` component that makes possible using [extended markdown syntax for d
 The usage is pretty [straightforward](https://github.com/neondatabase/website/pull/231/commits/8f795eaf700c31794a2267fc5978c22bfc649a0c):
 
 ```md
-{/_ other content here _/}
+{/* other content here */}
 
 <DefinitionList>
 {/* required new line */}
@@ -301,10 +301,10 @@ Another term for smoke test
 [Stress test](/)
 : First and **only** definition for both terms with additional markup <br/> Read more: [link](/)
 
-{/_ other content here _/}
+{/* other content here */}
 </DefinitionList>
 
-{/_ other content here _/}
+{/* other content here */}
 ```
 
 ### Acceptable markup for term

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -147,6 +147,27 @@ To add a single page <https://example.com/changelog> to the docs sidebar, add th
 
 All available languages for code blocks can be found [here](https://prismjs.com/index.html#supported-languages).
 
+You can use fenced code blocks with three backticks (```) on the lines before and after the code block.
+
+To display code with options, wrap your code with `<CodeBlock></CodeBlock>` component.
+
+Right now `<CodeBlock>` accepts the following fields:
+
+- `showLineNumbers` - flag to show on the line numbers in the code block.
+- `shouldWrap` - flag to enable code wrapping in the code block.
+
+Example:
+
+````md
+<CodeBlock shouldWrap>
+
+```powershell
+powershell -Command "Start-Process -FilePath powershell -Verb RunAs -ArgumentList '-NoProfile','-InputFormat None','-ExecutionPolicy Bypass','-Command ""iex (iwr -UseBasicParsing https://cli.configu.com/install.ps1)""'"
+```
+
+</CodeBlock>
+````
+
 ## Code Tabs
 
 To display code tabs, wrap all pieces of code with `<CodeTabs></CodeTabs>` and write labels of code tabs in order:
@@ -237,12 +258,12 @@ Example file structure:
 ```md
 ├── public
 │ ├── docs
-│   ├── conceptual-guides
-│     ├── neon_architecture_2.png // put images in a directory with the same name as the .md file
+│ ├── conceptual-guides
+│ ├── neon_architecture_2.png // put images in a directory with the same name as the .md file
 ├── content
 │ ├── docs
-│   ├── conceptual-guides
-│     ├── architecture-overview.md
+│ ├── conceptual-guides
+│ ├── architecture-overview.md
 ```
 
 Example content in `architecture-overview.md`:
@@ -260,7 +281,7 @@ Custom `mdx` component that makes possible using [extended markdown syntax for d
 The usage is pretty [straightforward](https://github.com/neondatabase/website/pull/231/commits/8f795eaf700c31794a2267fc5978c22bfc649a0c):
 
 ```md
-{/* other content here */}
+{/_ other content here _/}
 
 <DefinitionList>
 {/* required new line */}
@@ -280,10 +301,10 @@ Another term for smoke test
 [Stress test](/)
 : First and **only** definition for both terms with additional markup <br/> Read more: [link](/)
 
-{/* other content here */}
+{/_ other content here _/}
 </DefinitionList>
 
-{/* other content here */}
+{/_ other content here _/}
 ```
 
 ### Acceptable markup for term

--- a/src/components/pages/doc/code-tabs/code-tabs.jsx
+++ b/src/components/pages/doc/code-tabs/code-tabs.jsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 
 import CodeBlock from 'components/shared/code-block';
 
-const CodeTabs = ({ children = null, labels = [] }) => {
+const CodeTabs = ({ children = null, shouldWrap = false, labels = [] }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   return (
@@ -39,7 +39,11 @@ const CodeTabs = ({ children = null, labels = [] }) => {
         const { children, className } = child.props?.children.props ?? {};
 
         return (
-          <CodeBlock key={index} className={clsx(className, 'code-tab')} showLineNumbers>
+          <CodeBlock
+            key={index}
+            className={clsx(className, { 'code-wrap': shouldWrap }, 'code-tab')}
+            showLineNumbers
+          >
             {children}
           </CodeBlock>
         );
@@ -50,6 +54,7 @@ const CodeTabs = ({ children = null, labels = [] }) => {
 
 CodeTabs.propTypes = {
   children: PropTypes.node,
+  shouldWrap: PropTypes.bool,
   labels: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/src/components/shared/code-block/code-block.jsx
+++ b/src/components/shared/code-block/code-block.jsx
@@ -11,15 +11,22 @@ import CopyIcon from './images/copy.inline.svg';
 
 const DEFAULT_LANGUAGE = 'bash';
 
-const CodeBlock = ({ className = null, children, showLineNumbers = false, ...otherProps }) => {
+const CodeBlock = ({
+  className = null,
+  children,
+  showLineNumbers = false,
+  shouldWrap = false,
+  ...otherProps
+}) => {
   const { isCopied, handleCopy } = useCopyToClipboard(3000);
 
   const match = /language-(\w+)/.exec(className || '');
   const language = match ? match[1] : DEFAULT_LANGUAGE;
-  const code = children?.trim();
+  const code =
+    typeof children === 'string' ? children?.trim() : children.props?.children.props.children;
 
   return (
-    <div className={clsx('group relative', className)} {...otherProps}>
+    <div className={clsx('group relative', { 'code-wrap': shouldWrap }, className)} {...otherProps}>
       <SyntaxHighlighter
         language={language}
         useInlineStyles={false}
@@ -44,6 +51,7 @@ CodeBlock.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
   showLineNumbers: PropTypes.bool,
+  shouldWrap: PropTypes.bool,
 };
 
 export default CodeBlock;

--- a/src/components/shared/content/content.jsx
+++ b/src/components/shared/content/content.jsx
@@ -53,6 +53,7 @@ const components = {
   ),
   DefinitionList,
   Admonition,
+  CodeBlock,
   CodeTabs,
   IntroNavigation,
   TechnologyNavigation,

--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -68,20 +68,25 @@
 
       code {
         text-shadow: unset;
-        white-space: break-spaces !important;
 
-        @apply highlighted-code !max-w-full !break-words !font-mono !text-base !text-black;
+        @apply highlighted-code !font-mono !text-base !text-black;
       }
     }
 
     :not(pre) > code {
-      white-space: break-spaces !important;
-
-      @apply !max-w-full !break-words !rounded-sm !border !border-[#E5E5E5] bg-[#FBFBFB] !px-1.5 !py-0.5 !font-mono !font-normal !text-black;
+      @apply !rounded-sm !border !border-[#E5E5E5] bg-[#FBFBFB] !px-1.5 !py-0.5 !font-mono !font-normal !text-black;
 
       &::before,
       &::after {
         @apply hidden;
+      }
+    }
+
+    .code-wrap {
+      code {
+        white-space: break-spaces !important;
+
+        @apply !max-w-full !break-words;
       }
     }
 

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -109,20 +109,25 @@
 
       code {
         text-shadow: unset;
-        white-space: break-spaces !important;
 
-        @apply highlighted-code !max-w-full !break-words !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
+        @apply highlighted-code !font-mono text-sm !text-black dark:!text-white dark:![text-shadow:unset];
       }
     }
 
     :not(pre) > code {
-      white-space: break-spaces !important;
-
-      @apply !max-w-full !break-words !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
+      @apply !rounded-sm bg-gray-8 !px-1.5 !py-0.5 !font-mono !font-normal !text-black dark:bg-gray-2 dark:!text-white;
 
       &::before,
       &::after {
         @apply hidden;
+      }
+    }
+
+    .code-wrap {
+      code {
+        white-space: break-spaces !important;
+
+        @apply !max-w-full !break-words;
       }
     }
 


### PR DESCRIPTION
This PR enables code wrapping in the `mdx` custom components `CodeBlock` and `CodeTabs` instead of the default code wrapping