### PR TITLE
feat: reset cache control for docs images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -50,6 +50,15 @@ const defaultConfig = {
         ],
       },
       {
+        source: '/docs/:all*(svg|jpg|png)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, must-revalidate',
+          },
+        ],
+      },
+      {
         source: '/blog/parsing-json-from-postgres-in-js',
         headers: [
           {


### PR DESCRIPTION
This pull request sets the cache control `public, max-age=0, must-revalidate` for docs images, this kind of cache control is used for resources that need to be revalidated frequently to ensure they are up-to-date. It's useful for dynamic content or content that changes regularly as in the docs.