### PR TITLE
Add Technical Preview info to roadmap page

### DIFF
--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -8,10 +8,14 @@ redirectFrom:
 
 The Neon **Limited Preview** started in February, 2022, and was made available to a small number of select users and friends.
 
-On June 15th, 2022, the Neon team announced the **Technical Preview**, making Neon available to a wider audience. Thousands of users were able to try Neon's [Free Tier](../introduction/technical-preview-free-tier).
+On June 15th, 2022, the Neon team announced the [Technical Preview](#technical-preview), making Neon available to a wider audience. Thousands of users were able to try Neon's [Free Tier](../introduction/technical-preview-free-tier).
 
 On December 6th, 2022, Neon released its branching feature and dropped the invite gate, welcoming everyone to try Neon's Free Tier.
 
 On March 15th, 2023, Neon launched paid plans, providing increased limits and added features, including _Project sharing_ and _Autoscaling_. For information about Neon's paid  plans, refer to our [Pricing](https://neon.tech/pricing) page.
 
 Support for more regions and additional features will be released in the coming months.
+
+## Technical Preview
+
+Neon sets a high standard for what constitutes a feature-complete product, meaning that all intended core functionality is implemented and operates as expected. While many features may be operational today, there may still be some that are under development or refinement. Neon will remain in Technical Preview while the remaining features are still being developed and perfected.


### PR DESCRIPTION
We need to change this "Read more" link on the console, which currently points to the Free Tier page.
![image](https://github.com/neondatabase/website/assets/10074684/b536c603-8402-4737-b8d7-71475c43daf1)

The Technical Preview applies to Neon in general (all plans), not just to the Free Tier. A user asked why they are still in the "Technical Preview Free Tier" after upgrading to Pro.

To address this issue, I have added a "Technical Preview" section to our Roadmap page. Once we agree on the text, I will update the Read more link. Please review.

An alternative option is to just drop the "Read more" link. 
https://neon-next-git-dprice-add-technical-preview-6c1e12-neondatabase.vercel.app/docs/introduction/roadmap 

