### PR TITLE
refactor: minor refactoring for docs

### DIFF
--- a/src/components/pages/branching/branch-data/branch-data.jsx
+++ b/src/components/pages/branching/branch-data/branch-data.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
 

--- a/src/components/pages/branching/cta/cta.jsx
+++ b/src/components/pages/branching/cta/cta.jsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import React from 'react';
 
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';

--- a/src/components/pages/branching/features/features.jsx
+++ b/src/components/pages/branching/features/features.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';

--- a/src/components/pages/branching/hero/hero.jsx
+++ b/src/components/pages/branching/hero/hero.jsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import React from 'react';
 
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';

--- a/src/components/pages/branching/recovery/recovery.jsx
+++ b/src/components/pages/branching/recovery/recovery.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
 

--- a/src/components/pages/careers/hero/hero.jsx
+++ b/src/components/pages/careers/hero/hero.jsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import React from 'react';
 
 import Container from 'components/shared/container';
 

--- a/src/components/pages/developer-days/cta/cta.jsx
+++ b/src/components/pages/developer-days/cta/cta.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';

--- a/src/components/pages/developer-days/items-list/items-list.jsx
+++ b/src/components/pages/developer-days/items-list/items-list.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import Button from 'components/shared/button';
 import Link from 'components/shared/link';

--- a/src/components/pages/developer-days/register/register.jsx
+++ b/src/components/pages/developer-days/register/register.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';

--- a/src/components/pages/doc/admonition/admonition.jsx
+++ b/src/components/pages/doc/admonition/admonition.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const titleClassNames = {
   note: 'text-[#4C97FF]',

--- a/src/components/pages/home/advantages/advantages.jsx
+++ b/src/components/pages/home/advantages/advantages.jsx
@@ -1,7 +1,7 @@
 // import { motion } from 'framer-motion';
 // import { StaticImage } from 'gatsby-plugin-image';
 // import React, { useRef } from 'react';
-import React from 'react';
+
 import { useInView } from 'react-intersection-observer';
 
 // import BlinkingText from 'components/shared/blinking-text';

--- a/src/components/pages/home/advantages/icon/icon.jsx
+++ b/src/components/pages/home/advantages/icon/icon.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import useLottie from 'hooks/use-lottie';
 

--- a/src/components/pages/home/data-branching/data-branching-illustration/data-branching-illustration.jsx
+++ b/src/components/pages/home/data-branching/data-branching-illustration/data-branching-illustration.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import useLottie from 'hooks/use-lottie';
 

--- a/src/components/pages/home/data-branching/data-branching.jsx
+++ b/src/components/pages/home/data-branching/data-branching.jsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import Container from 'components/shared/container';

--- a/src/components/pages/home/features/features.jsx
+++ b/src/components/pages/home/features/features.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import BlinkingText from 'components/shared/blinking-text';

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import BlinkingText from 'components/shared/blinking-text';

--- a/src/components/pages/home/saas/saas-illustration/saas-illustration.jsx
+++ b/src/components/pages/home/saas/saas-illustration/saas-illustration.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import useLottie from 'hooks/use-lottie';
 

--- a/src/components/pages/home/saas/saas.jsx
+++ b/src/components/pages/home/saas/saas.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import BlinkingText from 'components/shared/blinking-text';

--- a/src/components/pages/home/scalability/scalability-illustration/scalability-illustration.jsx
+++ b/src/components/pages/home/scalability/scalability-illustration/scalability-illustration.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import useLottie from 'hooks/use-lottie';
 

--- a/src/components/pages/home/scalability/scalability.jsx
+++ b/src/components/pages/home/scalability/scalability.jsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import Container from 'components/shared/container';

--- a/src/components/pages/home/storage/storage-illustration/storage-illustration.jsx
+++ b/src/components/pages/home/storage/storage-illustration/storage-illustration.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import useLottie from 'hooks/use-lottie';
 

--- a/src/components/pages/home/storage/storage.jsx
+++ b/src/components/pages/home/storage/storage.jsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import Container from 'components/shared/container';

--- a/src/components/shared/anchor-heading/anchor-heading.jsx
+++ b/src/components/shared/anchor-heading/anchor-heading.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import slugify from 'slugify';
 
 import HashIcon from './images/hash.inline.svg';

--- a/src/components/shared/button/button.jsx
+++ b/src/components/shared/button/button.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import Link from 'components/shared/link';
 

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import Container from 'components/shared/container';

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -1,8 +1,5 @@
-'use client';
-
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { useInView } from 'react-intersection-observer';
 
 import Container from 'components/shared/container';
 import StatusBadge from 'components/shared/footer/status-badge';
@@ -14,11 +11,8 @@ import MENUS from 'constants/menus.js';
 const Footer = ({ isDocPage = false, withTopBorder = false, theme = 'white' }) => {
   const isDarkTheme = theme === 'black' || theme === 'black-new' || theme === 'gray-8';
 
-  const [ref, inView] = useInView({ triggerOnce: true });
-
   return (
     <footer
-      ref={ref}
       className={clsx(
         'z-999 safe-paddings relative mt-auto overflow-hidden dark:bg-gray-new-8 dark:text-white',
         !isDarkTheme && withTopBorder && 'border-t border-gray-new-90 dark:border-gray-new-20',
@@ -36,7 +30,7 @@ const Footer = ({ isDocPage = false, withTopBorder = false, theme = 'white' }) =
                 <span className="sr-only">Neon</span>
                 <Logo className="w-auto sm:h-6" isThemeBlack={isDarkTheme} />
               </Link>
-              <StatusBadge isDocPage={isDocPage} inView={inView} />
+              <StatusBadge isDocPage={isDocPage} />
             </div>
             {isDocPage && <ThemeSelect className="mt-7 xl:mt-6 md:mt-0" />}
           </div>

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useInView } from 'react-intersection-observer';

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -51,7 +51,7 @@ const Footer = ({ isDocPage = false, withTopBorder = false, theme = 'white' }) =
         <div className="flex space-x-[123px] xl:space-x-8 md:hidden">
           {MENUS.footer.map(({ heading, links }, index) => (
             <div className={clsx('flex flex-col xl:w-full')} key={index}>
-              <h3
+              <span
                 className={clsx(
                   {
                     'text-[13px] font-semibold text-gray-new-60':
@@ -61,7 +61,7 @@ const Footer = ({ isDocPage = false, withTopBorder = false, theme = 'white' }) =
                 )}
               >
                 {heading}
-              </h3>
+              </span>
               <ul className="mt-6 flex grow flex-col space-y-[18px]">
                 {links.map(({ to, text, icon: Icon }, index) => {
                   const isExternalUrl = to.startsWith('http');

--- a/src/components/shared/footer/status-badge/status-badge.jsx
+++ b/src/components/shared/footer/status-badge/status-badge.jsx
@@ -1,6 +1,8 @@
+'use client';
+
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Link from 'components/shared/link';
 
@@ -19,26 +21,24 @@ const statusData = {
   },
 };
 
-const StatusBadge = ({ isDocPage = false, inView = false }) => {
+const fetchStatus = async () => {
+  const res = await fetch('https://neonstatus.com/summary.json');
+  const data = await res.json();
+  return data.page.status;
+};
+
+const StatusBadge = ({ isDocPage = false }) => {
   const [currentStatus, setCurrentStatus] = useState(null);
 
-  const fetchStatus = async () => {
-    const res = await fetch('https://neonstatus.com/summary.json');
-    const data = await res.json();
-    return data.page.status;
-  };
-
   useEffect(() => {
-    if (inView) {
-      fetchStatus()
-        .then((status) => {
-          setCurrentStatus(status);
-        })
-        .catch((error) => {
-          console.error(error);
-        });
-    }
-  }, [inView]);
+    fetchStatus()
+      .then((status) => {
+        setCurrentStatus(status);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }, []);
 
   return (
     <Link

--- a/src/components/shared/footer/theme-select/theme-select.jsx
+++ b/src/components/shared/footer/theme-select/theme-select.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import { useTheme } from 'next-themes';

--- a/src/components/shared/header/burger/burger.jsx
+++ b/src/components/shared/header/burger/burger.jsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const ANIMATION_DURATION = 0.2;
 

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -2,12 +2,13 @@
 
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React, { forwardRef } from 'react';
+import { useRef, useState } from 'react';
 
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';
 import Link from 'components/shared/link';
 import Logo from 'components/shared/logo';
+import MobileMenu from 'components/shared/mobile-menu';
 import Search from 'components/shared/search';
 import LINKS from 'constants/links';
 import MENUS from 'constants/menus.js';
@@ -26,22 +27,28 @@ const icons = {
   aboutUs: AboutUsIcon,
 };
 
-const Header = forwardRef(
-  (
-    {
-      theme,
-      isMobileMenuOpen = false,
-      onBurgerClick,
-      isSignIn = false,
-      isSticky = false,
-      withBottomBorder = false,
-      isDocPage = false,
-    },
-    ref
-  ) => {
-    const isThemeBlack = theme === 'black' || theme === 'black-new' || theme === 'gray-8';
+const Header = ({
+  theme,
 
-    return (
+  isSignIn = false,
+  isSticky = false,
+  withBottomBorder = false,
+  isDocPage = false,
+}) => {
+  const isThemeBlack = theme === 'black' || theme === 'black-new' || theme === 'gray-8';
+  const headerRef = useRef(null);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const handleMobileMenuOutsideClick = () => {
+    if (isMobileMenuOpen) setIsMobileMenuOpen(false);
+  };
+
+  const handleBurgerClick = () => {
+    setIsMobileMenuOpen((isMobileMenuOpen) => !isMobileMenuOpen);
+  };
+
+  return (
+    <>
       <header
         className={clsx(
           'safe-paddings absolute left-0 right-0 top-0 z-40 w-full dark:bg-gray-new-8 lg:relative lg:h-14',
@@ -55,7 +62,7 @@ const Header = forwardRef(
           { 'lg:bg-black-new': theme === 'black-new' },
           { 'bg-white': theme === 'white' }
         )}
-        ref={ref}
+        ref={headerRef}
       >
         <Container className="flex items-center justify-between py-3.5" size="lg">
           <Link to="/">
@@ -159,20 +166,23 @@ const Header = forwardRef(
             <Burger
               className={clsx(isThemeBlack ? 'text-white' : 'text-black dark:text-white')}
               isToggled={isMobileMenuOpen}
-              onClick={onBurgerClick}
+              onClick={handleBurgerClick}
             />
           </div>
         </Container>
       </header>
-    );
-  }
-);
+      <MobileMenu
+        isOpen={isMobileMenuOpen}
+        headerRef={headerRef}
+        onOutsideClick={handleMobileMenuOutsideClick}
+      />
+    </>
+  );
+};
 
 Header.propTypes = {
   theme: PropTypes.oneOf(['white', 'black', 'black-new', 'gray-8']).isRequired,
   withBottomBorder: PropTypes.bool,
-  isMobileMenuOpen: PropTypes.bool,
-  onBurgerClick: PropTypes.func.isRequired,
   isSignIn: PropTypes.bool,
   isSticky: PropTypes.bool,
   isDocPage: PropTypes.bool,

--- a/src/components/shared/layout/layout.jsx
+++ b/src/components/shared/layout/layout.jsx
@@ -1,12 +1,8 @@
-'use client';
-
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React, { useState, useRef } from 'react';
 
 import Footer from 'components/shared/footer';
 import Header from 'components/shared/header';
-import MobileMenu from 'components/shared/mobile-menu';
 
 const Layout = ({
   className = null,
@@ -19,49 +15,28 @@ const Layout = ({
   headerWithBottomBorder = false,
   footerWithTopBorder = false,
   isDocPage = false,
-}) => {
-  const headerRef = useRef(null);
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-
-  const handleMobileMenuOutsideClick = () => {
-    if (isMobileMenuOpen) setIsMobileMenuOpen(false);
-  };
-
-  const handleHeaderBurgerClick = () => {
-    setIsMobileMenuOpen((isMobileMenuOpen) => !isMobileMenuOpen);
-  };
-
-  return (
-    // 44px is the height of the topbar
-    <div className="relative flex min-h-[calc(100vh-44px)] flex-col">
-      <Header
-        withBottomBorder={headerWithBottomBorder}
-        theme={headerTheme}
-        isMobileMenuOpen={isMobileMenuOpen}
-        ref={headerRef}
-        isSignIn={isSignIn}
-        isSticky={isHeaderSticky}
-        isDocPage={isDocPage}
-        onBurgerClick={handleHeaderBurgerClick}
-      />
-      <main
-        className={clsx(
-          withOverflowHidden && 'overflow-hidden',
-          'flex flex-1 flex-col dark:bg-black',
-          className
-        )}
-      >
-        {children}
-      </main>
-      <Footer isDocPage={isDocPage} theme={footerTheme} withTopBorder={footerWithTopBorder} />
-      <MobileMenu
-        isOpen={isMobileMenuOpen}
-        headerRef={headerRef}
-        onOutsideClick={handleMobileMenuOutsideClick}
-      />
-    </div>
-  );
-};
+}) => (
+  // 44px is the height of the topbar
+  <div className="relative flex min-h-[calc(100vh-44px)] flex-col">
+    <Header
+      withBottomBorder={headerWithBottomBorder}
+      theme={headerTheme}
+      isSignIn={isSignIn}
+      isSticky={isHeaderSticky}
+      isDocPage={isDocPage}
+    />
+    <main
+      className={clsx(
+        withOverflowHidden && 'overflow-hidden',
+        'flex flex-1 flex-col dark:bg-black',
+        className
+      )}
+    >
+      {children}
+    </main>
+    <Footer isDocPage={isDocPage} theme={footerTheme} withTopBorder={footerWithTopBorder} />
+  </div>
+);
 
 Layout.propTypes = {
   className: PropTypes.string,

--- a/src/components/shared/subscribe-minimalistic/subscribe-minimalistic.jsx
+++ b/src/components/shared/subscribe-minimalistic/subscribe-minimalistic.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Container from 'components/shared/container';
 import SubscriptionForm from 'components/shared/subscription-form';
 import { HUBSPOT_NEWSLETTERS_FORM_ID } from 'constants/forms';

--- a/src/components/shared/subscribe/subscribe.jsx
+++ b/src/components/shared/subscribe/subscribe.jsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import React from 'react';
 
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';


### PR DESCRIPTION
This pull request brings minor refactoring:
- removed importing react
- renamed heading `h3` in footer into `span` (avoid the error when heading hierarchy out of order
- set `layout` and `footer` components as server components
- removed IntersectionObserver for StatusBadge in footer