### PR TITLE
chore: add aria label for short link

### DIFF
--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -102,6 +102,7 @@
           slug: guides/elixir-ecto
         - title: Go
           slug: guides/go
+          ariaLabel: Connect a Go application to Neon
         - title: Java
           slug: guides/java
         - title: PHP

--- a/src/components/pages/doc/previous-and-next-links/previous-and-next-links.jsx
+++ b/src/components/pages/doc/previous-and-next-links/previous-and-next-links.jsx
@@ -55,11 +55,13 @@ PreviousAndNextLinks.propTypes = {
     title: PropTypes.string.isRequired,
     slug: PropTypes.string.isRequired,
     path: PropTypes.arrayOf(PropTypes.number).isRequired,
+    ariaLabel: PropTypes.string,
   }),
   nextLink: PropTypes.exact({
     title: PropTypes.string.isRequired,
     slug: PropTypes.string.isRequired,
     path: PropTypes.arrayOf(PropTypes.number).isRequired,
+    ariaLabel: PropTypes.string,
   }),
 };
 

--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -79,24 +79,7 @@ Item.propTypes = {
     PropTypes.exact({
       title: PropTypes.string.isRequired,
       slug: PropTypes.string,
-      items: PropTypes.arrayOf(
-        PropTypes.exact({
-          title: PropTypes.string,
-          slug: PropTypes.string,
-          items: PropTypes.arrayOf(
-            PropTypes.exact({
-              title: PropTypes.string,
-              slug: PropTypes.string,
-              items: PropTypes.arrayOf(
-                PropTypes.exact({
-                  title: PropTypes.string,
-                  slug: PropTypes.string,
-                })
-              ),
-            })
-          ),
-        })
-      ),
+      items: PropTypes.arrayOf(PropTypes.any),
     })
   ),
   currentSlug: PropTypes.string.isRequired,

--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -13,7 +13,14 @@ const isActiveItem = (items, currentSlug) =>
     ({ slug, items }) => slug === currentSlug || (items && isActiveItem(items, currentSlug))
   );
 
-const Item = ({ title, slug = null, isStandalone = null, items = null, currentSlug }) => {
+const Item = ({
+  title,
+  slug = null,
+  ariaLabel = null,
+  isStandalone = null,
+  items = null,
+  currentSlug,
+}) => {
   const [isOpen, setIsOpen] = useState(slug === currentSlug);
 
   if (!isOpen && isActiveItem(items, currentSlug)) {
@@ -40,6 +47,7 @@ const Item = ({ title, slug = null, isStandalone = null, items = null, currentSl
         type={slug ? undefined : 'button'}
         to={slug ? externalSlug || docSlug : undefined}
         target={externalSlug ? '_blank' : '_self'}
+        aria-label={ariaLabel}
         onClick={handleClick}
       >
         <span className="leading-snug">{title}</span>
@@ -75,10 +83,12 @@ Item.propTypes = {
   title: PropTypes.string.isRequired,
   isStandalone: PropTypes.bool,
   slug: PropTypes.string,
+  ariaLabel: PropTypes.string,
   items: PropTypes.arrayOf(
     PropTypes.exact({
       title: PropTypes.string.isRequired,
       slug: PropTypes.string,
+      ariaLabel: PropTypes.string,
       items: PropTypes.arrayOf(PropTypes.any),
     })
   ),

--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -47,10 +47,12 @@ const Item = ({
         type={slug ? undefined : 'button'}
         to={slug ? externalSlug || docSlug : undefined}
         target={externalSlug ? '_blank' : '_self'}
-        aria-label={ariaLabel}
         onClick={handleClick}
       >
-        <span className="leading-snug">{title}</span>
+        {ariaLabel && <span className="sr-only">{ariaLabel}</span>}
+        <span className="leading-snug" aria-hidden={!!ariaLabel}>
+          {title}
+        </span>
         <ChevronRight
           className={clsx(
             'mx-2 mt-[5px] shrink-0 transition-[transform,color] duration-200',

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -43,32 +43,23 @@ const Sidebar = ({ className = null, sidebar, currentSlug }) => (
   </aside>
 );
 
+export const sidebarPropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    slug: PropTypes.string,
+    items: PropTypes.arrayOf(
+      PropTypes.exact({
+        title: PropTypes.string.isRequired,
+        slug: PropTypes.string,
+        items: PropTypes.arrayOf(PropTypes.any),
+      })
+    ),
+  })
+).isRequired;
+
 Sidebar.propTypes = {
   className: PropTypes.string,
-  sidebar: PropTypes.arrayOf(
-    PropTypes.exact({
-      title: PropTypes.string.isRequired,
-      slug: PropTypes.string,
-      items: PropTypes.arrayOf(
-        PropTypes.exact({
-          title: PropTypes.string.isRequired,
-          slug: PropTypes.string,
-          items: PropTypes.arrayOf(
-            PropTypes.exact({
-              title: PropTypes.string.isRequired,
-              slug: PropTypes.string,
-              items: PropTypes.arrayOf(
-                PropTypes.exact({
-                  title: PropTypes.string,
-                  slug: PropTypes.string,
-                })
-              ),
-            })
-          ),
-        })
-      ),
-    })
-  ).isRequired,
+  sidebar: sidebarPropTypes,
   currentSlug: PropTypes.string.isRequired,
 };
 

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -47,10 +47,12 @@ export const sidebarPropTypes = PropTypes.arrayOf(
   PropTypes.shape({
     title: PropTypes.string.isRequired,
     slug: PropTypes.string,
+    ariaLabel: PropTypes.string,
     items: PropTypes.arrayOf(
       PropTypes.exact({
         title: PropTypes.string.isRequired,
         slug: PropTypes.string,
+        ariaLabel: PropTypes.string,
         items: PropTypes.arrayOf(PropTypes.any),
       })
     ),

--- a/src/components/shared/search/search.jsx
+++ b/src/components/shared/search/search.jsx
@@ -18,7 +18,7 @@ const Search = ({ className = null }) => {
       div = document.createElement('div');
       div.classList.add('fixed');
       div.setAttribute('data-docsearch-fixed', '');
-      div.innerHTML = '<input type="text">';
+      div.innerHTML = '<input type="text" aria-label="hidden">';
       document.body.appendChild(div);
     }
   }, []);


### PR DESCRIPTION
This pull request brings the descriptive text description:
- there is an <input type=“text” /> was added as a workaround to prevent scroll in Safari when closing the Docsearch’s modal, added aria-label=“hidden” to fix the error: “Form elements do not have associated labels”.
- added a prop ariaLabel to the sidebar item, as there is a link “Go” in the sidebar, the Lighthouse considers it as a generic link text (click here, click this, go, here, this, start, right here, more, learn more)