### PR TITLE
Add Neon CLI --psql examples

### DIFF
--- a/content/docs/reference/cli-connection-string.md
+++ b/content/docs/reference/cli-connection-string.md
@@ -42,7 +42,7 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 
 ### Examples
 
-- Generate a basic connection string for the current project, branch, and database:
+- Create a basic connection string for the current project, branch, and database:
 
     <CodeBlock shouldWrap>
 
@@ -53,7 +53,7 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 
     </CodeBlock>
 
-- Generate a pooled connection string for the current project, branch, and database with the `--pooled` option. This option adds a `-pooler` flag to the host name which enables connection pooling for clients that use this connection string.
+- Create a pooled connection string for the current project, branch, and database with the `--pooled` option. This option adds a `-pooler` flag to the host name which enables connection pooling for clients that use this connection string.
 
     <CodeBlock shouldWrap>
 
@@ -64,7 +64,7 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 
     </CodeBlock>
 
-- Generate a connection string for use with Prisma for the current project, branch, and database. The `--prisma` options adds `connect_timeout=30` option to the connection string to ensure that connections from Prisma Client do not timeout.
+- Create a connection string for use with Prisma for the current project, branch, and database. The `--prisma` options adds `connect_timeout=30` option to the connection string to ensure that connections from Prisma Client do not timeout.
 
     <CodeBlock shouldWrap>
 
@@ -74,5 +74,23 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
     ```
 
     </CodeBlock>
+
+- Create a connection string and connect with `psql`. The `psql` client must already be installed.
+
+    ```bash
+    neonctl connection-string --psql
+    ```
+
+- Create a connection string, connect with `psql`, and load data from an `.sql` file. The `psql` client must already be installed.
+
+    ```bash
+    neonctl connection-string --psql -- -f dump.sql
+    ```
+
+- Create a connection string, connect with `psql`, and run a query.
+
+    ```bash
+    neonctl connection-string --psql -- -c "SELECT version()"
+    ```
 
 <NeedHelp/>

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -160,6 +160,30 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
     }
     ```
 
+- Create a project and connect to it with `psql`. The `psql` client must already be installed.
+
+    ```bash
+    neonctl project create --psql
+    ```
+
+- Create a project, connect to it with `psql`, and load data from an `.sql` file. The `psql` client must already be installed.
+
+    ```bash
+    neonctl project create --psql -- -f dump.sql
+    ```
+
+- Create a project, connect to it with `psql`, and run a query.
+
+    ```bash
+    neonctl project create --psql -- -c "SELECT version()"
+    ```
+
+- Create a project and set the Neon CLI project and branch context
+
+    ```
+    neonctl project create --psql --set-context
+    ```
+
 ### update
 
 This subcommand allows you to update a Neon project.


### PR DESCRIPTION
Add Neon CLI --psql examples to projects create, branches create, and connection-string