### PR TITLE
fix: additional headers for blog post with custom embed iframe

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -49,6 +49,19 @@ const defaultConfig = {
           },
         ],
       },
+      {
+        source: '/blog/parsing-json-from-postgres-in-js',
+        headers: [
+          {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'require-corp',
+          },
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin',
+          },
+        ],
+      },
     ];
   },
   async redirects() {


### PR DESCRIPTION
This pull request brings additional headers for blog post /blog/parsing-json-from-postgres-in-js

```
Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Opener-Policy: same-origin
```