### PR TITLE
Update banner

### DIFF
--- a/src/components/shared/topbar/topbar.jsx
+++ b/src/components/shared/topbar/topbar.jsx
@@ -16,10 +16,10 @@ const TopBar = () => {
   return isTopBarHidden ? null : (
     <Link
       className="safe-paddings relative z-40 flex h-11 w-full items-center justify-center bg-primary-1 px-4 py-3 leading-none transition-colors duration-200 hover:bg-[#1AFFB2] xs:h-auto"
-      to="/blog/postgres-autoscaling"
+      to="/blog/sub-10ms-postgres-queries-for-vercel-edge-functions"
     >
       <span className="mr-4 truncate border-r border-black border-opacity-20 py-1 pr-4 text-sm font-semibold">
-        Announcing autoscaling in feature-preview!
+        Sub-10ms Postgres queries for Vercel Edge Functions 🚀{' '}
       </span>
       <span className="inline-flex items-center text-sm font-bold sm:hidden">
         <span>Learn More</span>


### PR DESCRIPTION
Update Banner to use the following text

> Sub-10ms Postgres queries for Vercel Edge Functions 🚀

<img width="1728" alt="Homepage with banner" src="https://github.com/neondatabase/website/assets/27310414/2514f8ec-ab7f-4461-b7b1-0e0e70e8a837">
