### PR TITLE
fix: expand width for Neon Docs AI button in siderbar

### DIFF
--- a/src/components/pages/doc/chat-widget/chat-widget.jsx
+++ b/src/components/pages/doc/chat-widget/chat-widget.jsx
@@ -281,7 +281,7 @@ const ChatWidgetTrigger = ({ className, isSidebar }) => {
   return (
     <button
       className={clsx(
-        'chat-widget group flex text-sm focus:outline-none',
+        'chat-widget group flex w-full text-sm focus:outline-none',
         isSidebar
           ? 'items-center space-x-3'
           : 'flex-col xl:flex-row xl:items-center xl:space-x-1.5',


### PR DESCRIPTION
Neon Docs AI button can click only text width.

- Other Icon Button
![image](https://github.com/neondatabase/website/assets/63291908/1f7c3960-83da-45fb-9b87-4525ff449482)
- Neon Docs AI Button
![image](https://github.com/neondatabase/website/assets/63291908/af158639-8acf-4493-b5e5-8fd33bae9d03)
