### PR TITLE
Remove draft setting for CLI docs

### DIFF
--- a/content/docs/reference/cli-auth.md
+++ b/content/docs/reference/cli-auth.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — auth
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — branches
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-completion.md
+++ b/content/docs/reference/cli-completion.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — completion
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-connection-string.md
+++ b/content/docs/reference/cli-connection-string.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — connection-string
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-databases.md
+++ b/content/docs/reference/cli-databases.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — databases
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-me.md
+++ b/content/docs/reference/cli-me.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — me
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-operations.md
+++ b/content/docs/reference/cli-operations.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — operations
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — projects
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/cli-roles.md
+++ b/content/docs/reference/cli-roles.md
@@ -2,7 +2,6 @@
 title: Neon CLI commands — roles
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 ## Before you begin

--- a/content/docs/reference/neon-cli.md
+++ b/content/docs/reference/neon-cli.md
@@ -2,7 +2,6 @@
 title: Neon CLI
 subtitle: Use the Neon CLI to manage Neon projects directly from your terminal
 enableTableOfContents: true
-isDraft: true
 ---
 
 The Neon CLI supports numerous operations, such as authentication and management of Neon projects, branches, compute endpoints, databases, roles, and more.


### PR DESCRIPTION
Remove the draft setting so that CLI docs show up on the docs site