### PR TITLE
fix: remove custom style of ol list

### DIFF
--- a/src/components/shared/anchor-heading/anchor-heading.jsx
+++ b/src/components/shared/anchor-heading/anchor-heading.jsx
@@ -9,6 +9,10 @@ const extractText = (children) => {
     return children;
   }
 
+  if (typeof children === 'object' && children.props) {
+    return extractText(children.props.children);
+  }
+
   if (Array.isArray(children)) {
     const text = children.reduce((acc, child) => {
       if (typeof child === 'string') {

--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -22,15 +22,14 @@
       }
     }
 
-    ul,
-    ol {
-      @apply list-none;
+    ul {
+      @apply list-none pl-3.5;
 
       > li {
         @apply relative pl-0;
 
         &::before {
-          @apply absolute -translate-y-1/2;
+          @apply absolute -left-3.5 top-3 h-1 w-1 -translate-y-1/2 rounded-[1px] bg-current content-[''];
         }
 
         ol {
@@ -39,26 +38,20 @@
       }
     }
 
-    ul {
-      @apply pl-3.5;
-
-      > li {
-        &::before {
-          @apply -left-3.5 top-3 h-1 w-1 rounded-[1px] bg-current content-[''];
-        }
-      }
-    }
-
     ol {
-      counter-reset: custom-counter;
       @apply pl-10 md:pl-5;
 
       > li {
-        counter-increment: custom-counter;
+        @apply pl-0;
 
-        &::before {
-          @apply -left-2 top-[12px] -translate-x-full text-current md:-left-1 md:top-3.5;
-          content: counter(custom-counter) '. ' !important;
+        ol {
+          @apply md:pl-4;
+        }
+      }
+
+      li {
+        &::marker {
+          @apply text-white;
         }
       }
     }

--- a/src/utils/get-react-content-with-lazy-blocks.jsx
+++ b/src/utils/get-react-content-with-lazy-blocks.jsx
@@ -183,7 +183,7 @@ export default function getReactContentWithLazyBlocks(content, pageComponents, i
         if (domNode.attribs?.class?.includes('wp-block-heading')) {
           return AnchorHeading(domNode.name)({
             children: domToReact(domNode.children),
-            className: `${domNode.attribs.class} scroll-mt-20`,
+            className: `${domNode.attribs.class} !scroll-mt-20`,
           });
         }
 


### PR DESCRIPTION
This pull request removes the custom styles of the ordered lists for Blog post pages  

Preview: https://neon-next-git-native-ol-neondatabase.vercel.app/blog/title-a-deep-dive-into-polyscales-architecture