### PR TITLE
docs/javascript-next-js-connection-snippets

### DIFF
--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
   - /docs/integrations/vercel
-updatedOn: '2023-08-05T08:44:53Z'
+updatedOn: '2023-10-03T18:28:23.117Z'
 ---
 
 Next.js by Vercel is an open-source web development framework that enables React-based web applications. This topic describes how to create a Neon project and access it from a Next.js application.
@@ -26,47 +26,143 @@ If you do not have one already, create a Neon project. Save your connection deta
 2. Click **New Project**.
 3. Specify your project settings and click **Create Project**.
 
-## Create a Next.js project
+## Create a Next.js project and add dependencies
 
-Create a Next.js project if you do not have one. For instructions, see [Create a Next.js App](https://nextjs.org/learn/basics/create-nextjs-app/setup), in the Vercel documentation.
+1. Create a Next.js project if you do not have one. For instructions, see [Create a Next.js App](https://nextjs.org/learn/basics/create-nextjs-app/setup), in the Vercel documentation.
 
-## Add a Postgres client to your app
 
-Add a PostgreSQL client to your app, such as `Postgres.js`. For instructions, refer to the [postgres.js Getting started](https://www.npmjs.com/package/postgres).
+2. Add project dependencies using one of the following commands:
 
-## Add your Neon connection details
+    <CodeTabs labels={["node-postgres", "postgres.js"]}>
+      ```shell
+      npm install pg
+      ```
 
-Add your Neon connection string to your `.env` file.
+      ```shell
+      npm install postgres
+      ```
+    </CodeTabs>
+
+
+
+## Store your Neon credentials
+
+Add a `.env` file to your project directory and add your Neon connection string to it. You can find the connection string for your database in the **Connection Details** widget on the Neon **Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
+
+
+<CodeBlock shouldWrap>
 
 ```shell
-DATABASE_URL=postgres://<user>:<password>@<hostname>:<port>/<database>
+DATABASE_URL=postgres://<users>:<password>@ep-snowy-unit-550577.us-east-2.aws.neon.tech/neondb?options=endpoint%3Dep-snowy-unit-550577
 ```
 
-where:
+</CodeBlock>
 
-- `<user>` is the database user.
-- `<password>` is the database user's password.
-- `<hostname>` the hostname of the branch's compute endpoint. The hostname has an `ep-` prefix and appears similar to this: `ep-tight-salad-272396.us-east-2.aws.neon.tech`.
-- `<port>` is the Neon port number. The default port number is `5432`.
-- `<database>` is the name of the database. The default Neon database is `neondb`
+## Configure the Postgres client 
 
-You can find all of the connection details listed above in the **Connection Details** widget on the Neon **Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app). If you have misplaced your password, see [Reset a password](/docs/manage/roles#reset-a-password).
+1. From your API handlers, add the following code snippet to connect to your Neon database:
 
-## Connect to the Neon database
+    <CodeTabs labels={["node-postgres", "postgres.js"]}>
+      ```javascript
+      import { Pool } from 'pg';
 
-From your API handlers or server functions, connect to the Neon database with the Postgres client and your Neon connection details. For example:
+      const pool = new Pool({
+        connectionString: process.env.DATABASE_URL,
+        ssl: {
+          require: true,
+        },
+      });
 
-```javascript pages/api/hello_worlds.js
-import postgres from 'postgres';
+      export default async function handler(req, res) {
+        const client = await pool.connect();
 
-const sql = postgres(process.env.DATABASE_URL);
+        try {
+          const response = await client.query('SELECT version()');
+          console.log(response.rows[0]);
+        } finally {
+          client.release();
+        }
+      }
 
-const result = await sql.unsafe(req.body);
+      ```
+      ```js
+      import postgres from 'postgres';
+
+      const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
+
+      export default async function handler(req, res) {
+        const response = await sql`select version()`;
+        console.log(response);
+      }
+
+      ```
+    </CodeTabs>
+
+
+2. From your server functions, add the following code snippet to connect to your Neon database:
+
+    <CodeTabs labels={["node-postgres", "postgres.js"]}>
+      ```javascript
+      import { Pool } from 'pg';
+
+      const pool = new Pool({
+        connectionString: process.env.DATABASE_URL,
+        ssl: {
+          require: true,
+        },
+      });
+
+      export async function getServerSideProps() {
+        const client = await pool.connect();
+
+        try {
+          const response = await client.query('SELECT version()');
+          console.log(response.rows[0]);
+          return { props: { data: response.rows[0] } };
+        } finally {
+          client.release();
+        }
+      }
+
+      export default function Page({ data }) {}
+
+      ```
+      ```js
+      import postgres from 'postgres';
+
+      export async function getServerSideProps() {
+        const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
+
+        const response = await sql`select version()`;
+        console.log(response);
+        return { props: { data: response } };
+      }
+
+      export default function Page({ data }) {}
+
+      ```
+    </CodeTabs>
+
+## Run the app
+
+For API handlers, and server functions you can expect to see one of the following in your terminal output.
+
+```shell
+# node-postgres
+
+{
+  version: 'PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit'
+}
+
+# postgres.js
+
+Result(1) [
+  {
+    version: 'PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit'
+  }
+]
 ```
 
-<Admonition type="important">
-Never expose your Neon credentials to the browser.
-</Admonition>
 
 ## Need help?
 

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
   - /docs/integrations/vercel
-updatedOn: '2023-10-03T18:28:23.117Z'
+updatedOn: '2023-10-03T19:39:46.165Z'
 ---
 
 Next.js by Vercel is an open-source web development framework that enables React-based web applications. This topic describes how to create a Neon project and access it from a Next.js application.
@@ -127,7 +127,7 @@ DATABASE_URL=postgres://<users>:<password>@ep-snowy-unit-550577.us-east-2.aws.ne
       export default function Page({ data }) {}
 
       ```
-      ```js
+      ```javascript
       import postgres from 'postgres';
 
       export async function getServerSideProps() {

--- a/content/docs/guides/node.md
+++ b/content/docs/guides/node.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/node
   - /docs/integrations/node
-updatedOn: '2023-08-05T08:44:53Z'
+updatedOn: '2023-10-03T18:28:23.118Z'
 ---
 
 This guide describes how to create a Neon project and connect to it from a Node.js application. Examples are provided for using the [node-postgres](https://www.npmjs.com/package/pg) and [Postgres.js](https://www.npmjs.com/package/postgres) clients. Use the client you prefer.
@@ -72,7 +72,7 @@ A special `endpoint` connection option is appended to the connection string abov
 To ensure the security of your data, never expose your Neon credentials to the browser.
 </Admonition>
 
-## Configure the app.js file
+## Configure the Postgres client 
 
 Add an `app.js` file to your project directory and add the following code snippet to connect to your Neon database:
   
@@ -81,20 +81,18 @@ Add an `app.js` file to your project directory and add the following code snippe
   const { Pool } = require('pg');
   require('dotenv').config();
 
-  const { DATABASE_URL } = process.env;
-
   const pool = new Pool({
-    connectionString: DATABASE_URL,
+    connectionString: process.env.DATABASE_URL,
     ssl: {
-      rejectUnauthorized: false,
+      require: true,
     },
   });
 
   async function getPostgresVersion() {
     const client = await pool.connect();
     try {
-      const res = await client.query('SELECT version()');
-      console.log(res.rows[0]);
+      const response = await client.query('SELECT version()');
+      console.log(response.rows[0]);
     } finally {
       client.release();
     }
@@ -106,13 +104,11 @@ Add an `app.js` file to your project directory and add the following code snippe
   const postgres = require('postgres');
   require('dotenv').config();
 
-  const { DATABASE_URL } = process.env;
-
-  const sql = postgres(DATABASE_URL, { ssl: 'require' });
+  const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
 
   async function getPostgresVersion() {
-    const result = await sql`select version()`;
-    console.log(result);
+    const response = await sql`select version()`;
+    console.log(response);
   }
 
   getPostgresVersion();
@@ -124,11 +120,9 @@ Add an `app.js` file to your project directory and add the following code snippe
 Run `node app.js` to view the result.
 
 ```shell
-node app.js
-
 Result(1) [
   {
-    version: 'PostgreSQL 15.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit'
+    version: 'PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit'
   }
 ]
 ```

--- a/content/docs/guides/prisma-migrate.md
+++ b/content/docs/guides/prisma-migrate.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/prisma
   - /docs/integrations/prisma
-updatedOn: '2023-08-11T10:04:55Z'
+updatedOn: '2023-10-03T18:28:23.119Z'
 ---
 
 This topic also describes how to configure Prisma Migrate when you need to connect to the same Neon database from Prisma Migrate, which requires a direct database connection, and serverless functions that require a pooled database connection.
@@ -47,8 +47,8 @@ When you are finished updating your `.env` file, your variable settings should a
 <CodeBlock shouldWrap>
 
 ```text
-DATABASE_URL="postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech:5432/neondb?pgbouncer=true"
-DIRECT_URL="postgres://daniel:<password>@ep-restless-rice-862380.us-east-2.aws.neon.tech:5432/neondb"
+DATABASE_URL="postgres://daniel:<password>@ep-restless-rice-862380-pooler.us-east-2.aws.neon.tech:5432/neondb?sslmode=require&pgbouncer=true"
+DIRECT_URL="postgres://daniel:<password>@ep-restless-rice-862380.us-east-2.aws.neon.tech:5432/neondb?sslmode=require"
 ```
 
 </CodeBlock>

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -6,7 +6,7 @@ redirectFrom:
   - /docs/quickstart/prisma
   - /docs/integrations/prisma
   - /docs/guides/prisma-guide
-updatedOn: '2023-09-04T12:07:16Z'
+updatedOn: '2023-10-03T18:28:23.119Z'
 ---
 
 Prisma is an open-source, next-generation ORM that enables you to manage and interact with your database. This guide explains how to connect Prisma to Neon, establish connections when using Prisma Client in serverless functions, and resolve [connection timeout](#connection-timeouts) issues.
@@ -35,12 +35,14 @@ To establish a basic connection from Prisma to Neon, perform the following steps
    }
    ```
 
-3. Add a `DATABASE_URL` variable to your `.env` file and set it to the Neon connection string that you copied in the previous step. Your setting will appear similar to the following:
+3. Add a `DATABASE_URL` variable to your `.env` file and set it to the Neon connection string that you copied in the previous step and add `?sslmode=require` to the end of the connection string. 
+
+Your setting will appear similar to the following:
 
    <CodeBlock shouldWrap>
 
    ```text
-   DATABASE_URL="postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb"
+   DATABASE_URL="postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb?sslmode=require"
    ```
 
    </CodeBlock>
@@ -51,19 +53,19 @@ If you are using Prisma Client from a serverless function, see [Connect from ser
 
 ## Connect from serverless functions
 
-Serverless functions typically require a large number of database connections. When connecting from Prisma Client to Neon from a serverless function, use a pooled Neon connection string together with a `?pgbouncer=true` flag, as shown:
+Serverless functions typically require a large number of database connections. When connecting from Prisma Client to Neon from a serverless function, use a pooled Neon connection string together with a `pgbouncer=true` flag, as shown:
 
 <CodeBlock shouldWrap>
 
 ```text
-DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071-pooler.us-east-2.aws.neon.tech/neondb?pgbouncer=true
+DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require&pgbouncer=true
 ```
 
 </CodeBlock>
 
 - A pooled Neon connection string appends `-pooler` to the endpoint ID, which tells Neon to use a pooled connection rather than a direct connection. The **Connection Details** widget on the Neon **Dashboard** provides a **Pooled connection** checkbox that adds `-pooler` suffix to your connection string.
-- Neon uses PgBouncer to provide [connection pooling](/docs/connect/connection-pooling). Prisma requires the `?pgbouncer=true` flag when using Prisma Client with PgBouncer, as described in the [Prisma documentation](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management/configure-pg-bouncer#add-pgbouncer-to-the-connection-url).
-- In summary, to use a pooled Neon connection with Prisma Client, you require **both** a pooled Neon connection string (one that includes `-pooler`) _and_ the `?pgbouncer=true` flag (required by Prisma Client). See the example above.
+- Neon uses PgBouncer to provide [connection pooling](/docs/connect/connection-pooling). Prisma requires the `pgbouncer=true` flag when using Prisma Client with PgBouncer, as described in the [Prisma documentation](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management/configure-pg-bouncer#add-pgbouncer-to-the-connection-url).
+- In summary, to use a pooled Neon connection with Prisma Client, you require **both** a pooled Neon connection string (one that includes `-pooler`) _and_ the `pgbouncer=true` flag (required by Prisma Client). See the example above.
 
 ## Connection timeouts
 
@@ -87,7 +89,7 @@ When you connect to an idle compute from Prisma, Neon automatically activates it
 <CodeBlock shouldWrap>
 
 ```text
-DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb?connect_timeout=10`
+DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb?sslmode=require&connect_timeout=10`
 ```
 
 </CodeBlock>
@@ -105,7 +107,7 @@ The default size of the Prisma connection pool is determined by the following fo
 <CodeBlock shouldWrap>
 
 ```text
-DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb/neondb?connect_timeout=15&connection_limit=20`
+DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb/neondb?sslmode=require&connect_timeout=15&connection_limit=20`
 ```
 
 </CodeBlock>
@@ -117,7 +119,7 @@ In addition to pool size, you can configure a `pool_timeout` setting. This setti
 <CodeBlock shouldWrap>
 
 ```text
-DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb/neondb?connect_timeout=15&connection_limit=20&pool_timeout=15`
+DATABASE_URL=postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb/neondb?sslmode=require&connect_timeout=15&connection_limit=20&pool_timeout=15`
 ```
 
 </CodeBlock>


### PR DESCRIPTION
- update nextjs, node and prisma snippets to include `sslmode`

I've added two different options for Next.js. One is for API Routes, the other is for `getServerProps`. Next and Node snippets should be pretty similar. The Prisma one is a little more clunky as the user is required to update the connection string, rather than add config options to the client. 