### PR TITLE
fix: set explicit image size on introduction page

### DIFF
--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -36,29 +36,29 @@ Or step through the [Neon tutorial](/docs/tutorial/neon-tutorial) to learn about
 
 <TechnologyNavigation>
 
-[![Vercel](/images/technology-logos/vercel-logo.svg 'Integrate Neon with Vercel')](/docs/guides/vercel-overview)
+<img src="/images/technology-logos/vercel-logo.svg"  width="42" height="36" alt="Vercel" href="/docs/guides/vercel-overview" title="Integrate Neon with Vercel" />
 
-[![Prisma](/images/technology-logos/prisma-logo.svg 'Connect from Prisma to Neon')](/docs/guides/prisma)
+<img src="/images/technology-logos/prisma-logo.svg" width="30" height="36" alt="Prisma" href="/docs/guides/prisma" title="Connect from Prisma to Neon" />
 
-[![Django](/images/technology-logos/django-logo.svg 'Connect a Django application to Neon')](/docs/guides/django)
+<img src="/images/technology-logos/django-logo.svg" width="29" height="36" alt="Django" href="/docs/guides/django" title="Connect a Django application to Neon" />
 
-[![Go](/images/technology-logos/go-logo.svg 'Connect a Go application to Neon')](/docs/guides/go)
+<img src="/images/technology-logos/go-logo.svg" width="80" height="36" alt="Go" href="/docs/guides/go" title="Connect a Go application to Neon" />
 
-[![Hasura](/images/technology-logos/hasura-logo.svg 'Connect from Hasura Cloud to Neon')](/docs/guides/hasura)
+<img src="/images/technology-logos/hasura-logo.svg" width="35" height="36" alt="Hasura" href="/docs/guides/hasura" title="Connect from Hasura Cloud to Neon" />
 
-[![Java](/images/technology-logos/java-logo.svg 'Connect a Java application to Neon')](/docs/guides/java)
+<img src="/images/technology-logos/java-logo.svg" width="27" height="36" alt="Java" href="/docs/guides/java" title="Connect a Java application to Neon" />
 
-[![Laravel](/images/technology-logos/laravel-logo.svg 'Connect a Laravel application to Neon')](/docs/guides/laravel)
+<img src="/images/technology-logos/laravel-logo.svg" width="35" height="36" alt="Laravel" href="/docs/guides/laravel" title="Connect a Laravel application to Neon" />
 
-[![Next.js](/images/technology-logos/nextjs-logo.svg 'Connect a Next.js application to Neon')](/docs/guides/vercel)
+<img src="/images/technology-logos/nextjs-logo.svg" width="36" height="36" alt="Next.js" href="/docs/guides/vercel" title="Connect a Next.js application to Neon" />
 
-[![Node.js](/images/technology-logos/nodejs-logo.svg 'Connect a Node.js application to Neon')](/docs/guides/node)
+<img src="/images/technology-logos/nodejs-logo.svg" width="33" height="36" alt="Node.js" href="/docs/guides/node" title="Connect a Node.js application to Neon" />
 
-[![Rust](/images/technology-logos/rust-logo.svg 'Connect a Rust application to Neon')](/docs/guides/rust)
+<img src="/images/technology-logos/rust-logo.svg" width="36" height="36" alt="Rust" href="/docs/guides/rust" title="Connect a Rust application to Neon" />
 
-[![SQLAlchemy](/images/technology-logos/sqlalchemy-logo.svg 'Connect an SQLAlchemy application to Neon')](/docs/guides/sqlalchemy)
+<img src="/images/technology-logos/sqlalchemy-logo.svg" width="102" height="36" alt="SQLAlchemy" href="/docs/guides/sqlalchemy" title="Connect an SQLAlchemy application to Neon" />
 
-[![Symfony](/images/technology-logos/symfony-logo.svg 'Connect from Symfony with Doctrine to Neon')](/docs/guides/symfony)
+<img src="/images/technology-logos/symfony-logo.svg" width="36" height="36" alt="Symfony" href="/docs/guides/symfony" title="Connect from Symfony with Doctrine to Neon" />
 
 </TechnologyNavigation>
 

--- a/src/components/pages/doc/mobile-nav/mobile-nav.jsx
+++ b/src/components/pages/doc/mobile-nav/mobile-nav.jsx
@@ -14,6 +14,7 @@ import useWindowSize from 'hooks/use-window-size';
 import ChevronRight from 'icons/chevron-right.inline.svg';
 
 import { ChatWidgetTrigger } from '../chat-widget';
+import { sidebarPropTypes } from '../sidebar/sidebar';
 
 const ANIMATION_DURATION = 0.2;
 
@@ -121,37 +122,7 @@ const MobileNav = ({ className = null, sidebar, currentSlug }) => {
 
 MobileNav.propTypes = {
   className: PropTypes.string,
-  sidebar: PropTypes.arrayOf(
-    PropTypes.exact({
-      title: PropTypes.string.isRequired,
-      isStandalone: PropTypes.bool,
-      slug: PropTypes.string,
-      items: PropTypes.arrayOf(
-        PropTypes.exact({
-          title: PropTypes.string.isRequired,
-          slug: PropTypes.string,
-          items: PropTypes.arrayOf(
-            PropTypes.exact({
-              title: PropTypes.string.isRequired,
-              slug: PropTypes.string,
-              items: PropTypes.arrayOf(
-                PropTypes.exact({
-                  title: PropTypes.string,
-                  slug: PropTypes.string,
-                  items: PropTypes.arrayOf(
-                    PropTypes.exact({
-                      title: PropTypes.string,
-                      slug: PropTypes.string,
-                    })
-                  ),
-                })
-              ),
-            })
-          ),
-        })
-      ),
-    })
-  ).isRequired,
+  sidebar: sidebarPropTypes,
   currentSlug: PropTypes.string.isRequired,
 };
 

--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -71,34 +71,17 @@ const Item = ({ title, slug = null, isStandalone = null, items = null, currentSl
   );
 };
 
+export const itemPropTypes = PropTypes.exact({
+  title: PropTypes.string.isRequired,
+  slug: PropTypes.string,
+  items: PropTypes.arrayOf(PropTypes.any),
+});
+
 Item.propTypes = {
   title: PropTypes.string.isRequired,
   isStandalone: PropTypes.bool,
   slug: PropTypes.string,
-  items: PropTypes.arrayOf(
-    PropTypes.exact({
-      title: PropTypes.string.isRequired,
-      slug: PropTypes.string,
-      items: PropTypes.arrayOf(
-        PropTypes.exact({
-          title: PropTypes.string,
-          slug: PropTypes.string,
-          items: PropTypes.arrayOf(
-            PropTypes.exact({
-              title: PropTypes.string,
-              slug: PropTypes.string,
-              items: PropTypes.arrayOf(
-                PropTypes.exact({
-                  title: PropTypes.string,
-                  slug: PropTypes.string,
-                })
-              ),
-            })
-          ),
-        })
-      ),
-    })
-  ),
+  items: PropTypes.arrayOf(itemPropTypes),
   currentSlug: PropTypes.string.isRequired,
 };
 

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -9,6 +9,7 @@ import MENUS from 'constants/menus';
 import { ChatWidgetTrigger } from '../chat-widget';
 
 import Item from './item';
+import { itemPropTypes } from './item/item';
 
 const Sidebar = ({ className = null, sidebar, currentSlug }) => (
   <aside
@@ -43,32 +44,17 @@ const Sidebar = ({ className = null, sidebar, currentSlug }) => (
   </aside>
 );
 
+export const sidebarPropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    slug: PropTypes.string,
+    items: PropTypes.arrayOf(itemPropTypes),
+  })
+).isRequired;
+
 Sidebar.propTypes = {
   className: PropTypes.string,
-  sidebar: PropTypes.arrayOf(
-    PropTypes.exact({
-      title: PropTypes.string.isRequired,
-      slug: PropTypes.string,
-      items: PropTypes.arrayOf(
-        PropTypes.exact({
-          title: PropTypes.string.isRequired,
-          slug: PropTypes.string,
-          items: PropTypes.arrayOf(
-            PropTypes.exact({
-              title: PropTypes.string.isRequired,
-              slug: PropTypes.string,
-              items: PropTypes.arrayOf(
-                PropTypes.exact({
-                  title: PropTypes.string,
-                  slug: PropTypes.string,
-                })
-              ),
-            })
-          ),
-        })
-      ),
-    })
-  ).isRequired,
+  sidebar: sidebarPropTypes,
   currentSlug: PropTypes.string.isRequired,
 };
 

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -19,12 +19,12 @@ const TechnologyNavigation = ({ children = null }) => {
     <>
       <ul className="not-prose !mb-2 !mt-9 grid grid-cols-12 gap-5 !p-0 xs:grid-cols-1">
         {React.Children.map(children, (child, index) => {
-          const {
-            children: {
-              props: { alt, src, title },
-            },
-            href,
-          } = child.props?.children.props ?? {};
+          if (!child) {
+            return null;
+          }
+
+          const { href, src, alt, title, width, height } = child.props;
+
           const isHiddenItem = index > 3 && !isOpen;
 
           return (
@@ -43,7 +43,8 @@ const TechnologyNavigation = ({ children = null }) => {
                   <img
                     className="h-9 w-auto shrink-0 dark:invert"
                     src={src}
-                    height={36}
+                    width={width}
+                    height={height}
                     alt={`${alt} logo`}
                     loading={index > 3 ? 'lazy' : 'eager'}
                   />


### PR DESCRIPTION
This pull request adds the images' explicit size for `TechnologyNavigation` component on `/docs/introduction` page.

<details>
<summary>Lighthouse</summary>

**Before**
<img width="973" alt="image" src="https://github.com/neondatabase/website/assets/48465000/416fa220-efec-4139-9e46-8fe75f90a24b">

**After**
There is no more error "Image elements do not have explicit width and height"
<img width="989" alt="image" src="https://github.com/neondatabase/website/assets/48465000/f7541613-5076-49d5-960c-15639304aef1">

</details>

