### PR TITLE
feat: set sidebar collapsed by default

### DIFF
--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -26,7 +26,7 @@ const Item = ({
   const currentSlug = pathname.replace(`${links.docs}/`, '');
 
   const hasActiveChild = isActiveItem(items, currentSlug);
-  const [isOpen, setIsOpen] = useState(() => slug === currentSlug || hasActiveChild);
+  const [isOpen, setIsOpen] = useState(() => hasActiveChild);
 
   if (!isOpen && isActiveItem(items, currentSlug)) {
     setIsOpen(true);


### PR DESCRIPTION
This pull request makes the docs sidebar collapsed by default

Preview: https://neon-next-git-sidebar-update-neondatabase.vercel.app/docs/introduction
<img width="1370" alt="image" src="https://github.com/neondatabase/website/assets/48465000/5eeec3d0-05ff-479a-9ea2-2463f9144f01">


