### PR TITLE
fix: update canonical urls for duplicated pages

### DIFF
--- a/src/app/all-things-open-2023/page.jsx
+++ b/src/app/all-things-open-2023/page.jsx
@@ -9,7 +9,12 @@ import Subscribe from 'components/shared/subscribe';
 import SEO_DATA from 'constants/seo-data';
 import getMetadata from 'utils/get-metadata';
 
-export const metadata = getMetadata({ ...SEO_DATA.index, robotsNoindex: 'noindex' });
+export const metadata = getMetadata({
+  title: SEO_DATA.index.title,
+  description: SEO_DATA.index.description,
+  pathname: '/all-things-open-2023',
+  robotsNoindex: 'noindex',
+});
 
 const AllThingsOpen = () => (
   <Layout headerTheme="black" isSignIn footerWithTopBorder withOverflowHidden>

--- a/src/app/last-week-in-aws/page.jsx
+++ b/src/app/last-week-in-aws/page.jsx
@@ -9,7 +9,12 @@ import Subscribe from 'components/shared/subscribe';
 import SEO_DATA from 'constants/seo-data';
 import getMetadata from 'utils/get-metadata';
 
-export const metadata = getMetadata({ ...SEO_DATA.index, robotsNoindex: 'noindex' });
+export const metadata = getMetadata({
+  title: SEO_DATA.index.title,
+  description: SEO_DATA.index.description,
+  pathname: '/last-week-in-aws',
+  robotsNoindex: 'noindex',
+});
 
 const LastWeekInAWS = () => (
   <Layout headerTheme="black" isSignIn footerWithTopBorder withOverflowHidden>

--- a/src/app/stackoverflow/page.jsx
+++ b/src/app/stackoverflow/page.jsx
@@ -9,7 +9,12 @@ import Subscribe from 'components/shared/subscribe';
 import SEO_DATA from 'constants/seo-data';
 import getMetadata from 'utils/get-metadata';
 
-export const metadata = getMetadata({ ...SEO_DATA.index, robotsNoindex: 'noindex' });
+export const metadata = getMetadata({
+  title: SEO_DATA.index.title,
+  description: SEO_DATA.index.description,
+  pathname: '/stackoverflow',
+  robotsNoindex: 'noindex',
+});
 
 const StackOverflowPage = () => (
   <Layout headerTheme="black" isSignIn footerWithTopBorder withOverflowHidden>


### PR DESCRIPTION
This pull request updates the canonical urls for pages:
- /all-things-open-2023
- /last-week-in-aws
- /stackoverflow