### PR TITLE
Point-in-time restore edits

### DIFF
--- a/content/docs/guides/branching-pitr.md
+++ b/content/docs/guides/branching-pitr.md
@@ -7,7 +7,7 @@ redirectFrom:
   - /docs/guides/branching-data-recovery
 ---
 
-Neon retains a 7-day history of data changes for all branches in a Neon project, which allows you to create a branch that restores data to any time within the defined retention period. You can use this capability to recover lost data, which is a form of Point-in-time restore (PITR).
+Neon retains a history of changes for all branches in a Neon project, which allows you to create a branch that restores data to any time within the defined history retention period. You can use this capability to recover lost data, which is a form of Point-in-time restore (PITR).
 
 The history retention period is configurable. The supported range is 0 to 7 days for [Free Tier](/docs/introduction/free-tier) users, and 0 to 30 days for [Pro plan](/docs/introduction/pro-plan) users. For configuration instructions, see [Configure history retention](/docs/manage/projects#configure-history-retention).
 
@@ -21,7 +21,7 @@ To create a point-in-time branch:
 
 1. Navigate to the **Branches** page in the Neon Console.
 1. Click **Create branch** to open the branch creation dialog.
-1. Enter a name for the branch. You can call it `data_recovery`, for example.
+1. Enter a name for the branch. You can call it `recovery_branch`, for example.
     ![Data recovery create branch dialog](/docs/guides/data_recovery_create_branch.png)
 1. For the **Parent branch**, select the branch where the data loss occurred.
 1. Select the **Time** option to create a branch with data as it existed at a specific date and time. For example, if the data loss occurred on July 11, 2023 at 10:01am, set the time to July 11, 2023, at 10:00am, just before the faulty query was run.
@@ -32,7 +32,7 @@ To create a point-in-time branch:
 You can also create point-in-time branches using the [Neon CLI](/docs/reference/neon-cli). For example, you can perform the same action described above with the following CLI command:
 
 ```bash
-neonctl branches create --name data_recovery --parent 2023-07-11T10:00:00Z
+neonctl branches create --name recovery_branch --parent 2023-07-11T10:00:00Z
 ```
 
 The timestamp must be provided in ISO 8601 format. You can use this [timestamp converter](https://www.timestamp-converter.com/).
@@ -50,7 +50,7 @@ You can also query the databases in a branch from the Neon SQL Editor. For instr
 To connect to your branch:
 
 1. In the Neon Console, select your project.
-2. On the project **Dashboard**, under **Connection Details**, select the `data_recovery` branch, the database, and the role you want to connect with.
+2. On the project **Dashboard**, under **Connection Details**, select your `recovery_branch`, the database, and the role you want to connect with.
 ![Connection details widget recovery branch](/docs/guides/data_recovery_connection_details.png)
 3. Copy the connection string. A connection string includes your role name, password, compute endpoint hostname, and database name.
 4. Connect with `psql`. Your connection string will look something like this:
@@ -65,7 +65,7 @@ To connect to your branch:
 
 ## Verify the data
 
-Check to see if the lost data is now present. For instance, if you lost an `orders` table, you might run a query like the following to verify that the data is available in your newly created branch:
+Check to see if the lost data is now present. For instance, if you lost an `orders` table, you might run a query like this one to verify that the data is available in your newly created branch:
 
 ```sql
 SELECT * FROM orders LIMIT 10;
@@ -79,13 +79,13 @@ To make the recovery branch your new primary:
 
 1. In the Neon Console, select a project.
 2. Select **Branches** to view the branches for the project.
-3. Select your `data_recovery` branch from the table.
+3. Select your `recovery_branch` from the table.
 4. On the branch details page, select **Set as Primary**.
 
 Making a branch your primary branch ensures that access to data on the branch is never interrupted, even when you exceed project limits. For more information, see [Primary branch](/docs/manage/branches#primary-branch).
 
 <Admonition type="note">
-If your previous primary branch was your project's root branch (the initial branch created with your project), it cannot be deleted. Deleting a root branch is not yet supported. In the meantime, you can rename a root branch (perhaps adding an `OLD` or `DO_NOT_USE` prefix to its name) and remove data from it to ensure that it's not used accidentally or taking up storage space.
+If your previous primary branch was your project's root branch (the initial branch created with your project), it cannot be deleted. Deleting a root branch is not yet supported. In the meantime, you can rename a root branch (perhaps adding an `OLD` or `DO_NOT_USE` prefix to its name) and remove data from it to ensure that it's not used accidentally or consuming storage space.
 </Admonition>
 
 ## Update your connections
@@ -111,7 +111,7 @@ To avoid changing connection details in your application, you can reassign the c
 - [Using Neon branching for instant point-in-time restore](https://neon.tech/blog/point-in-time-recovery). The blog post describes point-in-time restore and provides a script for creating a recovery branch, reassigning a compute endpoint, and setting the new branch as the primary.
 - [Time Travel with Serverless Postgres](https://neon.tech/blog/time-travel-with-postgres). This blog post (with video) describes a data recovery example that uses Neon's branching feature, the Neon API, and a bisect script to recover lost data.
 
-Check out the GitHub repositories for these examples:
+The following GitHub repositories are available for these examples:
 
 <DetailIconCards>
 <a href="https://github.com/neondatabase/restore-neon-branch" description="A script to restore a Neon branch to a previous state while preserving the same endpoint" icon="github">Restore a Neon database</a>

--- a/content/docs/introduction/billing.md
+++ b/content/docs/introduction/billing.md
@@ -111,9 +111,9 @@ _Project storage_ is the total volume of data and history stored in your Neon pr
 
 - **History**
 
-  Neon retains a history if data changes to support _point-in-time restore_ and _database branching_.
+  Neon retains a history of changes for all branches to support _point-in-time restore_.
 
-  - _Point-in-time restore_ is the ability to restore data to an earlier point in time. Neon retains a 7-day history in the form of WAL records for a Neon project, by default. You can configure the retention period. See [Point-in-time restore](/docs/introduction/point-in-time-restore). WAL records that age out of the retention period are evicted from storage and no longer count toward project storage.
+  - _Point-in-time restore_ is the ability to restore data to an earlier point in time. Neon retains a history of changes in the form of WAL records. You can configure the history retention period. See [Point-in-time restore](/docs/introduction/point-in-time-restore). WAL records that age out of the history retention period are evicted from storage and no longer count toward project storage.
   - A _database branch_ is a virtual snapshot of your data at the point of branch creation combined with WAL records that capture the branch's data change history from that point forward.
     When a branch is first created, it adds no storage. No data changes have been introduced yet, and the branch's virtual snapshot still exists in the parent branch's _history_, which means that it shares this data in common with the parent branch. A branch begins adding to storage when data changes are introduced or when the branch's virtual snapshot falls out of the parent branch's _history_, in which case the branch's data is no longer shared in common. In other words, branches add storage when you modify data or allow the branch to age out of the parent branch's _history_.
 

--- a/content/docs/introduction/point-in-time-restore.md
+++ b/content/docs/introduction/point-in-time-restore.md
@@ -4,19 +4,19 @@ subtitle: Restore your data to previous state
 enableTableOfContents: true
 ---
 
-Neon retains a history of data changes, enabling point-in-time restore. This feature allows you to restore data to any point within the retention period. You can use the point-in-time restore feature as a database [backup](/docs/manage/backups) strategy, to view the past state of your database, or to recover lost data.
+Neon retains a history of changes for all branches, enabling point-in-time restore. This feature allows you to restore data to any point within the retention period. You can use the point-in-time restore feature as a database [backup](/docs/manage/backups) strategy, to view the past state of your database, or to recover lost data.
 
 ## History retention
 
-Neon retains a 7-day history by default. The history retention period is configurable. The supported range is 0 to 7 days for [Free Tier](/docs/introduction/free-tier) users, and 0 to 30 days for [Pro plan](/docs/introduction/pro-plan) users.
+The history retention period is 7 days, by default, but is configurable. The supported range is 0 to 7 days for [Free Tier](/docs/introduction/free-tier) users, and 0 to 30 days for [Pro plan](/docs/introduction/pro-plan) users.
 
 You can configure the **History retention** setting in the Neon Console, under **Settings** > **Storage**. For further instructions, see [Configure history retention](/docs/manage/projects#configure-history-retention).
 ![History retention configuration](/docs/relnotes/history_retention.png)
 
-Increasing the history retention period affects all branches in your Neon project and increases [project storage](/docs/introduction/billing#project-storage). You can scale retained history to zero if reducing storage is more important than the point-in-time restore capability.
+Increasing the history retention period affects all branches in your Neon project and increases [project storage](/docs/introduction/billing#project-storage). You can scale **History retention** down to zero if reducing storage cost is more important than the ability to restore your data to a past state.
 
-History is retained in the form of Write-Ahead-Log (WAL) records. As WAL records that age out of the retention period, they are evicted from storage and no longer count toward project storage.
+History is retained in the form of Write-Ahead-Log (WAL) records. As WAL records age out of the retention period, they are evicted from storage and no longer count toward project storage.
 
 ## Point-in-time restore
 
-A point-in-time restore operation is performed by creating a branch using the **Time** or **LSN** option. Your retention period dictates how far back you can restore. To learn how to perform a point-in-time restore operation, refer to [Branching — Point-in-time restore](https://neon.tech/docs/guides/branching-pitr).
+A point-in-time restore operation is performed by creating a branch using the **Time** or **LSN** option. Your **History retention** period dictates how far back you can restore your data. To learn how to perform a point-in-time restore operation, refer to [Branching — Point-in-time restore](https://neon.tech/docs/guides/branching-pitr).

--- a/content/docs/manage/backups.md
+++ b/content/docs/manage/backups.md
@@ -7,19 +7,19 @@ Neon does not yet provide support for configuring automated backups in the Neon 
 
 ## Built-in backups with Neon's point-in-time restore feature
 
-By default, Neon keeps a 7-day history allowing you to restore your data to a particular date and time or Log Sequence Number (LSN). For Neon [Free Tier](/docs/introduction/free-tier) users, the 7-day history period is fixed. [Neon Pro plan](/docs/introduction/pro-plan) users can configure Neon to retain up to a 30 days of history. With this backup option, no action or automation is required. You can quickly restore your data to a past state by creating a database branch. This feature is referred to [Point-in-time restore](/docs/introduction/point-in-time-restore).
+By default, Neon retains a 7-day history of changes for all branches, allowing you to restore your data to a particular date and time or Log Sequence Number (LSN). The history retention period is configurable. The supported range is 0 to 7 days for [Free Tier](/docs/introduction/free-tier) users, and 0 to 30 days for [Pro plan](/docs/introduction/pro-plan) users. With this backup option, no action or automation is required. You can quickly restore your data to a past state by creating a database branch. This feature is referred to [Point-in-time restore](/docs/introduction/point-in-time-restore).
 
 For information about creating a point-in-time restore branch, see [Branching — Point-in-time restore](/docs/guides/branching-pitr).
 
 ## pg_dump
 
-You can backup a database using `pg_dump`, in the same way backups are created for a standalone Postgres instances.
+You can backup a database using `pg_dump`, in the same way backups are created for a standalone Postgres instance.
 
 This method dumps a single database in a single branch of your Neon project. If you need to create backups for multiple databases in multiple branches, you must perform a dump operation for each database in each branch separately.
 
 To dump a database from your Neon project, please refer to the `pg_dump` instructions in our [Import from Postgres](/docs/import/import-from-postgres) guide.
 
-Please be aware the dumping data from Neon is considered "data transfer". For data transfer costs, please refer to our [Billing](/docs/introduction/billing) documentation.
+Please be aware that dumping data from Neon is considered "data transfer". For data transfer costs, please refer to our [Billing](/docs/introduction/billing) documentation.
 
 ## Need help?
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -242,7 +242,7 @@ An 8KB unit of data, which is the smallest unit that Postgres uses for storing r
 
 ### Pageserver
 
-A Neon architecture component that reads WAL records from Safekeepers to identify modified pages. The Pageserver accumulates and indexes incoming WAL records in memory and writes them to disk in batches. Each batch is written to an immutable file that is never modified after creation. Using these files, the Pageserver can quickly reconstruct any version of a page dating back to the defined retention period. Neon retains 7-day history, by default.
+A Neon architecture component that reads WAL records from Safekeepers to identify modified pages. The Pageserver accumulates and indexes incoming WAL records in memory and writes them to disk in batches. Each batch is written to an immutable file that is never modified after creation. Using these files, the Pageserver can quickly reconstruct any version of a page dating back to the defined history retention period. Neon retains history of changes for all branches. The default history retention period is 7 days.
 
 The Pageserver uploads immutable files to cloud storage, which is the final, highly durable destination for data. After a file is successfully uploaded to cloud storage, the corresponding WAL records can be removed from the Safekeepers.
 
@@ -256,7 +256,7 @@ A custom volume-based paid plan offered by Neon that includes support for resale
 
 ### Point-in-time restore
 
-Restoration of data to a state that existed at an earlier time. Neon retains a history in the form of Write-Ahead-Log (WAL) records, which allows you to restore data to an earlier time. A point-in-time restore is performed by creating a branch using the **Time** or **LSN** option. By default, Neon retains a 7-day history of data changes for all branches in a project. The supported range  is 0 to 7 days for [Free Tier](/docs/introduction/free-tier) users, and 0 to 30 days for [Pro plan](/docs/introduction/pro-plan) users. For more information about this feature, see [Branching — Point-in-time restore](https://neon.tech/docs/guides/branching-pitr).
+Restoration of data to a state that existed at an earlier time. Neon retains a history of changes in the form of Write-Ahead-Log (WAL) records, which allows you to restore data to an earlier time. A point-in-time restore is performed by creating a branch using the **Time** or **LSN** option. By default, Neon retains a 7-day history of changes for all branches in a project. The supported range is 0 to 7 days for [Free Tier](/docs/introduction/free-tier) users, and 0 to 30 days for [Pro plan](/docs/introduction/pro-plan) users. For more information about this feature, see [Branching — Point-in-time restore](https://neon.tech/docs/guides/branching-pitr).
 
 ### PostgreSQL
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -242,7 +242,7 @@ An 8KB unit of data, which is the smallest unit that Postgres uses for storing r
 
 ### Pageserver
 
-A Neon architecture component that reads WAL records from Safekeepers to identify modified pages. The Pageserver accumulates and indexes incoming WAL records in memory and writes them to disk in batches. Each batch is written to an immutable file that is never modified after creation. Using these files, the Pageserver can quickly reconstruct any version of a page dating back to the defined history retention period. Neon retains history of changes for all branches. The default history retention period is 7 days.
+A Neon architecture component that reads WAL records from Safekeepers to identify modified pages. The Pageserver accumulates and indexes incoming WAL records in memory and writes them to disk in batches. Each batch is written to an immutable file that is never modified after creation. Using these files, the Pageserver can quickly reconstruct any version of a page dating back to the defined history retention period. Neon retains a history for all branches. The default history retention period is 7 days.
 
 The Pageserver uploads immutable files to cloud storage, which is the final, highly durable destination for data. After a file is successfully uploaded to cloud storage, the corresponding WAL records can be removed from the Safekeepers.
 


### PR DESCRIPTION
Various minor edits to align language around point-in-time restore and "history retention". 
- The label in the UI is "History retention", so use that term instead of just "history". 
- Other minor edits.