### PR TITLE
Edit Pricing Hero

### DIFF
--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -33,7 +33,7 @@ const items = [
   },
   {
     type: 'Pro',
-    price: '$5+/month',
+    price: '$3+/month',
     description:
       'A pro plan with features for production. Scales from $0 based on compute & storage usage.',
     features: [

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -42,7 +42,7 @@ const items = [
       { title: 'Unlimited projects, branches, databases' },
       { title: 'Configurable compute, unlimited storage' },
       { title: 'Pro support' },
-      { title: 'Autoscaling, read replicas, project sharing, IP Allow rules' },
+      { title: 'Autoscaling, read replicas, project sharing, IP allow rules' },
     ],
     button: {
       url: '#estimates',

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -16,7 +16,7 @@ import sendSegmentEvent from 'utils/send-segment-event';
 const items = [
   {
     type: 'Free Tier',
-    price: 'Start free',
+    price: '$0 Forever',
     description:
       'A generous free tier with essential features perfect for prototypes and personal projects.',
     features: [
@@ -32,8 +32,8 @@ const items = [
     },
   },
   {
-    type: 'Pro',
-    price: 'Pay as you go',
+    type: 'Pro Tier',
+    price: 'Usage-Based from $0',
     description:
       'A pro plan with features for production. Scales from $0 based on compute & storage usage.',
     features: [
@@ -51,7 +51,7 @@ const items = [
     },
   },
   {
-    type: 'Enterprise',
+    type: 'Enterprise Tier',
     price: 'Custom plans',
     description:
       'Custom volume-based plans for medium to large teams, database fleets, and resale.',

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -15,8 +15,8 @@ import sendSegmentEvent from 'utils/send-segment-event';
 
 const items = [
   {
-    type: 'Free Tier',
-    price: '$0 Forever',
+    type: 'Free',
+    price: '$0/month',
     description:
       'A generous free tier with essential features perfect for prototypes and personal projects.',
     features: [
@@ -32,8 +32,8 @@ const items = [
     },
   },
   {
-    type: 'Pro Tier',
-    price: 'Usage-Based from $0',
+    type: 'Pro',
+    price: '$5+/month',
     description:
       'A pro plan with features for production. Scales from $0 based on compute & storage usage.',
     features: [
@@ -51,7 +51,7 @@ const items = [
     },
   },
   {
-    type: 'Enterprise Tier',
+    type: 'Enterprise',
     price: 'Custom plans',
     description:
       'Custom volume-based plans for medium to large teams, database fleets, and resale.',

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -35,7 +35,7 @@ const items = [
     type: 'Pro',
     price: '$3+/month',
     description:
-      'A pro plan with features for production. Scales from $0 based on compute & storage usage.',
+      'A pro plan with all the features for production. Only pay for the compute & storage used.',
     features: [
       { title: 'Unlimited projects, branches, databases' },
       { title: 'Configurable compute, unlimited storage' },

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -42,7 +42,8 @@ const items = [
       { title: 'Unlimited projects, branches, databases' },
       { title: 'Configurable compute, unlimited storage' },
       { title: 'Pro support' },
-      { title: 'Autoscaling, read replicas, project sharing, IP allow rules' },
+      { title: 'Autoscaling, read replicas' },
+      { title: 'Project sharing, IP allow rules, and more' },
     ],
     button: {
       url: '#estimates',
@@ -128,9 +129,9 @@ const Hero = () => {
                 )}
                 style={{
                   '--accentColor':
-                    type === 'Free Tier' ? '#ade0eb' : type === 'Pro' ? '#00e599' : '#f0f075',
+                    type === 'Free' ? '#ade0eb' : type === 'Pro' ? '#00e599' : '#f0f075',
                   '--hoverColor':
-                    type === 'Free Tier' ? '#c6eaf1' : type === 'Pro' ? '#00ffaa' : '#f5f5a3',
+                    type === 'Free' ? '#c6eaf1' : type === 'Pro' ? '#00ffaa' : '#f5f5a3',
                 }}
                 key={index}
                 onPointerEnter={() => {

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -16,7 +16,8 @@ import sendSegmentEvent from 'utils/send-segment-event';
 const items = [
   {
     type: 'Free',
-    price: '$0/month',
+    price: '$0',
+    rate: '/ month',
     description:
       'A generous free tier with essential features perfect for prototypes and personal projects.',
     features: [
@@ -33,14 +34,15 @@ const items = [
   },
   {
     type: 'Pro',
-    price: '$3+/month',
+    price: '$3+',
+    rate: '/ month',
     description:
       'A pro plan with all the features for production. Only pay for the compute & storage used.',
     features: [
       { title: 'Unlimited projects, branches, databases' },
       { title: 'Configurable compute, unlimited storage' },
       { title: 'Pro support' },
-      { title: 'Autoscaling, read replicas, project sharing, IP Allow rules' }
+      { title: 'Autoscaling, read replicas, project sharing, IP Allow rules' },
     ],
     button: {
       url: '#estimates',
@@ -118,7 +120,7 @@ const Hero = () => {
         </p>
         <div className="relative mx-auto mt-16 max-w-[1220px] xl:mt-12 lg:w-full lg:max-w-[704px] md:mt-9">
           <ul className="relative z-10 grid grid-cols-3 gap-x-11 xl:gap-x-6 lg:grid-cols-1 lg:gap-x-4 lg:gap-y-4 md:grid-cols-1 md:gap-y-6">
-            {items.map(({ type, price, description, features, button }, index) => (
+            {items.map(({ type, price, rate, description, features, button }, index) => (
               <li
                 className={clsx(
                   'group relative rounded-[10px]',
@@ -160,6 +162,7 @@ const Hero = () => {
                     </span>
                     <h2 className="mt-7 text-[36px] font-light leading-none tracking-tighter xl:mt-5 xl:text-[32px] md:mt-4">
                       {price}
+                      {rate && <span className="ml-1 text-xl text-gray-new-70">{rate}</span>}
                     </h2>
                     <AnimatedButton
                       className="mt-7 w-full !bg-[var(--accentColor)] !py-4 !text-lg !font-medium tracking-tight group-hover:!bg-[var(--hoverColor)] xl:mt-7 sm:max-w-none"

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -52,7 +52,7 @@ const items = [
   },
   {
     type: 'Enterprise',
-    price: 'Custom plans',
+    price: 'Custom',
     description:
       'Custom volume-based plans for medium to large teams, database fleets, and resale.',
     features: [

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -40,8 +40,7 @@ const items = [
       { title: 'Unlimited projects, branches, databases' },
       { title: 'Configurable compute, unlimited storage' },
       { title: 'Pro support' },
-      { title: 'Autoscaling, read replicas, project sharing' },
-      { title: 'IP allow' },
+      { title: 'Autoscaling, read replicas, project sharing, IP Allow rules' }
     ],
     button: {
       url: '#estimates',


### PR DESCRIPTION
The pricing hero section needs to be more predictable. 
- Removing dollar figures solved some problems but created more problems. (People expect to see dollar figures.)
- "Start Free" undersells the free tier.

Before:
<img width="1265" alt="image" src="https://github.com/neondatabase/website/assets/11527560/7c960c0a-82e2-4b2e-92cb-c10d4629558d">

After:
<img width="1308" alt="image" src="https://github.com/neondatabase/website/assets/11527560/c7475070-a7d8-4634-9fc1-ae0a46d1b942">

Feel free to take over this PR and structure the edits the way they should be.
