### PR TITLE
Update aws-lambda.md

### DIFF
--- a/content/docs/guides/aws-lambda.md
+++ b/content/docs/guides/aws-lambda.md
@@ -150,7 +150,7 @@ Create the Lambda function using the [Serverless Framework](https://www.serverle
 
     module.exports.getAllUsers = async () => {
      if (!client) {
-       var client = new Client(process.env.DATABASE_URL);
+       client = new Client(process.env.DATABASE_URL);
        await client.connect();
      }
 

--- a/content/docs/guides/aws-lambda.md
+++ b/content/docs/guides/aws-lambda.md
@@ -146,11 +146,16 @@ Create the Lambda function using the [Serverless Framework](https://www.serverle
     'use strict';
 
     const { Client } = require('pg');
+    let client;
 
     module.exports.getAllUsers = async () => {
-     var client = new Client(process.env.DATABASE_URL);
-     client.connect();
-     var { rows } = await client.query('SELECT * from users');
+     if (!client) {
+       var client = new Client(process.env.DATABASE_URL);
+       await client.connect();
+     }
+
+     const { rows } = await client.query('SELECT * from users');
+
      return {
        statusCode: 200,
        body: JSON.stringify({


### PR DESCRIPTION
Using this approach (declaring client outside the handler func) ensures that the client connection is persisted across warm starts. This prevents too many new connections from being instantiated to the NEON DB.

Also, `client.connect()` returns a Promise, and that was overlooked in the previous example.