### PR TITLE
Postgres toc update

### DIFF
--- a/content/docs/connect/connection-latency.md
+++ b/content/docs/connect/connection-latency.md
@@ -48,7 +48,7 @@ Consider combining this strategy with Neon's _Autoscaling_ feature (available wi
 
 ![Connection warmup autosuspend and autoscaling configuration](/docs/connect/cold_start_compute_config.png)
 
-To determine what an "always-on" compute would cost per month, please refer to our [Billing](/docs/introduction/billing) documentation or the [pricing calculator](/calculator).
+To determine what an "always-on" compute would cost per month, please refer to our [Billing](/docs/introduction/billing) documentation or the [pricing calculator](https://neon.tech/calculator).
 
 For autoscaling configuration instructions, see [Compute size and autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration).
 

--- a/content/docs/extensions/pg-extensions.md
+++ b/content/docs/extensions/pg-extensions.md
@@ -1,5 +1,5 @@
 ---
-title: Postgres extensions
+title: Supported Postgres extensions
 enableTableOfContents: true
 redirectFrom:
   - /docs/reference/pg-extensions

--- a/content/docs/introduction/billing-calculators.md
+++ b/content/docs/introduction/billing-calculators.md
@@ -18,7 +18,7 @@ These questions translate into the metrics [active time](/docs/introduction/bill
 
 ## Pricing calculator
 
-The [Pricing](https://neon.tech/pricing) page on the Neon website provides a [calculator](https://neon.tech/calculator) that allows you to estimate monthly costs based on usage amounts that you provide.
+The Neon website provides a [pricing calculator](https://neon.tech/calculator) that allows you to estimate monthly costs based on usage amounts that you provide.
 
 ![Pricing page calculator](/docs/introduction/pricing_page_calculator.png)
 

--- a/content/docs/introduction/billing.md
+++ b/content/docs/introduction/billing.md
@@ -96,7 +96,7 @@ To estimate your own monthly _Compute time_ cost:
    ```
 
 <Admonition type="tip">
-Neon also provides calculators to help with cost estimates. See [Pricing calculators](#pricing-calculators).
+Neon also provides calculators to help with cost estimates. See [Pricing calculators](/docs/introduction/billing-calculators).
 </Admonition>
 
 ## Project storage

--- a/content/docs/introduction/pro-plan.md
+++ b/content/docs/introduction/pro-plan.md
@@ -42,7 +42,7 @@ In addition to our [Discord Server](https://discord.com/invite/92vNTzKDGp) and t
 
 ## How does billing work?
 
-The Neon Pro Plan bills for usage monthly. Please refer to our [Billing metrics](/docs/introduction/billing) page for information about metrics and rates. To estimate monthly costs, try the [pricing calculator](/calculator) or the [Pro Plan Cost Estimator](/docs/introduction/billing#pro-plan-cost-estimator) in the Neon Console. If you still have questions or need help estimating costs, please reach out to our [Sales](/contact-sales) team. We're ready to help.
+The Neon Pro Plan bills for usage monthly. Please refer to our [Billing metrics](/docs/introduction/billing) page for information about metrics and rates. To estimate monthly costs, try the [pricing calculator](https://neon.tech/calculator) or the [Pro Plan Cost Estimator](/docs/introduction/billing#pro-plan-cost-estimator) in the Neon Console. If you still have questions or need help estimating costs, please reach out to our [Sales](/contact-sales) team. We're ready to help.
 
 ## How do I upgrade to Pro?
 

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -124,7 +124,7 @@
 - title: Guides
   slug: guides/guides-intro
   items:
-    - title: Neon features
+    - title: Neon
       items: 
         - title: Autoscaling
           slug: guides/autoscaling-guide
@@ -169,13 +169,7 @@
             - title: Data analysis and reporting
               slug: guides/read-replica-data-analysis
             - title: Use read replicas with Prisma
-              slug: guides/read-replica-prisma
-        - title: Extensions
-          items:
-            - title: neon
-              slug: extensions/neon
-            - title: neon_utils
-              slug: extensions/neon-utils            
+              slug: guides/read-replica-prisma    
     - title: Frameworks
       items:
         - title: Next.js
@@ -302,6 +296,10 @@
       items:
         - title: Supported extensions
           slug: extensions/pg-extensions
+        - title: neon
+          slug: extensions/neon
+        - title: neon_utils
+          slug: extensions/neon-utils       
         - title: pgvector
           slug: extensions/pgvector
         - title: pg_tiktoken

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -299,8 +299,9 @@
 - title: Postgres
   items:
     - title: Extensions
-      slug: extensions/pg-extensions
       items:
+        - title: Supported extensions
+          slug: extensions/pg-extensions
         - title: pgvector
           slug: extensions/pgvector
         - title: pg_tiktoken
@@ -315,6 +316,8 @@
           slug: functions/json_build_object
         - title: json_extract_path
           slug: functions/json_extract_path
+    - title: Compatibility
+      slug: reference/compatibility
 - title: Import data
   slug: import/import-intro
   items:
@@ -369,8 +372,6 @@
       slug: reference/sdk
     - title: Glossary
       slug: reference/glossary
-    - title: Postgres compatibility
-      slug: reference/compatibility
 - title: Community
   slug: community/community-intro
   items:


### PR DESCRIPTION
- Move Compatibilty page under Postgres in TOC
- Make Extensions page selectable in the TOC for visibility (change to "Supported extensions")
- Moved Neon extensions (neon, neon_utils) under Extensions (previously located in the Guides section)
- Note: I changed "Postgres guides" to just "Postgres" since we already have a Guides section (wdyt?)
https://neon-next-git-dprice-postgres-toc-change-neondatabase.vercel.app/docs/introduction
- Unrelated: Fixed some pricing calculator links that were broken