### PR TITLE
fix: make ai input more contrast in light theme

### DIFF
--- a/src/components/pages/doc/chat-widget/chat-input/chat-input.jsx
+++ b/src/components/pages/doc/chat-widget/chat-input/chat-input.jsx
@@ -10,7 +10,7 @@ const ChatInput = forwardRef(({ onEnterPress }, ref) => {
 
   return (
     <input
-      className="peer w-full appearance-none rounded border border-gray-new-90 px-2.5 py-2 text-base leading-normal transition-colors duration-200 placeholder:text-gray-new-80 focus:outline-none dark:border-gray-new-20 dark:bg-black dark:placeholder:text-gray-new-30"
+      className="peer w-full appearance-none rounded border border-gray-new-80 px-2.5 py-2 text-base leading-normal transition-colors duration-200 placeholder:text-gray-new-80 focus:outline-none dark:border-gray-new-20 dark:bg-black dark:placeholder:text-gray-new-30"
       ref={ref}
       type="text"
       placeholder="How can I help you?"


### PR DESCRIPTION
This pull request makes the Neon docs AI more contrast

**Screenshots**
<img width="839" alt="image" src="https://github.com/neondatabase/website/assets/48465000/f067625f-d1fe-466f-8139-e373aaca17c1">
