### PR TITLE
fix: add link colors and hover to admonitions

### DIFF
--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -1,5 +1,8 @@
 @layer components {
   .admonition-text {
+    a {
+      @apply border-b border-transparent font-normal text-secondary-8 no-underline transition-[border-color] duration-200 ease-in-out hover:border-secondary-8 dark:text-primary-1 dark:hover:border-primary-1 sm:break-words;
+    }
     p:first-child {
       @apply mt-0;
     }


### PR DESCRIPTION
This PR resolves the missing link highlighting issue in Admonitions blocks in the docs

Before: 
![image](https://github.com/neondatabase/website/assets/48825888/027ae38d-beae-4922-935f-78358323ae54)

After:
![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/9e02c398-9c6f-4f55-833f-cf2a6a34fe9a/Untitled.png)