### PR TITLE
fix: update title for release notes on blog page

### DIFF
--- a/src/components/pages/blog/release-notes-list/release-notes-list.jsx
+++ b/src/components/pages/blog/release-notes-list/release-notes-list.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 
 import Link from 'components/shared/link/link';
 import LINKS from 'constants/links';
-import getExcerpt from 'utils/get-excerpt';
 import getReleaseNotesCategoryFromSlug from 'utils/get-release-notes-category-from-slug';
 import getReleaseNotesDateFromSlug from 'utils/get-release-notes-date-from-slug';
 
@@ -20,12 +19,9 @@ const ReleaseNotesList = ({ items }) => (
       </Link>
     </div>
     <ul className="mt-6 grid grid-cols-4 gap-x-[50px] border-t border-gray-new-20/60 pt-8 xl:grid-cols-3 lg:mt-6 lg:grid-cols-2 md:mt-5 md:grid-cols-1 md:gap-y-7 md:pt-6">
-      {items.map(({ slug, content }, index) => {
+      {items.map(({ slug, title }, index) => {
         const { capitalisedCategory: category } = getReleaseNotesCategoryFromSlug(slug);
         const { datetime, label } = getReleaseNotesDateFromSlug(slug);
-        const regex = /What's new\s?(-\s)?/i;
-
-        const title = getExcerpt(content, 200).replace(regex, '');
 
         return (
           <li

--- a/src/pages/api/release-notes.js
+++ b/src/pages/api/release-notes.js
@@ -5,6 +5,7 @@ import matter from 'gray-matter';
 
 import { RELEASE_NOTES_DIR_PATH } from 'constants/docs';
 import { getPostSlugs } from 'utils/api-docs';
+import getExcerpt from 'utils/get-excerpt';
 
 // TODO: move this function to utils/api-docs
 const getPostBySlug = async (slug, pathname) => {
@@ -13,7 +14,16 @@ const getPostBySlug = async (slug, pathname) => {
     const source = await fs.readFile(pathDirectory, 'utf8');
     const { data, content } = matter(source);
 
-    return { data, content };
+    const match = content.match(/### (.+)/);
+    let title;
+
+    if (match && match[1]) {
+      title = match[1];
+    } else {
+      title = getExcerpt(content, 200);
+    }
+
+    return { data, title };
   } catch (e) {
     console.error(`Error reading file ${pathname}/${slug}.md: `, e);
     return null;

--- a/src/pages/api/release-notes.js
+++ b/src/pages/api/release-notes.js
@@ -37,13 +37,13 @@ export default async function handler(req, res) {
     const releaseNotesPromises = slugs.map(async (slug) => {
       try {
         const post = await getPostBySlug(slug, RELEASE_NOTES_DIR_PATH);
-        const { data, content } = post;
+        const { data, title } = post;
         if (process.env.NODE_ENV === 'production') {
           if (data?.isDraft) {
             return null;
           }
         }
-        return { slug, isDraft: data?.isDraft, content };
+        return { slug, isDraft: data?.isDraft, title };
       } catch (error) {
         console.error(`Error fetching post by slug: ${slug}`, error);
         return null;


### PR DESCRIPTION
This pull request updates the release notes title on the Blog page

<img width="1354" alt="image" src="https://github.com/neondatabase/website/assets/48465000/bcaf097c-b3ac-40ba-a944-469398eaa9fa">
