### PR TITLE
Update pg_embedding.md

### DIFF
--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -221,7 +221,7 @@ CREATE EXTENSION embedding;
 CREATE INDEX ON items USING hnsw(embedding) WITH (dims=3, m=3, efconstruction=5, efsearch=5);
 ```
 
-<CodeBlock shouldWrap>
+</CodeBlock/>
 
 ## Upgrade to pg_embedding for on-disk indexes
 

--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -199,7 +199,7 @@ CREATE TABLE new_items (id BIGSERIAL PRIMARY KEY, embedding real[]);
 
 /* 
   Transfer data from your existing table to the new table and convert 
-  embedding to real[] array type
+  embeddings to real[]
 */
 INSERT INTO new_items (id, embedding)
 SELECT id, embedding::real[]

--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -179,16 +179,12 @@ Currently, you cannot install both `pgvector` and `pg_embedding` in the same dat
 
 The migration example is based on the following table and index defined for use with `pgvector`:
 
-<CodeBlock shouldWrap>
-
 ```sql
 CREATE EXTENSION vector;
 CREATE TABLE items (id BIGSERIAL PRIMARY KEY, embedding VECTOR(3));
 INSERT INTO items (embedding) VALUES ('[1,2,3]'), ('[4,5,6]');
 CREATE INDEX ON items USING ivfflat (embedding vector_l2_ops) WITH (lists = 100);
 ```
-
-</CodeBlock>
 
 Migrating the `items` table to `pg_embedding` involves the steps outline below. The same steps can be applied generally.
 
@@ -237,8 +233,6 @@ Migrating the `items` table to `pg_embedding` involves the steps outline below. 
     ```sql
     CREATE INDEX ON items USING hnsw(embedding) WITH (dims=3, m=3, efconstruction=5, efsearch=5);
     ```
-
-</CodeBlock>
 
 ## Upgrade to pg_embedding for on-disk indexes
 

--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -219,7 +219,7 @@ Migrating the `items` table to `pg_embedding` involves the steps outline below. 
 5. Drop the `pgvector` extension.
 
     ```sql
-    DROP EXTENSION vector;
+    DROP EXTENSION vector CASCADE;
     ```
 
 6. Add the `pg_embedding` extension.

--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -188,7 +188,11 @@ INSERT INTO items (embedding) VALUES ('[1,2,3]'), ('[4,5,6]');
 CREATE INDEX ON items USING ivfflat (embedding vector_l2_ops) WITH (lists = 100);
 ```
 
+</CodeBlock>
+
 For the example `items` table, migrating to `pg_embedding` involves the steps outline below. The same steps can be applied generally.
+
+<CodeBlock shouldWrap>
 
 ```sql
 /* 

--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -192,38 +192,51 @@ CREATE INDEX ON items USING ivfflat (embedding vector_l2_ops) WITH (lists = 100)
 
 For the example `items` table, migrating to `pg_embedding` involves the steps outline below. The same steps can be applied generally.
 
-<CodeBlock shouldWrap>
+1. Create a new table, but with the "embedding" column data type
+  defined as a `real[]` array.
 
-```sql
-/* 
-  Create a new table, but with the "embedding" column data type 
-  defined as a real[] array
-*/
-CREATE TABLE new_items (id BIGSERIAL PRIMARY KEY, embedding real[]);
+    ```sql
+    CREATE TABLE new_items (id BIGSERIAL PRIMARY KEY, embedding real[]);
+    ```
 
-/* 
-  Transfer data from your existing table to the new table and convert 
-  embeddings to real[]
-*/
-INSERT INTO new_items (id, embedding)
-SELECT id, embedding::real[]
-FROM items;
+2. Transfer data from your existing table to the new table and convert
+  embeddings to `real[]`.
 
--- Drop the old table
-DROP TABLE items;
+    ```sql
+    INSERT INTO new_items (id, embedding)
+    SELECT id, embedding::real[]
+    FROM items;
+    ```
 
--- Rename the new table to the name of the old table
-ALTER TABLE new_items RENAME TO items;
+3. Drop the old table.
 
--- Drop the pgvector extension
-DROP EXTENSION vector;
+    ```sql
+    DROP TABLE items;
+    ```
 
--- Add the pg_embedding extension
-CREATE EXTENSION embedding;
+4. Rename the new table to the name of the old table.
 
--- Create indexes to replace the ones you defined with pgvector
-CREATE INDEX ON items USING hnsw(embedding) WITH (dims=3, m=3, efconstruction=5, efsearch=5);
-```
+    ```sql
+    ALTER TABLE new_items RENAME TO items;
+    ```
+
+5. Drop the `pgvector` extension.
+
+    ```sql
+    DROP EXTENSION vector;
+    ```
+
+6. Add the `pg_embedding` extension
+
+    ```sql
+    CREATE EXTENSION embedding;
+    ```
+
+6. Create indexes to replace any indexes you defined previously with `pgvector`.
+
+    ```sql
+    CREATE INDEX ON items USING hnsw(embedding) WITH (dims=3, m=3, efconstruction=5, efsearch=5);
+    ```
 
 </CodeBlock>
 

--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -174,10 +174,10 @@ The key idea behind HNSW is that by starting the search at the top layer and mov
 The following example demonstrates how to migrate from `pgvector` to `pg_embedding`. The procedure involves creating a new table with embedding columns defined as `real[]` instead of `VECTOR`, copying data from the old table to the new table, dropping the old table, removing the `pgvector` extension, adding the `pg_embedding` extension, renaming the new table, and creating any required indexes.
 
 <Admonition type="note">
-Currently, you cannot install both `pgvector` and `pg_embedding` in the same database. If you have the `pgvector` extension installed and try to install `pg_embedding`, the following error is returned: `ERROR: access method "hnsw" already exists (SQLSTATE 42710)`.
+Currently, you cannot install both `pgvector` and `pg_embedding` in the same database. If you have the `pgvector` extension installed, trying to install `pg_embedding` returns this error: `ERROR: access method "hnsw" already exists (SQLSTATE 42710)`.
 </Admonition>
 
-The migration example is based on the following table and index, which is defined for use with `pgvector`:
+The migration example is based on the following table and index defined for use with `pgvector`:
 
 <CodeBlock shouldWrap>
 
@@ -190,7 +190,7 @@ CREATE INDEX ON items USING ivfflat (embedding vector_l2_ops) WITH (lists = 100)
 
 </CodeBlock>
 
-For the example `items` table, migrating to `pg_embedding` involves the steps outline below. The same steps can be applied generally.
+Migrating the `items` table to `pg_embedding` involves the steps outline below. The same steps can be applied generally.
 
 1. Create a new table, but with the "embedding" column data type
   defined as a `real[]` array.
@@ -226,7 +226,7 @@ For the example `items` table, migrating to `pg_embedding` involves the steps ou
     DROP EXTENSION vector;
     ```
 
-6. Add the `pg_embedding` extension
+6. Add the `pg_embedding` extension.
 
     ```sql
     CREATE EXTENSION embedding;

--- a/content/docs/extensions/pg_embedding.md
+++ b/content/docs/extensions/pg_embedding.md
@@ -221,7 +221,7 @@ CREATE EXTENSION embedding;
 CREATE INDEX ON items USING hnsw(embedding) WITH (dims=3, m=3, efconstruction=5, efsearch=5);
 ```
 
-</CodeBlock/>
+</CodeBlock>
 
 ## Upgrade to pg_embedding for on-disk indexes
 

--- a/src/components/pages/ai/integration/integration.jsx
+++ b/src/components/pages/ai/integration/integration.jsx
@@ -32,8 +32,8 @@ const items = [
   },
   {
     title: 'Compatible vector types',
-    code: `    SELECT embedding::real[] 
-    AS converted_vectors
+    code: `    INSERT INTO new_items (id, embedding) 
+    SELECT id, embedding::real[]
     FROM items;
     `,
     text: 'Compatible vector types make application migration easy.',


### PR DESCRIPTION
Update migration instructions in docs and update the AI page on the website. Casting is current not supported.
https://neon-next-git-dprice-update-pg-embedding-docs-neondatabase.vercel.app/docs/extensions/pg_embedding#migrate-from-pgvector-to-pgembedding

Site. See "Compatible vector types" tab
https://neon-next-git-dprice-update-pg-embedding-docs-neondatabase.vercel.app/ai