### PR TITLE
Add PgBouncer config content

### DIFF
--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -53,4 +53,39 @@ The **Connection Details** widget on the Neon **Dashboard** provides **Pooled co
 
 Neon uses PgBouncer in _transaction mode_, which does not support Postgres features such as prepared statements or [LISTEN](https://www.postgresql.org/docs/15/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/15/sql-notify.html). For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
 
+## Neon PgBouncer configuration settings
+
+This section describes Neon's PgBouncer configuration. The settings are not user-configurable.
+
+```ini
+[pgbouncer]
+listen_port=6432
+listen_addr=0.0.0.0
+auth_type=scram-sha-256
+auth_user=cloud_admin
+auth_dbname=postgres
+client_tls_sslmode=disable
+server_tls_sslmode=disable
+pool_mode=transaction
+max_client_conn=10000
+default_pool_size=64
+max_prepared_statements=0
+admin_users=cloud_admin
+```
+
+The following list describes explcitly set variables. You can assume that variables not configured explcitly, such as `query_wait_timeout`, use the default setting. For a full explanation of each parameter and possible values, please refer to the official [PgBouncer documentation](https://www.pgbouncer.org/config.html).
+
+- `listen_port=6432`: The port that PgBouncer will listen on for incoming connections.
+- `listen_addr=0.0.0.0`: The address to listen on for incoming connections. 0.0.0.0 means listening on all available interfaces.
+- `auth_type=scram-sha-256`: The method used for client authentication.
+- `auth_user=cloud_admin`: Default user for PgBouncer to connect to the databases. The `cloud_admin` user is a Neon-managed admin role.
+- `auth_dbname=postgres`: The database name used for authenticating users when `auth_user` is set.
+- `client_tls_sslmode=disable`: Disables TLS for client connections.
+- `server_tls_sslmode=disable`: Disables TLS for server connections.
+- `pool_mode=transaction`: The pooling mode PgBouncer uses, set to `transaction` pooling.
+- `max_client_conn=10000`: Maximum number of client connections allowed.
+- `default_pool_size=64`: Default number of server connections to allow per user/database pair.
+- `max_prepared_statements=0`: Maximum number of prepared statements a connection is allowed to have at the same time. `0` means prepared statements are disabled.
+- `admin_users=cloud_admin`: Users listed as admins can use the PgBouncer admin console. Only the Neon cloud_admin role can access the PgBouncer admin console. 
+
 <NeedHelp/>

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -49,10 +49,6 @@ The **Connection Details** widget on the Neon **Dashboard** provides **Pooled co
 
 ![Connection Details pooled connection string](/docs/connect/connection_details_pooled.png)
 
-## Connection pooling notes and limitations
-
-Neon uses PgBouncer in _transaction mode_, which does not support Postgres features such as prepared statements or [LISTEN](https://www.postgresql.org/docs/15/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/15/sql-notify.html). For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
-
 ## Neon PgBouncer configuration settings
 
 Neon's PgBouncer configuration is shown below. The settings are not user-configurable.
@@ -73,5 +69,9 @@ The following list describes each setting. For a full explanation of each parame
 - `default_pool_size=64`: Default number of server connections to allow per user/database pair.
 - `max_prepared_statements=0`: Maximum number of prepared statements a connection is allowed to have at the same time. `0` means prepared statements are disabled.
 - `query_wait_timeout=120`: Maximum time queries are allowed to spend waiting for execution. Neon uses the default setting of `120` seconds.
+
+## Connection pooling notes and limitations
+
+Neon uses PgBouncer in _transaction mode_, which does not support Postgres features such as prepared statements or [LISTEN](https://www.postgresql.org/docs/15/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/15/sql-notify.html). For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
 
 <NeedHelp/>

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -55,7 +55,7 @@ Neon uses PgBouncer in _transaction mode_, which does not support Postgres featu
 
 ## Neon PgBouncer configuration settings
 
-This section describes Neon's PgBouncer configuration. The settings are not user-configurable.
+Neon's PgBouncer configuration is shown below. The settings are not user-configurable.
 
 ```ini
 [pgbouncer]
@@ -66,11 +66,12 @@ max_prepared_statements=0
 query_wait_timeout=120
 ```
 
-The following list describes the settings shown above. For a full explanation of each parameter, please refer to the official [PgBouncer documentation](https://www.pgbouncer.org/config.html).
+The following list describes each setting. For a full explanation of each parameter, please refer to the official [PgBouncer documentation](https://www.pgbouncer.org/config.html).
 
 - `pool_mode=transaction`: The pooling mode PgBouncer uses, set to `transaction` pooling.
 - `max_client_conn=10000`: Maximum number of client connections allowed.
 - `default_pool_size=64`: Default number of server connections to allow per user/database pair.
 - `max_prepared_statements=0`: Maximum number of prepared statements a connection is allowed to have at the same time. `0` means prepared statements are disabled.
+- `query_wait_timeout=120`: Maximum time queries are allowed to spend waiting for execution. Neon uses the default setting of `120` seconds.
 
 <NeedHelp/>

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -73,7 +73,7 @@ max_prepared_statements=0
 admin_users=cloud_admin
 ```
 
-The following list describes explcitly set variables. You can assume that variables not configured explcitly, such as `query_wait_timeout`, use the default setting. For a full explanation of each parameter and possible values, please refer to the official [PgBouncer documentation](https://www.pgbouncer.org/config.html).
+The following list describes the explcitly set variable settings above. You can assume that variables not configured explcitly, such as `query_wait_timeout`, use the default setting. For a full explanation of each parameter, please refer to the official [PgBouncer documentation](https://www.pgbouncer.org/config.html).
 
 - `listen_port=6432`: The port that PgBouncer will listen on for incoming connections.
 - `listen_addr=0.0.0.0`: The address to listen on for incoming connections. 0.0.0.0 means listening on all available interfaces.

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -59,33 +59,18 @@ This section describes Neon's PgBouncer configuration. The settings are not user
 
 ```ini
 [pgbouncer]
-listen_port=6432
-listen_addr=0.0.0.0
-auth_type=scram-sha-256
-auth_user=cloud_admin
-auth_dbname=postgres
-client_tls_sslmode=disable
-server_tls_sslmode=disable
 pool_mode=transaction
 max_client_conn=10000
 default_pool_size=64
 max_prepared_statements=0
-admin_users=cloud_admin
+query_wait_timeout=120
 ```
 
-The following list describes the explcitly set variable settings above. You can assume that variables not configured explcitly, such as `query_wait_timeout`, use the default setting. For a full explanation of each parameter, please refer to the official [PgBouncer documentation](https://www.pgbouncer.org/config.html).
+The following list describes the settings shown above. For a full explanation of each parameter, please refer to the official [PgBouncer documentation](https://www.pgbouncer.org/config.html).
 
-- `listen_port=6432`: The port that PgBouncer will listen on for incoming connections.
-- `listen_addr=0.0.0.0`: The address to listen on for incoming connections. 0.0.0.0 means listening on all available interfaces.
-- `auth_type=scram-sha-256`: The method used for client authentication.
-- `auth_user=cloud_admin`: Default user for PgBouncer to connect to the databases. The `cloud_admin` user is a Neon-managed admin role.
-- `auth_dbname=postgres`: The database name used for authenticating users when `auth_user` is set.
-- `client_tls_sslmode=disable`: Disables TLS for client connections.
-- `server_tls_sslmode=disable`: Disables TLS for server connections.
 - `pool_mode=transaction`: The pooling mode PgBouncer uses, set to `transaction` pooling.
 - `max_client_conn=10000`: Maximum number of client connections allowed.
 - `default_pool_size=64`: Default number of server connections to allow per user/database pair.
 - `max_prepared_statements=0`: Maximum number of prepared statements a connection is allowed to have at the same time. `0` means prepared statements are disabled.
-- `admin_users=cloud_admin`: Users listed as admins can use the PgBouncer admin console. Only the Neon `cloud_admin` role can access the PgBouncer admin console. 
 
 <NeedHelp/>

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -86,6 +86,6 @@ The following list describes the explcitly set variable settings above. You can 
 - `max_client_conn=10000`: Maximum number of client connections allowed.
 - `default_pool_size=64`: Default number of server connections to allow per user/database pair.
 - `max_prepared_statements=0`: Maximum number of prepared statements a connection is allowed to have at the same time. `0` means prepared statements are disabled.
-- `admin_users=cloud_admin`: Users listed as admins can use the PgBouncer admin console. Only the Neon cloud_admin role can access the PgBouncer admin console. 
+- `admin_users=cloud_admin`: Users listed as admins can use the PgBouncer admin console. Only the Neon `cloud_admin` role can access the PgBouncer admin console. 
 
 <NeedHelp/>


### PR DESCRIPTION
Document Neon's PgBouncer configuration. 
https://neon-next-git-dprice-pgbouncer-settings-neondatabase.vercel.app/docs/connect/connection-pooling#neon-pgbouncer-configuration-settings

Questions: 
- Need to explain why the sslmode settings are disabled. Is this because pgBouncer sits behind the Neon proxy?
- default_pool_size=64 (is it different based on provisioner? e.g., 16)