### PR TITLE
feat: add support of special symbols in ToC

### DIFF
--- a/content/docs/extensions/pg_tiktoken.md
+++ b/content/docs/extensions/pg_tiktoken.md
@@ -14,14 +14,14 @@ Language models process text in units called tokens. A token can be as short as 
 
 For example, consider the sentence "Neon is serverless Postgres." It can be divided into seven tokens: ["Ne", "on", "is", "server", "less", "Post", "gres"].
 
-## pg_tiktoken functions
+## `pg_tiktoken` functions
 
 The `pg_tiktoken` offers two functions:
 
 - `tiktoken_encode`: Accepts text inputs and returns tokenized output, allowing you to seamlessly tokenize your text data.
 - `tiktoken_count`: Counts the number of tokens in a given text. This feature helps you adhere to text length limits, such as those set by OpenAI's language models.
 
-## Install the pg_tiktoken extension
+## Install the `pg_tiktoken` extension
 
 You can install the `pg_tiktoken` extension by running the following `CREATE EXTENSION` statement in the Neon **SQL Editor** or from a client such as `psql` that is connected to Neon.
 
@@ -31,7 +31,7 @@ CREATE EXTENSION pg_tiktoken
 
 For information about using the Neon **SQL Editor**, see [Query with Neon's SQL Editor](/docs/get-started-with-neon/query-with-neon-sql-editor). For information about using the `psql` client with Neon, see [Connect with psql](/docs/connect/query-with-psql-editor).
 
-## Use the tiktoken_encode function
+## Use the `tiktoken_encode` function
 
 The `tiktoken_encode` function tokenizes text input and returns a tokenized output. The function accepts encoding names and OpenAI model names as the first argument and the text you want to tokenize as the second argument, as shown:
 
@@ -46,7 +46,7 @@ tiktoken_encode
 
 The function tokenizes text using the [Byte Pair Encoding (BPE)](https://en.wikipedia.org/wiki/Byte_pair_encoding) algorithm.
 
-## Use the tiktoken_count function
+## Use the `tiktoken_count` function
 
 The `tiktoken_count` function counts the number of tokens in a text. The function accepts encoding names and OpenAI model names as the first argument and text as the second argument, as shown:
 
@@ -76,7 +76,7 @@ The following models are supported:
 | p50k_edit          | Use for edit models like text-davinci-edit-001, code-davinci-edit-001 |
 | r50k_base (or gpt2)| GPT-3 models like davinci                         |
 
-## Integrate pg_tiktoken with ChatGPT models
+## Integrate `pg_tiktoken` with ChatGPT models
 
 The `pg_tiktoken` extension allows you to store chat message history in a PostgreSQL database and retrieve messages that comply with OpenAI's model limitations.
 

--- a/src/components/pages/doc/table-of-contents/table-of-contents.jsx
+++ b/src/components/pages/doc/table-of-contents/table-of-contents.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import TOCIcon from './images/toc.inline.svg';
 
 const linkClassName =
-  'py-1.5 block text-sm leading-tight transition-colors duration-200 text-gray-new-40 hover:text-black-new dark:text-gray-new-90 dark:hover:text-white';
+  'py-1.5 block text-sm leading-tight transition-colors duration-200 text-gray-new-40 hover:text-black-new dark:text-gray-new-90 dark:hover:text-white [&_code]:rounded-sm [&_code]:bg-gray-new-94 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:font-normal dark:[&_code]:bg-gray-new-15';
 
 const TableOfContents = ({ items }) => {
   const handleAnchorClick = (e, anchor) => {
@@ -44,19 +44,17 @@ const TableOfContents = ({ items }) => {
                 <a
                   className={linkClassName}
                   href={linkHref}
+                  dangerouslySetInnerHTML={{ __html: item.title }}
                   onClick={(e) => handleAnchorClick(e, linkHref)}
-                >
-                  {item.title}
-                </a>
+                />
               )}
               {item.level === 3 && (
                 <a
                   className={clsx(linkClassName, 'ml-3')}
                   href={linkHref}
+                  dangerouslySetInnerHTML={{ __html: item.title }}
                   onClick={(e) => handleAnchorClick(e, linkHref)}
-                >
-                  {item.title}
-                </a>
+                />
               )}
             </li>
           );

--- a/src/components/pages/doc/table-of-contents/table-of-contents.jsx
+++ b/src/components/pages/doc/table-of-contents/table-of-contents.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import TOCIcon from './images/toc.inline.svg';
 
 const linkClassName =
-  'py-1.5 block text-sm leading-tight transition-colors duration-200 text-gray-new-40 hover:text-black-new dark:text-gray-new-90 dark:hover:text-white [&_code]:rounded-sm [&_code]:bg-gray-new-94 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:font-normal dark:[&_code]:bg-gray-new-15';
+  'py-1.5 block text-sm leading-tight transition-colors duration-200 text-gray-new-40 hover:text-black-new dark:text-gray-new-90 dark:hover:text-white [&_code]:rounded-sm [&_code]:leading-none [&_code]:py-px [&_code]:bg-gray-new-94 [&_code]:px-1.5 [&_code]:font-mono [&_code]:font-normal dark:[&_code]:bg-gray-new-15';
 
 const TableOfContents = ({ items }) => {
   const handleAnchorClick = (e, anchor) => {

--- a/src/components/shared/anchor-heading/anchor-heading.jsx
+++ b/src/components/shared/anchor-heading/anchor-heading.jsx
@@ -14,7 +14,7 @@ const AnchorHeading =
         : undefined;
 
     return (
-      <Tag id={id} className="not-prose group relative flex w-fit">
+      <Tag id={id} className="not-prose group relative w-fit">
         <a
           className="anchor absolute -right-16 top-1/2 flex h-full -translate-x-full -translate-y-[calc(50%-0.15rem)] items-center justify-center px-2.5 no-underline opacity-0 transition-opacity duration-200 hover:opacity-100 group-hover:opacity-100 sm:hidden"
           href={`#${id}`}

--- a/src/utils/api-docs.js
+++ b/src/utils/api-docs.js
@@ -107,11 +107,16 @@ const getTableOfContents = (content) => {
 
   const toc = [];
 
-  arr.forEach((item) => {
+  arr.forEach(async (item) => {
     const [depth, title] = parseMDXHeading(item);
+    // remove : from the end of the title
+    const titleWithoutColon = title.replace(/[:]$/, '');
+    // replace mdx inline code with html inline code
+    const titleWithInlineCode = titleWithoutColon.replace(/`([^`]+)`/g, '<code>$1</code>');
+
     if (title && depth && depth <= 2) {
       toc.push({
-        title: title.replace(/[^a-zA-Z\s]/g, ''),
+        title: titleWithInlineCode,
         id: slugify(title, { lower: true, strict: true, remove: /[*+~.()'"!:@]/g }),
         level: depth + 1,
       });

--- a/src/utils/api-docs.js
+++ b/src/utils/api-docs.js
@@ -107,12 +107,11 @@ const getTableOfContents = (content) => {
 
   const toc = [];
 
-  arr.forEach(async (item) => {
+  arr.forEach((item) => {
     const [depth, title] = parseMDXHeading(item);
-    // remove : from the end of the title
-    const titleWithoutColon = title.replace(/[:]$/, '');
+
     // replace mdx inline code with html inline code
-    const titleWithInlineCode = titleWithoutColon.replace(/`([^`]+)`/g, '<code>$1</code>');
+    const titleWithInlineCode = title.replace(/`([^`]+)`/g, '<code>$1</code>');
 
     if (title && depth && depth <= 2) {
       toc.push({


### PR DESCRIPTION
This pull request brings the support of inline code and special characters in Table of Contents

<details>
<summary>Screenshots</summary>
Before:
<img width="1101" alt="image" src="https://github.com/neondatabase/website/assets/48465000/01b5c88d-e9f7-401e-b2a7-da717e14fc00">


After:
<img width="1239" alt="image" src="https://github.com/neondatabase/website/assets/48465000/4c927ed1-ec46-44e8-abfe-c2bd2ddc18e5">

</details>

**Preview**: https://neon-next-git-special-symbols-neondatabase.vercel.app/docs/extensions/pg_tiktoken