### PR TITLE
docs(pages): link to neon docs when present

### DIFF
--- a/content/docs/functions/json_build_object.md
+++ b/content/docs/functions/json_build_object.md
@@ -201,20 +201,21 @@ This query returns the following results:
 
 ## Additional considerations
 
-### Alternative functions
-
-Depending on your requirements, you might want to consider similar functions:
-
-- `json_object` - Builds a JSON object out of a text array.
-- `json_agg` - Aggregates values, as a JSON array.
-- `row_to_json` - Returns a row as a JSON object.
-- `json_object_agg` - Aggregates key-value pairs into a JSON object.
-
-### Performance
+### Performance and indexing
 
 The performance of the `json_build_object` depends on various factors including the number of key-value pairs, nested levels (deeply nested objects can be more expensive to build). Consider using `JSONB` data type with `jsonb_build_object` for better performance.
 
 If your `JSON` objects have nested structures, indexing on specific paths within the nested data can be beneficial for targeted queries.
+
+### Alternative functions
+
+Depending on your requirements, you might want to consider similar functions:
+
+- [json_object](/docs/functions/json_object) - Builds a JSON object out of a text array.
+- `json_agg` - Aggregates values, as a JSON array.
+- `row_to_json` - Returns a row as a JSON object.
+- `json_object_agg` - Aggregates key-value pairs into a JSON object.
+
 
 ## Resources
 

--- a/content/docs/functions/json_extract_path.md
+++ b/content/docs/functions/json_extract_path.md
@@ -208,28 +208,21 @@ The `json_extract_path` function extracts the value of the `department` key from
 
 ## Additional considerations
 
-This section outlines additional considerations including alternative functions and performance considerations.
-
-### Alternative functions
-
-**json_extract_path_text**
-
-The regular `json_extract_path` function returns the extracted value as a `JSON` object or array, preserving its `JSON` structure, whereas the alternative
-`json_extract_path_text` function returns the extracted value as a plain text string, casting any `JSON` objects or arrays to their string representations.
-
-Use the regular `json_extract_path` function when you need to apply `JSON`-specific functions or operators to the extracted value, requiring `JSON` data types. The alternative `json_extract_path_text` function is preferable if you need to work directly with the extracted value as a string, for text processing, concatenation, or comparison.
-
-**jsonb_extract_path**
-
-The `jsonb_extract_path` function works with the `jsonb` data type, which offers a binary representation of `JSON` data. This alternative function is generally faster than `json_extract_path` for most operations, as it's optimized for the binary `jsonb` format. This difference in performance is often more pronounced with larger `JSON` structures and frequent path extractions.
-
-### Performance
+### Performance and Indexing
 
 The `json_extract_path` function performs well when extracting data from `JSON` documents, especially compared to extracting data in application code. It allows performing the extraction directly in the database, avoiding transferring entire `JSON` documents to the application.
 
 However, performance can degrade with highly nested `JSON` structures and very long text strings. In those cases, using the binary `JSONB` data type and the `jsonb_extract_path` function will likely offer better performance.
 
 Indexing `JSON` documents can also significantly improve `json_extract_path` query performance when filtering data based on values extracted from `JSON`.
+
+### Alternative functions
+
+- [json_extract_path_text](/docs/functions/json_extract_path_text) - The regular `json_extract_path` function returns the extracted value as a `JSON` object or array, preserving its `JSON` structure, whereas the alternative `json_extract_path_text` function returns the extracted value as a plain text string, casting any `JSON` objects or arrays to their string representations.
+
+    Use the regular `json_extract_path` function when you need to apply `JSON`-specific functions or operators to the extracted value, requiring `JSON` data types. The alternative `json_extract_path_text` function is preferable if you need to work directly with the extracted value as a string, for text processing, concatenation, or comparison.
+
+- `jsonb_extract_path` - The `jsonb_extract_path` function works with the `jsonb` data type, which offers a binary representation of `JSON` data. This alternative function is generally faster than `json_extract_path` for most operations, as it's optimized for the binary `jsonb` format. This difference in performance is often more pronounced with larger `JSON` structures and frequent path extractions.
 
 {/*
 This example does not work. It returns empty values.

--- a/content/docs/functions/json_extract_path_text.md
+++ b/content/docs/functions/json_extract_path_text.md
@@ -131,7 +131,7 @@ Performance considerations for `json_extract_path_text` are similar to those for
 ### Alternative functions
 
 - [json_extract_path](/docs/functions/json_extract_path) - This is a similar function that can extract data from a `JSON` object at the specified path. The difference is that it returns a `JSON` object, while `json_extract_path_text` always returns text. The right function to use depends on what you want to use the output data for. 
-- `jsonb_extract_path_text` - This is a similar function that can extract data from a `JSON` object at the specified path. It is more efficient but works only with data of the type `JSONB`.
+- [jsonb_extract_path_text](/docs/functions/jsonb_extract_path_text) - This is a similar function that can extract data from a `JSON` object at the specified path. It is more efficient but works only with data of the type `JSONB`.
 
 ## Resources
 

--- a/content/docs/functions/json_object.md
+++ b/content/docs/functions/json_object.md
@@ -89,12 +89,12 @@ This query returns the following result:
 
 ## Additional considerations
 
-### Gotchas
+### Gotchas and footguns
 
 - Ensure both keys and values arrays have the same number of elements. Mismatched arrays will result in an error. Or, if passing in a single key-value array, ensure that the array has an even number of elements. 
 - Be aware of data type conversions. Since `json_object` expects text arrays, you may need to explicitly cast non-text data types to text. 
 
-### Alternative options
+### Alternative functions
 
 - [jsonb_object](https://www.postgresql.org/docs/current/functions-json.html) - Same functionality as `json_object`, but returns a `JSONB` object instead of `JSON`. 
 - [row_to_json](https://www.postgresql.org/docs/current/functions-json.html) - It can be used to create a `JSON` object from a table row (or a row of a  composite type) without needing to specify keys and values explicitly. Although, it is less flexible than `json_object` since all fields in the row are included in the `JSON` object. 

--- a/content/docs/functions/json_populate_record.md
+++ b/content/docs/functions/json_populate_record.md
@@ -109,8 +109,8 @@ This query returns the following result:
 ### Alternative options
 
 - [json_to_record](/docs/functions/json_to_record) - It can be used similarly, with a couple differences. `json_populate_record` can be used with a base record of a pre-defined type, whereas `json_to_record` needs the record type defined inline in the `AS` clause. Further, `json_populate_record` can specify default values for missing fields through the base record, whereas `json_to_record` must assign them NULL values.
-- [json_populate_recordset](/docs/functions/json_populate_recordset) - It can be used similarly to parse `JSON`, the difference being that it returns a set of records instead of a single record. For example, if you have an array of `JSON` objects, you can use `json_populate_recordset` to convert each object into a new row. 
-- [jsonb_populate_record](/docs/functions/jsonb_populate_record.md) - It has the same functionality to `json_populate_record`, but accepts `JSONB` input instead of `JSON`. 
+- `json_populate_recordset` - It can be used similarly to parse `JSON`, the difference being that it returns a set of records instead of a single record. For example, if you have an array of `JSON` objects, you can use `json_populate_recordset` to convert each object into a new row. 
+- [jsonb_populate_record](/docs/functions/jsonb_populate_record) - It has the same functionality to `json_populate_record`, but accepts `JSONB` input instead of `JSON`. 
 
 ## Resources
 

--- a/content/docs/functions/jsonb_each.md
+++ b/content/docs/functions/jsonb_each.md
@@ -113,7 +113,7 @@ When working with large `JSONB` objects, `jsonb_each` may lead to performance ov
 
 - `jsonb_each_text` - Similar functionality to `jsonb_each` but returns the value as a text type instead of `JSONB`. 
 - `jsonb_object_keys` - It returns only the set of keys in the `JSONB` object, without the values.
-- `json_each` - It provides the same functionality as `jsonb_each`, but accepts `JSON` input instead of `JSONB`. 
+- [json_each](/docs/functions/json_each) - It provides the same functionality as `jsonb_each`, but accepts `JSON` input instead of `JSONB`. 
 
 ## Resources
 

--- a/content/docs/functions/jsonb_extract_path_text.md
+++ b/content/docs/functions/jsonb_extract_path_text.md
@@ -131,7 +131,7 @@ Performance considerations for `jsonb_extract_path_text` are similar to those fo
 ### Alternative functions
 
 - [jsonb_extract_path](/docs/functions/jsonb_extract_path) - This is a similar function that can extract data from a `JSONB` object at the specified path. The difference is that it returns a `JSONB` object, while `jsonb_extract_path_text` always returns text. The right function to use depends on what you want to use the output data for. 
-- `json_extract_path_text` - This is a similar function that can extract data from a `JSON` object, (instead of `JSONB`) at the specified path. 
+- [json_extract_path_text](/docs/functions/json_extract_path_text) - This is a similar function that can extract data from a `JSON` object, (instead of `JSONB`) at the specified path. 
 
 ## Resources
 

--- a/content/docs/functions/jsonb_object.md
+++ b/content/docs/functions/jsonb_object.md
@@ -96,9 +96,9 @@ This query returns the following result:
 
 ### Alternative options
 
-- [json_object](https://www.postgresql.org/docs/current/functions-json.html) - Same functionality as `jsonb_object`, but returns a `JSON` object instead of `JSONB`. 
+- [json_object](/docs/functions/json_object) - Same functionality as `jsonb_object`, but returns a `JSON` object instead of `JSONB`. 
 - [to_jsonb](https://www.postgresql.org/docs/current/functions-json.html) - It can be used to create a `JSONB` object from a table row (or a row of a  composite type) without needing to specify keys and values explicitly. Although, it is less flexible than `jsonb_object` since all fields in the row are included in the `JSONB` object. 
-- [jsonb_build_object](/docs/functions/jsonb_build_object) - Similar to `jsonb_object`, but allows for more flexibility in constructing the `JSONB` object, as it can take a variable number of arguments in the form of key-value pairs. 
+- [jsonb_build_object](https://www.postgresql.org/docs/current/functions-json.html) - Similar to `jsonb_object`, but allows for more flexibility in constructing the `JSONB` object, as it can take a variable number of arguments in the form of key-value pairs. 
 - [jsonb_object_agg](https://www.postgresql.org/docs/current/functions-json.html) - It is used to aggregate the key-value pairs from multiple rows into a single `JSONB` object. In contrast, `jsonb_object` outputs a `JSONB` object for each row. 
 
 ## Resources

--- a/content/docs/functions/jsonb_populate_record.md
+++ b/content/docs/functions/jsonb_populate_record.md
@@ -109,8 +109,8 @@ This query returns the following result:
 ### Alternative options
 
 - [jsonb_to_record](/docs/functions/jsonb_to_record) - It can be used similarly, with a couple differences. `jsonb_populate_record` can be used with a base record of a pre-defined type, whereas `jsonb_to_record` needs the record type defined inline in the `AS` clause. Further, `jsonb_populate_record` can specify default values for missing fields through the base record, whereas `jsonb_to_record` must assign them NULL values.
-- [jsonb_populate_recordset](/docs/functions/jsonb_populate_recordset) - It can be used similarly to parse `JSONB`, the difference being that it returns a set of records instead of a single record. For example, if you have an array of `JSONB` objects, you can use `jsonb_populate_recordset` to convert each object into a new row. 
-- [json_populate_record](/docs/functions/jsonb_populate_record.md) - It has the same functionality to `jsonb_populate_record`, but accepts `JSON` input instead of `JSONB`. 
+- `jsonb_populate_recordset` - It can be used similarly to parse `JSONB`, the difference being that it returns a set of records instead of a single record. For example, if you have an array of `JSONB` objects, you can use `jsonb_populate_recordset` to convert each object into a new row. 
+- [json_populate_record](/docs/functions/json_populate_record) - It has the same functionality to `jsonb_populate_record`, but accepts `JSON` input instead of `JSONB`. 
 
 ## Resources
 


### PR DESCRIPTION
When listing alternative functions for a postgres function, we link to neon docs when present. 