### PR TITLE
Create 2023-10-19-storage-and-compute.md

### DIFF
--- a/content/release-notes/2023-10-19-storage-and-compute.md
+++ b/content/release-notes/2023-10-19-storage-and-compute.md
@@ -1,0 +1,13 @@
+### Support for pgvector 0.5.1
+
+The `pgvector` extension for vector similarity search in Postgres was updated to a newer version:
+
+| Postgres extension           | Old version   | New version   |
+|------------------------------|---------------|---------------|
+| `pgvector`                   | 0.5.0         | 0.5.1         |
+
+The new version improves HNSW index build performance. For other included in the new version, refer to the [pgvector changelog](https://github.com/pgvector/pgvector/blob/master/CHANGELOG.md).
+
+If you installed this extensions previously and want to upgrade to the latest version, please refer to [Update an extension version](/docs/extensions/pg-extensions#update-an-extension-version) for instructions.
+
+For a complete list of Postgres extensions supported by Neon, see [Postgres extensions](/docs/extensions/pg-extensions).

--- a/content/release-notes/2023-10-19-storage-and-compute.md
+++ b/content/release-notes/2023-10-19-storage-and-compute.md
@@ -6,8 +6,8 @@ The `pgvector` extension for vector similarity search in Postgres was updated to
 |------------------------------|---------------|---------------|
 | `pgvector`                   | 0.5.0         | 0.5.1         |
 
-The new version improves HNSW index build performance. For other included in the new version, refer to the [pgvector changelog](https://github.com/pgvector/pgvector/blob/master/CHANGELOG.md).
+The new version of `pgvector` improves HNSW index build performance. For other updates, refer to the [pgvector changelog](https://github.com/pgvector/pgvector/blob/master/CHANGELOG.md).
 
-If you installed this extensions previously and want to upgrade to the latest version, please refer to [Update an extension version](/docs/extensions/pg-extensions#update-an-extension-version) for instructions.
+If you installed this extension previously and want to upgrade to the latest version, please refer to [Update an extension version](/docs/extensions/pg-extensions#update-an-extension-version) for instructions.
 
 For a complete list of Postgres extensions supported by Neon, see [Postgres extensions](/docs/extensions/pg-extensions).

--- a/content/release-notes/2023-10-19-storage-and-compute.md
+++ b/content/release-notes/2023-10-19-storage-and-compute.md
@@ -1,6 +1,6 @@
 ### Support for pgvector 0.5.1
 
-The `pgvector` extension for vector similarity search in Postgres was updated to a newer version:
+The `pgvector` extension for vector similarity search in Postgres was updated to a newer version.
 
 | Postgres extension           | Old version   | New version   |
 |------------------------------|---------------|---------------|


### PR DESCRIPTION
Release note:
https://neon-next-git-dprice-10-17-2023-storage-release-neondatabase.vercel.app/docs/release-notes

Release note for: https://github.com/neondatabase/neon/pull/5577
I only see this one item for the external notes.