### PR TITLE
Update PITR content

### DIFF
--- a/content/docs/guides/branching-pitr.md
+++ b/content/docs/guides/branching-pitr.md
@@ -104,7 +104,7 @@ To avoid changing connection details in your application, you can reassign the c
 ## Examples
 
 - [Using Neon branching for instant point-in-time restore](https://neon.tech/blog/point-in-time-recovery). The blog post describes point-in-time restore and provides a script for creating a recovery branch, reassigning a compute endpoint, and setting the new branch as the primary.
-- [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres). This blog post (and video) describe a data recovery example that uses Neon's branching feature, the Neon API, and a bisect script to recover lost data.
+- [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres). This blog post (with video) describes a data recovery example that uses Neon's branching feature, the Neon API, and a bisect script to recover lost data.
 
 Check out the GitHub repositories for the examples:
 

--- a/content/docs/guides/branching-pitr.md
+++ b/content/docs/guides/branching-pitr.md
@@ -106,11 +106,11 @@ To avoid changing connection details in your application, you can reassign the c
 - [Using Neon branching for instant point-in-time restore](https://neon.tech/blog/point-in-time-recovery). The blog post describes point-in-time restore and provides a script for creating a recovery branch, reassigning a compute endpoint, and setting the new branch as the primary.
 - [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres). This blog post (with video) describes a data recovery example that uses Neon's branching feature, the Neon API, and a bisect script to recover lost data.
 
-Check out the GitHub repositories for the examples:
+Check out the GitHub repositories for these examples:
 
 <DetailIconCards>
 <a href="https://github.com/neondatabase/restore-neon-branch" description="A script to restore a Neon branch to a previous state while preserving the same endpoint" icon="github">Restore a Neon database</a>
-<a href="https://github.com/kelvich/branching_demo_bisect" description="Use a bisect script and the Neon API to recover lost data" icon="github">Neon branch bisect demo</a>
+<a href="https://github.com/kelvich/branching_demo_bisect" description="Use Neon branching, the Neon API, and a bisect script to recover lost data" icon="github">Neon branch bisect demo</a>
 </DetailIconCards>
 
 ## Need help?

--- a/content/docs/guides/branching-pitr.md
+++ b/content/docs/guides/branching-pitr.md
@@ -109,8 +109,8 @@ To avoid changing connection details in your application, you can reassign the c
 Check out the GitHub repositories for these examples:
 
 <DetailIconCards>
-<a href="https://github.com/neondatabase/restore-neon-branch" description="Restore a Neon database to a previous state" icon="github">Restore a Neon database</a>
-<a href="https://github.com/kelvich/branching_demo_bisect" description="Use a bisect script and the Neon API to recover lost data" icon="github">Time travel demo</a>
+<a href="https://github.com/neondatabase/restore-neon-branch" description="A script to restore a Neon branch to a previous state while preserving the same endpoint" icon="github">Restore a Neon database</a>
+<a href="https://github.com/kelvich/branching_demo_bisect" description="Use a bisect script and the Neon API to recover lost data" icon="github">Neon branch bisect demo</a>
 </DetailIconCards>
 
 ## Need help?

--- a/content/docs/guides/branching-pitr.md
+++ b/content/docs/guides/branching-pitr.md
@@ -30,6 +30,8 @@ You can also create point-in-time branches using the [Neon CLI](/docs/reference/
 neonctl branches create --name data_recovery --parent 2023-07-11T10:00:00Z
 ```
 
+The timestamp must be provided in ISO 8601 format. You can use this [timestamp converter](https://www.timestamp-converter.com/).
+
 </Admonition>
 
 ## Connect to your branch
@@ -85,4 +87,32 @@ If your previous primary branch was your project's root branch (the initial bran
 
 To use your new primary branch with your applications, update your application connection details. To do so, replace your current connection details with the connection details for your new primary branch, which you retrieved earlier when connecting to your branch.
 
-For another data recovery example using Neon's branching feature, refer to [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres). This example uses a bisect script and the Neon API to create branches to recover your data to the last known good.
+Alternatively, if you do not want change connection details, you can move the compute endpoint from your old primary branch to the new  branch. See [Reassign your compute endpoint](#reassign-the-compute-endpoint) for instructions.
+
+## Reassign the compute endpoint
+
+To avoid changing connection details in your application, you can reassign the compute endpoint from your old primary branch to your new  branch. If you followed the steps above, you created a branch with a compute endpoint. In this case, you have to:
+
+1. **Remove the compute endpoint from the new branch.**
+
+   For instructions, see [Delete a compute endpoint](/docs/manage/endpoints#delete-a-compute-endpoint).
+
+2. **Move the compute endpoint from the old primary branch to the new branch.**
+
+   This action is currently only supported in the Neon API. See [Update a compute endpoint with the CLI](/docs/manage/endpoints#update-a-compute-endpoint-with-the-api) for instructions.
+
+## Examples
+
+- For a blog post that covers point-in-time restore (PITR), see [Using Neon branching for instant Point in time restore](https://neon.tech/blog/point-in-time-recovery). The blog post describes PITR and provides a script for creating a recovery branch, reassigning a compute endpoint, and setting the new branch as the primary branch.
+- For a data recovery example that uses Neon's branching feature, the Neon API, and a bisect script to recover lost data, refer to [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres).
+
+Check out the GitHub repositories for these examples:
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/restore-neon-branch" description="Restore a Neon database to a previous state" icon="github">Restore a Neon database</a>
+<a href="https://github.com/kelvich/branching_demo_bisect" description="Use a bisect script and the Neon API to recover lost data" icon="github">Time travel demo</a>
+</DetailIconCards>
+
+## Need help?
+
+Send a request to [support@neon.tech](mailto:support@neon.tech), or join the [Neon community forum](https://community.neon.tech/).

--- a/content/docs/guides/branching-pitr.md
+++ b/content/docs/guides/branching-pitr.md
@@ -93,20 +93,20 @@ Alternatively, if you do not want change connection details, you can move the co
 
 To avoid changing connection details in your application, you can reassign the compute endpoint from your old primary branch to your new  branch. If you followed the steps above, you created a branch with a compute endpoint. In this case, you have to:
 
-1. **Remove the compute endpoint from the new branch.**
+1. **Remove the compute endpoint from the new branch**
 
    For instructions, see [Delete a compute endpoint](/docs/manage/endpoints#delete-a-compute-endpoint).
 
-2. **Move the compute endpoint from the old primary branch to the new branch.**
+2. **Move the compute endpoint from the old primary branch to the new branch**
 
    This action is currently only supported in the Neon API. See [Update a compute endpoint with the CLI](/docs/manage/endpoints#update-a-compute-endpoint-with-the-api) for instructions.
 
 ## Examples
 
-- For a blog post that covers point-in-time restore (PITR), see [Using Neon branching for instant Point in time restore](https://neon.tech/blog/point-in-time-recovery). The blog post describes PITR and provides a script for creating a recovery branch, reassigning a compute endpoint, and setting the new branch as the primary branch.
-- For a data recovery example that uses Neon's branching feature, the Neon API, and a bisect script to recover lost data, refer to [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres).
+- [Using Neon branching for instant point-in-time restore](https://neon.tech/blog/point-in-time-recovery). The blog post describes point-in-time restore and provides a script for creating a recovery branch, reassigning a compute endpoint, and setting the new branch as the primary.
+- [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres). This blog post (and video) describe a data recovery example that uses Neon's branching feature, the Neon API, and a bisect script to recover lost data.
 
-Check out the GitHub repositories for these examples:
+Check out the GitHub repositories for the examples:
 
 <DetailIconCards>
 <a href="https://github.com/neondatabase/restore-neon-branch" description="A script to restore a Neon branch to a previous state while preserving the same endpoint" icon="github">Restore a Neon database</a>

--- a/content/docs/guides/branching-pitr.md
+++ b/content/docs/guides/branching-pitr.md
@@ -87,7 +87,7 @@ If your previous primary branch was your project's root branch (the initial bran
 
 To use your new primary branch with your applications, update your application connection details. To do so, replace your current connection details with the connection details for your new primary branch, which you retrieved earlier when connecting to your branch.
 
-Alternatively, if you do not want change connection details, you can move the compute endpoint from your old primary branch to the new  branch. See [Reassign your compute endpoint](#reassign-the-compute-endpoint) for instructions.
+Alternatively, if you do not want change connection details, you can move the compute endpoint from your old primary branch to the new  branch. See [Reassign the compute endpoint](#reassign-the-compute-endpoint) for instructions.
 
 ## Reassign the compute endpoint
 

--- a/content/docs/manage/endpoints.md
+++ b/content/docs/manage/endpoints.md
@@ -55,7 +55,7 @@ To edit a compute endpoint:
 
 1. In the Neon Console, select **Branches**.
 1. Select a branch.
-1. Click the compute endpoint kebab menu, and select **Edit**.
+1. Click the kebab menu in the **Computes** table, and select **Edit**.
 1. Specify your changes and click **Save**.
 
 ### Compute size and Autoscaling configuration
@@ -102,7 +102,7 @@ To delete a compute endpoint:
 
 1. In the Neon Console, select **Branches**.
 1. Select a branch.
-1. Click the compute endpoint kebab menu, and select **Delete**.
+1. Click the kebab menu in the **Computes** table, and select **Delete**.
 1. On the confirmation dialog, click **Delete**.
 
 ## Manage compute endpoints with the Neon API

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -235,6 +235,14 @@ neonctl branches create --name my_read_replica_branch --type read_only
 neonctl branches create --name my_child_branch --parent mybranch
 ```
 
+- Create a point-in-time restore branch by specifying the `--parent` option with a timestamp:
+
+```bash
+neonctl branches create --name data_recovery --parent 2023-07-11T10:00:00Z
+```
+
+The timestamp must be provided in ISO 8601 format. You can use this [timestamp converter](https://www.timestamp-converter.com/). For more information about point-in-time restore, see [Branching — Point-in-time restore (PITR)](/docs/guides/branching-pitr).
+
 ### rename
 
 This subcommand allows you to update a branch in a Neon project.
@@ -280,7 +288,7 @@ neonctl branches set-primary <id|name> [options]
 
 #### Options
 
-In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-options), the `updaterename` subcommand supports this option:
+In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-options), the `set-primary` subcommand supports this option:
 
 | Option        | Description | Type   | Required  |
 | ------------- | ----------- | ------ | :-----: |
@@ -311,7 +319,7 @@ neonctl branches add-compute <id|name>
 
 #### Options
 
-In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-options), the `updaterename` subcommand supports these options:
+In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-options), the `add-compute` subcommand supports these options:
 
 | Option        | Description | Type   | Required  |
 | ------------- | ----------- | ------ | :-----: |


### PR DESCRIPTION
- Include steps for moving the compute endpoint from the old primary branch to the new branch in case you do not want to change application connection details.
https://neon-next-git-dprice-add-replace-endpoint-i-4f58f2-neondatabase.vercel.app/docs/guides/branching-pitr#reassign-the-compute-endpoint

- Add examples section and links to GitHub repos.
https://neon-next-git-dprice-add-replace-endpoint-i-4f58f2-neondatabase.vercel.app/docs/guides/branching-pitr#examples

- Other very minor related updates & a couple of unrelated minor content fixes