### PR TITLE
Remove draft tags from community and contribution pages

### DIFF
--- a/content/docs/community/community-intro.md
+++ b/content/docs/community/community-intro.md
@@ -2,7 +2,6 @@
 title: Neon community
 subtitle: Learn how to get involved in the Neon community
 enableTableOfContents: true
-isDraft: true
 updatedOn: '2023-10-23T17:55:15.628Z'
 ---
 

--- a/content/docs/community/community-intro.md
+++ b/content/docs/community/community-intro.md
@@ -2,7 +2,7 @@
 title: Neon community
 subtitle: Learn how to get involved in the Neon community
 enableTableOfContents: true
-updatedOn: '2023-10-23T17:55:15.628Z'
+updatedOn: '2023-10-24T13:30:10.815Z'
 ---
 
 Neon has an enthusiastic and dynamic user community worldwide. Here's how you can get involved:

--- a/content/docs/community/contribution-guide.md
+++ b/content/docs/community/contribution-guide.md
@@ -2,7 +2,6 @@
 title: Documentation Contribution Guide
 subtitle: Learn how to contribute to the Neon documentation
 enableTableOfContents: true
-isDraft: true
 updatedOn: '2023-10-23T15:04:17.292Z'
 ---
 

--- a/content/docs/community/contribution-guide.md
+++ b/content/docs/community/contribution-guide.md
@@ -2,7 +2,7 @@
 title: Documentation Contribution Guide
 subtitle: Learn how to contribute to the Neon documentation
 enableTableOfContents: true
-updatedOn: '2023-10-23T15:04:17.292Z'
+updatedOn: '2023-10-24T13:30:10.819Z'
 ---
 
 This page provides guidelines for contributing to the Neon documentation. Our goal is to create an environment where our community has the information and knowledge required to confidently participate in improving the Neon documentation.


### PR DESCRIPTION
Pages were not showing up due to isDraft: true frontmatter items.