### PR TITLE
feat: last updated date in docs

### DIFF
--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 18
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
     - name: Set up Node.js
       uses: actions/setup-node@v2
@@ -21,6 +23,7 @@ jobs:
     - name: Get list of modified files
       id: get-modified-files
       run: |
+        git --version
         modified_files=$(git diff --name-only HEAD^ HEAD | grep '^content/docs/.*\.md$')
         echo "Modified files: $modified_files"
         echo "modified_files=$modified_files" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -29,7 +29,7 @@ jobs:
         echo "modified_files=$modified_files" >> $GITHUB_OUTPUT
       
     - name: Run update script
-      run: node scr/scripts/update-frontmatter.js ${{ steps.get-modified-files.outputs.modified_files }}
+      run: node src/scripts/update-frontmatter.js ${{ steps.get-modified-files.outputs.modified_files }}
 
     - name: Commit changes
       run: |

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         git config user.name "GitHub Action"
         git config user.email "action@github.com"
+        export HUSKY=0
         git add -A
-        git commit -m "Update frontmatter date" || echo "No changes to commit"
+        git commit -m "chore(docs): Update frontmatter date"
         git push

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -23,10 +23,12 @@ jobs:
     - name: Get list of modified files
       id: get-modified-files
       run: |
-        git --version
         modified_files=$(git diff --name-only HEAD^ HEAD | grep '^content/docs/.*\.md$')
         echo "Modified files: $modified_files"
         echo "modified_files=$modified_files" >> $GITHUB_OUTPUT
+
+    - name: Install packages
+      run: npm ci
       
     - name: Run update script
       run: node src/scripts/update-frontmatter.js ${{ steps.get-modified-files.outputs.modified_files }}

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -18,16 +18,15 @@ jobs:
       with:
         node-version: 18
 
-    - name: Get list of modified markdown files
-      id: getfile
+    - name: Get list of modified files
+      id: get-modified-files
       run: |
-        echo "::set-output name=markdownfiles::$(git diff-tree --no-commit-id --name-only -r HEAD | grep '^content/docs/.*\.md$')"
-        
-    - name: Run update script if there are markdown changes
-      run: |
-        if [[ -n "${{ steps.getfile.outputs.markdownfiles }}" ]]; then
-          node src/scripts/update-frontmatter.js ${{ steps.getfile.outputs.markdownfiles }}
-        fi
+        modified_files=$(git diff --name-only HEAD^ HEAD | grep '^content/docs/.*\.md$')
+        echo "Modified files: $modified_files"
+        echo "modified_files=$modified_files" >> $GITHUB_OUTPUT
+      
+    - name: Run update script
+      run: node scr/scripts/update-frontmatter.js ${{ steps.get-modified-files.outputs.modified_files }}
 
     - name: Commit changes
       run: |

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -18,11 +18,16 @@ jobs:
       with:
         node-version: 18
 
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Run update script
-      run: node src/scripts/update-frontmatter.js content/docs/**/*.md
+    - name: Get list of modified markdown files
+      id: getfile
+      run: |
+        echo "::set-output name=markdownfiles::$(git diff-tree --no-commit-id --name-only -r HEAD | grep '^content/docs/.*\.md$')"
+        
+    - name: Run update script if there are markdown changes
+      run: |
+        if [[ -n "${{ steps.getfile.outputs.markdownfiles }}" ]]; then
+          node src/scripts/update-frontmatter.js ${{ steps.getfile.outputs.markdownfiles }}
+        fi
 
     - name: Commit changes
       run: |

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -3,7 +3,7 @@ name: Update Frontmatter
 on:
   push:
     paths:
-      - 'content/docs/*.md'
+      - 'content/docs/**/*.md'
 
 jobs:
   update-date:
@@ -22,7 +22,7 @@ jobs:
       run: npm ci
 
     - name: Run update script
-      run: node src/scripts/update-frontmatter.js content/docs/*.md
+      run: node src/scripts/update-frontmatter.js content/docs/**/*.md
 
     - name: Commit changes
       run: |

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Get list of modified files
       id: get-modified-files
       run: |
-        modified_files=$(git diff --name-only HEAD^ HEAD | grep '^content/docs/.*\.md$')
+        modified_files=$(git diff --name-only HEAD^ HEAD | grep '^content/docs/.*\.md$' | xargs)
         echo "Modified files: $modified_files"
         echo "modified_files=$modified_files" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -1,0 +1,33 @@
+name: Update Frontmatter
+
+on:
+  push:
+    paths:
+      - 'content/docs/*.md'
+
+jobs:
+  update-date:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run update script
+      run: node src/scripts/update-frontmatter.js content/docs/*.md
+
+    - name: Commit changes
+      run: |
+        git config user.name "GitHub Action"
+        git config user.email "action@github.com"
+        git add -A
+        git commit -m "Update frontmatter date" || echo "No changes to commit"
+        git push

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -39,5 +39,9 @@ jobs:
         git config user.email "action@github.com"
         export HUSKY=0
         git add -A
-        git commit -m "chore(docs): Update frontmatter date"
-        git push
+        if git diff --staged | grep '.'; then
+          git commit -m "chore(docs): Update frontmatter date"
+          git push
+        else
+          echo "No changes to commit"
+        fi

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,4 @@
 {
   "*.{js,jsx,html,css}": "prettier --write",
-  "*.{js,jsx}": "eslint --cache --fix",
-  "**/*.{md,mdx}": "node src/scripts/update-frontmatter.js"
+  "*.{js,jsx}": "eslint --cache --fix"
 }

--- a/src/scripts/update-frontmatter.js
+++ b/src/scripts/update-frontmatter.js
@@ -32,7 +32,7 @@ const updateFrontmatter = async () => {
   // NOTE: to fetch the last update date from GitHub, uncomment the code above,
   // and slice the files array to 60 items
 
-  const mdFilePaths = process.argv.slice(2);
+  const mdFilePaths = process.argv.slice(2).filter(Boolean);
 
   const docsMdFilePaths = mdFilePaths.filter(
     (path) =>

--- a/src/scripts/update-frontmatter.js
+++ b/src/scripts/update-frontmatter.js
@@ -32,7 +32,7 @@ const updateFrontmatter = async () => {
   // NOTE: to fetch the last update date from GitHub, uncomment the code above,
   // and slice the files array to 60 items
 
-  const [, , ...mdFilePaths] = process.argv;
+  const mdFilePaths = process.argv.slice(2);
 
   const docsMdFilePaths = mdFilePaths.filter(
     (path) =>


### PR DESCRIPTION
This pull request adds the GitHub actions workflow that updates the last updated date in docs markdown files.

Whenever you make a change to a Markdown file inside content/docs, the GitHub Action will trigger, running the script and updating the `updatedOn` date in the frontmatter. 
If you make changes via the GitHub interface, the action will still trigger and make the necessary updates.

**TODO**
- [ ] drop test commits before merging
