### PR TITLE
feat: add AI section to blog index

### DIFF
--- a/src/app/blog/(index)/page.jsx
+++ b/src/app/blog/(index)/page.jsx
@@ -31,6 +31,7 @@ export default async function BlogPage() {
     videos,
     appearances,
     engineeringFeaturedPosts,
+    aiFeaturedPosts,
   } = await getWpBlogPage();
 
   return (
@@ -40,6 +41,7 @@ export default async function BlogPage() {
       <PostsList title="Community" posts={communityFeaturedPosts} alignment="right" />
       <ReleaseNotesList items={featuredReleaseNotes} />
       <PostsList title="Company" posts={companyFeaturedPosts} alignment="left" />
+      <PostsList title="AI" posts={aiFeaturedPosts} alignment="right" />
       <VideoList videos={videos} />
       <SubscribeForm size="md" dataTest="blog-subscribe-form" />
       <AppearanceEngineering

--- a/src/utils/api-posts.js
+++ b/src/utils/api-posts.js
@@ -235,6 +235,36 @@ const getWpBlogPage = async () => {
                   }
                 }
               }
+              aiFeaturedPosts {
+                post {
+                  ... on Post {
+                    title(format: RENDERED)
+                    slug
+                    date
+                    pageBlogPost {
+                      largeCover {
+                        altText
+                        mediaItemUrl
+                      }
+                      authors {
+                        author {
+                          ... on PostAuthor {
+                            title
+                            postAuthor {
+                              role
+                              url
+                              image {
+                                altText
+                                mediaItemUrl
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
               videos {
                 post {
                   ... on Video {


### PR DESCRIPTION
This pull request brings the AI section to the blog index page

**Screenshots**
<img width="1298" alt="image" src="https://github.com/neondatabase/website/assets/48465000/3fb5f035-a6ba-4812-bd47-e5cb82c9d7fb">

**TODO**
- [ ] rearrange AI posts on demand