### PR TITLE
docs/javascript-code-fence

### DIFF
--- a/content/docs/connect/connection-latency.md
+++ b/content/docs/connect/connection-latency.md
@@ -3,7 +3,7 @@ title: Connection latency and timeouts
 subtitle: Learn about strategies to manage connection latencies and timeouts
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2023-09-08T09:25:08Z'
+updatedOn: '2023-10-03T19:45:09.134Z'
 ---
 
 Neon's _Auto-suspend_ feature ('scale to zero') is designed to minimize costs by automatically scaling a compute resource down to zero after a period of inactivity. By default, Neon scales a compute to zero after 5 minutes of inactivity. A characteristic of this feature is the concept of a "cold start". During this process, a compute instance transitions from an idle state to an active state to process requests. Currently, activating a Neon compute from an idle state takes anywhere from 500 ms to a few seconds not counting other factors that can add to latencies such as the physical distance between your application and database or startup times of other services that participate in your connection process.
@@ -66,7 +66,7 @@ Here are examples of how to increase connection timeout settings in a few common
 
 <CodeTabs labels={["Node.js", "Python", "Java", "Prisma" ]}>
 
-```js
+```javascript
 const { Pool } = require('pg')
 
 const pool = new Pool({

--- a/content/docs/guides/aws-lambda.md
+++ b/content/docs/guides/aws-lambda.md
@@ -2,7 +2,7 @@
 title: Connect from AWS Lambda
 subtitle: Learn how to set up a Neon database and connect from an AWS Lambda function
 enableTableOfContents: true
-updatedOn: '2023-08-05T08:44:53Z'
+updatedOn: '2023-10-03T19:45:09.136Z'
 ---
 
 AWS Lambda is a serverless, event-driven compute service that allows you to run code without provisioning or managing servers. It is a convenient and cost-effective solution for running various types of workloads, including those that require a database.
@@ -143,7 +143,7 @@ Create the Lambda function using the [Serverless Framework](https://www.serverle
 
 5. In the `aws-node-project` directory, add a `users.js` file, and add the following code to it:
 
-    ```js
+    ```javascript
     'use strict';
 
     const { Client } = require('pg');

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
   - /docs/integrations/vercel
-updatedOn: '2023-10-03T19:39:46.165Z'
+updatedOn: '2023-10-03T19:45:09.136Z'
 ---
 
 Next.js by Vercel is an open-source web development framework that enables React-based web applications. This topic describes how to create a Neon project and access it from a Next.js application.
@@ -85,7 +85,7 @@ DATABASE_URL=postgres://<users>:<password>@ep-snowy-unit-550577.us-east-2.aws.ne
       }
 
       ```
-      ```js
+      ```javascript
       import postgres from 'postgres';
 
       const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });

--- a/content/docs/guides/node.md
+++ b/content/docs/guides/node.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/node
   - /docs/integrations/node
-updatedOn: '2023-10-03T18:28:23.118Z'
+updatedOn: '2023-10-03T19:45:09.137Z'
 ---
 
 This guide describes how to create a Neon project and connect to it from a Node.js application. Examples are provided for using the [node-postgres](https://www.npmjs.com/package/pg) and [Postgres.js](https://www.npmjs.com/package/postgres) clients. Use the client you prefer.
@@ -100,7 +100,7 @@ Add an `app.js` file to your project directory and add the following code snippe
 
   getPostgresVersion();
   ```
-  ```js
+  ```javascript
   const postgres = require('postgres');
   require('dotenv').config();
 

--- a/content/docs/serverless/serverless-driver.md
+++ b/content/docs/serverless/serverless-driver.md
@@ -1,8 +1,9 @@
 ---
 title: Neon serverless driver
 enableTableOfContents: true
-subtitle: Learn how to connect to Neon from serverless and edge environments over HTTP or WebSockets
-updatedOn: '2023-09-05T15:00:04Z'
+subtitle: Learn how to connect to Neon from serverless and edge environments over HTTP
+  or WebSockets
+updatedOn: '2023-10-03T19:45:09.137Z'
 ---
 
 The [Neon serverless driver](https://github.com/neondatabase/serverless) is a low-latency Postgres driver for JavaScript and TypeScript that allows you to query data from serverless and edge environments over HTTP or WebSockets in place of TCP.
@@ -58,7 +59,7 @@ export default async () => {
 }
 ```
 
-```js
+```javascript
 import { neon } from '@neondatabase/serverless';
 
 export default async (req: Request) => {
@@ -134,7 +135,7 @@ export default async () => {
 
 ```
 
-```js
+```javascript
 import { Pool } from '@neondatabase/serverless';
 
 export default async (req: Request, ctx: any) => {
@@ -188,7 +189,7 @@ The `neon(...)` function supports `arrayMode`, `fullResults`, and `fetchOptions`
 
 The `neon(...)` function also supports issuing multiple queries at once in a single, non-interactive transaction using the `transaction()` function, which is exposed as a property of the query function. For example:
 
-```js
+```javascript
 import { neon } from '@neondatabase/serverless';
 const sql = neon(process.env.DATABASE_URL);
 const showLatestN = 10;

--- a/content/release-notes/2023-03-30-drivers.md
+++ b/content/release-notes/2023-03-30-drivers.md
@@ -2,6 +2,6 @@
 
 The [Neon serverless driver](https://github.com/neondatabase/serverless) was verified to work with [Deno](https://github.com/denoland/deno). Where you would install another Postgres driver, run `npm install @neondatabase/serverless` instead, and then import the Neon serverless driver:
 
-  ```js
+  ```javascript
   import { Pool } from 'npm:@neondatabase/serverless';
   ```

--- a/content/release-notes/2023-08-16-drivers.md
+++ b/content/release-notes/2023-08-16-drivers.md
@@ -8,7 +8,7 @@ The driver now supports batched queries and a larger response size for queries o
 
 You can now issue multiple queries at once in a single, non-interactive transaction using the `transaction()` function, which is exposed as property of the query function. For example:
 
-```js
+```javascript
 import { neon } from '@neondatabase/serverless';
 const sql = neon(process.env.DATABASE_URL);
 const showLatestN = 10;


### PR DESCRIPTION
- change all `js` to `javascript` for code fence lang

We were using both `js` and `javascript` for the code fence lang, both will work but just to be consistent I've changed them all to `javascript`... or I can change them to all to `js`?