### PR TITLE
feat: add image border to the docs articles

### DIFF
--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -22,7 +22,7 @@
     }
 
     img {
-      @apply border border-gray-new-94 dark:border-gray-new-20;
+      @apply border border-gray-new-94 dark:border-gray-new-20 rounded;
     }
 
     ul,

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -21,6 +21,10 @@
       @apply mb-3 mt-10;
     }
 
+    img {
+      @apply border border-gray-new-94 dark:border-gray-new-20;
+    }
+
     ul,
     ol {
       @apply my-3 list-none;


### PR DESCRIPTION
This PR brings a subtle border for the docs illustrations to enhance readability.

[Preview](https://neon-next-git-docs-image-border-neondatabase.vercel.app/docs/guides/vercel)