### PR TITLE
Fix unsupported startup parameter description

### DIFF
--- a/content/docs/connect/connection-errors.md
+++ b/content/docs/connect/connection-errors.md
@@ -205,6 +205,6 @@ or
 unsupported startup parameter in options: <...>
 ```
 
-The error occurs when using a pooled Neon connection string with startup options that are not supported by PgBouncer. PgBouncer allows only startup parameters it can keep track of in startup packets. These include `client_encoding`, `datestyle`, `timezone`, `standard_conforming_strings`, and `application_name`. See **track_extra_parameters**, in the [PgBouncer documentation](https://www.pgbouncer.org/config.html#track_extra_parameters). To resolve this error, you can either remove the unsupported parameter from your connection string or use an unpooled Neon connection string. For more information about pooled and unpooled connections in Neon, see [Connection pooling](/docs/connect/connection-pooling).
+The error occurs when using a pooled Neon connection string with startup options that are not supported by PgBouncer. PgBouncer allows only startup parameters it can keep track of in startup packets. These include: `client_encoding`, `datestyle`, `timezone`, `standard_conforming_strings`, and `application_name`. See **track_extra_parameters**, in the [PgBouncer documentation](https://www.pgbouncer.org/config.html#track_extra_parameters). To resolve this error, you can either remove the unsupported parameter from your connection string or use an unpooled Neon connection string. For more information about pooled and unpooled connections in Neon, see [Connection pooling](/docs/connect/connection-pooling).
 
 <NeedHelp/>

--- a/content/docs/connect/connection-errors.md
+++ b/content/docs/connect/connection-errors.md
@@ -205,6 +205,6 @@ or
 unsupported startup parameter in options: <...>
 ```
 
-The error occurs when using a pooled Neon connection string with startup options that are not supported by PgBouncer. PgBouncer allows only startup parameters it can keep track of in startup packets: `client_encoding`, `datestyle`, `timezone`, `standard_conforming_strings` and `application_name`. See [PgBouncer documentation](https://www.pgbouncer.org/config.html#track_extra_parameters). To resolve this issue, you can either remove the unsupported parameter from your connection string or use an unpooled Neon connection string. For more information about pooled and unpooled connections in Neon, see [Connection pooling](/docs/connect/connection-pooling).
+The error occurs when using a pooled Neon connection string with startup options that are not supported by PgBouncer. PgBouncer allows only startup parameters it can keep track of in startup packets. These include `client_encoding`, `datestyle`, `timezone`, `standard_conforming_strings`, and `application_name`. See **track_extra_parameters**, in the [PgBouncer documentation](https://www.pgbouncer.org/config.html#track_extra_parameters). To resolve this error, you can either remove the unsupported parameter from your connection string or use an unpooled Neon connection string. For more information about pooled and unpooled connections in Neon, see [Connection pooling](/docs/connect/connection-pooling).
 
 <NeedHelp/>

--- a/content/docs/connect/connection-errors.md
+++ b/content/docs/connect/connection-errors.md
@@ -205,6 +205,6 @@ or
 unsupported startup parameter in options: <...>
 ```
 
-The error occurs when using a pooled Neon connection string with startup options that are not supported by PgBouncer. PgBouncer allows only startup parameters it can keep track of in startup packets: `client_encoding`, `datestyle`, `timezone`, and `standard_conforming_strings`. See [ignore_startup_parameters](ignore_startup_parameters). To resolve this issue, you can either remove the unsupported parameter from your connection string or use an unpooled Neon connection string. For more information about pooled and unpooled connections in Neon, see [Connection pooling](/docs/connect/connection-pooling).
+The error occurs when using a pooled Neon connection string with startup options that are not supported by PgBouncer. PgBouncer allows only startup parameters it can keep track of in startup packets: `client_encoding`, `datestyle`, `timezone`, `standard_conforming_strings` and `application_name`. See [PgBouncer documentation](https://www.pgbouncer.org/config.html#track_extra_parameters). To resolve this issue, you can either remove the unsupported parameter from your connection string or use an unpooled Neon connection string. For more information about pooled and unpooled connections in Neon, see [Connection pooling](/docs/connect/connection-pooling).
 
 <NeedHelp/>


### PR DESCRIPTION
Preview:
https://neon-next-git-fix-unsupported-startup-param-4208fb-neondatabase.vercel.app/docs/connect/connection-errors#unsupported-startup-parameter