### PR TITLE
feat: add sitemap generation for Postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ typings/
 # ignore local sitemap
 public/sitemap.xml
 public/sitemap-0.xml
+public/sitemap-postgres.xml
+public/sitemap-postgres-0.xml
 public/robots.txt
 
 # Mac files

--- a/next-sitemap-postgres.config.js
+++ b/next-sitemap-postgres.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.tech',
+  exclude: ['/docs/*', '!/docs/postgres*', '/*'],
+  sitemapBaseFileName: 'sitemap-postgres',
+};

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -9,7 +9,7 @@ module.exports = {
     '/all-things-open-2023',
     '/stackoverflow',
     '/thank-you',
-    // '/docs/postgres*',
+    '/docs/postgres*',
   ],
   generateRobotsTxt: true,
   robotsTxtOptions: {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "next dev",
     "build": "next build",
     "dev:build": "next build",
-    "postbuild": "next-sitemap",
+    "postbuild": "next-sitemap --config next-sitemap.config.js && next-sitemap --config next-sitemap-postgres.config.js",
     "start": "next start",
     "format": "prettier --write .",
     "lint": "npm run lint:js && npm run lint:md",


### PR DESCRIPTION
**Description:**
This pull request adds additional sitemap generation for `Postgres` documentation pages

**What problems does it solve?**
at the moment the main sitemap contains all `Postgres` documentation pages, due to which these pages get to the `Google Search Console` level - this is not necessary as these pages are closed from indexing which leads to additional errors and spoils interaction with `GSC`, but as these pages in the sitemap are important for `Algolia Crawler` we solve this problem by generating an additional sitemap for Postgres pages which we can explicitly specify only for `Algolia`.

[Main Sitemap](https://neon-next-git-fix-sitemaps-neondatabase.vercel.app/sitemap-0.xml) without Postgres pages
[Postgres Sitemap](https://neon-next-git-fix-sitemaps-neondatabase.vercel.app/sitemap-postgres-0.xml) without other pages

**After merge:**

- [ ] add `Postgres sitemap` to `Algolia Crawler`