### PR TITLE
Add pg_dump note about pooled connections

### DIFF
--- a/content/docs/import/import-from-postgres.md
+++ b/content/docs/import/import-from-postgres.md
@@ -10,7 +10,7 @@ updatedOn: '2023-11-24T11:25:06.758Z'
 This topic describes migrating data from another Postgres database to Neon using the `pg_dump` and `pg_restore` command line utilities.
 
 <Admonition type="warning">
-Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976)) for details. Use an unpooled connection instead.
+Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an unpooled connection instead.
 </Admonition>
 
 Repeat the `pg_dump` and `pg_restore` process for each database you want to migrate.

--- a/content/docs/import/import-from-postgres.md
+++ b/content/docs/import/import-from-postgres.md
@@ -9,7 +9,7 @@ updatedOn: '2023-11-24T11:25:06.758Z'
 
 This topic describes migrating data from another Postgres database to Neon using the `pg_dump` and `pg_restore` command line utilities.
 
-<Admonition type="warning">
+<Admonition type="important">
 Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an unpooled connection instead.
 </Admonition>
 

--- a/content/docs/import/import-from-postgres.md
+++ b/content/docs/import/import-from-postgres.md
@@ -9,6 +9,10 @@ updatedOn: '2023-11-24T11:25:06.758Z'
 
 This topic describes migrating data from another Postgres database to Neon using the `pg_dump` and `pg_restore` command line utilities.
 
+<Admonition type="warning">
+Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976)) for details. Use an unpooled connection instead.
+</Admonition>
+
 Repeat the `pg_dump` and `pg_restore` process for each database you want to migrate.
 
 ## Before you begin

--- a/content/docs/manage/backups.md
+++ b/content/docs/manage/backups.md
@@ -17,7 +17,7 @@ For information about creating a point-in-time restore branch, see [Branching â€
 You can backup a database using `pg_dump`, in the same way backups are created for a standalone Postgres instance.
 
 <Admonition type="warning">
-Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976)) for details. Use an unpooled connection instead.
+Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an unpooled connection instead.
 </Admonition>
 
 This method dumps a single database in a single branch of your Neon project. If you need to create backups for multiple databases in multiple branches, you must perform a dump operation for each database in each branch separately.

--- a/content/docs/manage/backups.md
+++ b/content/docs/manage/backups.md
@@ -16,7 +16,7 @@ For information about creating a point-in-time restore branch, see [Branching â€
 
 You can backup a database using `pg_dump`, in the same way backups are created for a standalone Postgres instance.
 
-<Admonition type="warning">
+<Admonition type="important">
 Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an unpooled connection instead.
 </Admonition>
 

--- a/content/docs/manage/backups.md
+++ b/content/docs/manage/backups.md
@@ -16,6 +16,10 @@ For information about creating a point-in-time restore branch, see [Branching â€
 
 You can backup a database using `pg_dump`, in the same way backups are created for a standalone Postgres instance.
 
+<Admonition type="warning">
+Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976)) for details. Use an unpooled connection instead.
+</Admonition>
+
 This method dumps a single database in a single branch of your Neon project. If you need to create backups for multiple databases in multiple branches, you must perform a dump operation for each database in each branch separately.
 
 To dump a database from your Neon project, please refer to the `pg_dump` instructions in our [Import from Postgres](/docs/import/import-from-postgres) guide.

--- a/content/postgresql/app-pgdump.md
+++ b/content/postgresql/app-pgdump.md
@@ -4,7 +4,7 @@
 
 pg\_dump — extract a PostgreSQL database into a script file or other archive file
 
-<Admonition type="warning" title="Neon note">
+<Admonition type="tip" title="Neon Postgres Note">
 Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an unpooled connection instead.
 </Admonition>
 

--- a/content/postgresql/app-pgdump.md
+++ b/content/postgresql/app-pgdump.md
@@ -5,7 +5,7 @@
 pg\_dump — extract a PostgreSQL database into a script file or other archive file
 
 <Admonition type="warning" title="Neon note">
-Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976)) for details. Use an unpooled connection instead.
+Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an unpooled connection instead.
 </Admonition>
 
 ## Synopsis

--- a/content/postgresql/app-pgdump.md
+++ b/content/postgresql/app-pgdump.md
@@ -4,6 +4,10 @@
 
 pg\_dump — extract a PostgreSQL database into a script file or other archive file
 
+<Admonition type="warning" title="Neon note">
+Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976)) for details. Use an unpooled connection instead.
+</Admonition>
+
 ## Synopsis
 
 `pg_dump` \[*`connection-option`*...] \[*`option`*...] \[*`dbname`*]

--- a/src/app/docs/(postgres)/postgres/[slug]/page.jsx
+++ b/src/app/docs/(postgres)/postgres/[slug]/page.jsx
@@ -70,7 +70,7 @@ const PostgresPage = async ({ params }) => {
           >
             official PostgreSQL documentation
           </Link>{' '}
-          is brought to you by Neon with ❤️.
+          is brought to you by Neon with ❤️
           <br className="flat-none sm:flat-break" /> Not all features and functions are supported.
           See <Link to="/docs/reference/compatibility">Postgres compatibility</Link> for details.
         </Admonition>

--- a/src/app/docs/(postgres)/postgres/[slug]/page.jsx
+++ b/src/app/docs/(postgres)/postgres/[slug]/page.jsx
@@ -71,8 +71,8 @@ const PostgresPage = async ({ params }) => {
             official PostgreSQL documentation
           </Link>{' '}
           is brought to you by Neon with ❤️
-          <br className="flat-none sm:flat-break" /> Not all features and functions are supported.
-          See <Link to="/docs/reference/compatibility">Postgres compatibility</Link> for details.
+          <br className="flat-none sm:flat-break" /> Not all information is applicable to Neon.
+          See <Link to="/docs/reference/compatibility#postgresql-documentation">Postgres compatibility</Link> for details.
         </Admonition>
         <Content className="mt-10" content={content} isPostgres />
       </article>


### PR DESCRIPTION
Backups:
https://neon-next-git-dprice-pg-dump-pooled-connections-neondatabase.vercel.app/docs/manage/backups

Import from Postgres:
https://neon-next-git-dprice-pg-dump-pooled-connections-neondatabase.vercel.app/docs/import/import-from-postgres

Added a "NEON POSTGRES NOTE" to the PostgreSQL mirrored docs:
https://neon-next-git-dprice-pg-dump-pooled-connections-neondatabase.vercel.app/docs/postgres/app-pgdump

Updated the Neon compatibility note in the PostgreSQL docs mirror to indicate that "not all information" is applicable to Neon, and changed the link to one that addresses this specifically.


