### PR TITLE
Wrap connection string codeblocks

### DIFF
--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -49,15 +49,23 @@ PGPORT='5432'
 
 Variable:
 
+<CodeBlock shouldWrap>
+
 ```text
 DATABASE_URL="postgres://daniel:<password>@ep-mute-rain-952417.us-east-2.aws.neon.tech:5432/neondb"
 ```
 
+</CodeBlock>
+
 Command-line:
+
+<CodeBlock shouldWrap>
 
 ```bash
 psql postgres://daniel:<password>@ep-mute-rain-952417.us-east-2.aws.neon.tech/neondb
 ```
+
+</CodeBlock>
 
 <Admonition type="note">
 Neon requires that all connections use SSL/TLS encryption, but you can increase the level of protection by appending an `sslmode` parameter setting to your connection string. For instructions, see [Connect to Neon securely](../connect/connect-securely).

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -31,9 +31,13 @@ Enabling connection pooling in Neon requires adding a `-pooler` suffix to the co
 
 Add the `-pooler` suffix to the endpoint ID, as shown:
 
+<CodeBlock shouldWrap>
+
 ```text
 postgres://sally:<password>@ep-throbbing-boat-918849-pooler.us-east-2.aws.neon.tech/neondb
 ```
+
+</CodeBlock>
 
 The **Connection Details** widget on the Neon **Dashboard** provides **Pooled connection** and **Direct connection** tabs, allowing you to copy a connection string with or without the `-pooler` option.
 

--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -33,15 +33,23 @@ The special connection option was previously named `project`. The `project` opti
 
 For example, instead of the following connection string:
 
+<CodeBlock shouldWrap>
+
 ```txt
 postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main
 ```
 
+</CodeBlock>
+
 You would use this one:
+
+<CodeBlock shouldWrap>
 
 ```txt
 postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
 ```
+
+<CodeBlock>
 
 The `endpoint` option is expected to work if your application or library permits it to be set. But not all of them do, especially in the case of GUI applications.
 

--- a/content/docs/connect/connectivity-issues.md
+++ b/content/docs/connect/connectivity-issues.md
@@ -49,7 +49,7 @@ You would use this one:
 postgres://<user>:<password>@ep-mute-recipe-239816.us-east-2.aws.neon.tech/main?options=endpoint%3Dep-mute-recipe-239816
 ```
 
-<CodeBlock>
+</CodeBlock>
 
 The `endpoint` option is expected to work if your application or library permits it to be set. But not all of them do, especially in the case of GUI applications.
 

--- a/content/docs/connect/query-with-psql-editor.md
+++ b/content/docs/connect/query-with-psql-editor.md
@@ -23,9 +23,13 @@ You can obtain a connection string from the **Connection Details** widget on the
 
 From your terminal or command prompt, run the `psql` client with the connection string copied from the Neon **Dashboard**, but be sure to add your password, as shown:
 
+<CodeBlock shouldWrap>
+
 ```bash
 psql postgres://daniel:<password>@ep-mute-rain-952417.us-east-2.aws.neon.tech/neondb
 ```
+
+</CodeBlock>
 
 <Admonition type="note">
 Neon requires that all connections use SSL/TLS encryption, but you can increase the level of protection by appending an `sslmode` parameter setting to your connection string. For instructions, see [Connect to Neon securely](../connect/connect-securely).
@@ -39,9 +43,13 @@ You can obtain a Neon connection string with your password from the Neon **Dashb
 
 Neon uses the default PostgreSQL port, `5432`. If you need to specify the port in your connection string, you can do so as follows:
 
+<CodeBlock shouldWrap>
+
 ```bash
 psql postgres://daniel:<password>@ep-mute-rain-952417.us-east-2.aws.neon.tech:5432/neondb
 ```
+
+</CodeBlock>
   
 ## Running queries
 

--- a/content/docs/guides/grafbase.md
+++ b/content/docs/guides/grafbase.md
@@ -89,15 +89,23 @@ A database connection string is required to forward queries to your Neon databas
 1. Navigate to the Neon **Dashboard**.
 2. Copy the connection string for your database from the **Connection Details** widget. The connection string should appear similar to the following:
 
+    <CodeBlock shouldWrap>
+
     ```text
     postgres://<user>:<password>@ep-crimson-wildflower-999999.eu-central-1.aws.neon.tech/neondb
     ```
 
+    </CodeBlock>
+
 3. Add a `DATABASE_URL` environment variable to your `grafbase/.env` file and set the value to your connection string. For example:
+
+    <CodeBlock shouldWrap>
 
     ```text
     DATABASE_URL=postgres://<user>:<password>@ep-crimson-wildflower-999999.eu-central-1.aws.neon.tech/neondb
     ```
+
+    </CodeBlock>
 
 ## Add code to the resolvers
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -36,7 +36,13 @@ To establish a basic connection from Prisma to Neon, perform the following steps
 
 3. Add a `DATABASE_URL` variable to your `.env` file and set it to the Neon connection string that you copied in the previous step. Your setting will appear similar to the following:
 
-   `DATABASE_URL="postgres://daniel:<password>@ep-mute-rain-952417.us-east-2.aws.neon.tech/neondb"`
+   <CodeBlock shouldWrap>
+
+   ```text
+   DATABASE_URL="postgres://daniel:<password>@ep-mute-rain-952417.us-east-2.aws.neon.tech/neondb"
+   ```
+
+   </CodeBlock>
 
 <Admonition type="important">
 If you are using Prisma Client from a serverless function, see [Connect from serverless functions](#connect-from-serverless-functions). To adjust your connection string to avoid connection timeouts issues, see [Connection timeouts](#connection-timeouts).

--- a/content/docs/guides/stepzen.md
+++ b/content/docs/guides/stepzen.md
@@ -29,9 +29,13 @@ Running the `init.sql` file creates the `address`, `customer`, `product`, and `o
 
 You can seed the database directly from the terminal by running the following `psql` command:
 
+<CodeBlock shouldWrap>
+
 ```bash
 psql postgres://daniel:*************@ep-mute-rain-952417.us-east-2.aws.neon.tech/neondb < init.sql
 ```
+
+</CodeBlock>
 
 The command takes a Neon connection string as the first argument and a file as the second argument.
 

--- a/content/docs/import/import-from-heroku.md
+++ b/content/docs/import/import-from-heroku.md
@@ -26,9 +26,13 @@ To migrate your data from Heroku to Neon:
 
     The example connection string used the instructions that follow is:
 
-    ```sh
+    <CodeBlock shouldWrap>
+
+    ```text
     postgres://jsmith:Wij8mIDXoQ8H@ep-polished-water-579720.us-east-2.aws.neon.tech:5432/neondb
     ```
+
+    </CodeBlock>
 
 ## Retrieve your Heroku app name and database name
 

--- a/content/docs/manage/branches.md
+++ b/content/docs/manage/branches.md
@@ -109,11 +109,15 @@ You can also query the databases in a branch from the Neon SQL Editor. For instr
 2. On the project **Dashboard**, under **Connection Details**, select the branch, the database, and the role you want to connect with.
 ![Connection details widget](/docs/connect/connection_details.png)
 3. Copy the connection string. A connection string includes your role name, the compute endpoint hostname, and database name.
-5. Connect with `psql` as shown below.
+4. Connect with `psql` as shown below.
+
+  <CodeBlock shouldWrap>
 
   ```bash
   psql postgres://daniel:<password>@ep-mute-rain-952417.us-east-2.aws.neon.tech/neondb
   ```
+
+  </CodeBlock>
 
 <Admonition type="tip">
 A compute endpoint hostname starts with an `ep-` prefix. You can also find a compute endpoint hostname on the **Branches** page in the Neon Console. See [View branches](#view-branches).

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -88,9 +88,13 @@ A method of creating a pool of connections and caching those connections for reu
 
 A string containing details for connecting to a Neon database. The details include a user name (role), compute endpoint hostname, and database name; for example:
 
+<CodeBlock shouldWrap>
+
 ```terminal
 postgres://casey@ep-polished-water-579720.us-east-2.aws.neon.tech/neondb
 ```
+
+</CodeBlock>
 
 The compute endpoint hostname includes an `endpoint_id` (`ep-polished-water-579720`), a region slug (`us-east-2`), the cloud platform (`aws`), and Neon domain (`neon.tech`).
 

--- a/content/docs/unused/integrations-deprecated
+++ b/content/docs/unused/integrations-deprecated
@@ -88,9 +88,13 @@ datasource db {
 
 Then, go to the Project dashboard in Neon and generate a connection string in the `Connection Details` widget. You can add this connection string in `.env`:
 
+<CodeBlock shouldWrap>
+
 ```shell
-DATABASE_URL=postgres://user:pass@project-name-123.cloud.neon.tech/main
+DATABASE_URL=postgres://user:pass@project-name-123.cloud.neon.tech/neondb
 ```
+
+</CodeBlock>
 
 #### Using Neon for development with Prisma
 
@@ -190,7 +194,7 @@ USERNAME = "<your-username>"
 ACCESS_TOKEN = "<your-access-token>"
 PORT = "5432"
 HOST = "<your project name>.cloud.neon.tech"
-DBNAME = "main"
+DBNAME = "neondb"
 
 conn = psycopg2.connect(
  host=HOST,
@@ -288,7 +292,7 @@ For example, if you configure your Symfony project with `.env` file, then DATABA
 
 ```shell
 # cat .env | grep DATABASE_URL
-DATABASE_URL="postgresql://<user>:<token>@<project_id>.cloud.neon.tech:5432/main?charset=utf8"
+DATABASE_URL="postgresql://<user>:<token>@<project_id>.cloud.neon.tech:5432/neondb?charset=utf8"
 ```
 
 Make sure that you are using `<user>%40neon` as username. This is url encoded value for `<user>`. You can find `<user>` string in the upper right corner of the UI.
@@ -302,7 +306,7 @@ The JDBC API is a Java API for relational databases. PostgreSQL has a well-suppo
 To get a JDBC connection URL, replace placeholders with your credentials in the following template:
 
 ```java
-jdbc:postgresql://<project>.cloud.neon.tech/main?user=<user>&password=<token>
+jdbc:postgresql://<project>.cloud.neon.tech/neondb?user=<user>&password=<token>
 ```
 
 For more information about JDBC, refer to the standard JDBC API documentation and [PostgreSQL JDBC Driver documentation](https://jdbc.postgresql.org/documentation/head/index.html).
@@ -314,7 +318,7 @@ Spring relies on JDBC and PostgreSQL driver to connect to PostgreSQL databases. 
 The only configuration required for connection is a datasource URL. It is specified in the `application.properties` file in the following format:
 
 ```java
-spring.datasource.url=jdbc:postgresql://<project>.cloud.neon.tech/main?user=<user>&password=<token>
+spring.datasource.url=jdbc:postgresql://<project>.cloud.neon.tech/neondb?user=<user>&password=<token>
 ```
 
 ### Using from Go
@@ -333,7 +337,7 @@ import (
 )
 
 func main() {
-    connStr := "user=<user> password=<token> dbname=main host=<project>.cloud.neon.tech"
+    connStr := "user=<user> password=<token> dbname=neondb host=<project>.cloud.neon.tech"
     db, err := sql.Open("postgres", connStr)
     if err != nil {
         log.Fatal(err)

--- a/content/docs/unused/prisma-guide.md
+++ b/content/docs/unused/prisma-guide.md
@@ -22,9 +22,13 @@ This guide steps you through how to connect from Prisma to Neon, how to use Pris
 
 The project is created and you are presented with a dialog that provides connection details. Copy the connection string, which looks similar to the following:
 
+<CodeBlock shouldWrap>
+
 ```text
 postgres://sally:************@ep-white-thunder-826300.us-east-2.aws.neon.tech/neondb
 ```
+
+</CodeBlock>
 
 <Admonition type="info">
 A Neon project is created with a default PostgreSQL role named for your account, and a default database named `neondb`. This guide uses the `neondb` database as the primary database.
@@ -42,9 +46,13 @@ For cloud-hosted databases like Neon, you must create the shadow database manual
 
 The connection string for this database should be the same as the connection string for your `neondb` database except for the database name:
 
+<CodeBlock shouldWrap>
+
 ```text
 postgres://sally:************@ep-white-thunder-826300.us-east-2.aws.neon.tech/shadow
 ```
+
+</CodeBlock>
 
 ## Set up your Prisma project
 
@@ -94,10 +102,14 @@ In this step, you will update your project's `.env` file with the connection str
 
 When you are finished, your `.env` file should have entries similar to the following:
 
+<CodeBlock shouldWrap>
+
 ```text
 DATABASE_URL=postgres://sally:************@ep-white-thunder-826300.us-east-2.aws.neon.tech/neondb?connect_timeout=10
 SHADOW_DATABASE_URL=postgres://sally:************@ep-white-thunder-826300.us-east-2.aws.neon.tech/shadow?connect_timeout=10
 ```
+
+</CodeBlock>
 
 <Admonition type="note">
 A `?connect_timeout=10` parameter is added to the connection strings above to avoid database connection timeouts. The default `connect_timeout` setting is 5 seconds, which is usually enough time for a database connection to be established. However, network latency combined with the short amount of time required to start an idle Neon compute instance can sometimes result in a connection failure. Setting `connect_timeout=10` helps avoid this issue.

--- a/content/release-notes/2023-02-06-console.md
+++ b/content/release-notes/2023-02-06-console.md
@@ -3,9 +3,13 @@
 - Integrations: You can now integrate Neon with your Vercel project directly from your Vercel account. The new integration, which is currently in Beta, is available from the [Vercel Integration Marketplace](https://vercel.com/integrations/neon). The integration allows you to connect your Vercel project to a new or existing Neon project. It also enables creating a database branch for each Vercel preview deployment and for your Vercel development environment. For more information about the Neon-Vercel integration, see [Connect Vercel and Neon](/docs/guides/vercel).
 - Control Plane: You can now enable connection pooling in Neon for individual connections. Pooling is enabled by adding a `-pooler` suffix to the endpoint ID in the Neon hostname. For example:
 
+  <CodeBlock shouldWrap>
+
   ```text
   postgres://sally@ep-square-sea-260584-pooler.us-east-2.aws.neon.tech/neondb
   ```
+
+  </CodeBlock>
 
   Connections that do not specify the `-pooler` suffix connect to the database directly. The ability to enable pooling for individual connections supports workflows that require both pooled and non-pooled connections to the same database. For example, serverless applications that use Prisma Client require a pooled connection, while Prisma Migrate requires a direct connection to the database. For more information, see [Enable connection pooling](/docs/connect/connection-pooling#enable-connection-pooling).
 


### PR DESCRIPTION
Add `<CodeBlock shouldWrap>` tags to wrap long connection strings so you do not have to scroll.