### PR TITLE
Add note about sharing a project with users that do not have a Neon account

### DIFF
--- a/content/docs/guides/project-sharing-guide.md
+++ b/content/docs/guides/project-sharing-guide.md
@@ -35,7 +35,7 @@ To share your project:
     An email is also sent to the email address informing the user that a project has been shared with them. The email includes an **Open project** link the user can click on to log in to Neon. After logging in, the user is directed to the **Dashboard** for the shared project in the Neon Console.
 
     <Admonition type="note">
-    A user **without** a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
+    A user **without** a Neon account will not receive an email notification when a project is shared. However, if the user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
     </Admonition>
 
 ## Shared project billing

--- a/content/docs/guides/project-sharing-guide.md
+++ b/content/docs/guides/project-sharing-guide.md
@@ -34,6 +34,10 @@ To share your project:
 
     An email is also sent to the email address informing the user that a project has been shared with them. The email includes an **Open project** link the user can click on to log in to Neon. After logging in, the user is directed to the **Dashboard** for the shared project in the Neon Console.
 
+    <Admonition type="note">
+    A user without a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the user will have access to the shared project when they log in to the Neon Console.
+    </Admonition>
+
 ## Shared project billing
 
 The costs associated with a shared project are charged to the Neon account that owns the project. For example, if you were to share your project with another Neon user account, any usage incurred by that user within your project is billed to your Neon account.

--- a/content/docs/guides/project-sharing-guide.md
+++ b/content/docs/guides/project-sharing-guide.md
@@ -35,7 +35,7 @@ To share your project:
     An email is also sent to the email address informing the user that a project has been shared with them. The email includes an **Open project** link the user can click on to log in to Neon. After logging in, the user is directed to the **Dashboard** for the shared project in the Neon Console.
 
     <Admonition type="note">
-    A user without a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the user will have access to the shared project when they log in to the Neon Console.
+    A user **without** a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
     </Admonition>
 
 ## Shared project billing

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -103,7 +103,13 @@ To share a project:
 
 The email you specify is added to the list of **People who have access to the project**. The Neon account associated with that email address is granted full access to the project with the exception privileges required to delete the project. When that user logs in to Neon, the shared project is listed on their **Projects** page, under **Shared with me**.
 
+<Admonition type="note">
+A user without a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the user will have access to the shared project when they log in to the Neon Console.
+</Admonition>
+
 The costs associated with a shared project are charged to the Neon account that owns the project. For example, if you were to share your project with another Neon user account, any usage incurred by that user within your project is billed to your Neon account, not theirs.
+
+For additional information, refer to our [Project sharing guide](/docs/guides/project-sharing-guide).
 
 ## Manage projects with the Neon API
 

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -104,7 +104,7 @@ To share a project:
 The email you specify is added to the list of **People who have access to the project**. The Neon account associated with that email address is granted full access to the project with the exception privileges required to delete the project. When that user logs in to Neon, the shared project is listed on their **Projects** page, under **Shared with me**.
 
 <Admonition type="note">
-A user **without** a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
+A user **without** a Neon account will not receive an email notification when a project is shared. However, if the user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
 </Admonition>
 
 The costs associated with a shared project are charged to the Neon account that owns the project. For example, if you were to share your project with another Neon user account, any usage incurred by that user within your project is billed to your Neon account, not theirs.

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -104,7 +104,7 @@ To share a project:
 The email you specify is added to the list of **People who have access to the project**. The Neon account associated with that email address is granted full access to the project with the exception privileges required to delete the project. When that user logs in to Neon, the shared project is listed on their **Projects** page, under **Shared with me**.
 
 <Admonition type="note">
-A user without a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
+A user **without** a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
 </Admonition>
 
 The costs associated with a shared project are charged to the Neon account that owns the project. For example, if you were to share your project with another Neon user account, any usage incurred by that user within your project is billed to your Neon account, not theirs.

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -104,7 +104,7 @@ To share a project:
 The email you specify is added to the list of **People who have access to the project**. The Neon account associated with that email address is granted full access to the project with the exception privileges required to delete the project. When that user logs in to Neon, the shared project is listed on their **Projects** page, under **Shared with me**.
 
 <Admonition type="note">
-A user without a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the user will have access to the shared project when they log in to the Neon Console.
+A user without a Neon account will not receive an email notification when a project is shared. However, if a user creates a Neon account afterward with the specified email address, the shared project will be available when the user logs in to the Neon Console.
 </Admonition>
 
 The costs associated with a shared project are charged to the Neon account that owns the project. For example, if you were to share your project with another Neon user account, any usage incurred by that user within your project is billed to your Neon account, not theirs.


### PR DESCRIPTION
Added note to address user feedback: https://neondb.slack.com/archives/C04BT3XH8PL/p1695398603131709

https://neon-next-git-dprice-update-project-sharing-neondatabase.vercel.app/docs/manage/projects#share-a-project
https://neon-next-git-dprice-update-project-sharing-neondatabase.vercel.app/docs/guides/project-sharing-guide

![image](https://github.com/neondatabase/website/assets/10074684/46f755d0-ad14-4020-aa9d-0e7c73e119a6)



