### PR TITLE
chore: add stackoverflow page & exclude it from indexing

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '/last-week-in-aws',
     '/ping-thing',
     '/all-things-open-2023',
+    '/stackoverflow',
   ],
   generateRobotsTxt: true,
   robotsTxtOptions: {
@@ -18,6 +19,7 @@ module.exports = {
           '/last-week-in-aws$',
           '/ping-thing$',
           '/all-things-open-2023$',
+          '/stackoverflow$',
         ],
       },
     ],

--- a/src/app/stackoverflow/page.jsx
+++ b/src/app/stackoverflow/page.jsx
@@ -1,0 +1,28 @@
+import Community from 'components/pages/home/community';
+import DataBranching from 'components/pages/home/data-branching';
+import FirstSection from 'components/pages/home/first-section';
+import Scalability from 'components/pages/home/scalability';
+import SecondSection from 'components/pages/home/second-section';
+import Storage from 'components/pages/home/storage';
+import Layout from 'components/shared/layout';
+import Subscribe from 'components/shared/subscribe';
+import SEO_DATA from 'constants/seo-data';
+import getMetadata from 'utils/get-metadata';
+
+export const metadata = getMetadata({ ...SEO_DATA.index, robotsNoindex: 'noindex' });
+
+const StackOverflowPage = () => (
+  <Layout headerTheme="black" isSignIn footerWithTopBorder withOverflowHidden>
+    <FirstSection />
+    <Community />
+    <Scalability />
+    <Storage />
+    <DataBranching />
+    <SecondSection />
+    <Subscribe />
+  </Layout>
+);
+
+export default StackOverflowPage;
+
+export const revalidate = 60;


### PR DESCRIPTION
This PR brings a home page duplicate [/stackoverflow](https://neon-next-git-stackoverflow-page-neondatabase.vercel.app/stackoverflow) and blocks from page indexing, excludes from sitemap.

