### PR TITLE
docs/next-js-app-router-snippet

### DIFF
--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -5,7 +5,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
   - /docs/integrations/vercel
-updatedOn: '2023-10-03T20:31:35.165Z'
+updatedOn: '2023-10-05T22:01:21.215Z'
 ---
 
 Next.js by Vercel is an open-source web development framework that enables React-based web applications. This topic describes how to create a Neon project and access it from a Next.js application.

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -60,88 +60,143 @@ DATABASE_URL=postgres://[user]:[password]@[neon_hostname]/[dbname]
 
 ## Configure the Postgres client 
 
-1. From your API handlers, add the following code snippet to connect to your Neon database:
+There a multiple ways to make server side requests with Next.js. See below for the different implementations.
 
-    <CodeTabs labels={["node-postgres", "postgres.js"]}>
-      ```javascript
-      import { Pool } from 'pg';
+### App Router
 
-      const pool = new Pool({
-        connectionString: process.env.DATABASE_URL,
-        ssl: {
-          require: true,
-        },
-      });
+From your server functions using the App Router, add the following code snippet to connect to your Neon database:
 
-      export default async function handler(req, res) {
-        const client = await pool.connect();
+<CodeTabs labels={["node-postgres", "postgres.js"]}>
+  ```javascript
+  import { Pool } from 'pg';
 
-        try {
-          const response = await client.query('SELECT version()');
-          console.log(response.rows[0]);
-        } finally {
-          client.release();
-        }
-      }
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: {
+      require: true,
+    },
+  });
 
-      ```
-      ```javascript
-      import postgres from 'postgres';
+  async function getData() {
+    const client = await pool.connect();
 
-      const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
+    try {
+      const response = await client.query('SELECT version()');
+      console.log(response.rows[0]);
+      return response.rows[0];
+    } finally {
+      client.release();
+    }
+  }
 
-      export default async function handler(req, res) {
-        const response = await sql`select version()`;
-        console.log(response);
-      }
+  export default async function Page() {
+    const data = await getData();
+  }
+  ```
+  ```javascript
+  import postgres from 'postgres';
 
-      ```
-    </CodeTabs>
+  async function getData() {
+    const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
+
+    const response = await sql`select version()`;
+    console.log(response);
+    return response;
+  }
+
+  export default async function Page() {
+    const data = await getData();
+  }
+  ```
+</CodeTabs>
 
 
-2. From your server functions, add the following code snippet to connect to your Neon database:
+### Pages Router
 
-    <CodeTabs labels={["node-postgres", "postgres.js"]}>
-      ```javascript
-      import { Pool } from 'pg';
+From your server functions using the Pages Router, add the following code snippet to connect to your Neon database:
 
-      const pool = new Pool({
-        connectionString: process.env.DATABASE_URL,
-        ssl: {
-          require: true,
-        },
-      });
+<CodeTabs labels={["node-postgres", "postgres.js"]}>
+  ```javascript
+  import { Pool } from 'pg';
 
-      export async function getServerSideProps() {
-        const client = await pool.connect();
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: {
+      require: true,
+    },
+  });
 
-        try {
-          const response = await client.query('SELECT version()');
-          console.log(response.rows[0]);
-          return { props: { data: response.rows[0] } };
-        } finally {
-          client.release();
-        }
-      }
+  export async function getServerSideProps() {
+    const client = await pool.connect();
 
-      export default function Page({ data }) {}
+    try {
+      const response = await client.query('SELECT version()');
+      console.log(response.rows[0]);
+      return { props: { data: response.rows[0] } };
+    } finally {
+      client.release();
+    }
+  }
 
-      ```
-      ```javascript
-      import postgres from 'postgres';
+  export default function Page({ data }) {}
 
-      export async function getServerSideProps() {
-        const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
+  ```
+  ```javascript
+  import postgres from 'postgres';
 
-        const response = await sql`select version()`;
-        console.log(response);
-        return { props: { data: response } };
-      }
+  export async function getServerSideProps() {
+    const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
 
-      export default function Page({ data }) {}
+    const response = await sql`select version()`;
+    console.log(response);
+    return { props: { data: response } };
+  }
 
-      ```
-    </CodeTabs>
+  export default function Page({ data }) {}
+
+  ```
+</CodeTabs>
+
+
+### API Routes
+
+From your API handlers, add the following code snippet to connect to your Neon database:
+
+<CodeTabs labels={["node-postgres", "postgres.js"]}>
+  ```javascript
+  import { Pool } from 'pg';
+
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: {
+      require: true,
+    },
+  });
+
+  export default async function handler(req, res) {
+    const client = await pool.connect();
+
+    try {
+      const response = await client.query('SELECT version()');
+      console.log(response.rows[0]);
+    } finally {
+      client.release();
+    }
+  }
+
+  ```
+  ```javascript
+  import postgres from 'postgres';
+
+  const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
+
+  export default async function handler(req, res) {
+    const response = await sql`select version()`;
+    console.log(response);
+  }
+  ```
+</CodeTabs>
+
 
 ## Run the app
 


### PR DESCRIPTION
- add app router code snippets.

App Router is the "new" way to use Next.js so I've moved it to the top of the examples. It's followed by the "old" way using the Pages Router then finally, the API Routes example.

@danieltprice, I had a bit of trouble with Prettier and the code blocks, would you mind giving this a quick pull and seeing if auto-format works? I kept getting errors, but I couldn't figure out why. 