### PR TITLE
Revise CLI intro content for SEO

### DIFF
--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -43,7 +43,7 @@ CREATE ROLE neon_superuser CREATEDB CREATEROLE NOLOGIN IN ROLE pg_read_all_data,
 - `pg_read_all_data role`: A predefined role in PostgreSQL that provides the ability to select from all tables and views.
 - `pg_write_all_data`: A predefined role in PostgreSQL that provides the ability to insert, update, and delete in all tables and use all sequences in a database.
 
-In addition, the `neon_superuser` role is able to add [PostgreSQL extensions](/docs/extensions/pg_extensions) that are available for use with Neon.
+In addition, the `neon_superuser` role is able to add [PostgreSQL extensions](/docs/extensions/pg-extensions) that are available for use with Neon.
 
 You can think of roles with `neon_superuser` privileges as administrators. For all other users, you can create roles and manage database object access privileges with SQL. See [Manage roles with SQL](#manage-roles-with-sql).
 

--- a/content/docs/reference/cli-auth.md
+++ b/content/docs/reference/cli-auth.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+Before running the `auth` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 
 ## The `auth` command
 

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-- Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+- Before running the `branches` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 - If you have not authenticated with the [neonctl auth](/docs/reference/cli-auth) command, running a Neon CLI command automatically launches the Neon CLI browser authentication process. Alternatively, you can specify a Neon API key using the `--api-key` option when running a command. See [Connect](/docs/reference/neon-cli#connect).
 
 ## The `branches` command

--- a/content/docs/reference/cli-completion.md
+++ b/content/docs/reference/cli-completion.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+Before running the `completion` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 
 ## The `completion` command
 

--- a/content/docs/reference/cli-connection-string.md
+++ b/content/docs/reference/cli-connection-string.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-- Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+- Before running the `connection-string` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 - If you have not authenticated with the [neonctl auth](/docs/reference/cli-auth) command, running a Neon CLI command automatically launches the Neon CLI browser authentication process. Alternatively, you can specify a Neon API key using the `--api-key` option when running a command. See [Connect](/docs/reference/neon-cli#connect).
 
 For information about connecting to Neon, see [Connect from any application](/docs/connect/connect-from-any-app).

--- a/content/docs/reference/cli-databases.md
+++ b/content/docs/reference/cli-databases.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-- Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+- Before running the `databases` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 - If you have not authenticated with the [neonctl auth](/docs/reference/cli-auth) command, running a Neon CLI command automatically launches the Neon CLI browser authentication process. Alternatively, you can specify a Neon API key using the `--api-key` option when running a command. See [Connect](/docs/reference/neon-cli#connect).
 
 For information about databases in Neon, see [Manage databases](/docs/manage/databases).

--- a/content/docs/reference/cli-me.md
+++ b/content/docs/reference/cli-me.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-- Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+- Before running the `me` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 - If you have not authenticated with the [neonctl auth](/docs/reference/cli-auth) command, running a Neon CLI command automatically launches the Neon CLI browser authentication process. Alternatively, you can specify a Neon API key using the `--api-key` option when running a command. See [Connect](/docs/reference/neon-cli#connect).
 
 ## The `me` command

--- a/content/docs/reference/cli-operations.md
+++ b/content/docs/reference/cli-operations.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-- Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+- Before running the `operations` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 - If you have not authenticated with the [neonctl auth](/docs/reference/cli-auth) command, running a Neon CLI command automatically launches the Neon CLI browser authentication process. Alternatively, you can specify a Neon API key using the `--api-key` option when running a command. See [Connect](/docs/reference/neon-cli#connect).
 
 For information about operations in Neon, see [Operations](/docs/manage/operations).

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-- Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+- Before running the `projects` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 - If you have not authenticated with the [neonctl auth](/docs/reference/cli-auth) command, running a Neon CLI command automatically launches the Neon CLI browser authentication process. Alternatively, you can specify a Neon API key using the `--api-key` option when running a command. See [Connect](/docs/reference/neon-cli#connect).
 
 For information about projects in Neon, see [Projects](/docs/manage/projects).

--- a/content/docs/reference/cli-roles.md
+++ b/content/docs/reference/cli-roles.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 ## Before you begin
 
-- Ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
+- Before running the `roles` command, ensure that you have [installed the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli).
 - If you have not authenticated with the [neonctl auth](/docs/reference/cli-auth) command, running a Neon CLI command automatically launches the Neon CLI browser authentication process. Alternatively, you can specify a Neon API key using the `--api-key` option when running a command. See [Connect](/docs/reference/neon-cli#connect).
 
 For information about roles in Neon, see [Manage roles](/docs/manage/roles).


### PR DESCRIPTION
This fix is to avoid duplicate meta description issues reported by the Semrush SEO Audit