### PR TITLE
feat: implement blog code tabs

### DIFF
--- a/src/app/blog/[slug]/page.jsx
+++ b/src/app/blog/[slug]/page.jsx
@@ -2,6 +2,7 @@ import { draftMode } from 'next/headers';
 import { notFound } from 'next/navigation';
 
 import Aside from 'components/pages/blog-post/aside';
+import CodeTabs from 'components/pages/blog-post/code-tabs';
 import Content from 'components/pages/blog-post/content';
 import CTA from 'components/pages/blog-post/cta';
 import Hero from 'components/pages/blog-post/hero';
@@ -42,6 +43,7 @@ const BlogPage = async ({ params, searchParams }) => {
     content,
     {
       blogpostcode: CodeBlock,
+      blogpostcodetabs: CodeTabs,
       blogpostcta: CTA,
     },
     true

--- a/src/components/pages/blog-post/code-tabs/code-tabs.jsx
+++ b/src/components/pages/blog-post/code-tabs/code-tabs.jsx
@@ -1,0 +1,58 @@
+'use client';
+
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+
+import CodeBlock from 'components/shared/code-block';
+
+const CodeTabs = ({ items }) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  return (
+    <figure className="my-5 max-w-full overflow-hidden rounded-md bg-black-new">
+      <div className="no-scrollbars relative flex w-full flex-nowrap overflow-auto after:absolute after:bottom-0 after:h-px after:w-full after:bg-gray-new-20">
+        {items.map(({ label }, index) => (
+          <button
+            className={clsx(
+              'relative z-10 cursor-pointer whitespace-nowrap border-b-2 px-[18px] pb-3.5 pt-3 text-base font-semibold leading-none transition-colors duration-200 hover:text-green-45',
+              index === currentIndex
+                ? 'border-green-45 text-green-45 after:opacity-100'
+                : 'border-transparent text-gray-new-90'
+            )}
+            key={`lb-${index}`}
+            type="button"
+            onClick={() => setCurrentIndex(index)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {items
+        .filter((_, index) => index === currentIndex)
+        .map(({ language, code, highlight }, index) => (
+          <CodeBlock
+            className="[&_pre]:my-0"
+            language={language}
+            key={index}
+            highlight={highlight.toString()}
+            showLineNumbers
+            isBlogPost
+          >
+            {code}
+          </CodeBlock>
+        ))}
+    </figure>
+  );
+};
+
+CodeTabs.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      language: PropTypes.string.isRequired,
+      code: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+};
+
+export default CodeTabs;

--- a/src/components/pages/blog-post/code-tabs/index.js
+++ b/src/components/pages/blog-post/code-tabs/index.js
@@ -1,0 +1,3 @@
+import CodeTabs from './code-tabs';
+
+export default CodeTabs;

--- a/src/components/shared/code-block/code-block.jsx
+++ b/src/components/shared/code-block/code-block.jsx
@@ -60,7 +60,7 @@ const CodeBlock = ({
         language={snippetLanguage}
         useInlineStyles={false}
         showLineNumbers={showLineNumbers || highlight !== ''}
-        className="no-scrollbars"
+        className={clsx('no-scrollbars', { highlight: highlight !== '' })}
         lineProps={(lineNumber) => ({
           style: {
             display: 'flex',

--- a/src/components/shared/code-block/code-block.jsx
+++ b/src/components/shared/code-block/code-block.jsx
@@ -38,6 +38,7 @@ const CodeBlock = ({
   isTrimmed = true,
   highlight = '',
   as: Tag = 'div',
+  isBlogPost = false,
   ...otherProps
 }) => {
   const { resolvedTheme: theme } = useTheme();
@@ -64,15 +65,17 @@ const CodeBlock = ({
           style: {
             display: 'flex',
             position: 'relative',
-            padding: '1.5px 16px',
-            marginLeft: '-1rem',
-            marginRight: '-1rem',
+            padding: isBlogPost ? '1.5px 24px' : '1.5px 16px',
+            marginLeft: isBlogPost ? '-1.5rem' : '-1rem',
+            marginRight: isBlogPost ? '-1.5rem' : '-1rem',
             backgroundColor:
               highlightedLines.includes(lineNumber) &&
-              (theme === 'dark' ? 'rgba(0, 229, 153, 0.08)' : 'rgba(0, 85, 255, 0.08)'),
+              (theme === 'dark' || isBlogPost
+                ? 'rgba(0, 229, 153, 0.08)'
+                : 'rgba(0, 85, 255, 0.08)'),
             boxShadow:
               highlightedLines.includes(lineNumber) &&
-              (theme === 'dark'
+              (theme === 'dark' || isBlogPost
                 ? 'inset 3px 0px 0px 0px #00E599'
                 : 'inset 3px 0px 0px 0px #0055ff'),
           },
@@ -108,6 +111,7 @@ CodeBlock.propTypes = {
   isTrimmed: PropTypes.bool,
   highlight: PropTypes.string,
   as: PropTypes.oneOf(['figure', 'pre']),
+  isBlogPost: PropTypes.bool,
 };
 
 export default CodeBlock;

--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -80,12 +80,12 @@
     }
 
     pre {
-      @apply !bg-black-new;
+      @apply !bg-black-new px-0;
 
-      code {
+      > code {
         text-shadow: unset !important;
 
-        @apply highlighted-code overflow-x-auto !font-mono !text-sm leading-normal !text-white md:min-w-[686px];
+        @apply highlighted-code inline-block overflow-x-auto px-6 !font-mono !text-sm leading-normal !text-white md:min-w-[686px];
       }
     }
 

--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -80,12 +80,20 @@
     }
 
     pre {
-      @apply !bg-black-new px-0;
+      @apply !bg-black-new;
+
+      &.highlight {
+        @apply px-0;
+
+        > code {
+          @apply inline-block w-full px-6 !leading-relaxed;
+        }
+      }
 
       > code {
         text-shadow: unset !important;
 
-        @apply highlighted-code inline-block w-full overflow-x-auto px-6 !font-mono !text-sm !leading-[1.725] !text-white md:min-w-[686px];
+        @apply highlighted-code overflow-x-auto !font-mono !text-sm !text-white md:min-w-[686px];
       }
     }
 

--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -85,7 +85,7 @@
       > code {
         text-shadow: unset !important;
 
-        @apply highlighted-code inline-block overflow-x-auto px-6 !font-mono !text-sm leading-normal !text-white md:min-w-[686px];
+        @apply highlighted-code inline-block w-full overflow-x-auto px-6 !font-mono !text-sm !leading-[1.725] !text-white md:min-w-[686px];
       }
     }
 

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -100,7 +100,7 @@
       > code {
         text-shadow: unset;
 
-        @apply highlighted-code inline-block px-4 !font-mono text-sm !text-black-new dark:!text-white dark:![text-shadow:unset] md:min-w-[686px];
+        @apply highlighted-code inline-block w-full px-4 !font-mono text-sm !leading-[1.725] !text-black-new dark:!text-white dark:![text-shadow:unset] md:min-w-[686px];
       }
     }
 

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -95,12 +95,12 @@
     }
 
     pre {
-      @apply my-5 !bg-gray-new-98 dark:!bg-gray-new-10;
+      @apply my-5 !bg-gray-new-98 px-0 dark:!bg-gray-new-10;
 
-      code {
+      > code {
         text-shadow: unset;
 
-        @apply highlighted-code !font-mono text-sm !text-black-new dark:!text-white dark:![text-shadow:unset];
+        @apply highlighted-code inline-block px-4 !font-mono text-sm !text-black-new dark:!text-white dark:![text-shadow:unset] md:min-w-[686px];
       }
     }
 

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -95,12 +95,20 @@
     }
 
     pre {
-      @apply my-5 !bg-gray-new-98 px-0 dark:!bg-gray-new-10;
+      @apply my-5 !bg-gray-new-98 dark:!bg-gray-new-10;
+
+      &.highlight {
+        @apply px-0;
+
+        > code {
+          @apply inline-block w-full px-4 !leading-relaxed;
+        }
+      }
 
       > code {
         text-shadow: unset;
 
-        @apply highlighted-code inline-block w-full px-4 !font-mono text-sm !leading-[1.725] !text-black-new dark:!text-white dark:![text-shadow:unset] md:min-w-[686px];
+        @apply highlighted-code !font-mono text-sm !text-black-new dark:!text-white dark:![text-shadow:unset] md:min-w-[686px];
       }
     }
 


### PR DESCRIPTION
This pull request brings the code tabs for the blog posts

**Additional changes**
- add code line highlight support

**TODO**
- [x] remove examples from WP before merging
 
**Screenshots**
<img width="755" alt="image" src="https://github.com/neondatabase/website/assets/48465000/729e9bd8-b108-4ab7-9a14-a4ba7f1013cb">

**Preview**: https://neon-next-git-blog-code-tabs-neondatabase.vercel.app/blog/hello-world
