### PR TITLE
feat: send pricing gtag events

### DIFF
--- a/src/components/pages/pricing/calculator/calculator.jsx
+++ b/src/components/pages/pricing/calculator/calculator.jsx
@@ -13,6 +13,7 @@ import ArrowRight from 'icons/arrow-sm.inline.svg';
 import CheckIcon from 'icons/check.inline.svg';
 import infoHoveredIcon from 'icons/tooltip-hovered.svg';
 import infoIcon from 'icons/tooltip.svg';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const COMPUTE_TIME_PRICE = 0.102;
 const PROJECT_STORAGE_PRICE = 0.000164;
@@ -454,6 +455,16 @@ const Calculator = () => {
               linesOffsetSide={26}
               linesOffsetBottom={55}
               isAnimated
+              onClick={() => {
+                sendGtagEvent('pricing_estimated_price', {
+                  price: estimatedPrice,
+                  computeUnits,
+                  activeTime,
+                  storageValue,
+                  dataTransferValue,
+                  writtenDataValue,
+                });
+              }}
             >
               {estimatedPrice >= CUSTOM_THRESHOLD ? 'Get Custom Quote' : 'Get Started'}
             </AnimatedButton>

--- a/src/components/pages/pricing/cta/cta.jsx
+++ b/src/components/pages/pricing/cta/cta.jsx
@@ -9,6 +9,7 @@ import AnimatedButton from 'components/shared/animated-button';
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
 import links from 'constants/links';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const CTA = () => {
   const [contentRef, isContentInView] = useInView({ rootMargin: '50px 0px', triggerOnce: true });
@@ -55,6 +56,9 @@ const CTA = () => {
             linesOffsetSide={24}
             linesOffsetBottom={50}
             isAnimated
+            onClick={() => {
+              sendGtagEvent('pricing_cta_click');
+            }}
           >
             Talk to sales
           </AnimatedButton>

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -10,6 +10,7 @@ import Heading from 'components/shared/heading';
 import Link from 'components/shared/link';
 import LINKS from 'constants/links';
 import CheckIcon from 'icons/check.inline.svg';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const items = [
   {
@@ -27,6 +28,7 @@ const items = [
       url: 'https://console.neon.tech/sign_in',
       text: 'Get Started',
       theme: 'white-outline',
+      event: 'pricing_hero_free_btn_click',
     },
   },
   {
@@ -45,6 +47,7 @@ const items = [
       url: 'https://console.neon.tech/app/projects?show_enroll_to_pro=true',
       text: 'Upgrade',
       theme: 'primary',
+      event: 'pricing_hero_pro_btn_click',
     },
   },
   {
@@ -62,6 +65,7 @@ const items = [
       url: LINKS.contactSales,
       text: 'Contact Sales',
       theme: 'white-outline',
+      event: 'pricing_hero_custom_btn_click',
     },
   },
 ];
@@ -141,6 +145,9 @@ const Hero = () => {
                     activeItemIndex !== index ? 'bg-gray-new-8' : 'bg-transparent'
                   )}
                   to={button.url}
+                  onClick={() => {
+                    sendGtagEvent(button.event);
+                  }}
                 >
                   <div className="mb-6 min-h-[280px] flex flex-col border-b border-dashed border-gray-new-20 pb-4 xl:mb-7 lg:min-h-max">
                     <span className="text-xl font-medium leading-none tracking-tight text-[var(--accentColor)]">


### PR DESCRIPTION
This pull request adds GA events to the Pricing page including:
- CTA buttons in hero section
- `Talk to Sales` button
- `Get started` button with all pricing params (estimatedPrice, computeUnits, activeTime, storageValue, dataTransferValue, writtenDataValue)