### PR TITLE
Update node.md to make it consistent with the Neon console

### DIFF
--- a/content/docs/guides/node.md
+++ b/content/docs/guides/node.md
@@ -71,7 +71,7 @@ ENDPOINT_ID='[endpoint_id]'
 </CodeBlock>
 
 <Admonition type="note">
-A special `ENDPOINT_ID` variable is included in the `.env` file above. This variable can be used with Postgres clients that do not support Server Name Indication (SNI), which Neon relies on to route incoming connections. For more information, see [connection errors](/docs/connect/connection-errors).
+A special `ENDPOINT_ID` variable is included in the `.env` file above. This variable can be used with older Postgres clients that do not support Server Name Indication (SNI), which Neon relies on to route incoming connections. If you are using a newer [node-postgres](https://node-postgres.com/) or [postgres.js](https://github.com/porsager/postgres) client, you won't need it. For more information, see [Endpoint ID variable](#endpoint-id-variable).
 </Admonition>
 
 <Admonition type="important">
@@ -147,6 +147,37 @@ Run `node app.js` to view the result.
 {
   version: 'PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit'
 }
+```
+
+## Endpoint ID variable
+
+For older clients that do not support Server Name Indication (SNI), the `postgres.js` example below shows how to include the `ENDPOINT_ID` variable in your application's connection configuration. This is a workaround that is not required if you are using a newer [node-postgres](https://node-postgres.com/) or [postgres.js](https://github.com/porsager/postgres) client. For more information about this workaround and when it is required, see [The endpoint ID is not specified](https://neon.tech/docs/connect/connection-errors#the-endpoint-id-is-not-specified) in our [connection errors](/docs/connect/connection-errors) documentation.
+
+```javascript
+// app.js
+const postgres = require('postgres');
+require('dotenv').config();
+
+let { PGHOST, PGDATABASE, PGUSER, PGPASSWORD, ENDPOINT_ID } = process.env;
+
+const sql = postgres({
+  host: PGHOST,
+  database: PGDATABASE,
+  username: PGUSER,
+  password: PGPASSWORD,
+  port: 5432,
+  ssl: 'require',
+  connection: {
+    options: `project=${ENDPOINT_ID}`,
+  },
+});
+
+async function getPgVersion() {
+  const result = await sql`select version()`;
+  console.log(result);
+}
+
+getPgVersion();
 ```
 
 <NeedHelp/>


### PR DESCRIPTION
The examples given in the file were not consistent with the output gotten from the Neon console: For nodes.js the console is not giving a connection string but individual variables. The example program for postgres.js in the console is using those variables. Now both examples in this document are using them as well to be consistent with the console.

In addition removed the usage of the endpoint id from the example. It is no longer needed for pg and postgres.js. We should also remove them from the example in the console, I think.

Also made the two examples a bit more consistent.