### PR TITLE
docs/astro-guide-amend

### DIFF
--- a/content/docs/guides/astro.md
+++ b/content/docs/guides/astro.md
@@ -113,7 +113,7 @@ console.log(response);
 
 ## Run the app
 
-For server-side requests you can expect to see one of the following in your terminal output:
+You can expect to see one of the following in your terminal output:
 
 <CodeBlock shouldWrap>
 


### PR DESCRIPTION
- change run the app copy

Just a small change to the wording for "Run the app". This Astro guide will only have server functions. 