### PR TITLE
Highlight the connection-string CLI command

### DIFF
--- a/content/docs/guides/branching-neon-cli.md
+++ b/content/docs/guides/branching-neon-cli.md
@@ -6,6 +6,8 @@ enableTableOfContents: true
 
 The examples in this guide demonstrate creating, viewing, and deleting branches using the Neon CLI. For other branch-related CLI commands, refer to [Neon CLI commands — branches](/docs/reference/cli-branches). This guide also describes how to use the `--api-key` option to authenticate CLI branching commands from the command line.
 
+The examples show the default `table` output format. The Neon CLI also supports `json` and `yaml` output formats. For example, if you prefer output in `json`, add `--output json` to your Neon CLI command.
+
 ## Prerequisites
 
 - The Neon CLI. See [Install the Neon CLI](/docs/reference/neon-cli#install-the-neon-cli) for instructions.
@@ -44,7 +46,7 @@ connection_uris
 ```
 
 <Admonition type="tip">
-If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection-string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+The Neon CLI provides a `neonctl connection-string` command you can use to extract a connection uri programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
 </Admonition>
 
 ## List branches with the CLI
@@ -90,11 +92,6 @@ After exporting your key, source the profile file (source `~/.bashrc` or source 
 You do not need to specify the variable name explicitly when using a Neon CLI command. A Neon CLI command looks for a `NEON_API_KEY` variable setting by default.
 
 This API key configuration ensures that the API key is kept secure while still providing a way to authenticate your CLI commands. Remember, you should handle your API key with the same level of security as your other credentials.
-
-Additionally, when integrating the CLI into your toolchains, you may prefer a different output format than the default `table` format. The Neon CLI supports both `json` and `yaml` output formats. For example, if you prefer output in `json` format, add `--output json` to your Neon CLI command.
-
-If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
-</Admonition>
 
 ## Need help?
 

--- a/content/docs/guides/branching-neon-cli.md
+++ b/content/docs/guides/branching-neon-cli.md
@@ -43,6 +43,10 @@ connection_uris
 └───────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+<Admonition type="tip">
+If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection-string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+</Admonition>
+
 ## List branches with the CLI
 
 The following Neon CLI command lists branches in your Neon project. If your Neon account has more than one project, you will be required to specify a project ID using the `--project-id` option. To view the CLI documentation for this method, refer to the [Neon CLI reference](https://neon.tech/docs/reference/cli-branches#list).
@@ -86,6 +90,11 @@ After exporting your key, source the profile file (source `~/.bashrc` or source 
 You do not need to specify the variable name explicitly when using a Neon CLI command. A Neon CLI command looks for a `NEON_API_KEY` variable setting by default.
 
 This API key configuration ensures that the API key is kept secure while still providing a way to authenticate your CLI commands. Remember, you should handle your API key with the same level of security as your other credentials.
+
+Additionally, when integrating the CLI into your toolchains, you may prefer a different output format than the default `table` format. The Neon CLI supports both `json` and `yaml` output formats. For example, if you prefer output in `json` format, add `--output json` to your Neon CLI command.
+
+If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+</Admonition>
 
 ## Need help?
 

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -151,7 +151,7 @@ connection_uris
 ```
 
 <Admonition type="tip">
-If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection-string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+You can use the `neonctl connection-string` command to extract a `connection_uri` programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
 </Admonition>
 
 - Create a branch with the `--output` format of the command set to `json`. This output format returns all of the branch response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -131,17 +131,90 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 
 ```bash
 neonctl branches create
-┌─────────────────────┬─────────────────────┬─────────┬──────────────────────┬──────────────────────┐
-│ Id                  │ Name                │ Primary │ Created At           │ Updated At           │
-├─────────────────────┼─────────────────────┼─────────┼──────────────────────┼──────────────────────┤
-│ br-round-sun-825586 │ br-round-sun-825586 │ false   │ 2023-07-12T05:25:39Z │ 2023-07-12T05:25:39Z │
-└─────────────────────┴─────────────────────┴─────────┴──────────────────────┴──────────────────────┘
+┌─────────────────────────┬─────────────────────────┬─────────┬──────────────────────┬──────────────────────┐
+│ Id                      │ Name                    │ Primary │ Created At           │ Updated At           │
+├─────────────────────────┼─────────────────────────┼─────────┼──────────────────────┼──────────────────────┤
+│ br-mute-sunset-67218628 │ br-mute-sunset-67218628 │ false   │ 2023-08-03T20:07:27Z │ 2023-08-03T20:07:27Z │
+└─────────────────────────┴─────────────────────────┴─────────┴──────────────────────┴──────────────────────┘
 endpoints
-┌────────────────────────┬──────────────────────┐
-│ Id                     │ Created At           │
-├────────────────────────┼──────────────────────┤
-│ ep-empty-shadow-588175 │ 2023-07-12T05:25:39Z │
-└────────────────────────┴──────────────────────┘
+┌───────────────────────────┬──────────────────────┐
+│ Id                        │ Created At           │
+├───────────────────────────┼──────────────────────┤
+│ ep-floral-violet-94096438 │ 2023-08-03T20:07:27Z │
+└───────────────────────────┴──────────────────────┘
+connection_uris
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│ Connection Uri                                                                           │
+├──────────────────────────────────────────────────────────────────────────────────────────┤
+│ postgres://daniel:<password>@ep-floral-violet-94096438.us-east-2.aws.neon.tech/neondb    │
+└──────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+<Admonition type="tip">
+If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection-string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+</Admonition>
+
+- Create a branch with the `--output` format of the command set to `json`. This output format returns all of the branch response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.
+
+```bash
+neonctl branches create --output json 
+{
+  "branch": {
+    "id": "br-frosty-art-30264288",
+    "project_id": "polished-shape-60485499",
+    "parent_id": "br-polished-fire-02083731",
+    "parent_lsn": "0/1E887C8",
+    "name": "br-frosty-art-30264288",
+    "current_state": "init",
+    "pending_state": "ready",
+    "creation_source": "neonctl",
+    "primary": false,
+    "cpu_used_sec": 0,
+    "compute_time_seconds": 0,
+    "active_time_seconds": 0,
+    "written_data_bytes": 0,
+    "data_transfer_bytes": 0,
+    "created_at": "2023-08-03T20:12:24Z",
+    "updated_at": "2023-08-03T20:12:24Z"
+  },
+  "endpoints": [
+    {
+      "host": "ep-patient-sun-49170531.us-east-2.aws.neon.tech",
+      "id": "ep-patient-sun-49170531",
+      "project_id": "polished-shape-60485499",
+      "branch_id": "br-frosty-art-30264288",
+      "autoscaling_limit_min_cu": 1,
+      "autoscaling_limit_max_cu": 1,
+      "region_id": "aws-us-east-2",
+      "type": "read_write",
+      "current_state": "init",
+      "pending_state": "active",
+      "settings": {},
+      "pooler_enabled": false,
+      "pooler_mode": "transaction",
+      "disabled": false,
+      "passwordless_access": true,
+      "creation_source": "neonctl",
+      "created_at": "2023-08-03T20:12:24Z",
+      "updated_at": "2023-08-03T20:12:24Z",
+      "proxy_host": "us-east-2.aws.neon.tech",
+      "suspend_timeout_seconds": 0,
+      "provisioner": "k8s-pod"
+    }
+  ],
+  "connection_uris": [
+    {
+      "connection_uri": "postgres://daniel:<password>@ep-patient-sun-49170531.us-east-2.aws.neon.tech/neondb",
+      "connection_parameters": {
+        "database": "neondb",
+        "password": "<password>",
+        "role": "daniel",
+        "host": "ep-patient-sun-49170531.us-east-2.aws.neon.tech",
+        "pooler_host": "ep-patient-sun-49170531-pooler.us-east-2.aws.neon.tech"
+      }
+    }
+  ]
+}
 ```
 
 - Create a branch with a user-defined name:

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -129,93 +129,93 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 
 - Create a branch:
 
-```bash
-neonctl branches create
-┌─────────────────────────┬─────────────────────────┬─────────┬──────────────────────┬──────────────────────┐
-│ Id                      │ Name                    │ Primary │ Created At           │ Updated At           │
-├─────────────────────────┼─────────────────────────┼─────────┼──────────────────────┼──────────────────────┤
-│ br-mute-sunset-67218628 │ br-mute-sunset-67218628 │ false   │ 2023-08-03T20:07:27Z │ 2023-08-03T20:07:27Z │
-└─────────────────────────┴─────────────────────────┴─────────┴──────────────────────┴──────────────────────┘
-endpoints
-┌───────────────────────────┬──────────────────────┐
-│ Id                        │ Created At           │
-├───────────────────────────┼──────────────────────┤
-│ ep-floral-violet-94096438 │ 2023-08-03T20:07:27Z │
-└───────────────────────────┴──────────────────────┘
-connection_uris
-┌──────────────────────────────────────────────────────────────────────────────────────────┐
-│ Connection Uri                                                                           │
-├──────────────────────────────────────────────────────────────────────────────────────────┤
-│ postgres://daniel:<password>@ep-floral-violet-94096438.us-east-2.aws.neon.tech/neondb    │
-└──────────────────────────────────────────────────────────────────────────────────────────┘
-```
+    ```bash
+    neonctl branches create
+    ┌─────────────────────────┬─────────────────────────┬─────────┬──────────────────────┬──────────────────────┐
+    │ Id                      │ Name                    │ Primary │ Created At           │ Updated At           │
+    ├─────────────────────────┼─────────────────────────┼─────────┼──────────────────────┼──────────────────────┤
+    │ br-mute-sunset-67218628 │ br-mute-sunset-67218628 │ false   │ 2023-08-03T20:07:27Z │ 2023-08-03T20:07:27Z │
+    └─────────────────────────┴─────────────────────────┴─────────┴──────────────────────┴──────────────────────┘
+    endpoints
+    ┌───────────────────────────┬──────────────────────┐
+    │ Id                        │ Created At           │
+    ├───────────────────────────┼──────────────────────┤
+    │ ep-floral-violet-94096438 │ 2023-08-03T20:07:27Z │
+    └───────────────────────────┴──────────────────────┘
+    connection_uris
+    ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+    │ Connection Uri                                                                           │
+    ├──────────────────────────────────────────────────────────────────────────────────────────┤
+    │ postgres://daniel:<password>@ep-floral-violet-94096438.us-east-2.aws.neon.tech/neondb    │
+    └──────────────────────────────────────────────────────────────────────────────────────────┘
+    ```
 
-<Admonition type="tip">
-You can use the `neonctl connection-string` command to extract a `connection_uri` programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
-</Admonition>
+    <Admonition type="tip">
+    The Neon CLI provides a `neonctl connection-string` command you can use to extract a connection uri programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+    </Admonition>
 
 - Create a branch with the `--output` format of the command set to `json`. This output format returns all of the branch response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.
 
-```bash
-neonctl branches create --output json 
-{
-  "branch": {
-    "id": "br-frosty-art-30264288",
-    "project_id": "polished-shape-60485499",
-    "parent_id": "br-polished-fire-02083731",
-    "parent_lsn": "0/1E887C8",
-    "name": "br-frosty-art-30264288",
-    "current_state": "init",
-    "pending_state": "ready",
-    "creation_source": "neonctl",
-    "primary": false,
-    "cpu_used_sec": 0,
-    "compute_time_seconds": 0,
-    "active_time_seconds": 0,
-    "written_data_bytes": 0,
-    "data_transfer_bytes": 0,
-    "created_at": "2023-08-03T20:12:24Z",
-    "updated_at": "2023-08-03T20:12:24Z"
-  },
-  "endpoints": [
+    ```bash
+    neonctl branches create --output json 
     {
-      "host": "ep-patient-sun-49170531.us-east-2.aws.neon.tech",
-      "id": "ep-patient-sun-49170531",
-      "project_id": "polished-shape-60485499",
-      "branch_id": "br-frosty-art-30264288",
-      "autoscaling_limit_min_cu": 1,
-      "autoscaling_limit_max_cu": 1,
-      "region_id": "aws-us-east-2",
-      "type": "read_write",
-      "current_state": "init",
-      "pending_state": "active",
-      "settings": {},
-      "pooler_enabled": false,
-      "pooler_mode": "transaction",
-      "disabled": false,
-      "passwordless_access": true,
-      "creation_source": "neonctl",
-      "created_at": "2023-08-03T20:12:24Z",
-      "updated_at": "2023-08-03T20:12:24Z",
-      "proxy_host": "us-east-2.aws.neon.tech",
-      "suspend_timeout_seconds": 0,
-      "provisioner": "k8s-pod"
-    }
-  ],
-  "connection_uris": [
-    {
-      "connection_uri": "postgres://daniel:<password>@ep-patient-sun-49170531.us-east-2.aws.neon.tech/neondb",
-      "connection_parameters": {
-        "database": "neondb",
-        "password": "<password>",
-        "role": "daniel",
+    "branch": {
+        "id": "br-frosty-art-30264288",
+        "project_id": "polished-shape-60485499",
+        "parent_id": "br-polished-fire-02083731",
+        "parent_lsn": "0/1E887C8",
+        "name": "br-frosty-art-30264288",
+        "current_state": "init",
+        "pending_state": "ready",
+        "creation_source": "neonctl",
+        "primary": false,
+        "cpu_used_sec": 0,
+        "compute_time_seconds": 0,
+        "active_time_seconds": 0,
+        "written_data_bytes": 0,
+        "data_transfer_bytes": 0,
+        "created_at": "2023-08-03T20:12:24Z",
+        "updated_at": "2023-08-03T20:12:24Z"
+    },
+    "endpoints": [
+        {
         "host": "ep-patient-sun-49170531.us-east-2.aws.neon.tech",
-        "pooler_host": "ep-patient-sun-49170531-pooler.us-east-2.aws.neon.tech"
-      }
+        "id": "ep-patient-sun-49170531",
+        "project_id": "polished-shape-60485499",
+        "branch_id": "br-frosty-art-30264288",
+        "autoscaling_limit_min_cu": 1,
+        "autoscaling_limit_max_cu": 1,
+        "region_id": "aws-us-east-2",
+        "type": "read_write",
+        "current_state": "init",
+        "pending_state": "active",
+        "settings": {},
+        "pooler_enabled": false,
+        "pooler_mode": "transaction",
+        "disabled": false,
+        "passwordless_access": true,
+        "creation_source": "neonctl",
+        "created_at": "2023-08-03T20:12:24Z",
+        "updated_at": "2023-08-03T20:12:24Z",
+        "proxy_host": "us-east-2.aws.neon.tech",
+        "suspend_timeout_seconds": 0,
+        "provisioner": "k8s-pod"
+        }
+    ],
+    "connection_uris": [
+        {
+        "connection_uri": "postgres://daniel:<password>@ep-patient-sun-49170531.us-east-2.aws.neon.tech/neondb",
+        "connection_parameters": {
+            "database": "neondb",
+            "password": "<password>",
+            "role": "daniel",
+            "host": "ep-patient-sun-49170531.us-east-2.aws.neon.tech",
+            "pooler_host": "ep-patient-sun-49170531-pooler.us-east-2.aws.neon.tech"
+        }
+        }
+    ]
     }
-  ]
-}
-```
+    ```
 
 - Create a branch with a user-defined name:
 

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -79,7 +79,9 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 | `--name` | The project name. The project ID is used if a name is not specified.               | string  |                                       |
 | `--region-id` | The region ID. Possible values: `aws-us-west-2`, `aws-ap-southeast-1`, `aws-eu-central-1`, `aws-us-east-2`, `aws-us-east-1`. Defaults to `aws-us-east-2` if not specified. | string number  |                                       |
 
-#### Example
+#### Examples
+
+-- Create a project with a user-defined name in a specific region:
 
 ```bash
 neonctl projects create --name mynewproject --region-id aws-us-west-2
@@ -94,6 +96,61 @@ neonctl projects create --name mynewproject --region-id aws-us-west-2
 ├──────────────────────────────────────────────────────────────────────────────────────┤
 │ postgres://daniel:<password>@ep-bitter-field-476253.us-west-2.aws.neon.tech/neondb   │
 └──────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+<Admonition type="tip">
+If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection-string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+</Admonition>
+
+-- Create a project with the `--output` format of the command set to `json`. This output format returns all of the project response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.
+
+```bash
+neonctl projects create --output json
+{
+"0": {
+    "data_storage_bytes_hour": 0,
+    "data_transfer_bytes": 0,
+    "written_data_bytes": 0,
+    "compute_time_seconds": 0,
+    "active_time_seconds": 0,
+    "cpu_used_sec": 0,
+    "id": "polished-shape-60485499",
+    "platform_id": "aws",
+    "region_id": "aws-us-east-2",
+    "name": "polished-shape-60485499",
+    "provisioner": "k8s-pod",
+    "default_endpoint_settings": {
+    "autoscaling_limit_min_cu": 1,
+    "autoscaling_limit_max_cu": 1,
+    "suspend_timeout_seconds": 0
+    },
+
+    "pg_version": 15,
+    "proxy_host": "us-east-2.aws.neon.tech",
+    "branch_logical_size_limit": 204800,
+    "branch_logical_size_limit_bytes": 214748364800,
+    "store_passwords": true,
+    "creation_source": "neonctl",
+    "history_retention_seconds": 604800,
+    "created_at": "2023-08-03T19:50:44Z",
+    "updated_at": "2023-08-03T19:50:44Z",
+    "consumption_period_start": "0001-01-01T00:00:00Z",
+    "consumption_period_end": "0001-01-01T00:00:00Z",
+    "owner_id": "e56ad68e-7f2f-4d74-928c-9ea25d7e9864"
+},
+"1": [
+    {
+    "connection_uri": "postgres://<role>:daniel@ep-patient-rice-89630622.us-east-2.aws.neon.tech/neondb",
+    "connection_parameters": {
+        "database": "neondb",
+        "password": "<password>",
+        "role": "daniel",
+        "host": "ep-patient-rice-89630622.us-east-2.aws.neon.tech",
+        "pooler_host": "ep-patient-rice-89630622-pooler.us-east-2.aws.neon.tech"
+    }
+    }
+]
+}
 ```
 
 ### update

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -107,24 +107,23 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
     ```bash
     neonctl projects create --output json
     {
-    "0": {
+    "project": {
         "data_storage_bytes_hour": 0,
         "data_transfer_bytes": 0,
         "written_data_bytes": 0,
         "compute_time_seconds": 0,
         "active_time_seconds": 0,
         "cpu_used_sec": 0,
-        "id": "polished-shape-60485499",
+        "id": "long-wind-77910944",
         "platform_id": "aws",
         "region_id": "aws-us-east-2",
-        "name": "polished-shape-60485499",
+        "name": "long-wind-77910944",
         "provisioner": "k8s-pod",
         "default_endpoint_settings": {
         "autoscaling_limit_min_cu": 1,
         "autoscaling_limit_max_cu": 1,
         "suspend_timeout_seconds": 0
         },
-
         "pg_version": 15,
         "proxy_host": "us-east-2.aws.neon.tech",
         "branch_logical_size_limit": 204800,
@@ -132,21 +131,21 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
         "store_passwords": true,
         "creation_source": "neonctl",
         "history_retention_seconds": 604800,
-        "created_at": "2023-08-03T19:50:44Z",
-        "updated_at": "2023-08-03T19:50:44Z",
+        "created_at": "2023-08-04T16:16:45Z",
+        "updated_at": "2023-08-04T16:16:45Z",
         "consumption_period_start": "0001-01-01T00:00:00Z",
         "consumption_period_end": "0001-01-01T00:00:00Z",
         "owner_id": "e56ad68e-7f2f-4d74-928c-9ea25d7e9864"
     },
-    "1": [
+    "connection_uris": [
         {
-        "connection_uri": "postgres://<role>:daniel@ep-patient-rice-89630622.us-east-2.aws.neon.tech/neondb",
+        "connection_uri": "postgres://daniel:<password>@ep-bitter-heart-24388432.us-east-2.aws.neon.tech/neondb",
         "connection_parameters": {
             "database": "neondb",
             "password": "<password>",
             "role": "daniel",
-            "host": "ep-patient-rice-89630622.us-east-2.aws.neon.tech",
-            "pooler_host": "ep-patient-rice-89630622-pooler.us-east-2.aws.neon.tech"
+            "host": "ep-bitter-heart-24388432.us-east-2.aws.neon.tech",
+            "pooler_host": "ep-bitter-heart-24388432-pooler.us-east-2.aws.neon.tech"
         }
         }
     ]

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -83,75 +83,75 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 
 - Create a project with a user-defined name in a specific region:
 
-```bash
-neonctl projects create --name mynewproject --region-id aws-us-west-2
-┌───────────────────┬──────────────┬───────────────┬──────────────────────┐
-│ Id                │ Name         │ Region Id     │ Created At           │
-├───────────────────┼──────────────┼───────────────┼──────────────────────┤
-│ muddy-wood-859533 │ mynewproject │ aws-us-west-2 │ 2023-07-09T17:04:29Z │
-└───────────────────┴──────────────┴───────────────┴──────────────────────┘
+    ```bash
+    neonctl projects create --name mynewproject --region-id aws-us-west-2
+    ┌───────────────────┬──────────────┬───────────────┬──────────────────────┐
+    │ Id                │ Name         │ Region Id     │ Created At           │
+    ├───────────────────┼──────────────┼───────────────┼──────────────────────┤
+    │ muddy-wood-859533 │ mynewproject │ aws-us-west-2 │ 2023-07-09T17:04:29Z │
+    └───────────────────┴──────────────┴───────────────┴──────────────────────┘
 
-┌──────────────────────────────────────────────────────────────────────────────────────┐
-│ Connection Uri                                                                       │
-├──────────────────────────────────────────────────────────────────────────────────────┤
-│ postgres://daniel:<password>@ep-bitter-field-476253.us-west-2.aws.neon.tech/neondb   │
-└──────────────────────────────────────────────────────────────────────────────────────┘
-```
+    ┌──────────────────────────────────────────────────────────────────────────────────────┐
+    │ Connection Uri                                                                       │
+    ├──────────────────────────────────────────────────────────────────────────────────────┤
+    │ postgres://daniel:<password>@ep-bitter-field-476253.us-west-2.aws.neon.tech/neondb   │
+    └──────────────────────────────────────────────────────────────────────────────────────┘
+    ```
 
-<Admonition type="tip">
-The Neon CLI provides a `neonctl connection-string` command you can use to extract a connection uri programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
-</Admonition>
+    <Admonition type="tip">
+    The Neon CLI provides a `neonctl connection-string` command you can use to extract a connection uri programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+    </Admonition>
 
 - Create a project with the `--output` format of the command set to `json`. This output format returns all of the project response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.
 
-```bash
-neonctl projects create --output json
-{
-"0": {
-    "data_storage_bytes_hour": 0,
-    "data_transfer_bytes": 0,
-    "written_data_bytes": 0,
-    "compute_time_seconds": 0,
-    "active_time_seconds": 0,
-    "cpu_used_sec": 0,
-    "id": "polished-shape-60485499",
-    "platform_id": "aws",
-    "region_id": "aws-us-east-2",
-    "name": "polished-shape-60485499",
-    "provisioner": "k8s-pod",
-    "default_endpoint_settings": {
-    "autoscaling_limit_min_cu": 1,
-    "autoscaling_limit_max_cu": 1,
-    "suspend_timeout_seconds": 0
-    },
-
-    "pg_version": 15,
-    "proxy_host": "us-east-2.aws.neon.tech",
-    "branch_logical_size_limit": 204800,
-    "branch_logical_size_limit_bytes": 214748364800,
-    "store_passwords": true,
-    "creation_source": "neonctl",
-    "history_retention_seconds": 604800,
-    "created_at": "2023-08-03T19:50:44Z",
-    "updated_at": "2023-08-03T19:50:44Z",
-    "consumption_period_start": "0001-01-01T00:00:00Z",
-    "consumption_period_end": "0001-01-01T00:00:00Z",
-    "owner_id": "e56ad68e-7f2f-4d74-928c-9ea25d7e9864"
-},
-"1": [
+    ```bash
+    neonctl projects create --output json
     {
-    "connection_uri": "postgres://<role>:daniel@ep-patient-rice-89630622.us-east-2.aws.neon.tech/neondb",
-    "connection_parameters": {
-        "database": "neondb",
-        "password": "<password>",
-        "role": "daniel",
-        "host": "ep-patient-rice-89630622.us-east-2.aws.neon.tech",
-        "pooler_host": "ep-patient-rice-89630622-pooler.us-east-2.aws.neon.tech"
+    "0": {
+        "data_storage_bytes_hour": 0,
+        "data_transfer_bytes": 0,
+        "written_data_bytes": 0,
+        "compute_time_seconds": 0,
+        "active_time_seconds": 0,
+        "cpu_used_sec": 0,
+        "id": "polished-shape-60485499",
+        "platform_id": "aws",
+        "region_id": "aws-us-east-2",
+        "name": "polished-shape-60485499",
+        "provisioner": "k8s-pod",
+        "default_endpoint_settings": {
+        "autoscaling_limit_min_cu": 1,
+        "autoscaling_limit_max_cu": 1,
+        "suspend_timeout_seconds": 0
+        },
+
+        "pg_version": 15,
+        "proxy_host": "us-east-2.aws.neon.tech",
+        "branch_logical_size_limit": 204800,
+        "branch_logical_size_limit_bytes": 214748364800,
+        "store_passwords": true,
+        "creation_source": "neonctl",
+        "history_retention_seconds": 604800,
+        "created_at": "2023-08-03T19:50:44Z",
+        "updated_at": "2023-08-03T19:50:44Z",
+        "consumption_period_start": "0001-01-01T00:00:00Z",
+        "consumption_period_end": "0001-01-01T00:00:00Z",
+        "owner_id": "e56ad68e-7f2f-4d74-928c-9ea25d7e9864"
+    },
+    "1": [
+        {
+        "connection_uri": "postgres://<role>:daniel@ep-patient-rice-89630622.us-east-2.aws.neon.tech/neondb",
+        "connection_parameters": {
+            "database": "neondb",
+            "password": "<password>",
+            "role": "daniel",
+            "host": "ep-patient-rice-89630622.us-east-2.aws.neon.tech",
+            "pooler_host": "ep-patient-rice-89630622-pooler.us-east-2.aws.neon.tech"
+        }
+        }
+    ]
     }
-    }
-]
-}
-```
+    ```
 
 ### update
 

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -81,7 +81,7 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 
 #### Examples
 
--- Create a project with a user-defined name in a specific region:
+- Create a project with a user-defined name in a specific region:
 
 ```bash
 neonctl projects create --name mynewproject --region-id aws-us-west-2
@@ -102,7 +102,7 @@ neonctl projects create --name mynewproject --region-id aws-us-west-2
 The Neon CLI provides a `neonctl connection-string` command you can use to extract a connection uri programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
 </Admonition>
 
--- Create a project with the `--output` format of the command set to `json`. This output format returns all of the project response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.
+- Create a project with the `--output` format of the command set to `json`. This output format returns all of the project response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.
 
 ```bash
 neonctl projects create --output json

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -99,7 +99,7 @@ neonctl projects create --name mynewproject --region-id aws-us-west-2
 ```
 
 <Admonition type="tip">
-If you need to extract a `connection_uri` programmatically, the Neon CLI provides a `neonctl connection-string` command you can use. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
+The Neon CLI provides a `neonctl connection-string` command you can use to extract a connection uri programmatically. See [Neon CLI commands — connection-string](https://neon.tech/docs/reference/cli-connection-string).
 </Admonition>
 
 -- Create a project with the `--output` format of the command set to `json`. This output format returns all of the project response data, whereas the default `table` output format (shown in the preceding example) is limited in the information it can display.


### PR DESCRIPTION
Added the following tip to:
https://neon-next-git-dprice-cli-mention-connection-a5cd9d-neondatabase.vercel.app/docs/guides/branching-neon-cli
https://neon-next-git-dprice-cli-mention-connection-a5cd9d-neondatabase.vercel.app/docs/reference/cli-branches#create
https://neon-next-git-dprice-cli-mention-connection-a5cd9d-neondatabase.vercel.app/docs/reference/cli-projects#create
![image](https://github.com/neondatabase/website/assets/10074684/decef582-59dc-4f74-a2cc-473753666c1a)
