### PR TITLE
Drop vector extension migration instructions

### DIFF
--- a/content/docs/ai/ai-concepts.md
+++ b/content/docs/ai/ai-concepts.md
@@ -51,8 +51,6 @@ Vector similarity search computes similarities (the distance) between data point
 
 Different distance metrics can be more appropriate for different tasks, depending on the nature of the data and the specific relationships you're interested in. For instance, cosine similarity is often used in text analysis.
 
-The [pg_embedding](/docs/extensions/pg_embedding) and [pgvector](/docs/extensions/pgvector) extensions, which enable Postgres as a vector database, support different distance metrics, including those described above.
-
 ## Generating embeddings
 
 A common approach to generate embeddings is to use OpenAI’s Embeddings API. This API allows you to input a text string into an API endpoint, which then returns the corresponding embedding. The "cow jumped over the moon" example above is a simplistic example with 3 dimensions. Most embedding models generate a much larger number of embeddings. OpenAI's `text-embedding-ada-002` model, for example, generates 1536 embeddings.
@@ -103,24 +101,24 @@ To learn more about OpenAI's embeddings, see [Embeddings](https://platform.opena
 
 ## Storing vector embeddings in Postgres
 
-Neon supports the [pg_embedding](/docs/extensions/pg_embedding) and [pgvector](/docs/extensions/pgvector) Postgres extensions, which enable storing and retrieving vector embeddings directly within your Postgres database. When building AI and LLM applications, installing either of these extensions eliminates the need to build out your architecture to include a separate vector store.
+Neon supports the [pgvector](/docs/extensions/pgvector) and [pg_embedding](/docs/extensions/pg_embedding) Postgres extensions, which enable storing and retrieving vector embeddings directly within your Postgres database. When building AI and LLM applications, installing either of these extensions eliminates the need to build out your architecture to include a separate vector store.
 
-After installing an extension, you can create a table to store your embeddings. For example, if you install the `pg_embedding` extension, you might define a table similar to the following to store your embeddings:
+After installing an extension, you can create a table to store your embeddings. For example, if you install the `pgvector` extension, you might define a table similar to the following to store your embeddings:
 
 ```sql
-CREATE TABLE documents(id BIGSERIAL PRIMARY KEY, embedding REAL[1536]);
+CREATE TABLE items(id BIGSERIAL PRIMARY KEY, embedding VECTOR(1536));
 ```
 
 To add embeddings to the table, you would insert the data as shown:
 
 ```sql
-INSERT INTO documents(embedding) VALUES (ARRAY[
+INSERT INTO items(embedding) VALUES ('[
     -0.006929283495992422,
     -0.005336422007530928,
     ...
     -4.547132266452536e-05,
     -0.024047505110502243
-]);
+]');
 ```
 
 ## Building AI apps with embeddings
@@ -137,6 +135,6 @@ The concepts described above provide an introduction to the basic building block
 For example applications built based on this general process, see the following:
 
 <DetailIconCards>
-<a href="https://github.com/neondatabase/yc-idea-matcher" description="Build an AI-powered semantic search application with pg_embedding" icon="github">Semantic search app</a>
+<a href="https://github.com/neondatabase/yc-idea-matcher" description="Build an AI-powered semantic search application" icon="github">Semantic search app</a>
 <a href="https://github.com/neondatabase/ask-neon" description="Build an AI-powered chatbot with pgvector" icon="github">Chatbot app</a>
 </DetailIconCards>

--- a/content/docs/ai/ai-intro.md
+++ b/content/docs/ai/ai-intro.md
@@ -18,8 +18,6 @@ Neon supports the following extensions for enabling Postgres as your vector data
 
 `pg_embedding` is an open-source extension that enables storing vector embeddings and graph-based vector similarity search in Postgres using the Hierarchical Navigable Small World (HNSW) algorithm. It supports HNSW indexes. To get started, see [The pg_embedding extension](/docs/extensions/pg_embedding).
 
-If you are currently using `pgvector` and want to try `pg_embedding`, refer to [Migrate from pgvector to pg_embedding](/docs/extensions/pg_embedding#migrate-from-pgvector-to-pgembedding).
-
 ### pgvector
 
 `pgvector` is an open-source extension that enables storing vector embeddings and vector similarity search in Postgres. It supports both ivfflat and HNSW indexes. To get started, see [The pgvector extension](/docs/extensions/pgvector).
@@ -29,7 +27,7 @@ If you are currently using `pgvector` and want to try `pg_embedding`, refer to [
 Check out the following AI application examples built with Neon.
 
 <DetailIconCards>
-<a href="https://github.com/neondatabase/yc-idea-matcher" description="Build an AI-powered semantic search application with pg_embedding" icon="github">Semantic search app</a>
+<a href="https://github.com/neondatabase/yc-idea-matcher" description="Build an AI-powered semantic search application" icon="github">Semantic search app</a>
 <a href="https://github.com/neondatabase/ask-neon" description="Build an AI-powered chatbot with pgvector" icon="github">Chatbot app</a>
 <a href="https://vercel.com/templates/next.js/postgres-pgvector" description="Enable vector similarity search with Vercel Postgres" icon="github">Vercel Postgres pgvector Starter</a>
 <a href="https://github.com/neondatabase/postgres-ai-playground" description="Build an AI-enabled SQL playground for natural language queries" icon="github">Web-based AI SQL Playground</a>

--- a/content/docs/ai/ai-intro.md
+++ b/content/docs/ai/ai-intro.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 Vector databases enable efficient storage and retrieval of vector data, which is an essential component in building AI applications that leverage Large Language Models (LLMs) such as OpenAI.
 
-Neon supports the `pg_embedding` and `pgvector` open-source extensions, either of which allow you to enable Postgres as a vector database for storing and querying vector embeddings.
+Neon supports the `pgvector` and `pg_embedding` open-source extensions, either of which allow you to enable Postgres as a vector database for storing and querying vector embeddings.
 
 By enabling Postgres as a vector database, you can keep your data in the open source database that you know and trust. There's no need for data migration or a proprietary vector storage solution.
 
@@ -14,13 +14,13 @@ By enabling Postgres as a vector database, you can keep your data in the open so
 
 Neon supports the following extensions for enabling Postgres as your vector database.
 
-### pg_embedding
-
-`pg_embedding` is an open-source extension that enables storing vector embeddings and graph-based vector similarity search in Postgres using the Hierarchical Navigable Small World (HNSW) algorithm. It supports HNSW indexes. To get started, see [The pg_embedding extension](/docs/extensions/pg_embedding).
-
 ### pgvector
 
 `pgvector` is an open-source extension that enables storing vector embeddings and vector similarity search in Postgres. It supports both ivfflat and HNSW indexes. To get started, see [The pgvector extension](/docs/extensions/pgvector).
+
+### pg_embedding
+
+`pg_embedding` is an open-source extension that enables storing vector embeddings and graph-based vector similarity search in Postgres using the Hierarchical Navigable Small World (HNSW) algorithm. It supports HNSW indexes. To get started, see [The pg_embedding extension](/docs/extensions/pg_embedding).
 
 ## Example applications
 

--- a/content/release-notes/2023-08-03-storage-and-compute.md
+++ b/content/release-notes/2023-08-03-storage-and-compute.md
@@ -28,6 +28,4 @@ Additionally, `pg_embedding` now supports cosine and Manhattan distance metrics.
 
 If you have an existing `pg_embedding` installation and want to upgrade to the new version,  see [Upgrade to pg_embedding with on-disk indexes](/docs/extensions/pg_embedding#upgrade-to-pgembedding-for-on-disk-indexes) for instructions.
 
-If you currently use `pgvector` and want to try `pg_embedding`, refer to [Migrate from pgvector to pg_embedding](/docs/extensions/pg_embedding#migrate-from-pgvector-to-pgembedding). The vector storage types in `pg_embedding` and `pgvector` are compatible, allowing you to migrate without modifying tables.
-
 Also, be sure to check out the new [Neon AI page](https://neon.tech/ai) on our website, and our [docs](https://neon.tech/docs/ai/ai-intro), which include links to new [AI example applications](https://neon.tech/docs/ai/ai-intro#example-applications) built with Neon Serverless Postgres.

--- a/src/app/ai/page.jsx
+++ b/src/app/ai/page.jsx
@@ -21,7 +21,7 @@ const items = [
     icon: updateIcon,
     title: 'Reliable & actively maintained',
     description:
-      'pg_embedding is open-source and actively maintained by a team of Postgres committers at Neon',
+      'The pgvector and pg_embedding extensions are open-source and actively maintained',
   },
   {
     icon: scalabilityIcon,
@@ -32,12 +32,12 @@ const items = [
     icon: searchIcon,
     title: 'Blazingly fast search',
     description:
-      'pg_embedding supports HNSW indexes for fast and scalable vector similarity search',
+      'Use HNSW indexes for fast and scalable vector similarity search in Postgres',
   },
   {
     icon: compatibilityIcon,
     title: 'Highly compatible',
-    description: 'Easily switch to pg_embedding in your Postgres and LangChain projects',
+    description: 'Use Neon with pgvector or pg_embedding in your Postgres and LangChain projects',
   },
 ];
 

--- a/src/components/pages/ai/integration/integration.jsx
+++ b/src/components/pages/ai/integration/integration.jsx
@@ -37,7 +37,7 @@ const items = [
     FROM items;
     `,
     text: 'Compatible vector types make application migration easy.',
-    linkUrl: '/docs/extensions/pg_embedding#migrate-from-pgvector-to-pgembedding',
+    linkUrl: '/docs/extensions/pg_embedding',
   },
 ];
 

--- a/src/components/pages/ai/integration/integration.jsx
+++ b/src/components/pages/ai/integration/integration.jsx
@@ -30,15 +30,6 @@ const items = [
     text: 'Store embeddings and perform graph-based vector similarity search with pg_embedding.',
     linkUrl: '/docs/extensions/pg_embedding',
   },
-  {
-    title: 'Compatible vector types',
-    code: `    SELECT embedding::real[] 
-    AS converted_vectors
-    FROM items;
-    `,
-    text: 'Compatible vector types make application migration easy.',
-    linkUrl: '/docs/extensions/pg_embedding',
-  },
 ];
 
 const Integration = () => {


### PR DESCRIPTION
- Remove vector extension migration instructions
https://neon-next-git-dprice-drop-extension-migrati-d9c87b-neondatabase.vercel.app/docs/extensions/pg_embedding
- Start Deemphasizing
- Drop the "Compatible vector types" tab from AI page and adjust text a little to deemphasize
- https://neon-next-git-dprice-drop-extension-migrati-d9c87b-neondatabase.vercel.app/ai