### PR TITLE
chore: replace inline svg with mask image

### DIFF
--- a/public/images/chevron-right.svg
+++ b/public/images/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.428711 0.714294L4.71442 5.00001L0.428711 9.28572" stroke="currentColor"/>
+</svg>

--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -6,7 +6,6 @@ import React, { useState } from 'react';
 
 import Link from 'components/shared/link';
 import { DOCS_BASE_PATH } from 'constants/docs';
-import ChevronRight from 'icons/chevron-right-sm.inline.svg';
 
 const isActiveItem = (items, currentSlug) =>
   items?.some(
@@ -43,16 +42,21 @@ const Item = ({ title, slug = null, isStandalone = null, items = null, currentSl
         onClick={handleClick}
       >
         <span className="leading-snug">{title}</span>
-        <ChevronRight
+        <span
           className={clsx(
-            'mx-2 mt-[5px] shrink-0 transition-[transform,color] duration-200',
+            'block h-4 w-4 transition-[transform,background-color] duration-200',
             currentSlug === slug
-              ? 'text-black-new dark:text-white'
-              : 'text-gray-new-40 group-hover:text-black-new dark:text-gray-new-90 dark:group-hover:text-white',
-
+              ? 'bg-black-new dark:bg-white'
+              : 'bg-gray-new-40 group-hover:bg-black-new dark:bg-gray-new-90 dark:group-hover:bg-white',
             items?.length ? 'block' : 'hidden',
             isOpen ? 'rotate-90' : 'rotate-0'
           )}
+          style={{
+            WebkitMaskImage: "url('/images/chevron-right.svg')",
+            WebkitMaskSize: '6px 10px',
+            WebkitMaskRepeat: 'no-repeat',
+            WebkitMaskPosition: 'center',
+          }}
         />
       </Tag>
       {!!items?.length && (


### PR DESCRIPTION
This pull request replaces chevrons in the sidebar as inline SVG to mask-image to reduce the DOM size from 1581 elements to 1380 elements.

<details>
<summary>Lighthouse</summary>

**Before**
<img width="969" alt="image" src="https://github.com/neondatabase/website/assets/48465000/0cb86264-57ea-4764-b26f-c1f383ef69bc">

**After**
<img width="973" alt="image" src="https://github.com/neondatabase/website/assets/48465000/2fc24c4d-5664-4071-af44-a8d4fe588b43">

</details>