### PR TITLE
fix: rename message key in partners form

### DIFF
--- a/src/components/pages/partners/apply/form/form.jsx
+++ b/src/components/pages/partners/apply/form/form.jsx
@@ -78,8 +78,8 @@ const Form = ({ className }) => {
 
   const onSubmit = async (formData, e) => {
     e.preventDefault();
-
-    const data = { ...formData };
+    const { message, ...rest } = formData;
+    const data = { ...rest, 'TICKET.content': message };
 
     data.application_scope = data.application_scope?.map(({ id }) => id).join(';');
     data.integration_type = data.integration_type.name;


### PR DESCRIPTION
This PR brings the renaming of message key in partners' form
- rename from `message` to `TICKET.content`