### PR TITLE
07-13 Console release notes

### DIFF
--- a/content/docs/reference/neon-cli.md
+++ b/content/docs/reference/neon-cli.md
@@ -38,6 +38,12 @@ To install the Neon CLI, run the following command:
 npm i -g neonctl
 ```
 
+Homebrew is also supported:
+
+```bash
+brew install neonctl
+```
+
 ### Upgrade
 
 To upgrade to the latest version of the Neon CLI, run the `npm i -g neonctl` command again.

--- a/content/release-notes/2023-07-13-console.md
+++ b/content/release-notes/2023-07-13-console.md
@@ -4,8 +4,8 @@ label: 'Console'
 
 ### What's new
 
-- Control Plane: The polling interval for a branch deletion operation was decreased from approximately 20 seconds to 1 second. A branch deletion operation typically takes a few seconds but appeared to take longer due to the long polling delay.
+- Control Plane: The polling interval for a branch deletion operation was decreased from approximately 20 seconds to 1 second. A branch deletion operation typically takes a few seconds but appeared to take longer due to the polling delay.
 
 ### Bug fixes
 
-- UI: Fixed the code example copy button in the **Connection Details** widget, which failed to remain stationary when scrolling.
+- UI: Fixed the code example copy button in the **Connection Details** widget, which failed to remain stationary while scrolling.

--- a/content/release-notes/2023-07-13-console.md
+++ b/content/release-notes/2023-07-13-console.md
@@ -1,0 +1,11 @@
+---
+label: 'Console'
+---
+
+### What's new
+
+- Control Plane: The polling interval for a branch deletion operation was decreased from approximately 20 seconds to 1 second. A branch deletion operation typically takes a few seconds but appeared to take longer due to the long polling delay.
+
+### Bug fixes
+
+- UI: Fixed the code example copy button in the **Connection Details** widget, which failed to remain stationary when scrolling.


### PR DESCRIPTION
Console release notes for 7-13 release (Please pardon the delay. I am playing catch-up after launch week.)
https://neon-next-git-dprice-07-13-console-release-notes-neondatabase.vercel.app/docs/release-notes/2023-07-13-console

- Just a couple of items. Mostly internal changes and fixes.
- Minor addition to CLI content (for Homebrew install support)
Note: Dark theme was covered in 07-14 release notes that coincided with launch week announcement date, so it's not included here.

