### PR TITLE
SEO fixes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -107,7 +107,7 @@ const defaultConfig = {
       },
       {
         source: '/api-reference',
-        destination: 'https://api-docs.neon.tech/',
+        destination: 'https://api-docs.neon.tech',
         permanent: true,
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -117,7 +117,7 @@ const defaultConfig = {
       },
       {
         source: '/ycmatcher',
-        destination: 'https://yc-idea-matcher.vercel.app/',
+        destination: 'https://yc-idea-matcher.vercel.app',
         permanent: true,
       },
       ...docsRedirects,

--- a/src/app/docs/release-notes/[...slug]/page.jsx
+++ b/src/app/docs/release-notes/[...slug]/page.jsx
@@ -4,7 +4,6 @@ import Hero from 'components/pages/release-notes/hero';
 import { RELEASE_NOTES_CATEGORIES } from 'components/pages/release-notes/release-notes-filter';
 import Container from 'components/shared/container';
 import Content from 'components/shared/content';
-import Heading from 'components/shared/heading';
 import Link from 'components/shared/link';
 import { RELEASE_NOTES_BASE_PATH, RELEASE_NOTES_SLUG_REGEX } from 'constants/docs';
 import { DEFAULT_IMAGE_PATH } from 'constants/seo-data';
@@ -102,20 +101,18 @@ const ReleaseNotePage = async ({ currentSlug }) => {
           className="flex justify-center dark:bg-gray-new-8 dark:text-white lg:pt-16 md:py-10 sm:py-7"
           date={label}
           withContainer
-          isReleaseNotePost
         />
-        <div className="grow pb-28 dark:bg-gray-new-8 lg:pb-20 md:pb-16">
+        <div className="grow pb-28 dark:bg-gray-new-8 lg:pb-20 md:pb-16 flex">
           <Container size="xs" className="relative flex pb-10">
             <article className="relative flex max-w-full flex-col items-start">
-              <time
-                className="mt-3 whitespace-nowrap text-gray-new-20 dark:text-gray-new-70"
-                dateTime={datetime}
-              >
-                {label}
-              </time>
-              <Heading className="sr-only" tag="h1" size="sm" theme="black">
-                {capitalisedCategory} release - {label}
-              </Heading>
+              <h2>
+                <time
+                  className="mt-3 whitespace-nowrap text-gray-new-20 dark:text-gray-new-70"
+                  dateTime={datetime}
+                >
+                  {label}
+                </time>
+              </h2>
               <Content className="mt-8 max-w-full prose-h3:text-xl" content={mdxSource} />
               <Link
                 className="mt-10 font-semibold lg:mt-8"

--- a/src/app/docs/release-notes/[...slug]/page.jsx
+++ b/src/app/docs/release-notes/[...slug]/page.jsx
@@ -40,6 +40,7 @@ export async function generateMetadata({ params }) {
 
   let label = '';
   let description = '';
+  let socialPreviewTitle = '';
   const currentSlug = slug.join('/');
   const isReleaseNotePage = RELEASE_NOTES_SLUG_REGEX.test(currentSlug);
   const { capitalisedCategory } = getReleaseNotesCategoryFromSlug(currentSlug);
@@ -50,10 +51,11 @@ export async function generateMetadata({ params }) {
     const { label: date } = getReleaseNotesDateFromSlug(currentSlug);
     const { content } = getPostBySlug(currentSlug, RELEASE_NOTES_DIR_PATH);
     label = `${capitalisedCategory} release ${date}`;
+    socialPreviewTitle = `Release notes - ${date}`;
     description = getExcerpt(content, 160);
   }
 
-  const encodedLabel = Buffer.from(label).toString('base64');
+  const encodedLabel = Buffer.from(socialPreviewTitle ?? label).toString('base64');
 
   return getMetadata({
     title: `${label} - Neon`,

--- a/src/app/docs/release-notes/[...slug]/page.jsx
+++ b/src/app/docs/release-notes/[...slug]/page.jsx
@@ -42,14 +42,14 @@ export async function generateMetadata({ params }) {
   let description = '';
   const currentSlug = slug.join('/');
   const isReleaseNotePage = RELEASE_NOTES_SLUG_REGEX.test(currentSlug);
-
+  const { capitalisedCategory } = getReleaseNotesCategoryFromSlug(currentSlug);
   label = 'Release notes';
   description = `The latest product updates from Neon`;
 
   if (isReleaseNotePage) {
     const { label: date } = getReleaseNotesDateFromSlug(currentSlug);
     const { content } = getPostBySlug(currentSlug, RELEASE_NOTES_DIR_PATH);
-    label = `Release notes - ${date}`;
+    label = `${capitalisedCategory} release ${date}`;
     description = getExcerpt(content, 160);
   }
 
@@ -69,6 +69,7 @@ export async function generateMetadata({ params }) {
 
 const ReleaseNotePage = async ({ currentSlug }) => {
   const { datetime, label } = getReleaseNotesDateFromSlug(currentSlug);
+  const { capitalisedCategory } = getReleaseNotesCategoryFromSlug(currentSlug);
 
   const { content } = getPostBySlug(currentSlug, RELEASE_NOTES_DIR_PATH);
   const mdxSource = await serializeMdx(content);
@@ -78,7 +79,7 @@ const ReleaseNotePage = async ({ currentSlug }) => {
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Article',
-    headline: `Release notes — ${label}`,
+    headline: `${capitalisedCategory} release ${label}`,
     datePublished: datetime,
     author: {
       '@type': 'Organization',
@@ -111,7 +112,7 @@ const ReleaseNotePage = async ({ currentSlug }) => {
                 {label}
               </time>
               <Heading className="sr-only" tag="h1" size="sm" theme="black">
-                Release notes - {label}
+                {capitalisedCategory} release - {label}
               </Heading>
               <Content className="mt-8 max-w-full prose-h3:text-xl" content={mdxSource} />
               <Link

--- a/src/app/docs/release-notes/[...slug]/page.jsx
+++ b/src/app/docs/release-notes/[...slug]/page.jsx
@@ -103,8 +103,8 @@ const ReleaseNotePage = async ({ currentSlug }) => {
           withContainer
         />
         <div className="grow pb-28 dark:bg-gray-new-8 lg:pb-20 md:pb-16 flex">
-          <Container size="xs" className="relative flex pb-10">
-            <article className="relative flex max-w-full flex-col items-start">
+          <Container size="xs" className="relative flex pb-10 w-full">
+            <article className="relative flex max-w-full flex-col items-start w-full">
               <h2>
                 <time
                   className="mt-3 whitespace-nowrap text-gray-new-20 dark:text-gray-new-70"
@@ -113,7 +113,7 @@ const ReleaseNotePage = async ({ currentSlug }) => {
                   {label}
                 </time>
               </h2>
-              <Content className="mt-8 max-w-full prose-h3:text-xl" content={mdxSource} />
+              <Content className="mt-8 max-w-full prose-h3:text-xl w-full" content={mdxSource} />
               <Link
                 className="mt-10 font-semibold lg:mt-8"
                 to={RELEASE_NOTES_BASE_PATH}

--- a/src/components/pages/release-notes/hero/hero.jsx
+++ b/src/components/pages/release-notes/hero/hero.jsx
@@ -20,7 +20,7 @@ const Hero = ({ className = null, withContainer = false }) => {
         })}
         size="sm"
       >
-        <span className="text-[36px] font-semibold xl:text-3xl">{TITLE}</span>
+        <h1 className="text-[36px] font-semibold xl:text-3xl">{TITLE}</h1>
         <div className="flex items-center justify-between sm:flex-col sm:items-start sm:gap-y-4">
           <p>{DESCRIPTION}</p>
           {!withContainer && (

--- a/src/components/pages/release-notes/hero/hero.jsx
+++ b/src/components/pages/release-notes/hero/hero.jsx
@@ -9,9 +9,9 @@ import RSSLogo from './images/rss.inline.svg';
 const TITLE = 'Release notes';
 const DESCRIPTION = 'The latest product updates from Neon';
 
-const Hero = ({ className = null, withContainer = false, isReleaseNotePost }) => {
+const Hero = ({ className = null, withContainer = false }) => {
   const Tag = withContainer ? Container : 'div';
-  const TitleTag = isReleaseNotePost ? 'span' : 'h1';
+
   return (
     <div className={className}>
       <Tag
@@ -20,7 +20,7 @@ const Hero = ({ className = null, withContainer = false, isReleaseNotePost }) =>
         })}
         size="sm"
       >
-        <TitleTag className="text-[36px] font-semibold xl:text-3xl">{TITLE}</TitleTag>
+        <span className="text-[36px] font-semibold xl:text-3xl">{TITLE}</span>
         <div className="flex items-center justify-between sm:flex-col sm:items-start sm:gap-y-4">
           <p>{DESCRIPTION}</p>
           {!withContainer && (

--- a/src/components/pages/release-notes/release-note-list/release-note-list.jsx
+++ b/src/components/pages/release-notes/release-note-list/release-note-list.jsx
@@ -23,12 +23,9 @@ const ReleaseNoteList = ({ className, items }) => (
               className="transition-colors duration-200 hover:text-secondary-8 dark:hover:text-green-45"
               to={releaseNotesPath}
             >
-              <time
-                className="whitespace-nowrap text-xl font-semibold leading-normal"
-                dateTime={datetime}
-              >
-                {label}
-              </time>
+              <h2 className="whitespace-nowrap text-xl font-semibold leading-normal">
+                <time dateTime={datetime}>{label}</time>
+              </h2>
             </Link>
 
             <Content

--- a/src/utils/generate-doc-page-path.js
+++ b/src/utils/generate-doc-page-path.js
@@ -1,7 +1,7 @@
 const { DOCS_BASE_PATH } = require('../constants/docs');
 
 function generateDocPagePath(slug) {
-  return `${DOCS_BASE_PATH}${slug}/`;
+  return `${DOCS_BASE_PATH}${slug}`;
 }
 
 module.exports = generateDocPagePath;


### PR DESCRIPTION
This pull request returns the category name of release notes for the page title and `h1`, and removes the trailing slash from the redirects