### PR TITLE
Storage release notes 05-16

### DIFF
--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -11,13 +11,13 @@ In most cases, copying a connection string from the Neon **Dashboard** and using
 ERROR: The endpoint ID is not specified. Either upgrade the PostgreSQL client library (libpq) for SNI support or pass the endpoint ID (the first part of the domain name) as a parameter: '&options=endpoint%3D'. See [https://neon.tech/sni](https://neon.tech/sni) for more information.
 ```
 
-In most cases, this happens if your client library or application does not support the **SNI (Server Name Indication)** mechanism in TLS. See [How Neon routes connections](#how-neon-routes-connections) for more context and [Workarounds](#workarounds) for a list of ways to work around the SNI requirement.
+In most cases, this happens if your client library or application does not support the **Server Name Indication (SNI)** mechanism in TLS. See [How Neon routes connections](#how-neon-routes-connections) for more context and [Workarounds](#workarounds) for a list of ways to work around the SNI requirement.
 
 ## How Neon routes connections
 
-Neon uses compute endpoint domain names to route incoming connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask you to connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the SNI (Server Name Indication) extension of the `TLS` protocol to do this. This is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive the "endpoint ID is not specified" error mentioned above.
+Neon uses compute endpoint domain names to route incoming connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask you to connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the SNI extension of the `TLS` protocol to do this. This is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive the "endpoint ID is not specified" error mentioned above.
 
-`SNI` support was added to the `libpq` (an official PostgreSQL client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if the system `libpq`  version is >= 14.
+SNI support was added to the `libpq` (an official PostgreSQL client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if the system `libpq`  version is >= 14.
 
 ## Workarounds
 
@@ -57,7 +57,7 @@ This workaround is expected to work with all `libpq`-based applications.
 
 ### C. Set verify-full for golang-based clients
 
-If your application or service uses golang PostgreSQL clients like `pgx` and `lib/pg`, you can set `sslmode=verify-full`, which causes `SNI` information to be sent. Most likely, this behavior is not intentional but happens inadvertently due to the golang's TLS library API design.
+If your application or service uses golang PostgreSQL clients like `pgx` and `lib/pg`, you can set `sslmode=verify-full`, which causes SNI information to be sent. Most likely, this behavior is not intentional but happens inadvertently due to the golang's TLS library API design.
 
 ### D. Specify the endpoint ID in the password field
 
@@ -67,7 +67,7 @@ You can specify the endpoint ID in the password field as a last resort. So, inst
 endpoint=ep-mute-recipe-239816;<password>
 ```
 
-This approach is the least secure of all the recommended workarounds. It causes the authentication method to be downgraded from `scram-sha-256` (never transfers a plain text password) to `password` (transfers a plain text password) on the fly. The connection is still TLS-encrypted, so the amount of security is the same as with `https` websites. However, we intend deprecate this option when most libraries and applications provide `SNI` support.
+This approach is the least secure of all the recommended workarounds. It causes the authentication method to be downgraded from `scram-sha-256` (never transfers a plain text password) to `password` (transfers a plain text password) on the fly. The connection is still TLS-encrypted, so the amount of security is the same as with `https` websites. However, we intend deprecate this option when most libraries and applications provide SNI support.
 
 ## Applications
 

--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -8,57 +8,63 @@ redirectFrom:
 In most cases, copying a connection string from the Neon **Dashboard** and using it in your project should work as is. However, with older clients and some native PostgreSQL clients, you may receive the following error:
 
 ```txt
-ERROR: The endpoint ID is not specified. Either upgrade the PostgreSQL client library (libpq) for SNI support or pass the endpoint ID (the first part of the domain name) as a parameter: '&options=project%3D'. See [https://neon.tech/sni](https://neon.tech/sni) for more information.
+ERROR: The endpoint ID is not specified. Either upgrade the PostgreSQL client library (libpq) for SNI support or pass the endpoint ID (the first part of the domain name) as a parameter: '&options=endpoint%3D'. See [https://neon.tech/sni](https://neon.tech/sni) for more information.
 ```
 
 In most cases, this happens if your client library or application does not support the **SNI (Server Name Indication)** mechanism in TLS. See [How Neon routes connections](#how-neon-routes-connections) for more context and [Workarounds](#workarounds) for a list of ways to work around the SNI requirement.
 
 ## How Neon routes connections
 
-Neon uses different compute endpoint domain names to route incoming connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask you to connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so we rely on the SNI (Server Name Indication) extension of the `TLS` protocol, which allows a client to indicate what domain name it is attempting to connect to. This is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. `SNI` support was added to the `libpq` (an official PostgreSQL client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if the system `libpq`  version is >= 14.
+Neon uses compute endpoint domain names to route incoming connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask you to connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the SNI (Server Name Indication) extension of the `TLS` protocol to do this. This is the same mechanism that allows hosting several `https`-enabled websites on a single IP address. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive the "endpoint ID is not specified" error mentioned above.
+
+`SNI` support was added to the `libpq` (an official PostgreSQL client library) in version 14, released in September 2021. All `libpq`-based clients like Python's `psycopg2` and Ruby's `ruby-pg` should work if the system `libpq`  version is >= 14.
 
 ## Workarounds
 
-If you encounter a `Project ID is not specified` error and a library or application upgrade does not help, we provide several fallback options. When SNI domain name information is missing, we need to obtain this information through other means.
+If you encounter the `endpoint ID is not specified` error, and a library or application upgrade does not help, we provide several workarounds for client connections to provide the required domain name information.
 
 ### A. Pass the endpoint ID as an option
 
-We support a special connection option named `project`, which you can set to identify the compute endpoint you are connecting to. Specifically, you can set pass `options=project%3Dmy-endpoint-123456` as a `GET` parameter in the connection string. The `%3D` is a URL-encoded `=`.
+We support a special connection option named `endpoint`, which you can set to identify the compute endpoint you are connecting to. Specifically, you can pass `options=endpoint%3Dep-mute-recipe-239816` as a parameter in the connection string. The `%3D` is a URL-encoded `=`.
+
+<Admonition type="note">
+The special connection option was previously named `project`. The `project` option is deprecated but remains supported for backward compatibility.
+</Admonition>
 
 For example, instead of the following connection string:
 
 ```txt
-postgres://<user>:<password>@my-endpoint-123456.us-east-2.aws.neon.tech/main
+postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main
 ```
 
 You would use this one:
 
 ```txt
-postgres://<user>:<password>@my-endpoint-123456.us-east-2.aws.neon.tech/main?options=project%3Dmy-endpoint-123456
+postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
 ```
 
-The `project` option is expected to work if your application or library permits it to be set. But not all of them do, especially in the case of GUI applications.
+The `endpoint` option is expected to work if your application or library permits it to be set. But not all of them do, especially in the case of GUI applications.
 
 ### B. Use libpq key=value syntax in the database field
 
-If your application or client is `libpq`-based and you can't easily upgrade the library, such as when the library is compiled inside of a pre-built application, you can take advantage of the fact that `libpq` permits adding options to the database name. So, instead of only the database name, you can specify:
+If your application or client is `libpq`-based and you can't easily upgrade the library, such as when the library is compiled inside of a pre-built application, you can take advantage of the fact that `libpq` permits adding options to the database name. So, in addition to the database name, you can specify:
 
 ```txt
-dbname=main options=project=<endpoint_id>
+dbname=neondb options=endpoint=<endpoint_id>
 ```
 
 This workaround is expected to work with all `libpq`-based applications.
 
 ### C. Set verify-full for golang-based clients
 
-If your application or service uses golang PostgreSQL clients like `pgx` and `lib/pg`, you can set `sslmode=verify-full,` which causes `SNI` information to be sent. Most likely, this behavior is not intentional but happens inadvertently due to the golang's TLS library API design.
+If your application or service uses golang PostgreSQL clients like `pgx` and `lib/pg`, you can set `sslmode=verify-full`, which causes `SNI` information to be sent. Most likely, this behavior is not intentional but happens inadvertently due to the golang's TLS library API design.
 
 ### D. Specify the endpoint ID in the password field
 
-You can specify the endpoint ID in the password field as a last resort. So, instead of your actual password, you can define a string consisting of the endpoint and the password. For example:
+You can specify the endpoint ID in the password field as a last resort. So, instead of your actual password, you define a string consisting of the endpoint and the password. For example:
 
 ```txt
-project=ep-mute-recipe-239816;<password>
+endpoint=ep-mute-recipe-239816;<password>
 ```
 
 This approach is the least secure of all the recommended workarounds. It causes the authentication method to be downgraded from `scram-sha-256` (never transfers a plain text password) to `password` (transfers a plain text password) on the fly. The connection is still TLS-encrypted, so the amount of security is the same as with `https` websites. However, we intend deprecate this option when most libraries and applications provide `SNI` support.

--- a/content/docs/guides/node.md
+++ b/content/docs/guides/node.md
@@ -82,7 +82,7 @@ const postgres = require('postgres');
 require('dotenv').config();
 
 const { PGHOST, PGDATABASE, PGUSER, PGPASSWORD, ENDPOINT_ID } = process.env;
-const URL = `postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}/${PGDATABASE}?options=project%3D${ENDPOINT_ID}`;
+const URL = `postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}/${PGDATABASE}?options=endpoint%3D${ENDPOINT_ID}`;
 
 const sql = postgres(URL, { ssl: 'require' });
 

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -4,8 +4,7 @@ label: 'Storage'
 
 ### What's new
 
-- Compute: Updated supported PostgreSQL versions to 14.8 and 15.3, respectively.
-- Compute: Neon uses compute endpoint domain names to route incoming client connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask that you connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the SNI (Server Name Indication) extension of the TLS protocol to do this. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive an error indicating that the "endpoint ID is not specified".  
+- Proxy: Neon uses compute endpoint domain names to route incoming client connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask that you connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the Server Name Indication (SNI) extension of the TLS protocol to do this. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive an error indicating that the "endpoint ID is not specified".  
   
    As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The connection option was previously named `project`. This option name is now deprecated but remains supported for backward compatibility. The new name for the connection option is `endpoint`, which is used as shown in the following example:
 

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -1,0 +1,22 @@
+---
+label: 'Storage'
+---
+
+### What's new
+
+- Compute: Neon uses compute endpoint domain names to route incoming client connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask that you connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the SNI (Server Name Indication) extension of the TLS protocol to do this. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive an error indicating that the "endpoint ID is not specified".  
+  
+   As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The special connection option was previously named `project`. The `project` option name is now deprecated but remains supported for backward compatibility. The new name for the special connection option is `endpoint`, which is used as shown in the following example:
+
+````md
+<CodeBlock shouldWrap>
+
+```txt
+postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
+```
+
+</CodeBlock>
+````
+
+   For more information about the special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](../docs/connect/connectivity-issues#workarounds) documentation.
+</Admonition>

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -4,6 +4,7 @@ label: 'Storage'
 
 ### What's new
 
+- Compute: Updated supported PostgreSQL versions to 14.8 and 15.3, respectively.
 - Compute: Neon uses compute endpoint domain names to route incoming client connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask that you connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the SNI (Server Name Indication) extension of the TLS protocol to do this. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive an error indicating that the "endpoint ID is not specified".  
   
    As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The connection option was previously named `project`. This option name is now deprecated but remains supported for backward compatibility. The new name for the connection option is `endpoint`, which is used as shown in the following example:
@@ -18,4 +19,10 @@ label: 'Storage'
    </CodeBlock>
    ````
 
-   For more information about the special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](../docs/connect/connectivity-issues#workarounds) documentation.
+   For more information about this special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](../docs/connect/connectivity-issues#workarounds) documentation.
+
+
+### Bug fixes
+
+- Pageserver: Branch deletion status was not tracked in S3 storage, which could result in a deleted branch remaining accessible.
+- Pageserver: Addressed intermittent  `failed to flush page requests` errors by adjusting Pageserver timeout settings.

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -22,4 +22,4 @@ label: 'Storage'
 ### Bug fixes
 
 - Pageserver: Branch deletion status was not tracked in S3 storage, which could result in a deleted branch remaining accessible.
-- Pageserver: Addressed intermittent  `failed to flush page requests` errors by adjusting Pageserver timeout settings.
+- Pageserver: Addressed intermittent `failed to flush page requests` errors by adjusting Pageserver timeout settings.

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -6,17 +6,16 @@ label: 'Storage'
 
 - Compute: Neon uses compute endpoint domain names to route incoming client connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask that you connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the SNI (Server Name Indication) extension of the TLS protocol to do this. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive an error indicating that the "endpoint ID is not specified".  
   
-   As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The special connection option was previously named `project`. The `project` option name is now deprecated but remains supported for backward compatibility. The new name for the special connection option is `endpoint`, which is used as shown in the following example:
+   As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The connection option was previously named `project`. This option name is now deprecated but remains supported for backward compatibility. The new name for the connection option is `endpoint`, which is used as shown in the following example:
 
-````md
-<CodeBlock shouldWrap>
+   ````md
+   <CodeBlock shouldWrap>
 
-```txt
-postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
-```
+   ```txt
+   postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
+   ```
 
-</CodeBlock>
-````
+   </CodeBlock>
+   ````
 
    For more information about the special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](../docs/connect/connectivity-issues#workarounds) documentation.
-</Admonition>

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -9,7 +9,6 @@ label: 'Storage'
   
    As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The connection option was previously named `project`. This option name is now deprecated but remains supported for backward compatibility. The new name for the connection option is `endpoint`, which is used as shown in the following example:
 
-   ````md
    <CodeBlock shouldWrap>
 
    ```txt
@@ -17,7 +16,6 @@ label: 'Storage'
    ```
 
    </CodeBlock>
-   ````
 
    For more information about this special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](../docs/connect/connectivity-issues#workarounds) documentation.
 

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -21,7 +21,6 @@ label: 'Storage'
 
    For more information about this special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](../docs/connect/connectivity-issues#workarounds) documentation.
 
-
 ### Bug fixes
 
 - Pageserver: Branch deletion status was not tracked in S3 storage, which could result in a deleted branch remaining accessible.


### PR DESCRIPTION
Release notes:
https://neon-next-git-dprice-05-16-storage-release-neondatabase.vercel.app/docs/release-notes
Related connection doc updates:
https://neon-next-git-dprice-05-16-storage-release-neondatabase.vercel.app/docs/connect/connectivity-issues#a-pass-the-endpoint-id-as-an-option