### PR TITLE
Add cards to guides and import landing pages

### DIFF
--- a/content/docs/guides/guides-intro.md
+++ b/content/docs/guides/guides-intro.md
@@ -26,13 +26,19 @@ Learn about Neon's [Auto-suspend](/docs/introduction/auto-suspend) feature, whic
 
 Explore Neon's [branching feature](/docs/introduction/branching) with our branching guides.
 
-- [Branching — Point-in-time restore](/docs/guides/branching-pitr)
-- [Branching — Testing queries](/docs/guides/branching-test-queries)
-- [Branching with the CLI](/docs/guides/branching-neon-cli)
-- [Branching with the API](/docs/guides/branching-neon-api)
-- [Branching with GitHub Actions](/docs/guides/branching-github-actions)
-- [Refresh a branch with the Neon API](/docs/guides/branch-refresh)
-- [Promote a branch to primary with the Neon API](/docs/guides/branch-promote)
+<a href="/docs/guides/branching-pitr" description="Restore your data to a past state with database branching" icon="split-branch">Point-in-time restore</a>
+
+<a href="/docs/guides/branching-test-queries" description="Use branching to test queries before running them in production" icon="split-branch">Test queries on a branch</a>
+
+<a href="/docs/guides/branching-neon-cli" description="Create and manage branches with the Neon CLI" icon="split-branch">Branching with the CLI</a>
+
+<a href="/docs/guides/branching-neon-api" description="Create and manage branches with the Neon API" icon="split-branch">Branching with the API</a>
+
+<a href="(/docs/guides/branching-github-actions" description="Automate branching with GitHub Actions" icon="split-branch">Branching with GitHub Actions</a>
+
+<a href="(/docs/guides/branch-refresh" description="Refresh a development branch with the Neon API" icon="split-branch">Refresh a branch</a>
+
+<a href="(/docs/guides/branch-promote" description="Promote a branch to primary with the the Neon API" icon="split-branch">Promote a branch to primary</a>
 
 #### Project sharing
 

--- a/content/docs/guides/guides-intro.md
+++ b/content/docs/guides/guides-intro.md
@@ -8,7 +8,7 @@ Welcome to the guides section of our documentation. Whether you're looking for d
 
 ### Framework, language, and platform guides
 
-Integrate your applications with our framework, language, and platform guides.
+Integrate your applications with Neon.
 
 <TechnologyNavigation>
 
@@ -44,21 +44,19 @@ Explore Neon's capabilities with our feature guides.
 
 #### Autoscaling
 
-Learn how to enable Neon's [Autoscaling feature](/docs/guides/autoscaling-guide) to automatically scale compute resources up and down based on demand.
+Automatically scale compute resources up and down based on demand.
 
 <DetailIconCards>
 
-<a href="/docs/introduction/autoscaling" description="Learn about Neon's Autoscaling feature" icon="ladder">Learn about Autoscaling</a>
+<a href="/docs/introduction/autoscaling" description="Learn about  Autoscaling" icon="ladder">Learn about Autoscaling</a>
 
 <a href="/docs/guides/autoscaling-guide" description="Enable Autoscaling to automatically scale compute resources on demand" icon="ladder">Enable Autoscaling</a>
 
 </DetailIconCards>
 
-[Enable Autoscaling in Neon](/docs/guides/autoscaling-guide)
-
 #### Auto-suspend
 
-Learn about Neon's [Auto-suspend](/docs/introduction/auto-suspend) feature, which controls when Neon compute resources scale to zero.
+Control when Neon compute resources scale to zero.
 
 <DetailIconCards>
 
@@ -70,7 +68,7 @@ Learn about Neon's [Auto-suspend](/docs/introduction/auto-suspend) feature, whic
 
 #### Branching
 
-Explore Neon's branching feature with our branching guides.
+Branch data the same way you branch your code.
 
 <DetailIconCards>
 
@@ -94,7 +92,7 @@ Explore Neon's branching feature with our branching guides.
 
 #### Project sharing
 
-Learn how to share your Neon project with anyone using Neon's project sharing feature.
+Share your Neon project with anyone.
 
 <DetailIconCards>
 

--- a/content/docs/guides/guides-intro.md
+++ b/content/docs/guides/guides-intro.md
@@ -48,7 +48,7 @@ Automatically scale compute resources up and down based on demand.
 
 <DetailIconCards>
 
-<a href="/docs/introduction/autoscaling" description="Learn about  Autoscaling" icon="ladder">Learn about Autoscaling</a>
+<a href="/docs/introduction/autoscaling" description="Find out how autoscaling can reduce your costs." icon="ladder">Learn about Autoscaling</a>
 
 <a href="/docs/guides/autoscaling-guide" description="Enable Autoscaling to automatically scale compute resources on demand" icon="ladder">Enable Autoscaling</a>
 
@@ -60,7 +60,7 @@ Control when Neon compute resources scale to zero.
 
 <DetailIconCards>
 
-<a href="/docs/introduction/auto-suspend" description="Learn about Neon's Auto-suspend feature" icon="transactions">Learn about Auto-suspend</a>
+<a href="/docs/introduction/auto-suspend" description="Discover how Neon can reduce your compute to zero when not in use" icon="transactions">Learn about Auto-suspend</a>
 
 <a href="/docs/guides/autoscaling-guide" description="Configure Auto-suspend to control when your compute scales to zero" icon="transactions">Configure Auto-suspend</a>
 
@@ -72,7 +72,7 @@ Branch data the same way you branch your code.
 
 <DetailIconCards>
 
-<a href="/docs/introduction/branching" description="Learn about Neon's branching feature" icon="split-branch">Learn about branching</a>
+<a href="/docs/introduction/branching" description="With Neon you can instantly branch your data in the same way that you branch your code" icon="split-branch">Learn about branching</a>
 
 <a href="/docs/guides/branching-pitr" description="Restore your data to a past state with database branching" icon="split-branch">Point-in-time restore</a>
 
@@ -96,7 +96,7 @@ Share your Neon project with anyone.
 
 <DetailIconCards>
 
-<a href="/docs/guides/project-sharing-guide" description="Share a Neon project" icon="split-branch">Learn how to share your Neon project with others</a>
+<a href="/docs/guides/project-sharing-guide" description="Give other users access to your project from the Neon Console, API, and CLI" icon="split-branch">Learn how to share your Neon project with others</a>
 
 </DetailIconCards>
 
@@ -106,9 +106,9 @@ Learn how Neon read replicas can help you scale and manage read-only workloads.
 
 <DetailIconCards>
 
-<a href="/docs/introduction/read-replicas" description="Learn about Neon's read replica feature" icon="import">Learn about read replicas</a>
+<a href="/docs/introduction/read-replicas" description="Learn how Neon maximizes scalability and more with instant read replicas" icon="import">Learn about read replicas</a>
 
-<a href="/docs/guides/read-replica-guide" description="Learn how to create and manage read replicas" icon="import">Working with read replicas</a>
+<a href="/docs/guides/read-replica-guide" description="How to create and manage read replicas" icon="import">Working with read replicas</a>
 
 <a href="/docs/guides/read-replica-data-analysis" description="Offload data analysis and reporting queries to read replicas" icon="import">Data analysis and reporting</a>
 

--- a/content/docs/guides/guides-intro.md
+++ b/content/docs/guides/guides-intro.md
@@ -24,7 +24,11 @@ Learn about Neon's [Auto-suspend](/docs/introduction/auto-suspend) feature, whic
 
 #### Branching
 
-Explore Neon's [branching feature](/docs/introduction/branching) with our branching guides.
+Explore Neon's branching feature with our branching guides.
+
+<DetailIconCards>
+
+<a href="/docs/introduction/branching" description="Learn about Neon's branching feature" icon="split-branch">Learn about branching</a>
 
 <a href="/docs/guides/branching-pitr" description="Restore your data to a past state with database branching" icon="split-branch">Point-in-time restore</a>
 
@@ -39,6 +43,8 @@ Explore Neon's [branching feature](/docs/introduction/branching) with our branch
 <a href="(/docs/guides/branch-refresh" description="Refresh a development branch with the Neon API" icon="split-branch">Refresh a branch</a>
 
 <a href="(/docs/guides/branch-promote" description="Promote a branch to primary with the the Neon API" icon="split-branch">Promote a branch to primary</a>
+
+</DetailIconCards>
 
 #### Project sharing
 

--- a/content/docs/guides/guides-intro.md
+++ b/content/docs/guides/guides-intro.md
@@ -4,61 +4,7 @@ subtitle: Explore Neon features and how to integrate with different frameworks, 
 enableTableOfContents: true
 ---
 
-Welcome to the guides section of our documentation. Whether you're exploring Neon's features or looking for detailed instructions for integration across various frameworks, languages, and platforms, our guides are tailored to assist you.
-
-### Feature guides
-
-Explore Neon's capabilities with our feature guides.
-
-#### Autoscaling
-
-Learn how to enable Neon's [Autoscaling feature](/docs/guides/autoscaling-guide) to automatically scale compute resources up and down based on demand.
-
-[Enable Autoscaling in Neon](/docs/guides/autoscaling-guide)
-
-#### Auto-suspend
-
-Learn about Neon's [Auto-suspend](/docs/introduction/auto-suspend) feature, which controls when Neon compute resources scale to zero.
-
-[Configure Auto-suspend for Neon computes](/docs/guides/auto-suspend-guide)
-
-#### Branching
-
-Explore Neon's branching feature with our branching guides.
-
-<DetailIconCards>
-
-<a href="/docs/introduction/branching" description="Learn about Neon's branching feature" icon="split-branch">Learn about branching</a>
-
-<a href="/docs/guides/branching-pitr" description="Restore your data to a past state with database branching" icon="split-branch">Point-in-time restore</a>
-
-<a href="/docs/guides/branching-test-queries" description="Use branching to test queries before running them in production" icon="split-branch">Test queries on a branch</a>
-
-<a href="/docs/guides/branching-neon-cli" description="Create and manage branches with the Neon CLI" icon="split-branch">Branching with the CLI</a>
-
-<a href="/docs/guides/branching-neon-api" description="Create and manage branches with the Neon API" icon="split-branch">Branching with the API</a>
-
-<a href="(/docs/guides/branching-github-actions" description="Automate branching with GitHub Actions" icon="split-branch">Branching with GitHub Actions</a>
-
-<a href="(/docs/guides/branch-refresh" description="Refresh a development branch with the Neon API" icon="split-branch">Refresh a branch</a>
-
-<a href="(/docs/guides/branch-promote" description="Promote a branch to primary with the the Neon API" icon="split-branch">Promote a branch to primary</a>
-
-</DetailIconCards>
-
-#### Project sharing
-
-Learn how to share your Neon project with anyone using Neon's project sharing feature.
-
-[Project sharing](/docs/guides/project-sharing-guide)
-
-#### Read replicas
-
-Learn about Neon [read replicas](/docs/introduction/read-replicas).
-
-- [Working with read replicas](/docs/guides/read-replica-guide)
-- [Data analysis and reporting](/docs/guides/read-replica-data-analysis)
-- [Use read replicas with Prisma](/docs/guides/read-replica-prisma)
+Welcome to the guides section of our documentation. Whether you're looking for detailed instructions for integration across various frameworks, languages, and platforms, or exploring Neon's features, our guides are tailored to assist you.
 
 ### Framework, language, and platform guides
 
@@ -91,3 +37,83 @@ Integrate your applications with our framework, language, and platform guides.
 <img src="/images/technology-logos/symfony-logo.svg" width="36" height="36" alt="Symfony" href="/docs/guides/symfony" title="Connect from Symfony with Doctrine to Neon" />
 
 </TechnologyNavigation>
+
+### Feature guides
+
+Explore Neon's capabilities with our feature guides.
+
+#### Autoscaling
+
+Learn how to enable Neon's [Autoscaling feature](/docs/guides/autoscaling-guide) to automatically scale compute resources up and down based on demand.
+
+<DetailIconCards>
+
+<a href="/docs/introduction/autoscaling" description="Learn about Neon's Autoscaling feature" icon="ladder">Learn about Autoscaling</a>
+
+<a href="/docs/guides/autoscaling-guide" description="Enable Autoscaling to automatically scale compute resources on demand" icon="ladder">Enable Autoscaling</a>
+
+</DetailIconCards>
+
+[Enable Autoscaling in Neon](/docs/guides/autoscaling-guide)
+
+#### Auto-suspend
+
+Learn about Neon's [Auto-suspend](/docs/introduction/auto-suspend) feature, which controls when Neon compute resources scale to zero.
+
+<DetailIconCards>
+
+<a href="/docs/introduction/auto-suspend" description="Learn about Neon's Auto-suspend feature" icon="transactions">Learn about Auto-suspend</a>
+
+<a href="/docs/guides/autoscaling-guide" description="Configure Auto-suspend to control when your compute scales to zero" icon="transactions">Configure Auto-suspend</a>
+
+</DetailIconCards>
+
+#### Branching
+
+Explore Neon's branching feature with our branching guides.
+
+<DetailIconCards>
+
+<a href="/docs/introduction/branching" description="Learn about Neon's branching feature" icon="split-branch">Learn about branching</a>
+
+<a href="/docs/guides/branching-pitr" description="Restore your data to a past state with database branching" icon="split-branch">Point-in-time restore</a>
+
+<a href="/docs/guides/branching-test-queries" description="Use branching to test queries before running them in production" icon="split-branch">Test queries on a branch</a>
+
+<a href="/docs/guides/branching-neon-cli" description="Create and manage branches with the Neon CLI" icon="split-branch">Branching with the CLI</a>
+
+<a href="/docs/guides/branching-neon-api" description="Create and manage branches with the Neon API" icon="split-branch">Branching with the API</a>
+
+<a href="(/docs/guides/branching-github-actions" description="Automate branching with GitHub Actions" icon="split-branch">Branching with GitHub Actions</a>
+
+<a href="(/docs/guides/branch-refresh" description="Refresh a development branch with the Neon API" icon="split-branch">Refresh a branch</a>
+
+<a href="(/docs/guides/branch-promote" description="Promote a branch to primary with the the Neon API" icon="split-branch">Promote a branch to primary</a>
+
+</DetailIconCards>
+
+#### Project sharing
+
+Learn how to share your Neon project with anyone using Neon's project sharing feature.
+
+<DetailIconCards>
+
+<a href="/docs/guides/project-sharing-guide" description="Share a Neon project" icon="split-branch">Learn how to share your Neon project with others</a>
+
+</DetailIconCards>
+
+#### Read replicas
+
+Learn how Neon read replicas can help you scale and manage read-only workloads.
+
+<DetailIconCards>
+
+<a href="/docs/introduction/read-replicas" description="Learn about Neon's read replica feature" icon="import">Learn about read replicas</a>
+
+<a href="/docs/guides/read-replica-guide" description="Learn how to create and manage read replicas" icon="import">Working with read replicas</a>
+
+<a href="/docs/guides/read-replica-data-analysis" description="Offload data analysis and reporting queries to read replicas" icon="import">Data analysis and reporting</a>
+
+<a href="/docs/guides/read-replica-prisma" description="Scale your applications with Neon read replicas and Prisma Client" icon="import">Point-in-time restore</a>
+
+</DetailIconCards>

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -8,9 +8,18 @@ Welcome to the data import section. This part of the documentation provides guid
 
 ### Data import guides
 
-- [Import from Postgres](import/import-from-postgres)
-- [Import from a Neon project](import/import-from-neon)
-- [Import from CSV](import/import-from-csv)
-- [Import from Heroku](import/import-from-heroku)
-- [Migrate data with AWS DMS](import/migrate-aws-dms)
-- [Sample data](import/import-sample-data)
+<DetailIconCards>
+
+<a href="/docs/import/import-from-postgres" description="Import data from another Postgres database" icon="import">Import from Postgres</a>
+
+<a href="/docs/import/import-from-neon" description="Import data from another Neon project to upgrade Postgres or change regions" icon="import">Import from a Neon project</a>
+
+<a href="/docs/import/import-from-csv" description="Import data from a CSV file" icon="import">Import from CSV</a>
+
+<a href="/docs/import/import-from-heroku" description="Import data from a Heroku Postgres database" icon="import">Import from Heroku</a>
+
+<a href="/docs/import/migrate-aws-dms" description="Migrate data using AWS Data Migration Service" icon="import">Migrate with AWS DMS</a>
+
+<a href="(/docs/import/import-sample-data" description="Load sample data for evaluation and learning" icon="import">Load sample data</a>
+
+</DetailIconCards>

--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -12,7 +12,7 @@ Welcome to the data import section. This part of the documentation provides guid
 
 <a href="/docs/import/import-from-postgres" description="Import data from another Postgres database" icon="import">Import from Postgres</a>
 
-<a href="/docs/import/import-from-neon" description="Import data from another Neon project to upgrade Postgres or change regions" icon="import">Import from a Neon project</a>
+<a href="/docs/import/import-from-neon" description="Import data from another Neon project for upgrade or region migration" icon="import">Import from a Neon project</a>
 
 <a href="/docs/import/import-from-csv" description="Import data from a CSV file" icon="import">Import from CSV</a>
 
@@ -20,6 +20,6 @@ Welcome to the data import section. This part of the documentation provides guid
 
 <a href="/docs/import/migrate-aws-dms" description="Migrate data using AWS Data Migration Service" icon="import">Migrate with AWS DMS</a>
 
-<a href="(/docs/import/import-sample-data" description="Load sample data for evaluation and learning" icon="import">Load sample data</a>
+<a href="(/docs/import/import-sample-data" description="Load sample data for exploration and testing" icon="import">Load sample data</a>
 
 </DetailIconCards>


### PR DESCRIPTION
Improve landing pages for onboarding docs links:
![image](https://github.com/neondatabase/website/assets/10074684/e72310ad-1364-44b2-a72e-50f91f1c9905)

Guides intro page with cards:
https://neon-next-git-docs-update-guides-intro-neondatabase.vercel.app/docs/guides/guides-intro

Import intro page with cards:
https://neon-next-git-docs-update-guides-intro-neondatabase.vercel.app/docs/import/import-intro