### PR TITLE
docs/go-connection-snippets

### DIFF
--- a/content/docs/guides/go.md
+++ b/content/docs/guides/go.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/go
   - /docs/integrations/go
-updatedOn: '2023-10-04T12:27:20.313Z'
+updatedOn: '2023-10-05T13:29:38.514Z'
 ---
 
 To connect to Neon from a Go application:
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-    connStr := "user=<user> password=<password> dbname=neondb host=<hostname>?sslmode=require"
+    connStr := "postgres://[user]:[password]@[neon_hostname]/[dbname]?sslmode=require"
     db, err := sql.Open("postgres", connStr)
     if err != nil {
         panic(err)

--- a/content/docs/guides/go.md
+++ b/content/docs/guides/go.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/go
   - /docs/integrations/go
-updatedOn: '2023-08-05T08:44:53Z'
+updatedOn: '2023-10-04T12:27:20.313Z'
 ---
 
 To connect to Neon from a Go application:
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-    connStr := "user=<user> password=<password> dbname=neondb host=<hostname>"
+    connStr := "user=<user> password=<password> dbname=neondb host=<hostname>?sslmode=require"
     db, err := sql.Open("postgres", connStr)
     if err != nil {
         panic(err)
@@ -60,12 +60,6 @@ func main() {
 }
 ```
 
-where:
-
-- `<user>` is the database user.
-- `<password>` is the database user's password.
-- `<dbname>` is the name of the database. The default Neon database is `neondb`.
-- `<hostname>` is the hostname of the branch's compute endpoint. The hostname has an `ep-` prefix and appears similar to this: `ep-tight-salad-272396.us-east-2.aws.neon.tech`.
 
 You can find all of the connection details listed above in the **Connection Details** widget on the Neon **Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 


### PR DESCRIPTION
## Update:

Squares boys have now been used. I've also removed the "explanation" for connection string parts. I'm thinking we point users to the "Connect from any application." then the breakdown will only ever live in one place in the docs. — What do you think @danieltprice / @bgrenon 


---
- add `sslmode=require` to go snippet

This is a good candidate for why we should perhaps rethink how we display connection strings. 

This, IMO is quite confusing.
```
connStr := "user=<user> password=<password> dbname=neondb host=<hostname>?sslmode=require"
```

It might make more sense if it were.

```
postgres://<user>:<password>@ep-snowy-unit-550577.us-east-2.aws.neon.tech/neondb?sslmode=require
```