### PR TITLE
Fix Sydney region name

### DIFF
--- a/content/docs/introduction/regions.md
+++ b/content/docs/introduction/regions.md
@@ -17,7 +17,7 @@ Neon currently supports the following AWS regions:
 - US West (Oregon) &mdash; `aws-us-west-2`
 - Europe (Frankfurt) &mdash; `aws-eu-central-1`
 - Asia Pacific (Singapore) &mdash; `aws-ap-southeast-1`
-- Asia Pacific (Sydney)	&mdash; `ap-southeast-2`
+- Asia Pacific (Sydney)	&mdash; `aws-ap-southeast-2`
 - Israel (Tel Aviv) &mdash; `aws-il-central-1`
 
 ## Select a region for your Neon project


### PR DESCRIPTION
`ap-southeast-2` -> `aws-ap-southeast-2`

https://neon-next-git-bayandin-patch-1-neondatabase.vercel.app/docs/introduction/regions