### PR TITLE
feat: add preconnect links

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -35,6 +35,8 @@ const RootLayout = ({ children }) => (
           key={index}
         />
       ))}
+      <link rel="preconnect" href="https://console.neon.tech" />
+      <link rel="preconnect" href="https://auth.neon.tech" />
     </head>
     <body>
       {process.env.NODE_ENV === 'production' && (


### PR DESCRIPTION
This pull request brings the preconnect links to project layout:

```html
<link rel="preconnect" href="https://console.neon.tech" />
<link rel="preconnect" href="https://auth.neon.tech" />
```

https://pagespeed.web.dev/analysis/https-neon-tech/mcnjt2wqxz?form_factor=desktop
<details>
<summary>Before</summary>
<img width="988" alt="image" src="https://github.com/neondatabase/website/assets/48465000/afda3af3-b32d-466c-8f7a-b6d7dbae8625">

</details>

https://pagespeed.web.dev/analysis/https-neon-next-git-preconnect-links-neondatabase-vercel-app/v2nzogzpde?form_factor=desktop
<details>
<summary>After</summary>
<img width="1000" alt="image" src="https://github.com/neondatabase/website/assets/48465000/88ef683e-3676-4b9e-aad4-6bad9934fe25">

</details>