### PR TITLE
Note ipv4 support

### DIFF
--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -92,6 +92,8 @@ Our *Guides* documentation also provides connection examples.
 
 Neon currently supports **IPv4**. Support for other network protocols, including IPv6, is **not available** at this time.
 
+Additionally, Neon provides a serverless driver that supports both WebSocket and HTTP connections. For further information, refer to our [Neon serverless driver](/docs/serverless/serverless-driver) documentation.
+
 ## Connection notes
 
 - Some older client libraries and drivers, including older `psql` executables, are built without [Server Name Indication (SNI)](/docs/reference/glossary#sni) support and require a workaround. For more information, see [Connection errors](/docs/connect/connection-errors).

--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -90,7 +90,7 @@ Our *Guides* documentation also provides connection examples.
 
 ## Network Protocol Support
 
-Neon currently supports **IPv4**. Support for other network protocols, including IPv6, is **not available** at this time. Please ensure you are using IPv4 when connecting to Neon.
+Neon currently supports **IPv4**. Support for other network protocols, including IPv6, is **not available** at this time.
 
 ## Connection notes
 

--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -88,7 +88,7 @@ The **Connection Details** widget on the **Neon Dashboard** also provides connec
 
 Our *Guides* documentation also provides connection examples.
 
-## Network Protocol Support
+## Network protocol support
 
 Neon currently supports **IPv4**. Support for other network protocols, including IPv6, is **not available** at this time.
 

--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -88,6 +88,10 @@ The **Connection Details** widget on the **Neon Dashboard** also provides connec
 
 Our *Guides* documentation also provides connection examples.
 
+## Network Protocol Support
+
+Neon currently supports **IPv4**. Support for other network protocols, including IPv6, is **not available** at this time. Please ensure you are using IPv4 when connecting to Neon.
+
 ## Connection notes
 
 - Some older client libraries and drivers, including older `psql` executables, are built without [Server Name Indication (SNI)](/docs/reference/glossary#sni) support and require a workaround. For more information, see [Connection errors](/docs/connect/connection-errors).


### PR DESCRIPTION
Neon currently supports ipv4. Mention this in the docs.
https://neon-next-git-dprice-ipv4-support-neondatabase.vercel.app/docs/connect/connect-from-any-app#network-protocol-support