### PR TITLE
Storage release 11-27-2023

### DIFF
--- a/content/docs/extensions/neon.md
+++ b/content/docs/extensions/neon.md
@@ -3,7 +3,7 @@ title: The neon extension
 enableTableOfContents: true
 ---
 
-With each Neon project, Neon creates  a "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are owned by a Neon system role (`cloud_admin`) but you are able to view them by connecting to the `postgres` database using `psql` and executing the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
+With each Neon project, Neon creates  a "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are owned by a Neon system role (`cloud_admin`), but you are able to view them by connecting to the `postgres` database using `psql` and executing the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
 
 <CodeBlock shouldWrap>
 

--- a/content/docs/extensions/neon.md
+++ b/content/docs/extensions/neon.md
@@ -5,19 +5,20 @@ enableTableOfContents: true
 
 With each Neon project, Neon creates  a "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are owned by a Neon system role (`cloud_admin`) but you are able to view them by connecting to the `postgres` database using `psql` and executing the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
 
-    <CodeBlock shouldWrap>
+<CodeBlock shouldWrap>
 
-    ```bash
-    psql 'postgresql://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/postgres?sslmode=require'
+```bash
+psql 'postgresql://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/postgres?sslmode=require'
 
-    postgres=> \dv neon.*
-                List of relations
-    Schema |      Name      | Type |    Owner    
-    --------+----------------+------+-------------
-    neon   | local_cache    | view | cloud_admin
-    neon   | neon_lfc_stats | view | cloud_admin
-    (2 rows)
+postgres=> \dv neon.*
+            List of relations
+Schema |      Name      | Type |    Owner    
+--------+----------------+------+-------------
+neon   | local_cache    | view | cloud_admin
+neon   | neon_lfc_stats | view | cloud_admin
+(2 rows)
+```
 
-    </CodeBlock>
+</CodeBlock>
 
 <NeedHelp/>

--- a/content/docs/extensions/neon.md
+++ b/content/docs/extensions/neon.md
@@ -1,0 +1,21 @@
+---
+title: The neon extension
+enableTableOfContents: true
+---
+
+With each Neon project, Neon creates  a "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are owned by a Neon system role (`cloud_admin`) but you are able to view them by connecting to the `postgres` database using `psql` and executing the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
+
+    <CodeBlock shouldWrap>
+
+    ```bash
+    psql 'postgresql://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/postgres?sslmode=require'
+
+    postgres=> \dv neon.*
+                List of relations
+    Schema |      Name      | Type |    Owner    
+    --------+----------------+------+-------------
+    neon   | local_cache    | view | cloud_admin
+    neon   | neon_lfc_stats | view | cloud_admin
+    (2 rows)
+
+<NeedHelp/>

--- a/content/docs/extensions/neon.md
+++ b/content/docs/extensions/neon.md
@@ -18,4 +18,6 @@ With each Neon project, Neon creates  a "neon" extension, which includes functio
     neon   | neon_lfc_stats | view | cloud_admin
     (2 rows)
 
+    </CodeBlock>
+
 <NeedHelp/>

--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -39,6 +39,8 @@ Roles created in the Neon console, CLI, or API, including the default role creat
 
 You can think of roles with `neon_superuser` privileges as administrator roles. If you require roles with limited privileges, such as a read-only role, you can create those roles from an SQL client. For more information, see [Manage database access](/docs/manage/database-access).
 
+Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is not permitted. It should not be used directly or modified.
+
 ## Manage roles in the Neon console
 
 This section describes how to create, view, and delete roles in the Neon Console. All roles created in the Neon console are granted membership in the [neon_superuser](#the-neon_superuser-role) role.

--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -39,7 +39,7 @@ Roles created in the Neon console, CLI, or API, including the default role creat
 
 You can think of roles with `neon_superuser` privileges as administrator roles. If you require roles with limited privileges, such as a read-only role, you can create those roles from an SQL client. For more information, see [Manage database access](/docs/manage/database-access).
 
-Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is not permitted. It should not be used directly or modified.
+Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is not permitted. This `NOLOGIN` role should not be used directly or modified.
 
 ## Manage roles in the Neon console
 

--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -40,7 +40,7 @@ Roles created in the Neon console, CLI, or API, including the default role creat
 You can think of roles with `neon_superuser` privileges as administrator roles. If you require roles with limited privileges, such as a read-only role, you can create those roles from an SQL client. For more information, see [Manage database access](/docs/manage/database-access).
 
 <Admonition type="note">
-Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is _not_ permitted. This `NOLOGIN` role should not be used directly or modified.
+Creating a database with the `neon_superuser` role, altering a database to have owner `neon_superuser`, and altering the `neon_superuser role` itself are _not_ permitted. This `NOLOGIN` role is not intended to be used directly or modified.
 </Admonition>
 
 ## Manage roles in the Neon console

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -140,8 +140,10 @@
               slug: guides/read-replica-prisma
         - title: Extensions
           items:
+            - title: neon
+              slug: extensions/neon
             - title: neon_utils
-              slug: extensions/neon-utils
+              slug: extensions/neon-utils            
     - title: Frameworks
       items:
         - title: Next.js

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -1,0 +1,8 @@
+---
+description: Read about the latest fixes and improvements in Neon Serverless Postgres.
+---
+
+### Fixes & improvements
+
+- Compute: Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and cannot be used directly. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
+

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -4,7 +4,7 @@ description: Neon metrics collection and new usage guidelines for the neon_super
 
 ### Fixes & improvements
 
-- Compute: Neon now creates a `neon` extension in the `neon` schema in the `postgres` database. This extension contains functions and views for collecting Neon-specific metrics for the purpose of improving our service. The views are fully accessible. You can access them by connecting to the `postgres` database via `psql` and running a `\dv neon.*` command, as shown below. Currently, the extension includes two views for collecting local file cache metrics. Additional views may be added in future releases.
+- Compute: Neon has introduced a new "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are readily available for access. You can view them by connecting to the `postgres` database using `psql` and execute the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
 
     ```bash
     psql 'postgresql://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/postgres?sslmode=require'

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -22,5 +22,5 @@ description: Neon metrics collection and new usage guidelines for the neon_super
 
     </CodeBlock>
 
-- Compute: Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and should not be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
+- Compute: Creating a database with the `neon_superuser` role, altering a database to have owner `neon_superuser`, and altering the `neon_superuser role` itself are no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and should not be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
 

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -4,5 +4,4 @@ description: Read about the latest fixes and improvements in Neon Serverless Pos
 
 ### Fixes & improvements
 
-- Compute: Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and cannot be used directly. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
-
+Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and cannot be used directly. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -6,6 +6,8 @@ description: Neon metrics collection and new usage guidelines for the neon_super
 
 - Compute: Neon has introduced a new "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are readily available for access. You can view them by connecting to the `postgres` database using `psql` and execute the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
 
+    <CodeBlock shouldWrap>
+
     ```bash
     psql 'postgresql://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/postgres?sslmode=require'
 
@@ -17,6 +19,8 @@ description: Neon metrics collection and new usage guidelines for the neon_super
     neon   | neon_lfc_stats | view | cloud_admin
     (2 rows)
     ```
+
+    </CodeBlock>
 
 - Compute: Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and should not be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
 

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -4,7 +4,7 @@ description: Neon metrics collection and new usage guidelines for the neon_super
 
 ### Fixes & improvements
 
-- Compute: Neon has introduced a new "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are readily available for access. You can view them by connecting to the `postgres` database using `psql` and execute the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
+- Compute: Neon has introduced a new pre-installed "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are owned by a Neon system role (`cloud_admin`) but you are able to view them by connecting to the `postgres` database using `psql` and executing the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
 
     <CodeBlock shouldWrap>
 

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -4,4 +4,4 @@ description: Read about the latest fixes and improvements in Neon Serverless Pos
 
 ### Fixes & improvements
 
-Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and cannot be used directly. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
+Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and should not be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -4,7 +4,7 @@ description: Neon metrics collection and new usage guidelines for the neon_super
 
 ### Fixes & improvements
 
-- Compute: Neon has introduced a new pre-installed "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are owned by a Neon system role (`cloud_admin`) but you are able to view them by connecting to the `postgres` database using `psql` and executing the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
+- Compute: Neon has introduced a new pre-installed "neon" extension, which includes functions and views designed to gather Neon-specific metrics. The metrics are intended for use by the Neon team for the purpose of enhancing our service. The views are owned by a Neon system role (`cloud_admin`), but you are able to view them by connecting to the `postgres` database using `psql` and executing the command `\dv neon.*`, as shown below. At present, the extension includes two views for local file cache metrics. We may incorporate additional views in future releases.
 
     <CodeBlock shouldWrap>
 

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -1,7 +1,22 @@
 ---
-description: Read about the latest fixes and improvements in Neon Serverless Postgres.
+description: Neon metrics collection and new usage guidelines for the neon_superuser role
 ---
 
 ### Fixes & improvements
 
-Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and should not be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
+- Compute: Neon now creates a `neon` extension in the `neon` schema in the `postgres` database. This extension contains functions and views for collecting Neon-specific metrics for the purpose of improving our service. The views are fully accessible. You can access them by connecting to the `postgres` database via `psql` and running a `\dv neon.*` command, as shown below. Currently, the extension includes two views for collecting local file cache metrics. Additional views may be added in future releases.
+
+    ```bash
+    psql 'postgresql://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/postgres?sslmode=require'
+
+    postgres=> \dv neon.*
+                List of relations
+    Schema |      Name      | Type |    Owner    
+    --------+----------------+------+-------------
+    neon   | local_cache    | view | cloud_admin
+    neon   | neon_lfc_stats | view | cloud_admin
+    (2 rows)
+    ```
+
+- Compute: Creating a database with the `neon_superuser` role using `CREATE DATABASE dbname WITH OWNER neon_superuser` syntax is no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and should not be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
+

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -23,4 +23,3 @@ description: Neon metrics collection and new usage guidelines for the neon_super
     </CodeBlock>
 
 - Compute: Creating a database with the `neon_superuser` role, altering a database to have owner `neon_superuser`, and altering the `neon_superuser role` itself are no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and is not intended to be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
-

--- a/content/release-notes/2023-11-27-storage-and-compute.md
+++ b/content/release-notes/2023-11-27-storage-and-compute.md
@@ -22,5 +22,5 @@ description: Neon metrics collection and new usage guidelines for the neon_super
 
     </CodeBlock>
 
-- Compute: Creating a database with the `neon_superuser` role, altering a database to have owner `neon_superuser`, and altering the `neon_superuser role` itself are no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and should not be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
+- Compute: Creating a database with the `neon_superuser` role, altering a database to have owner `neon_superuser`, and altering the `neon_superuser role` itself are no longer permitted. The `neon_superuser` role is a `NOLOGIN` role used by Neon to grant prvileges to PostgreSQL roles created via the Neon Console, CLI, or API, and is not intended to be used directly or modified. For more information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
 


### PR DESCRIPTION
Release notes preview:
https://neon-next-git-dprice-storage-11-27-2023-neondatabase.vercel.app/docs/release-notes/2023-11-27-storage-and-compute

Accompanying doc update for neon_superuser:
https://neon-next-git-dprice-storage-11-27-2023-neondatabase.vercel.app/docs/manage/roles#the-neonsuperuser-role

neon extension doc (we should mention it in the docs if we're mentioning it in the release notes)
https://neon-next-git-dprice-storage-11-27-2023-neondatabase.vercel.app/docs/extensions/neon
