### PR TITLE
chore: remove unused dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@react-hook/window-scroll": "^1.3.0",
         "@rive-app/react-canvas": "^4.1.4",
         "@splinetool/react-spline": "^2.2.6",
-        "@splinetool/runtime": "^0.9.425",
         "@tailwindcss/typography": "github:tailwindcss/typography",
         "clsx": "^2.0.0",
         "copy-to-clipboard": "^3.3.3",
@@ -3451,6 +3450,7 @@
       "version": "0.9.425",
       "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-0.9.425.tgz",
       "integrity": "sha512-47HPaxXXjJTlG0Dj2SP575daIvL0cd7lKVYRWLSn1X8Ov7efAK6p7Ngw7E69o73PYc7auX0V8gdOXMPmRQJ2PA==",
+      "peer": true,
       "dependencies": {
         "on-change": "^4.0.0",
         "semver-compare": "^1.0.0"
@@ -9908,6 +9908,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.2.tgz",
       "integrity": "sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -11342,7 +11343,8 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "peer": true
     },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -15371,6 +15373,7 @@
       "version": "0.9.425",
       "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-0.9.425.tgz",
       "integrity": "sha512-47HPaxXXjJTlG0Dj2SP575daIvL0cd7lKVYRWLSn1X8Ov7efAK6p7Ngw7E69o73PYc7auX0V8gdOXMPmRQJ2PA==",
+      "peer": true,
       "requires": {
         "on-change": "^4.0.0",
         "semver-compare": "^1.0.0"
@@ -19412,7 +19415,8 @@
     "on-change": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.2.tgz",
-      "integrity": "sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA=="
+      "integrity": "sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==",
+      "peer": true
     },
     "once": {
       "version": "1.4.0",
@@ -20232,7 +20236,8 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "peer": true
     },
     "serialize-javascript": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@react-hook/window-scroll": "^1.3.0",
     "@rive-app/react-canvas": "^4.1.4",
     "@splinetool/react-spline": "^2.2.6",
-    "@splinetool/runtime": "^0.9.425",
     "@tailwindcss/typography": "github:tailwindcss/typography",
     "clsx": "^2.0.0",
     "copy-to-clipboard": "^3.3.3",

--- a/src/app/docs/layout.jsx
+++ b/src/app/docs/layout.jsx
@@ -1,10 +1,13 @@
+import dynamic from 'next/dynamic';
+
 import ChatProvider from 'app/chat-provider';
-import ChatWidget from 'components/pages/doc/chat-widget';
 import MobileNav from 'components/pages/doc/mobile-nav';
 import Sidebar from 'components/pages/doc/sidebar';
 import Container from 'components/shared/container';
 import Layout from 'components/shared/layout';
 import { getSidebar } from 'utils/api-docs';
+
+const ChatWidget = dynamic(() => import('components/pages/doc/chat-widget'));
 
 const DocsLayout = async ({ children }) => {
   const sidebar = await getSidebar();

--- a/src/components/pages/404/hero/hero.jsx
+++ b/src/components/pages/404/hero/hero.jsx
@@ -12,7 +12,7 @@ import Link from 'components/shared/link';
 
 import illustration from './images/illustration.png';
 
-const Search = dynamic(() => import('components/shared/search'));
+const Search = dynamic(() => import('components/shared/search'), { ssr: false });
 
 const CTA = ({ isDocsPage = false }) =>
   isDocsPage ? (

--- a/src/components/pages/404/hero/hero.jsx
+++ b/src/components/pages/404/hero/hero.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import PropTypes from 'prop-types';
@@ -8,9 +9,10 @@ import { useEffect, useState } from 'react';
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';
 import Link from 'components/shared/link';
-import Search from 'components/shared/search';
 
 import illustration from './images/illustration.png';
+
+const Search = dynamic(() => import('components/shared/search'));
 
 const CTA = ({ isDocsPage = false }) =>
   isDocsPage ? (

--- a/src/components/pages/ai/hero/hero.jsx
+++ b/src/components/pages/ai/hero/hero.jsx
@@ -12,9 +12,7 @@ import Container from 'components/shared/container/container';
 import LINKS from 'constants/links';
 import useIsTouchDevice from 'hooks/use-is-touch-device';
 
-const Spline = dynamic(() => import('@splinetool/react-spline'), {
-  ssr: false,
-});
+const Spline = dynamic(() => import('@splinetool/react-spline'));
 
 const MOBILE_WIDTH = 768;
 

--- a/src/components/pages/ai/hero/hero.jsx
+++ b/src/components/pages/ai/hero/hero.jsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Spline from '@splinetool/react-spline';
 import clsx from 'clsx';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
@@ -11,6 +11,10 @@ import Button from 'components/shared/button/button';
 import Container from 'components/shared/container/container';
 import LINKS from 'constants/links';
 import useIsTouchDevice from 'hooks/use-is-touch-device';
+
+const Spline = dynamic(() => import('@splinetool/react-spline'), {
+  ssr: false,
+});
 
 const MOBILE_WIDTH = 768;
 

--- a/src/components/pages/blog/sidebar/sidebar.jsx
+++ b/src/components/pages/blog/sidebar/sidebar.jsx
@@ -1,10 +1,13 @@
+import dynamic from 'next/dynamic';
+
 import BlogNavLink from 'components/pages/blog/blog-nav-link';
-import Search from 'components/shared/search';
 import LINKS from 'constants/links';
 import GitHubIcon from 'icons/github-sm.inline.svg';
 import LinkedInIcon from 'icons/linkedin-sm.inline.svg';
 import TwitterIcon from 'icons/twitter-sm.inline.svg';
 import YouTubeIcon from 'icons/youtube-sm.inline.svg';
+
+const Search = dynamic(() => import('components/shared/search/search'));
 
 const categories = [
   {

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -1,13 +1,15 @@
 import clsx from 'clsx';
+import dynamic from 'next/dynamic';
 import PropTypes from 'prop-types';
 
 import Link from 'components/shared/link/link';
-import Search from 'components/shared/search';
 import MENUS from 'constants/menus';
 
 import { ChatWidgetTrigger } from '../chat-widget';
 
 import Item from './item';
+
+const Search = dynamic(() => import('components/shared/search/search'));
 
 const Sidebar = ({ className = null, sidebar }) => (
   <aside

--- a/src/components/pages/partners/apply/form/form.jsx
+++ b/src/components/pages/partners/apply/form/form.jsx
@@ -2,6 +2,7 @@
 
 import { yupResolver } from '@hookform/resolvers/yup';
 import clsx from 'clsx';
+import dynamic from 'next/dynamic';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -17,10 +18,18 @@ import { doNowOrAfterSomeTime, sendHubspotFormData } from 'utils/forms';
 
 import LoadingIcon from '../images/loading.inline.svg';
 
-import CallbackUrlFields from './callback-url-fields';
-import Field from './field';
-import MultiSelect from './multi-select';
-import Select from './select';
+const Select = dynamic(() => import('./select'), {
+  ssr: false,
+});
+const MultiSelect = dynamic(() => import('./multi-select'), {
+  ssr: false,
+});
+const CallbackUrlFields = dynamic(() => import('./callback-url-fields'), {
+  ssr: false,
+});
+const Field = dynamic(() => import('./field'), {
+  ssr: false,
+});
 
 const integrationTypeOptions = [
   { id: 'oauth', name: 'OAuth' },

--- a/src/components/shared/footer/theme-select/theme-select.jsx
+++ b/src/components/shared/footer/theme-select/theme-select.jsx
@@ -118,7 +118,7 @@ const ThemeSelect = ({ className = null }) => {
         <button
           className="flex h-[30px] w-full items-center py-[7px] pl-2.5 pr-3"
           type="button"
-          aria-label="Select theme"
+          aria-label={`Switch theme. Current theme: ${theme}`}
           onClick={handleDropdown}
         >
           <ActiveThemeIcon theme={theme} />

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -17,7 +17,7 @@ import sendGtagEvent from 'utils/send-gtag-event';
 import Burger from './burger';
 import Github from './images/header-github.inline.svg';
 
-const Search = dynamic(() => import('components/shared/search'));
+const Search = dynamic(() => import('components/shared/search'), { ssr: false });
 
 const Header = ({
   className = null,

--- a/src/components/shared/search/search.jsx
+++ b/src/components/shared/search/search.jsx
@@ -85,7 +85,7 @@ const Search = ({ className = null, indexName, isBlog = false }) => {
     <div className={clsx('relative flex items-center justify-between', className)}>
       <DocSearchButton
         ref={searchButtonRef}
-        aria-label="Open search with command CTRL+K/Command+K"
+        aria-label="Open search with CTRL+K or Command+K"
         onClick={onOpen}
       />
       {isOpen &&

--- a/src/components/shared/search/search.jsx
+++ b/src/components/shared/search/search.jsx
@@ -83,7 +83,11 @@ const Search = ({ className = null, indexName, isBlog = false }) => {
 
   return (
     <div className={clsx('relative flex items-center justify-between', className)}>
-      <DocSearchButton ref={searchButtonRef} aria-label="Search K" onClick={onOpen} />
+      <DocSearchButton
+        ref={searchButtonRef}
+        aria-label="Open search with command CTRL+K/Command+K"
+        onClick={onOpen}
+      />
       {isOpen &&
         createPortal(
           <div className={clsx({ dark: isBlog })}>

--- a/src/components/shared/search/search.jsx
+++ b/src/components/shared/search/search.jsx
@@ -85,7 +85,7 @@ const Search = ({ className = null, indexName, isBlog = false }) => {
     <div className={clsx('relative flex items-center justify-between', className)}>
       <DocSearchButton
         ref={searchButtonRef}
-        aria-label="Use command Search + K or click to open search"
+        aria-label="Use command Search K or click to open search"
         onClick={onOpen}
       />
       {isOpen &&

--- a/src/components/shared/search/search.jsx
+++ b/src/components/shared/search/search.jsx
@@ -83,11 +83,7 @@ const Search = ({ className = null, indexName, isBlog = false }) => {
 
   return (
     <div className={clsx('relative flex items-center justify-between', className)}>
-      <DocSearchButton
-        ref={searchButtonRef}
-        aria-label="Use command Search K or click to open search"
-        onClick={onOpen}
-      />
+      <DocSearchButton ref={searchButtonRef} aria-label="Search K" onClick={onOpen} />
       {isOpen &&
         createPortal(
           <div className={clsx({ dark: isBlog })}>

--- a/src/components/shared/search/search.jsx
+++ b/src/components/shared/search/search.jsx
@@ -83,7 +83,11 @@ const Search = ({ className = null, indexName, isBlog = false }) => {
 
   return (
     <div className={clsx('relative flex items-center justify-between', className)}>
-      <DocSearchButton ref={searchButtonRef} onClick={onOpen} />
+      <DocSearchButton
+        ref={searchButtonRef}
+        aria-label="Use command Search + K or click to open search"
+        onClick={onOpen}
+      />
       {isOpen &&
         createPortal(
           <div className={clsx({ dark: isBlog })}>


### PR DESCRIPTION
This pull request brings some updates, that enhance the pages' performance
- dynamically import spline 
- dynamically search and chat widget in docs layout
- uninstalled unused plugin `@splinetool/runtime`

**Screenshots**
<details>
<summary>Home page</summary>

[Before](https://pagespeed.web.dev/analysis/https-neon-tech/tg8nfzsew4?form_factor=desktop):
<img width="985" alt="image" src="https://github.com/neondatabase/website/assets/48465000/b28359bb-e7f3-4730-af25-b10644c84c91">

[After](https://pagespeed.web.dev/analysis/https-neon-next-git-pagespeed-neondatabase-vercel-app/mbx75747ji?form_factor=desktop):
<img width="987" alt="image" src="https://github.com/neondatabase/website/assets/48465000/63e79bda-6e9e-46f7-b395-cb27514c8866">


</details>

<details>
<summary>Docs page</summary>

[Before](https://pagespeed.web.dev/analysis/https-neon-tech-docs-introduction/7tqqp4nlex?form_factor=desktop):
<img width="997" alt="image" src="https://github.com/neondatabase/website/assets/48465000/60f33c30-975a-491b-9122-f01541dc0b0c">

[After](https://pagespeed.web.dev/analysis/https-neon-next-git-pagespeed-neondatabase-vercel-app-docs-introduction/7l1wx0xg6o?form_factor=desktop):
<img width="1021" alt="image" src="https://github.com/neondatabase/website/assets/48465000/bc58746b-91d7-48cc-a577-6e5e0239c395">
</details>