### PR TITLE
fix: remove discourse banner in introduction page

### DIFF
--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -108,6 +108,4 @@ Refer to our _Get started_ documentation to get up and running in just a few min
 
 If you have questions about Neon or Postgres, reach out to Neon community members and developers in the [Neon Discord Server](/discord) or [Neon Discourse Community](https://community.neon.tech/).
 
-<CommunityBanner buttonText="Join community" buttonUrl="https://community.neon.tech" logo="discourse">Welcome to the Neon Discourse Community!</CommunityBanner>
-
 <CommunityBanner buttonText="Join server" buttonUrl="https://discord.gg/92vNTzKDGp" logo="discord">Welcome to the Neon Discord Server!</CommunityBanner>


### PR DESCRIPTION
This pull request removes Discourse banner from docs introduction page