### PR TITLE
docs/next-js-static-props-snippet

### DIFF
--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -121,7 +121,7 @@ There are two methods for fetching data using server-side requests in Next.js th
 1. `getServerSideProps` fetches data at runtime so that content is always fresh.
 2. `getStaticProps` pre-renders pages at build time for data that is static or changes infrequently.
 
-### getServerSideProps
+#### getServerSideProps
 
 From `getServerSideProps` using the Pages Router, add the following code snippet to connect to your Neon database:
 
@@ -169,7 +169,7 @@ export default function Page({ data }) {}
 
 </CodeTabs>
 
-### getStaticProps
+#### getStaticProps
 
 From `getStaticProps` using the Pages Router, add the following code snippet to connect to your Neon database:
 

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -116,7 +116,7 @@ export default async function Page() {
 
 ### Pages Router
 
-From your server functions using the Pages Router, add the following code snippet to connect to your Neon database:
+From `getServerSideProps` using the Pages Router, add the following code snippet to connect to your Neon database:
 
 <CodeTabs labels={["node-postgres", "postgres.js"]}>
 
@@ -149,6 +149,52 @@ export default function Page({ data }) {}
 import postgres from 'postgres';
 
 export async function getServerSideProps() {
+  const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
+
+  const response = await sql`SELECT version()`;
+  console.log(response);
+  return { props: { data: response } };
+}
+
+export default function Page({ data }) {}
+
+```
+
+</CodeTabs>
+
+From `getStaticProps` using the Pages Router, add the following code snippet to connect to your Neon database:
+
+<CodeTabs labels={["node-postgres", "postgres.js"]}>
+
+```javascript
+import { Pool } from 'pg';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: {
+    require: true,
+  },
+});
+
+export async function getStaticProps() {
+  const client = await pool.connect();
+
+  try {
+    const response = await client.query('SELECT version()');
+    console.log(response.rows[0]);
+    return { props: { data: response.rows[0] } };
+  } finally {
+    client.release();
+  }
+}
+
+export default function Page({ data }) {}
+```
+
+```javascript
+import postgres from 'postgres';
+
+export async function getStaticProps() {
   const sql = postgres(process.env.DATABASE_URL, { ssl: 'require' });
 
   const response = await sql`SELECT version()`;

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -116,6 +116,13 @@ export default async function Page() {
 
 ### Pages Router
 
+There are two methods for fetching data using server-side requests in Next.js they are:
+
+1. `getServerSideProps` fetches data at runtime so that content is always fresh.
+2. `getStaticProps` pre-renders pages at build time for data that is static or changes infrequently.
+
+### getServerSideProps
+
 From `getServerSideProps` using the Pages Router, add the following code snippet to connect to your Neon database:
 
 <CodeTabs labels={["node-postgres", "postgres.js"]}>
@@ -161,6 +168,8 @@ export default function Page({ data }) {}
 ```
 
 </CodeTabs>
+
+### getStaticProps
 
 From `getStaticProps` using the Pages Router, add the following code snippet to connect to your Neon database:
 


### PR DESCRIPTION
- add code snippet for `getStaticProps`. This method is almost identical to `getServerSideProps` but I've added it for good measure. I'm not sure if these should be under their own heading though, what do you think @danieltprice? 