### PR TITLE
Add import intro

### DIFF
--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -4,7 +4,7 @@ subtitle: Learn how to import data from different sources or load sample data
 enableTableOfContents: true
 ---
 
-Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. Additionally, if you're new to Neon and want to try it out, our sample guide provides datasets for exploration and testing.
+Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. Additionally, if you're new to Neon and want to try it out, our sample data guide provides datasets for exploration and testing.
 
 ### Data import guides
 

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 
 Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. For those looking to migrate from different database sources, the AWS DMS guide offers a comprehensive solution. Additionally, if you're new to Neon and want to try it out, the sample data guide provides datasets for exploration and testing.
 
-### Data Import Guides:
+### Data import guides:
 
 - [Import from Postgres](import/import-from-postgres)
 - [Import from Heroku](import/import-from-heroku)

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -6,11 +6,11 @@ enableTableOfContents: true
 
 Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. For those looking to migrate from different database sources, the AWS DMS guide offers a comprehensive solution. Additionally, if you're new to Neon and want to try it out, the sample data guide provides datasets for exploration and testing.
 
-### Data import guides:
+### Data import guides
 
 - [Import from Postgres](import/import-from-postgres)
-- [Import from Heroku](import/import-from-heroku)
-- [Import from CSV](import/import-from-csv)
 - [Import from a Neon project](import/import-from-neon)
+- [Import from CSV](import/import-from-csv)
+- [Import from Heroku](import/import-from-heroku)
 - [Migrate data with AWS DMS](import/migrate-aws-dms)
 - [Sample data](import/import-sample-data)

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -1,0 +1,16 @@
+---
+title: Neon data import guides
+subtitle: Learn how to import data into Neon form different sources or load sample data for exploring Neon features
+enableTableOfContents: true
+---
+
+Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. For those looking to migrate from different database sources, the AWS DMS guide offers a comprehensive solution. Additionally, if you're new to Neon and want to try it out, the sample data guide provides datasets for exploration and testing.
+
+### Data Import Guides:
+
+- [Import from Postgres](import/import-from-postgres)
+- [Import from Heroku](import/import-from-heroku)
+- [Import from CSV](import/import-from-csv)
+- [Import from a Neon project](import/import-from-neon)
+- [Migrate data with AWS DMS](import/migrate-aws-dms)
+- [Sample data](import/import-sample-data)

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -4,7 +4,7 @@ subtitle: Learn how to import data from different sources or load sample data
 enableTableOfContents: true
 ---
 
-Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. For those looking to migrate from different database sources, the AWS DMS guide offers a comprehensive solution. Additionally, if you're new to Neon and want to try it out, our sample guide provides datasets for exploration and testing.
+Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. Additionally, if you're new to Neon and want to try it out, our sample guide provides datasets for exploration and testing.
 
 ### Data import guides
 

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -1,6 +1,6 @@
 ---
 title: Neon data import guides
-subtitle: Learn how to import data from different sources or load sample data for exploring Neon
+subtitle: Learn how to import data from different sources or load sample data
 enableTableOfContents: true
 ---
 

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -1,10 +1,10 @@
 ---
 title: Neon data import guides
-subtitle: Learn how to import data into Neon form different sources or load sample data for exploring Neon features
+subtitle: Learn how to import data from different sources or load sample data for exploring Neon
 enableTableOfContents: true
 ---
 
-Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. For those looking to migrate from different database sources, the AWS DMS guide offers a comprehensive solution. Additionally, if you're new to Neon and want to try it out, the sample data guide provides datasets for exploration and testing.
+Welcome to the data import section. This part of the documentation provides guides on importing data into Neon from different sources. You'll find instructions for importing data from Postgres, CSV, other Neon projects, and more. For those looking to migrate from different database sources, the AWS DMS guide offers a comprehensive solution. Additionally, if you're new to Neon and want to try it out, our sample guide provides datasets for exploration and testing.
 
 ### Data import guides
 

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -237,12 +237,12 @@
   items:
     - title: Import from Postgres
       slug: import/import-from-postgres
-    - title: Import from Heroku
-      slug: import/import-from-heroku
-    - title: Import from CSV
-      slug: import/import-from-csv
     - title: Import from a Neon project
       slug: import/import-from-neon
+    - title: Import from CSV
+      slug: import/import-from-csv
+    - title: Import from Heroku
+      slug: import/import-from-heroku
     - title: Migrate data with AWS DMS
       slug: import/migrate-aws-dms
     - title: Sample data

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -233,6 +233,7 @@
 - title: Postgres extensions
   slug: extensions/pg-extensions
 - title: Import data
+  slug: import/import-intro
   items:
     - title: Import from Postgres
       slug: import/import-from-postgres


### PR DESCRIPTION
Add an intro topic to link to from the new docs banner we're adding to the console. Use this intro page instead of the Postgres import topic.

![image](https://github.com/neondatabase/website/assets/10074684/4d8472cc-7613-4bf5-9813-d6f2fda8411d)

https://neon-next-git-docs-import-intro-neondatabase.vercel.app/docs/import/import-intro