### PR TITLE
fix: remove postgres docs class from neon docs

### DIFF
--- a/content/docs/introduction/billing.md
+++ b/content/docs/introduction/billing.md
@@ -85,7 +85,7 @@ To estimate your own monthly _Compute time_ cost:
 
 1. Determine the compute size you require, in Compute Units (CUs).
 1. Estimate the amount of _Active time_ per month for your compute(s).
-1. Find the _Compute-time_ price for your region. The [billing rates](/docs/introduction/billing#billing-rates) table shows _Compute-time_ prices by region.
+1. Find the _Compute-time_ price for your region. The [billing rates](#billing-rates) table shows _Compute-time_ prices by region.
 1. Input the values into the _Compute time_ cost formula:
 
    ```text

--- a/src/components/shared/content/content.jsx
+++ b/src/components/shared/content/content.jsx
@@ -105,7 +105,11 @@ const getComponents = (withoutAnchorHeading, isReleaseNote, isPostgres) => ({
 
     const id = href?.startsWith('#') ? href.replace('#', '') : undefined;
 
-    return <p className={clsx(className, { 'postgres-paragraph': id })} id={id} {...props} />;
+    if (isPostgres) {
+      return <p className={clsx(className, { 'postgres-paragraph': id })} id={id} {...props} />;
+    }
+
+    return <p {...props} />;
   },
   YoutubeIframe,
   DefinitionList,


### PR DESCRIPTION
This pull request removes unnecessary Postgres props for paragraphs from Neon docs. 
