### PR TITLE
Apply `String.to_charlist` for `server_name_indication`

### DIFF
--- a/content/docs/guides/elixir-ecto.md
+++ b/content/docs/guides/elixir-ecto.md
@@ -94,8 +94,8 @@ Follow these steps to complete the configuration:
     hostname: "ep-billowing-sun-767748.us-west-2.aws.neon.tech",
     ssl: true,
     ssl_opts: [
-    server_name_indication: 'ep-billowing-sun-767748.us-west-2.aws.neon.tech',
-    verify: :verify_none
+      server_name_indication: String.to_charlist('ep-billowing-sun-767748.us-west-2.aws.neon.tech'),
+      verify: :verify_none
     ]
     ```
 


### PR DESCRIPTION
### WHY
- `server_name_indication` won't work with string

### WHAT
- apply `String.to_charlist`