### PR TITLE
feat: add last week in aws page and block it from indexing

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,12 +1,17 @@
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.tech',
-  exclude: ['/blog/wp-draft-post-preview-page', '/blog/rss.xml', '/docs/release-notes/rss.xml'],
+  exclude: [
+    '/blog/wp-draft-post-preview-page',
+    '/blog/rss.xml',
+    '/docs/release-notes/rss.xml',
+    '/last-week-in-aws',
+  ],
   generateRobotsTxt: true,
   robotsTxtOptions: {
     policies: [
       {
         userAgent: '*',
-        disallow: '/blog/wp-draft-post-preview-page$',
+        disallow: ['/blog/wp-draft-post-preview-page$', '/last-week-in-aws$'],
       },
     ],
   },

--- a/src/app/last-week-in-aws/page.jsx
+++ b/src/app/last-week-in-aws/page.jsx
@@ -1,0 +1,28 @@
+import Community from 'components/pages/home/community';
+import DataBranching from 'components/pages/home/data-branching';
+import FirstSection from 'components/pages/home/first-section';
+import Scalability from 'components/pages/home/scalability';
+import SecondSection from 'components/pages/home/second-section';
+import Storage from 'components/pages/home/storage';
+import Layout from 'components/shared/layout';
+import Subscribe from 'components/shared/subscribe';
+import SEO_DATA from 'constants/seo-data';
+import getMetadata from 'utils/get-metadata';
+
+export const metadata = getMetadata(SEO_DATA.lastWeekInAws);
+
+const LastWeekInAWS = () => (
+  <Layout headerTheme="black" isSignIn footerWithTopBorder withOverflowHidden>
+    <FirstSection />
+    <Community />
+    <Scalability />
+    <Storage />
+    <DataBranching />
+    <SecondSection />
+    <Subscribe />
+  </Layout>
+);
+
+export default LastWeekInAWS;
+
+export const revalidate = 60;

--- a/src/constants/seo-data.js
+++ b/src/constants/seo-data.js
@@ -77,6 +77,13 @@ export default {
     description: 'Thank you for subscribing to the Neon newsletter',
     pathname: LINKS.thankYou,
   },
+  lastWeekInAws: {
+    title: 'Neon — Serverless, Fault-Tolerant, Branchable Postgres',
+    description:
+      'Postgres made for developers. Easy to Use, Scalable, Cost efficient solution for your next project.',
+    pathname: '',
+    robotsNoindex: 'noindex',
+  },
 };
 
 export const getBlogCategoryDescription = (category) => {


### PR DESCRIPTION
This PR brings a home page duplicate for Last Week in AWS newsletter and blocks this page from indexing