### PR TITLE
docs/change-ssl-modes

### DIFF
--- a/content/docs/guides/astro.md
+++ b/content/docs/guides/astro.md
@@ -70,7 +70,7 @@ import { Pool } from 'pg';
 const pool = new Pool({
   connectionString: import.meta.env.DATABASE_URL,
   ssl: {
-    require: true,
+    rejectUnauthorized: true,
   },
 });
 

--- a/content/docs/guides/astro.md
+++ b/content/docs/guides/astro.md
@@ -103,7 +103,7 @@ console.log(response);
 ---
 import { neon } from '@neondatabase/serverless';
 
-const sql = neon(import.meta.env.DATABASE_URL, { ssl: 'require' });
+const sql = neon(import.meta.env.DATABASE_URL);
 
 const response = await sql`SELECT version()`;
 console.log(response);

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -75,7 +75,7 @@ import { Pool } from 'pg';
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: {
-    require: true,
+    rejectUnauthorized: true,
   },
 });
 
@@ -150,7 +150,7 @@ import { Pool } from 'pg';
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: {
-    require: true,
+    rejectUnauthorized: true,
   },
 });
 
@@ -211,7 +211,7 @@ import { Pool } from 'pg';
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: {
-    require: true,
+    rejectUnauthorized: true,
   },
 });
 
@@ -273,7 +273,7 @@ import { Pool } from 'pg';
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: {
-    require: true,
+    rejectUnauthorized: true,
   },
 });
 

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -116,7 +116,7 @@ export default async function Page() {
 import { neon } from '@neondatabase/serverless';
 
 async function getData() {
-  const sql = neon(process.env.DATABASE_URL, { ssl: 'require' });
+  const sql = neon(process.env.DATABASE_URL);
 
   const response = await sql`SELECT version()`;
   console.log(response);
@@ -187,7 +187,7 @@ export default function Page({ data }) {}
 import { neon } from '@neondatabase/serverless';
 
 export async function getServerSideProps() {
-  const sql = neon(process.env.DATABASE_URL, { ssl: 'require' });
+  const sql = neon(process.env.DATABASE_URL);
 
   const response = await sql`SELECT version()`;
   console.log(response);
@@ -248,7 +248,7 @@ export default function Page({ data }) {}
 import { neon } from '@neondatabase/serverless';
 
 export async function getServerSideProps() {
-  const sql = neon(process.env.DATABASE_URL, { ssl: 'require' });
+  const sql = neon(process.env.DATABASE_URL);
 
   const response = await sql`SELECT version()`;
   console.log(response);
@@ -312,7 +312,7 @@ export default async function handler(req, res) {
 ```javascript
 import { neon } from '@neondatabase/serverless';
 
-const sql = neon(process.env.DATABASE_URL, { ssl: 'require' });
+const sql = neon(process.env.DATABASE_URL);
 
 export default async function handler(req, res) {
   const response = await sql`SELECT version()`;
@@ -333,7 +333,7 @@ From your Edge Functions, add the following code snippet and connect to your Neo
 ```javascript
 import { neon } from '@neondatabase/serverless';
 
-const sql = neon(process.env.DATABASE_URL, { ssl: 'require' });
+const sql = neon(process.env.DATABASE_URL);
 
 export default async function handler(req, res) {
   const response = await sql`SELECT version()`;


### PR DESCRIPTION
- remove ` ssl: 'require' ` from neon function.
- I've also made a change to the `pg` `ssl` values. Apparently `true` is for older versions and `rejectUnauthorized ` is for newer versions of `pg`

I checked in with George MacKerron and `ssl: 'require'` isn't required when using the neon function.  

> All connections from the serverless driver to a Neon DB are secure (over an https POST request or a wss WebSocket). We don’t support unencrypted connections, so there are no relevant options here (unless you’re running your own WebSocket proxy in front of your own DB)