### PR TITLE
Mention active compute limit

### DIFF
--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -37,7 +37,7 @@ For information about how Neon bills for paid plans, please refer to our [Billin
 
 **Notes:**
 
-- The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to our [Sales](https://neon.tech/contact-sales) team. The simultaneously active compute limit does not affect the primary branch compute, which always remains available.
+- The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to [support@neon.tech](mailto:support@neon.tech). The simultaneously active compute limit does not affect the primary branch compute, which always remains available.
 - The Free Tier has an [Active time](/docs/reference/glossary#active-time) limit of 100 hours per month, but that limit only affects non-primary branch compute usage. Active time on all computes is counted toward the limit, but when the limit is exceeded, only non-primary branch computes are subject to suspension. **Your primary branch compute always remains available regardless of the limit, ensuring that access to data on your primary branch is never interrupted.** You can monitor _Active time_ on the **Usage** widget on the Neon **Dashboard**. The _Active time_ limit resets at the beginning of each month.
 
 ## Support

--- a/content/docs/introduction/pro-plan.md
+++ b/content/docs/introduction/pro-plan.md
@@ -21,7 +21,7 @@ Upgrading to the Neon Pro plan gives you higher limits, advanced features, and a
 - **Unlimited databases:** There is no limit on PostgreSQL databases in any Neon plan. You can create as many databases as you need.
 
 <Admonition type="note">
-The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to our Sales team. The simultaneously active compute limit does not affect the primary branch compute, which always remains available. If you reach the simultaneously active compute limit, you may see `Console request failed` errors.
+The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to [support@neon.tech](mailto:support@neon.tech). The simultaneously active compute limit does not affect the primary branch compute, which always remains available. If you reach the simultaneously active compute limit, you may see `Console request failed` errors.
 </Admonition>
 
 ### Advanced features

--- a/content/docs/introduction/pro-plan.md
+++ b/content/docs/introduction/pro-plan.md
@@ -21,7 +21,7 @@ Upgrading to the Neon Pro plan gives you higher limits, advanced features, and a
 - **Unlimited databases:** There is no limit on PostgreSQL databases in any Neon plan. You can create as many databases as you need.
 
 <Admonition type="note">
-The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to [support@neon.tech](mailto:support@neon.tech). The simultaneously active compute limit does not affect the primary branch compute, which always remains available. If you encounter `Console request failed` errors, this may indicate that you have reached the active compute limit.
+The Pro plan has default limit of 20 simultaneously active computes to protect against unintended usage. To increase this limit, reach out to [support@neon.tech](mailto:support@neon.tech). The simultaneously active compute limit does not affect the primary branch compute, which always remains available. If you encounter `Console request failed` errors, this may indicate that you have reached the active compute limit.
 </Admonition>
 
 ### Advanced features

--- a/content/docs/introduction/pro-plan.md
+++ b/content/docs/introduction/pro-plan.md
@@ -21,7 +21,7 @@ Upgrading to the Neon Pro plan gives you higher limits, advanced features, and a
 - **Unlimited databases:** There is no limit on PostgreSQL databases in any Neon plan. You can create as many databases as you need.
 
 <Admonition type="note">
-The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to [support@neon.tech](mailto:support@neon.tech). The simultaneously active compute limit does not affect the primary branch compute, which always remains available. If you reach the simultaneously active compute limit, you may see `Console request failed` errors.
+The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to [support@neon.tech](mailto:support@neon.tech). The simultaneously active compute limit does not affect the primary branch compute, which always remains available. If you encounter `Console request failed` errors, this may indicate that you have reached the active compute limit.
 </Admonition>
 
 ### Advanced features

--- a/content/docs/introduction/pro-plan.md
+++ b/content/docs/introduction/pro-plan.md
@@ -20,6 +20,10 @@ Upgrading to the Neon Pro plan gives you higher limits, advanced features, and a
 - **Unlimited branches:** With the Pro plan, there is no limit on branches. You can create as many branches as required to support your CI/CD pipeline. You can instantly and cost-effectively create a database branch for every preview deployment, client, or developer.
 - **Unlimited databases:** There is no limit on PostgreSQL databases in any Neon plan. You can create as many databases as you need.
 
+<Admonition type="note">
+The Pro plan has default limits of 20 projects, 200 GB of storage, and 20 simultaneously active computes to protect against unintended usage. To increase these limits, reach out to our Sales team. The simultaneously active compute limit does not affect the primary branch compute, which always remains available. If you reach the simultaneously active compute limit, you may see `Console request failed` errors.
+</Admonition>
+
 ### Advanced features
 
 The Neon Pro plan comes with the following advanced features, and we plan to add more.


### PR DESCRIPTION
Mention active compute limit and related error in the Pro plan topic
https://neon-next-git-dprice-mention-active-compute-limit-neondatabase.vercel.app/docs/introduction/pro-plan