### PR TITLE
Add connection pooling limitation for Autoscaling

### DIFF
--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -8,7 +8,7 @@ redirectFrom:
 Each PostgreSQL connection creates a new process in the operating system, which consumes resources. For this reason, PostgreSQL limits the number of open connections. Neon permits 100 simultaneous PostgreSQL connections, by default, with a `max_connections=100` setting, which is the typical default for this parameter. A small number of those connections are reserved for administrative purposes. A connection limit of 100 may not be sufficient for some applications. To increase the number of connections that Neon supports, you can enable connection pooling.
 
 <Admonition type="note">
-Connection pooling is not yet supported with our [Autoscaling](../introduction/autoscaling) feature, which is currently in Beta. If you expect a large number of concurrent connections, we recommend using a **Fixed size** compute (the default), which supports connection pooling. For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
+Connection pooling is not yet supported with [Autoscaling](../introduction/autoscaling) (Beta). If you expect a large number of concurrent connections, we recommend using a **Fixed size** compute (the default), which supports connection pooling. For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
 </Admonition>
 
 ## Connection pooling
@@ -39,7 +39,7 @@ The previous method of enabling connection pooling for a compute endpoint is dep
 
 ## Connection pooling notes and limitations
 
-Connection pooling is not yet supported with our [Autoscaling](../introduction/autoscaling) feature. To use connection pooling, use a **Fixed size** compute (the default). For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
+Connection pooling is not yet supported with [Autoscaling](../introduction/autoscaling) (Beta). To use connection pooling, use a **Fixed size** compute (the default). For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
 
 Neon uses PgBouncer in _transaction mode_, which does not support PostgreSQL features such as prepared statements or [LISTEN](https://www.postgresql.org/docs/15/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/15/sql-notify.html). For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
 

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -9,7 +9,7 @@ Each PostgreSQL connection creates a new process in the operating system, which 
 
 <Admonition type="note">
 Connection pooling is not yet supported with our [Autoscaling](../introduction/autoscaling) feature, which is currently in Beta. If you expect a large number of concurrent connections, we recommend using a **Fixed size** compute (the default), which supports connection pooling. For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
-</Adminition>
+</Admonition>
 
 ## Connection pooling
 

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -7,6 +7,10 @@ redirectFrom:
 
 Each PostgreSQL connection creates a new process in the operating system, which consumes resources. For this reason, PostgreSQL limits the number of open connections. Neon permits 100 simultaneous PostgreSQL connections, by default, with a `max_connections=100` setting, which is the typical default for this parameter. A small number of those connections are reserved for administrative purposes. A connection limit of 100 may not be sufficient for some applications. To increase the number of connections that Neon supports, you can enable connection pooling.
 
+<Admonition type="note">
+Connection pooling is not yet supported with our [Autoscaling](../introduction/autoscaling) feature, which is currently in Beta. If you expect a large number of concurrent connections, we recommend using a **Fixed size** compute (the default), which supports connection pooling. For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
+</Adminition>
+
 ## Connection pooling
 
 Some applications open numerous connections, with most eventually becoming inactive. This behavior can often be attributed to database driver limitations, to running many instances of an application, or to applications with serverless functions. With regular PostgreSQL, new connections are rejected when reaching the `max_connections` limit. To overcome this limitation, Neon supports connection pooling using [PgBouncer](https://www.pgbouncer.org/), allowing Neon to support up to 10000 concurrent connections.
@@ -34,6 +38,8 @@ The previous method of enabling connection pooling for a compute endpoint is dep
 </Admonition>
 
 ## Connection pooling notes and limitations
+
+Connection pooling is not yet supported with our [Autoscaling](../introduction/autoscaling) feature. To use connection pooling, use a **Fixed size** compute (the default). For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
 
 Neon uses PgBouncer in _transaction mode_, which does not support PostgreSQL features such as prepared statements or [LISTEN](https://www.postgresql.org/docs/15/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/15/sql-notify.html). For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
 

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -8,7 +8,7 @@ redirectFrom:
 Each PostgreSQL connection creates a new process in the operating system, which consumes resources. For this reason, PostgreSQL limits the number of open connections. Neon permits 100 simultaneous PostgreSQL connections, by default, with a `max_connections=100` setting, which is the typical default for this parameter. A small number of those connections are reserved for administrative purposes. A connection limit of 100 may not be sufficient for some applications. To increase the number of connections that Neon supports, you can enable connection pooling.
 
 <Admonition type="note">
-Connection pooling is not yet supported with [Autoscaling](../introduction/autoscaling) (Beta). If you expect a large number of concurrent connections, we recommend using a **Fixed size** compute (the default), which supports connection pooling. For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
+Connection pooling is not yet supported with [Autoscaling](../introduction/autoscaling) <b><sup>Beta</sup></b>. If you expect a large number of concurrent connections, we recommend using a **Fixed size** compute (the default), which supports connection pooling. For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
 </Admonition>
 
 ## Connection pooling
@@ -39,7 +39,7 @@ The previous method of enabling connection pooling for a compute endpoint is dep
 
 ## Connection pooling notes and limitations
 
-Connection pooling is not yet supported with [Autoscaling](../introduction/autoscaling) (Beta). To use connection pooling, use a **Fixed size** compute (the default). For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
+Connection pooling is not yet supported with [Autoscaling](../introduction/autoscaling) <b><sup>Beta</sup></b>. To use connection pooling, use a **Fixed size** compute (the default). For compute configuration instructions, see [Compute size and Autoscaling configuration](../manage/endpoints#compute-size-and-autoscaling-configuration).
 
 Neon uses PgBouncer in _transaction mode_, which does not support PostgreSQL features such as prepared statements or [LISTEN](https://www.postgresql.org/docs/15/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/15/sql-notify.html). For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
 

--- a/content/docs/manage/endpoints.md
+++ b/content/docs/manage/endpoints.md
@@ -77,7 +77,7 @@ Neon supports two compute size configuration options:
 - **Autoscaling:** This option allows you to specify a minimum and maximum compute size. Neon scales the compute size up and down within the selected compute size boundaries to meet workload demand. _Autoscaling_ currently supports a range of 1/4 CU to 7 CU. For information about how Neon implements the _Autoscaling_ feature, see [Autoscaling](../introduction/autoscaling).
 
 <Admonition type="note">
-Switching between **Fixed Size** and **Autoscaling** is not yet supported.
+[Connection pooling](../connect/connection-pooling) is not yet supported with Autoscaling. To use connection pooling, use a **Fixed size** compute.
 </Admonition>
 
 ### Auto-suspend configuration

--- a/content/docs/manage/endpoints.md
+++ b/content/docs/manage/endpoints.md
@@ -77,7 +77,7 @@ Neon supports two compute size configuration options:
 - **Autoscaling:** This option allows you to specify a minimum and maximum compute size. Neon scales the compute size up and down within the selected compute size boundaries to meet workload demand. _Autoscaling_ currently supports a range of 1/4 CU to 7 CU. For information about how Neon implements the _Autoscaling_ feature, see [Autoscaling](../introduction/autoscaling).
 
 <Admonition type="note">
-[Connection pooling](../connect/connection-pooling) is not yet supported with Autoscaling (Beta). To use connection pooling, use a **Fixed size** compute.
+[Connection pooling](../connect/connection-pooling) is not yet supported with Autoscaling <b><sup>Beta</sup></b>. To use connection pooling, use a **Fixed size** compute.
 </Admonition>
 
 ### Auto-suspend configuration

--- a/content/docs/manage/endpoints.md
+++ b/content/docs/manage/endpoints.md
@@ -77,7 +77,7 @@ Neon supports two compute size configuration options:
 - **Autoscaling:** This option allows you to specify a minimum and maximum compute size. Neon scales the compute size up and down within the selected compute size boundaries to meet workload demand. _Autoscaling_ currently supports a range of 1/4 CU to 7 CU. For information about how Neon implements the _Autoscaling_ feature, see [Autoscaling](../introduction/autoscaling).
 
 <Admonition type="note">
-[Connection pooling](../connect/connection-pooling) is not yet supported with Autoscaling, which is currently in Beta. To use connection pooling, use a **Fixed size** compute.
+[Connection pooling](../connect/connection-pooling) is not yet supported with Autoscaling (Beta). To use connection pooling, use a **Fixed size** compute.
 </Admonition>
 
 ### Auto-suspend configuration

--- a/content/docs/manage/endpoints.md
+++ b/content/docs/manage/endpoints.md
@@ -77,7 +77,7 @@ Neon supports two compute size configuration options:
 - **Autoscaling:** This option allows you to specify a minimum and maximum compute size. Neon scales the compute size up and down within the selected compute size boundaries to meet workload demand. _Autoscaling_ currently supports a range of 1/4 CU to 7 CU. For information about how Neon implements the _Autoscaling_ feature, see [Autoscaling](../introduction/autoscaling).
 
 <Admonition type="note">
-[Connection pooling](../connect/connection-pooling) is not yet supported with Autoscaling. To use connection pooling, use a **Fixed size** compute.
+[Connection pooling](../connect/connection-pooling) is not yet supported with Autoscaling, which is currently in Beta. To use connection pooling, use a **Fixed size** compute.
 </Admonition>
 
 ### Auto-suspend configuration


### PR DESCRIPTION
Previews:
https://neon-next-git-dprice-autoscaling-connection-limit-neondatabase.vercel.app/docs/connect/connection-pooling
https://neon-next-git-dprice-autoscaling-connection-limit-neondatabase.vercel.app/docs/manage/endpoints#compute-size-and-autoscaling-configuration