### PR TITLE
fix: align the release notes label

### DIFF
--- a/src/components/pages/release-notes/aside/aside.jsx
+++ b/src/components/pages/release-notes/aside/aside.jsx
@@ -1,15 +1,21 @@
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
 import { RELEASE_NOTES_CATEGORIES } from 'components/pages/release-notes/release-notes-filter';
 import getReleaseNotesCategoryFromSlug from 'utils/get-release-notes-category-from-slug';
 import getReleaseNotesDateFromSlug from 'utils/get-release-notes-date-from-slug';
 
-const Aside = ({ slug, isReleaseDateExist = false }) => {
+const Aside = ({ className = '', slug, isReleaseDateExist = false }) => {
   const { datetime, label } = getReleaseNotesDateFromSlug(slug);
   const { category, capitalisedCategory } = getReleaseNotesCategoryFromSlug(slug);
 
   return (
-    <aside className="absolute left-0 top-0.5 z-10 flex min-w-[8rem] max-w-fit flex-col items-end gap-3 rounded-md xl:sticky xl:top-10 xl:mr-9 xl:mt-0 xl:max-h-24 sm:static sm:max-h-max sm:flex-row sm:items-center">
+    <aside
+      className={clsx(
+        'flex flex-col items-end gap-3 rounded-md xl:sticky xl:top-10 xl:mr-9 xl:mt-0 xl:max-h-24 sm:static sm:max-h-max sm:flex-row sm:items-center',
+        className
+      )}
+    >
       {!isReleaseDateExist && (
         <time className="whitespace-nowrap text-xl font-semibold leading-none" dateTime={datetime}>
           {label}
@@ -19,13 +25,14 @@ const Aside = ({ slug, isReleaseDateExist = false }) => {
         {RELEASE_NOTES_CATEGORIES.map(
           ({ slug, icon: Icon }, index) => slug === category && <Icon className="h-4" key={index} />
         )}
-        <span className="ml-1">{capitalisedCategory}</span>
+        <span className="ml-1 whitespace-nowrap">{capitalisedCategory}</span>
       </span>
     </aside>
   );
 };
 
 Aside.propTypes = {
+  className: PropTypes.string,
   slug: PropTypes.string.isRequired,
   isReleaseDateExist: PropTypes.bool,
 };

--- a/src/components/pages/release-notes/hero/hero.jsx
+++ b/src/components/pages/release-notes/hero/hero.jsx
@@ -25,7 +25,7 @@ const Hero = ({ className = null, withContainer = false, isReleaseNotePost }) =>
           <p>{DESCRIPTION}</p>
           {!withContainer && (
             <a
-              className="ml-3 flex items-center text-secondary-8 transition-colors duration-200 hover:text-secondary-7 dark:text-primary-1 dark:hover:text-primary-2"
+              className="ml-3 flex items-center text-secondary-8 transition-colors duration-200 hover:text-secondary-7 dark:text-primary-1 dark:hover:text-primary-2 sm:ml-0"
               href={`${RELEASE_NOTES_BASE_PATH}rss.xml`}
             >
               <RSSLogo className="mr-1.5" />

--- a/src/components/pages/release-notes/release-note-list/release-note-list.jsx
+++ b/src/components/pages/release-notes/release-note-list/release-note-list.jsx
@@ -9,7 +9,7 @@ import generateReleaseNotePath from 'utils/generate-release-note-path';
 import getReleaseNotesDateFromSlug from 'utils/get-release-notes-date-from-slug';
 
 const ReleaseNoteList = ({ items }) => (
-  <div className="relative before:absolute before:bottom-3 before:left-[179px] before:top-4 before:h-auto before:w-px before:bg-gray-7 dark:before:bg-gray-2 xl:before:hidden sm:space-y-16">
+  <div className="sm:space-y-16">
     {items.map(({ slug, content }, index, array) => {
       const prevItem = array[index - 1];
       const { datetime } = getReleaseNotesDateFromSlug(slug);
@@ -17,17 +17,23 @@ const ReleaseNoteList = ({ items }) => (
         prevItem && getReleaseNotesDateFromSlug(prevItem.slug).datetime === datetime;
       const releaseNotesPath = generateReleaseNotePath(slug);
 
-      return (
-        <article
-          className={clsx(
-            'relative flex first:mt-0 sm:flex-col sm:space-y-3',
-            isReleaseDateExist ? 'mt-6' : 'mt-12'
-          )}
-          key={index}
-        >
-          <Aside slug={slug} isReleaseDateExist={isReleaseDateExist} />
+      const nextItem = array[index + 1];
+      const isNextReleaseDateExist =
+        nextItem && getReleaseNotesDateFromSlug(nextItem.slug).datetime === datetime;
 
-          <div className="relative w-full pl-56 before:absolute before:left-[175px] before:top-3 before:h-[9px] before:w-[9px] before:rounded-full before:bg-primary-1 dark:before:bg-secondary-2 xl:max-w-[75%] xl:pl-0 xl:before:hidden sm:max-w-full">
+      return (
+        <article className={clsx('group flex first:mt-0 sm:flex-col sm:space-y-3')} key={index}>
+          <Aside
+            className="w-full max-w-[149px] shrink-0 pt-0.5"
+            slug={slug}
+            isReleaseDateExist={isReleaseDateExist}
+          />
+          <div
+            className={clsx(
+              'relative ml-7 w-[calc(100%-176px)] pl-7 before:absolute before:-left-1 before:top-2 before:z-10 before:h-[9px] before:w-[9px] before:rounded-full before:bg-primary-1 after:absolute after:bottom-0 after:left-0 after:top-0 after:h-auto after:w-px after:bg-gray-7 group-first:after:top-2 group-last:after:bottom-6 dark:before:bg-secondary-2 dark:after:bg-gray-2 xl:w-[calc(100%-212px)] xl:max-w-[75%] xl:pl-0 xl:before:hidden xl:after:hidden sm:ml-0 sm:w-full sm:max-w-full sm:pb-0',
+              isNextReleaseDateExist ? 'pb-6' : 'pb-12'
+            )}
+          >
             <Content content={content} withoutAnchorHeading />
             <Link
               className="flex items-center font-medium text-secondary-8 hover:text-secondary-7 dark:text-primary-1"


### PR DESCRIPTION
This pull request aligns the release notes date and label

**Screenshots**
Before:
<img width="959" alt="image" src="https://github.com/neondatabase/website/assets/48465000/6535932a-7951-4d86-8c25-87e9235c5b1e">

After:
<img width="999" alt="image" src="https://github.com/neondatabase/website/assets/48465000/ec081ece-758f-4496-a7c6-cc2a405633e6">
