### PR TITLE
fix: broken links on release notes

### DIFF
--- a/content/docs/import/import-from-postgres.md
+++ b/content/docs/import/import-from-postgres.md
@@ -60,7 +60,7 @@ where:
 - `<user>` is the PostgreSQL role.
 - `<password>` is the role's password.
 - `ep-polished-water-579720.us-east-2.aws.neon.tech` is the hostname of the Neon PostgreSQL instance. Your hostname will differ.
-- `<dbname>` is the name of the database. You can use the default `neondb` database or create your own. For instructions, see [Create a database](../docs/manage/databases#create-a-database).
+- `<dbname>` is the name of the database. You can use the default `neondb` database or create your own. For instructions, see [Create a database](/docs/manage/databases#create-a-database).
 
 <Admonition type="note">
 Neon uses the default PostgreSQL port, `5432`, so it does not need to be specified explicitly in the Neon connection string.
@@ -84,47 +84,47 @@ This section describes using the `pg_dump` utility to dump data from an existing
 
 1. Start by retrieving the connection strings for the existing PostgreSQL database and your Neon database.
 
-    You must supply the connection string for your existing PostgreSQL database. You can obtain the connection string for your Neon database from the **Connection Details** widget on the Neon **Dashboard**. The Neon connection string will look something like this:
+   You must supply the connection string for your existing PostgreSQL database. You can obtain the connection string for your Neon database from the **Connection Details** widget on the Neon **Dashboard**. The Neon connection string will look something like this:
 
-    <CodeBlock shouldWrap>
+   <CodeBlock shouldWrap>
 
-    ```bash
-    postgres://<user>:<password>@ep-polished-water-579720.us-east-2.aws.neon.tech/<dbname>
-    ```
+   ```bash
+   postgres://<user>:<password>@ep-polished-water-579720.us-east-2.aws.neon.tech/<dbname>
+   ```
 
-    </CodeBlock>
+   </CodeBlock>
 
 2. Dump the database from your existing PostgreSQL instance. You can use a `pg_dump` command similar to the following:
 
-    <CodeBlock shouldWrap>
+   <CodeBlock shouldWrap>
 
-    ```bash
-    pg_dump "postgres://<user>:<hostname>:<port>/<dbname>" --file=dumpfile.bak -Fc -Z 6 -v
-    ```
+   ```bash
+   pg_dump "postgres://<user>:<hostname>:<port>/<dbname>" --file=dumpfile.bak -Fc -Z 6 -v
+   ```
 
-    </CodeBlock>
+   </CodeBlock>
 
-    The example above includes some optional arguments. The `-Fc` option sends the output to a custom-format archive suitable for input into `pg_restore`. The `-Z 6` option specifies a compression level of 6 (the default). The `-v` option runs `pg_dump` in verbose mode, allowing you to monitor what happens during the dump.
+   The example above includes some optional arguments. The `-Fc` option sends the output to a custom-format archive suitable for input into `pg_restore`. The `-Z 6` option specifies a compression level of 6 (the default). The `-v` option runs `pg_dump` in verbose mode, allowing you to monitor what happens during the dump.
 
-    The `pg_dump` command provides many other options to modify your database dump. To learn  more, refer to the [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) documentation.
+   The `pg_dump` command provides many other options to modify your database dump. To learn more, refer to the [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) documentation.
 
 3. Load the database dump into Neon using `pg_restore`. For example:
 
-      <CodeBlock shouldWrap>
+     <CodeBlock shouldWrap>
 
-      ```bash
-      pg_restore -d postgres://[user]:[password]@[hostname]/<dbname> -Fc --single-transaction dumpfile.bak.gz -c -v
-      ```
+   ```bash
+   pg_restore -d postgres://[user]:[password]@[hostname]/<dbname> -Fc --single-transaction dumpfile.bak.gz -c -v
+   ```
 
-      </CodeBlock>
+     </CodeBlock>
 
-    The example above includes some optional arguments. The `-Fc` option sends the output a custom-format archive suitable for input into `pg_restore`. The `--single-transaction` option forces the operation to run as an atomic transaction, which ensures that no data is left behind when an import operation fails. (Retrying an import operation after a failed attempt that leaves data behind may result in "duplicate key value" errors.) The `-c` option tells the restore operation to run `clean`, meaning that it drops database objects before recreating them. The `-v` option runs `pg_dump` in verbose mode, allowing you to monitor what happens during the restore operation.
+   The example above includes some optional arguments. The `-Fc` option sends the output a custom-format archive suitable for input into `pg_restore`. The `--single-transaction` option forces the operation to run as an atomic transaction, which ensures that no data is left behind when an import operation fails. (Retrying an import operation after a failed attempt that leaves data behind may result in "duplicate key value" errors.) The `-c` option tells the restore operation to run `clean`, meaning that it drops database objects before recreating them. The `-v` option runs `pg_dump` in verbose mode, allowing you to monitor what happens during the restore operation.
 
-    <Admonition type="note">
-    `pg_restore` also supports a `-j` option that specifies the number of concurrent jobs, which can make imports faster. This option is not used in the example above because multiple jobs cannot be used together with the `--single-transaction` option.
-    </Admonition>
+   <Admonition type="note">
+   `pg_restore` also supports a `-j` option that specifies the number of concurrent jobs, which can make imports faster. This option is not used in the example above because multiple jobs cannot be used together with the `--single-transaction` option.
+   </Admonition>
 
-    The `pg_restore` command provides other options to modify your database import.  To learn more, refer to the [pg_restore](https://www.postgresql.org/docs/current/app-pgrestore.html) documentation.
+   The `pg_restore` command provides other options to modify your database import. To learn more, refer to the [pg_restore](https://www.postgresql.org/docs/current/app-pgrestore.html) documentation.
 
 ## Data import notes
 

--- a/content/release-notes/2023-05-11-console.md
+++ b/content/release-notes/2023-05-11-console.md
@@ -5,7 +5,7 @@ label: 'Console'
 ### What's new
 
 - UI: Adjusted how Autoscaling minimum and maximum compute sizes are displayed in the **Compute endpoints** table on the branch details page.
-- UI: Added a **History retention** metric to the **Storage** widget on the Neon **Dashboard**. By default, Neon retains a 7-day history of data changes to support [point-in-time restore](../docs/reference/glossary#point-in-time-restore). History retention will become a configurable setting in a future release.
+- UI: Added a **History retention** metric to the **Storage** widget on the Neon **Dashboard**. By default, Neon retains a 7-day history of data changes to support [point-in-time restore](/docs/reference/glossary#point-in-time-restore). History retention will become a configurable setting in a future release.
 - UI: Enhanced the **Request Downgrade** modal, which is accessible from the **Billing** page in the console. Downgrading from Neon's [Pro plan](/docs/introduction/pro-plan) back to the [Free Tier](/docs/introduction/technical-preview-free-tier) is now a fully automated and instant process. This change eliminates the previously required step of sending a downgrade request to Neon support.
 - Control Plane: Adjusted the time interval for measuring compute utilization in Neon to avoid rounding decisions and ensure accuracy for fractional compute sizes.
 

--- a/content/release-notes/2023-05-16-console.md
+++ b/content/release-notes/2023-05-16-console.md
@@ -6,7 +6,7 @@ label: 'Console'
 
 - Control Plane: Project limit checks are now performed for the Neon project owner rather than the currently logged in user. This change enables project limits to be checked against Pro plan limits rather than Free Tier limits when a Free Tier user accesses a project shared by a Pro plan user.
 - Control Plane: Newly created Neon projects in a particular region are now assigned Pageservers through a random selection process, which is weighted according to Pageserver free space.
-- Control Plane: Removed an unnecessary fetch of project parameters by the [Activity Monitor](../docs/reference/glossary#activity-monitor).
+- Control Plane: Removed an unnecessary fetch of project parameters by the [Activity Monitor](/docs/reference/glossary#activity-monitor).
 - UI: Implemented usability improvements for modals. The changes ensure that modals receive focus when opened and that modal buttons are disabled until there is a valid change and while a form is being submitted. New error messages were also added.
 - UI: Improved the hover effect when hovering over steps in the onboarding section on the Neon **Dashboard**.
 

--- a/content/release-notes/2023-05-16-storage-and-compute.md
+++ b/content/release-notes/2023-05-16-storage-and-compute.md
@@ -4,19 +4,19 @@ label: 'Storage'
 
 ### What's new
 
-- Proxy: Neon uses compute endpoint domain names to route incoming client connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask that you connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the Server Name Indication (SNI) extension of the TLS protocol to do this. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive an error indicating that the "endpoint ID is not specified".  
-  
-   As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The connection option was previously named `project`. This option name is now deprecated but remains supported for backward compatibility. The new name for the connection option is `endpoint`, which is used as shown in the following example:
+- Proxy: Neon uses compute endpoint domain names to route incoming client connections. For example, to connect to the compute endpoint `ep-mute-recipe-239816`, we ask that you connect to `ep-mute-recipe-239816.us-east-2.aws.neon.tech`. However, the PostgreSQL wire protocol does not transfer the server domain name, so Neon relies on the Server Name Indication (SNI) extension of the TLS protocol to do this. Unfortunately, not all PostgreSQL clients support SNI. When these clients attempt to connect, they receive an error indicating that the "endpoint ID is not specified".
+
+  As a workaround, Neon provides a special connection option that allows clients to specify the compute endpoint they are connecting to. The connection option was previously named `project`. This option name is now deprecated but remains supported for backward compatibility. The new name for the connection option is `endpoint`, which is used as shown in the following example:
 
    <CodeBlock shouldWrap>
 
-   ```txt
-   postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
-   ```
+  ```txt
+  postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
+  ```
 
    </CodeBlock>
 
-   For more information about this special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](../docs/connect/connectivity-issues#workarounds) documentation.
+  For more information about this special connection option for PostgreSQL clients that do not support SNI, refer to our [connection workarounds](/docs/connect/connectivity-issues#workarounds) documentation.
 
 ### Bug fixes
 

--- a/content/release-notes/2023-05-19-console.md
+++ b/content/release-notes/2023-05-19-console.md
@@ -5,11 +5,10 @@ label: 'Console'
 ### What's new
 
 - Control Plane: Neon's Autoscaling feature now supports fractional (1/4 and 1/2) minimum compute sizes. Previously, the minimum compute size for Autoscaling was 1.
-![Autoscaling fractional compute sizes](/docs/relnotes/fractional_compute_sizes.png)
-  
-  Autoscaling is a [Neon Pro plan](/docs/introduction/pro-plan) feature. For configuration instructions, see [Compute size and Autoscaling configuration](../docs/manage/endpoints#compute-size-and-autoscaling-configuration).
+  ![Autoscaling fractional compute sizes](/docs/relnotes/fractional_compute_sizes.png)
+  Autoscaling is a [Neon Pro plan](/docs/introduction/pro-plan) feature. For configuration instructions, see [Compute size and Autoscaling configuration](/docs/manage/endpoints#compute-size-and-autoscaling-configuration).
 - UI: Added a **Billing** page to the Neon Console where Free Tier users can view [Free Tier](/docs/introduction/technical-preview-free-tier) limits and learn about the benefits of upgrading to the [Neon Pro plan](/docs/introduction/pro-plan). The **Billing** page is accessible from the sidebar in the Neon Console.
-![Free Tier Billing page](/docs/relnotes/free_tier_billing.png)
+  ![Free Tier Billing page](/docs/relnotes/free_tier_billing.png)
 - UI: Implemented minor copy, stylistic, and functional improvements for the **Request Downgrade** modal accessed from the **Billing** page.
 
 ### Bug fixes


### PR DESCRIPTION
*Describe the changes*
This PR fixes internal links on the following pages:
 - content/docs/import/import-from-postgres.md
 - content/release-notes/2023-05-11-console.md
 - content/release-notes/2023-05-16-console.md
 - content/release-notes/2023-05-16-storage-and-compute.md
 - content/release-notes/2023-05-19-console.md
 
 Closes #748 
 
 cc @danieltprice 