### PR TITLE
Remove role and database access management example.

### DIFF
--- a/content/docs/guides/manage-database-access.md
+++ b/content/docs/guides/manage-database-access.md
@@ -2,6 +2,7 @@
 title: Manage roles and database access with SQL
 subtitle: Learn how to create roles and manage database access in Neon with SQL
 enableTableOfContents: true
+isDraft: true
 ---
 
 This guide shows how to manage database access in Neon using SQL. This guide will lead you through connecting to Neon with an administrator role, creating a database, creating a role for privilege management, and granting privileges to that role. It will then show how to create roles for database users and grant role membership to those users that will allow them to use the new database.

--- a/content/docs/manage/databases.md
+++ b/content/docs/manage/databases.md
@@ -313,8 +313,6 @@ Most standard [PostgreSQL CREATE DATABASE parameters](https://www.postgresql.org
 
 The role that creates a database is the owner of the database. This role has the typical default PostgreSQL privileges on the database, including the ability to `DROP` the database, `CONNECT` to the database, and create new `SCHEMAS` in it. For more information about database object privileges in PostgreSQL, see [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html).
 
-For a database creation example, refer to the [Manage roles and database access with SQL](/docs/guides/manage-database-access) guide.
-
 ## Need help?
 
 Send a request to [support@neon.tech](mailto:support@neon.tech), or join the [Neon community forum](https://community.neon.tech/).

--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -45,7 +45,9 @@ CREATE ROLE neon_superuser CREATEDB CREATEROLE NOLOGIN IN ROLE pg_read_all_data,
 
 In addition, the `neon_superuser` role is able to add [PostgreSQL extensions](/docs/extensions/pg-extensions) that are available for use with Neon.
 
-You can think of roles with `neon_superuser` privileges as administrators. For all other users, you can create roles and manage database object access privileges with SQL. See [Manage roles with SQL](#manage-roles-with-sql).
+You can think of roles with `neon_superuser` privileges as administrators. For all other users, you can create roles and manage database object privileges with SQL. See [Manage roles with SQL](#manage-roles-with-sql).
+
+Roes in Neon are not permitted to grant or revoke membership in other roles.
 
 ## Manage roles in the Neon console
 

--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -354,8 +354,6 @@ CREATE ROLE <name> WITH LOGIN PASSWORD 'password';
     The guidelines should help you create a password with approximately 60 bits of entropy. However, depending on the exact characters used, the actual entropy might vary slightly. Always aim for a longer and more complex password if you're uncertain. It's also recommended to use a trusted password manager to create and store your complex passwords safely.
     </Admonition>
 
-For role creation and access management examples, refer to the [Manage roles and database access with SQL](/docs/guides/manage-database-access) guide.
-
 ## Need help?
 
 Send a request to [support@neon.tech](mailto:support@neon.tech), or join the [Neon community forum](https://community.neon.tech/).

--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -11,9 +11,19 @@ Neon is protocol and application-compatible with PostgreSQL. However, when using
 
 Neon cloud service is currently compatible with PostgreSQL 14 and PostgreSQL 15. You can select the PostgreSQL version you want to use when creating a Neon project. PostgreSQL 15 is selected, by default. For information about creating a Neon project, See [Manage projects](/docs/manage/projects).
 
-## Permissions and extension support
+## Extension support
 
-The Neon cloud service does not currently provide roles with access permissions other than those granted to standard database owners in PostgreSQL. Therefore, Neon roles cannot access replication methods, create additional roles from a PostgreSQL connection, or install PostgreSQL extensions other than those permitted by Neon. For information about the PostgreSQL extensions that Neon supports, see [PostgreSQL Extensions](/docs/extensions/pg-extensions).
+ Neon supports numerous PostgreSQL extensions, and we regularly add support for more. For a list of supported extensions, see [PostgreSQL Extensions](/docs/extensions/pg-extensions). To request support for additional extensions, please contact us at [support@neon.tech](mailto:support@neon.tech) or post your request to the [Neon community forum](https://community.neon.tech/).
+
+## Roles and permissions
+
+Neon is a managed PostgreSQL service, so you cannot access the host operating system, and you can't connect using the PostgreSQL `superuser` account like you can in a stand-alone PostgreSQL installation.
+
+Roles created in the Neon console, CLI, or API, including the default role created with a Neon project, are granted membership in the `neon_superuser` role. For information about the privileges associated with this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
+
+Roles created in Neon with SQL syntax, from a command-line tool like `psql` or the [Neon SQL Editor](/docs/connect/query-with-psql-editor), have the same privileges as newly created roles in a stand-alone PostgreSQL installation. These roles are not granted membership in the `neon_superuser` role. You must grant these roles the privileges you want them to have. For more information, see [Manage roles with SQL](/docs/manage/roles#manage-roles-with-sql).
+
+Neon roles cannot access replication methods, install PostgreSQL extensions other than those permitted by Neon, or grant membership in other roles.
 
 <a id="default-parameters/"></a>
 

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -100,8 +100,6 @@
   items:
     - title: Neon features
       items: 
-        - title: Manage roles and databases with SQL
-          slug: guides/manage-database-access
         - title: Read replicas
           slug: guides/read-replica-guide
     - title: Languages


### PR DESCRIPTION
Remove role and database access management example. We seem to have removed the ability to grant membership in another role (GRANT dev_users TO dev_user1;), which requires the ADMIN OPTION privilege.

```
neondb=> GRANT dev_users TO dev_user2;
ERROR:  permission denied to grant role "dev_users"
DETAIL:  Only roles with the ADMIN option on role "dev_users" may grant this role.
```

Updated neon_superuser section to indicate that roles in Neon cannot grant or revoke membership in other roles.

Note: 07/24. This issue is under investigation. It may not be an intended restriction.