### PR TITLE
feat: add trust page link to footer and configure redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -120,6 +120,11 @@ const defaultConfig = {
         destination: 'https://yc-idea-matcher.vercel.app',
         permanent: true,
       },
+      {
+        source: '/trust',
+        destination: 'https://trust.neon.tech',
+        permanent: true,
+      },
       ...docsRedirects,
     ];
   },

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -31,4 +31,5 @@ export default {
   ai: '/ai',
   awsIsrael: '/partners/aws-israel',
   thankYou: '/thank-you',
+  trust: '/trust',
 };

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -58,10 +58,6 @@ export default {
       heading: 'Company',
       links: [
         {
-          text: 'Blog',
-          to: LINKS.blog,
-        },
-        {
           text: 'About us',
           to: LINKS.aboutUs,
         },
@@ -72,6 +68,10 @@ export default {
         {
           text: 'Partners',
           to: LINKS.partners,
+        },
+        {
+          text: 'Trust',
+          to: LINKS.trust,
         },
         {
           text: 'Pricing',
@@ -94,6 +94,10 @@ export default {
         {
           text: 'AI',
           to: LINKS.ai,
+        },
+        {
+          text: 'Blog',
+          to: LINKS.blog,
         },
         {
           text: 'Docs',


### PR DESCRIPTION
This PR brings a Trust page link to the footer menu for Security & Compliance purposes and adds a redirect to https://trust.neon.tech/. 
The Pr also moves the Blog link from Company submenu to Resources submenu in the Footer where it belongs.