### PR TITLE
feat: add anchor headings for blog posts

### DIFF
--- a/src/components/shared/anchor-heading/anchor-heading.jsx
+++ b/src/components/shared/anchor-heading/anchor-heading.jsx
@@ -32,7 +32,7 @@ const AnchorHeading =
     );
 
     return (
-      <Tag id={id} className={clsx('not-prose group relative w-fit', className)}>
+      <Tag id={id} className={clsx('not-prose group relative w-fit lg:scroll-mt-5', className)}>
         <a
           className="anchor absolute -right-16 top-1/2 flex h-full -translate-x-full -translate-y-[calc(50%-0.15rem)] items-center justify-center px-2.5 no-underline opacity-0 transition-opacity duration-200 hover:opacity-100 group-hover:opacity-100 sm:hidden"
           href={`#${id}`}

--- a/src/components/shared/anchor-heading/anchor-heading.jsx
+++ b/src/components/shared/anchor-heading/anchor-heading.jsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import PropTypes from 'prop-types';
 import slugify from 'slugify';
 
 import HashIcon from './images/hash.inline.svg';
@@ -24,14 +25,14 @@ const extractText = (children) => {
 const AnchorHeading =
   (Tag) =>
   // eslint-disable-next-line react/prop-types
-  ({ children }) => {
+  ({ children, className = null }) => {
     const id = slugify(extractText(children), { lower: true, remove: /[*+~.()'"!?:@]/g }).replace(
       /_/g,
       ''
     );
 
     return (
-      <Tag id={id} className="not-prose group relative w-fit scroll-mt-20 lg:scroll-mt-5">
+      <Tag id={id} className={clsx('not-prose group relative w-fit', className)}>
         <a
           className="anchor absolute -right-16 top-1/2 flex h-full -translate-x-full -translate-y-[calc(50%-0.15rem)] items-center justify-center px-2.5 no-underline opacity-0 transition-opacity duration-200 hover:opacity-100 group-hover:opacity-100 sm:hidden"
           href={`#${id}`}
@@ -46,5 +47,10 @@ const AnchorHeading =
       </Tag>
     );
   };
+
+AnchorHeading.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
 
 export default AnchorHeading;

--- a/src/components/shared/anchor-heading/anchor-heading.jsx
+++ b/src/components/shared/anchor-heading/anchor-heading.jsx
@@ -31,7 +31,7 @@ const AnchorHeading =
     );
 
     return (
-      <Tag id={id} className="not-prose group relative w-fit">
+      <Tag id={id} className="not-prose group relative w-fit scroll-mt-20 lg:scroll-mt-5">
         <a
           className="anchor absolute -right-16 top-1/2 flex h-full -translate-x-full -translate-y-[calc(50%-0.15rem)] items-center justify-center px-2.5 no-underline opacity-0 transition-opacity duration-200 hover:opacity-100 group-hover:opacity-100 sm:hidden"
           href={`#${id}`}

--- a/src/utils/get-react-content-with-lazy-blocks.jsx
+++ b/src/utils/get-react-content-with-lazy-blocks.jsx
@@ -145,6 +145,10 @@ export default function getReactContentWithLazyBlocks(content, pageComponents, i
           return <EmbedTweet {...props}>{domToReact(children)}</EmbedTweet>;
         }
 
+        if (domNode.attribs?.class?.includes('wp-block-heading')) {
+          return AnchorHeading(domNode.name)({ children: domToReact(domNode.children) });
+        }
+
         if (!includeBaseTags) return <></>;
       }
     },

--- a/src/utils/get-react-content-with-lazy-blocks.jsx
+++ b/src/utils/get-react-content-with-lazy-blocks.jsx
@@ -146,7 +146,10 @@ export default function getReactContentWithLazyBlocks(content, pageComponents, i
         }
 
         if (domNode.attribs?.class?.includes('wp-block-heading')) {
-          return AnchorHeading(domNode.name)({ children: domToReact(domNode.children) });
+          return AnchorHeading(domNode.name)({
+            children: domToReact(domNode.children),
+            className: `${domNode.attribs.class} scroll-mt-20 lg:scroll-mt-5`,
+          });
         }
 
         if (!includeBaseTags) return <></>;

--- a/src/utils/get-react-content-with-lazy-blocks.jsx
+++ b/src/utils/get-react-content-with-lazy-blocks.jsx
@@ -148,7 +148,7 @@ export default function getReactContentWithLazyBlocks(content, pageComponents, i
         if (domNode.attribs?.class?.includes('wp-block-heading')) {
           return AnchorHeading(domNode.name)({
             children: domToReact(domNode.children),
-            className: `${domNode.attribs.class} scroll-mt-20 lg:scroll-mt-5`,
+            className: `${domNode.attribs.class} scroll-mt-20`,
           });
         }
 


### PR DESCRIPTION
This pull request brings the anchor headings for blog posts

<img width="835" alt="image" src="https://github.com/neondatabase/website/assets/48465000/ef011659-6dc6-4b00-8487-564c446b2a3a">
