### PR TITLE
feat: add highlight word for code snippets

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -208,14 +208,6 @@ You can use fenced code blocks with three backticks (```) on the lines before an
   }
   ```
 
-- enable highlighting words.
-
-  ```js /Hello/
-  const msg = 'Hello World'
-  console.log(msg)
-  console.log(msg) // prints Hello World
-  ```
-
 - use `[!code word:xxx]` to highlight a word.
 
   ```ts

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -200,6 +200,31 @@ You can use fenced code blocks with three backticks (```) on the lines before an
 
     ````
 
+- use `[!code highlight]` to highlight a line.
+
+  ```ts
+  export function foo() {
+    console.log('Highlighted') // [!code highlight]
+  }
+  ```
+
+- enable highlighting words.
+
+  ```js /Hello/
+  const msg = 'Hello World'
+  console.log(msg)
+  console.log(msg) // prints Hello World
+  ```
+
+- use `[!code word:xxx]` to highlight a word.
+
+  ```ts
+  export function foo() { // [!code word:Hello]
+    const msg = 'Hello World'
+    console.log(msg) // prints Hello World
+  }
+  ```
+
 - `showLineNumbers` - flag to show on the line numbers in the code block.
   
   Example:

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -65,11 +65,11 @@ From your server functions using the App Router, add the following code snippet 
 
 <CodeTabs labels={["node-postgres", "postgres.js", "Neon serverless driver"]}>
 
-```javascript /Pool/
-import { Pool } from 'pg'; // [!code word:pool]
+```javascript {8,9-18}
+import { Pool } from 'pg'; // [!code word:ssl]
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+const pool = new Pool({ 
+  connectionString: process.env.DATABASE_URL, // [!code highlight]
   ssl: true
 });
 

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -65,11 +65,11 @@ From your server functions using the App Router, add the following code snippet 
 
 <CodeTabs labels={["node-postgres", "postgres.js", "Neon serverless driver"]}>
 
-```javascript {8,9-18}
-import { Pool } from 'pg'; // [!code word:ssl]
+```javascript
+import { Pool } from 'pg';
 
 const pool = new Pool({ 
-  connectionString: process.env.DATABASE_URL, // [!code highlight]
+  connectionString: process.env.DATABASE_URL,
   ssl: true
 });
 

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -65,8 +65,8 @@ From your server functions using the App Router, add the following code snippet 
 
 <CodeTabs labels={["node-postgres", "postgres.js", "Neon serverless driver"]}>
 
-```javascript
-import { Pool } from 'pg';
+```javascript /Pool/
+import { Pool } from 'pg'; // [!code word:pool]
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "react-use": "^17.4.1",
         "remark-gfm": "^3.0.1",
         "rss": "^1.2.2",
-        "shiki": "^1.0.0-beta.1",
         "slugify": "^1.6.6",
         "tailwindcss-safe-area": "^0.4.1",
         "unist-util-visit": "^5.0.0",
@@ -66,6 +65,7 @@
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-conventional": "^18.4.3",
         "@next/eslint-plugin-next": "^14.0.3",
+        "@shikijs/transformers": "^1.1.1",
         "@svgr/webpack": "^8.1.0",
         "autoprefixer": "^10.4.16",
         "cypress": "^13.6.0",
@@ -84,6 +84,7 @@
         "postcss-import": "^15.1.0",
         "prettier": "^3.1.0",
         "prettier-plugin-tailwindcss": "^0.5.7",
+        "shiki": "^1.1.1",
         "svgo-loader": "^4.0.0",
         "tailwindcss": "^3.3.5",
         "url-loader": "^4.1.1"
@@ -3679,9 +3680,19 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.0.0-beta.1.tgz",
-      "integrity": "sha512-z3gdznaRj/DJSLQdR2Gdx6AB3e5+Il/kSGdLTGHI7HnalgPL15RbGgBSdLHW8rKAz4+dezAcTdnxm8z6YTu7nA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-WSHuW0i4W04+UZgim378oxHBAp4S5X3hVI2zXh+t5v2fx2u/7QXz9VNisoOD/CA4O9Lc6Zs97TrKiDbWyZua6Q==",
+      "dev": true
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.1.1.tgz",
+      "integrity": "sha512-kOGqxMWtgPxivmDB6WH/lq3oUv0FrGPleovfBCqNVYsyGwRDa01OBOqQxO6oz8a7QbdEq0fbt7CaK1yjv4epXw==",
+      "dev": true,
+      "dependencies": {
+        "shiki": "1.1.1"
+      }
     },
     "node_modules/@splinetool/react-spline": {
       "version": "2.2.6",
@@ -15646,11 +15657,12 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.0.0-beta.1.tgz",
-      "integrity": "sha512-iq32WxjemJVlAHg5HjYoL1qCxGmvyh3Z8kr2E/gMTQdcxyXxTpMhahIC7myxFBapAk9o8QN8mxCpr4JT5rqpRQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.1.1.tgz",
+      "integrity": "sha512-7ksyiu01NltBvEcLq9GcguF+7RGa5lDwozjgdbiXnlkro1FtMCcrVtHUWbKuYBSOZW74gC4KlnBcgRCwK2ERAw==",
+      "dev": true,
       "dependencies": {
-        "@shikijs/core": "1.0.0-beta.1"
+        "@shikijs/core": "1.1.1"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "react-use": "^17.4.1",
     "remark-gfm": "^3.0.1",
     "rss": "^1.2.2",
-    "shiki": "^1.0.0-beta.1",
     "slugify": "^1.6.6",
     "tailwindcss-safe-area": "^0.4.1",
     "unist-util-visit": "^5.0.0",
@@ -82,6 +81,7 @@
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",
     "@next/eslint-plugin-next": "^14.0.3",
+    "@shikijs/transformers": "^1.1.1",
     "@svgr/webpack": "^8.1.0",
     "autoprefixer": "^10.4.16",
     "cypress": "^13.6.0",
@@ -100,6 +100,7 @@
     "postcss-import": "^15.1.0",
     "prettier": "^3.1.0",
     "prettier-plugin-tailwindcss": "^0.5.7",
+    "shiki": "^1.1.1",
     "svgo-loader": "^4.0.0",
     "tailwindcss": "^3.3.5",
     "url-loader": "^4.1.1"

--- a/src/components/pages/blog-post/code-block/code-block.jsx
+++ b/src/components/pages/blog-post/code-block/code-block.jsx
@@ -12,8 +12,7 @@ const CodeBlock = async (props) => {
     codeContent = JSON.stringify(codeContent, null, 2);
   }
 
-  const highlightedLines = `${props.highlight}`;
-  const highlightCode = await highlight(codeContent, props.language, highlightedLines);
+  const highlightCode = await highlight(codeContent, props.language);
 
   return <CodeBlockWrapper>{parse(highlightCode)}</CodeBlockWrapper>;
 };

--- a/src/components/pages/blog-post/code-tabs/code-tabs-navigation.jsx
+++ b/src/components/pages/blog-post/code-tabs/code-tabs-navigation.jsx
@@ -35,7 +35,11 @@ const CodeTabsNavigation = ({ items, highlightedItems }) => {
             return null;
           }
 
-          return <CodeBlockWrapper key={index}>{parse(item)}</CodeBlockWrapper>;
+          return (
+            <CodeBlockWrapper as="div" key={index}>
+              {parse(item)}
+            </CodeBlockWrapper>
+          );
         })}
       </div>
     </>

--- a/src/components/pages/blog-post/code-tabs/code-tabs.jsx
+++ b/src/components/pages/blog-post/code-tabs/code-tabs.jsx
@@ -19,7 +19,7 @@ CodeTabs.propTypes = {
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       language: PropTypes.string,
-      code: PropTypes.string.isRequired,
+      code: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
     })
   ).isRequired,
 };

--- a/src/components/shared/admonition/admonition.jsx
+++ b/src/components/shared/admonition/admonition.jsx
@@ -26,7 +26,7 @@ const Admonition = ({ children = null, type = 'note', title = null, asHTML = fal
   return (
     <div
       className={clsx(
-        'admonition not-prose mt-5 flex flex-col rounded-[1px] border-l-4 bg-gray-new-98 px-5 py-4 leading-normal dark:bg-gray-new-10 [&_pre[data-theme]]:!bg-white [&_pre[data-theme]]:dark:!bg-gray-new-8 [&_pre]:px-4 [&_pre]:py-3 [&_pre_code]:!text-sm',
+        'admonition not-prose mt-5 flex flex-col rounded-[1px] border-l-4 bg-gray-new-98 px-5 py-4 leading-normal dark:bg-gray-new-10 [&_pre[data-language]]:!bg-white [&_pre[data-language]]:dark:!bg-gray-new-8 [&_pre]:px-4 [&_pre]:py-3 [&_pre_code]:!text-sm',
         borderClassNames[lowerCaseType]
       )}
     >

--- a/src/components/shared/code-block-wrapper/code-block-wrapper.jsx
+++ b/src/components/shared/code-block-wrapper/code-block-wrapper.jsx
@@ -44,7 +44,7 @@ const CodeBlockWrapper = ({
   className = '',
   copyButtonClassName = '',
   children,
-
+  as: Tag = 'figure',
   ...otherProps
 }) => {
   const { isCopied, handleCopy } = useCopyToClipboard(3000);
@@ -52,7 +52,7 @@ const CodeBlockWrapper = ({
   const code = extractTextFromNode(children);
 
   return (
-    <figure className={clsx('code-block group relative', className)} {...otherProps}>
+    <Tag className={clsx('code-block group relative', className)} {...otherProps}>
       {children}
       <button
         className={clsx(
@@ -70,7 +70,7 @@ const CodeBlockWrapper = ({
           <CopyIcon className="text-current" />
         )}
       </button>
-    </figure>
+    </Tag>
   );
 };
 

--- a/src/components/shared/code-block/code-block.jsx
+++ b/src/components/shared/code-block/code-block.jsx
@@ -11,7 +11,7 @@ const CodeBlock = async (props) => {
   const language = children?.props?.className?.replace('language-', '');
   const meta = children?.props?.meta;
   const code = children?.props?.children?.trim();
-  const html = await highlight(code, language, meta);
+  const html = await highlight(code, language);
 
   return (
     <CodeBlockWrapper

--- a/src/components/shared/code-block/code-block.jsx
+++ b/src/components/shared/code-block/code-block.jsx
@@ -11,7 +11,7 @@ const CodeBlock = async (props) => {
   const language = children?.props?.className?.replace('language-', '');
   const meta = children?.props?.meta;
   const code = children?.props?.children?.trim();
-  const html = await highlight(code, language);
+  const html = await highlight(code, language, meta);
 
   return (
     <CodeBlockWrapper

--- a/src/lib/shiki.js
+++ b/src/lib/shiki.js
@@ -86,7 +86,6 @@ export default async function highlight(code, lang = 'bash', meta = '', theme = 
 
   await highlighter.loadLanguage(language);
 
-  // return tokensToHTML(tokens, language, highlightedLines);
   return html;
 }
 

--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -78,7 +78,7 @@
     }
 
     pre {
-      @apply !bg-black-new;
+      @apply !bg-black-new px-0;
 
       &.highlight {
         @apply px-0;

--- a/src/styles/highlighted-code.css
+++ b/src/styles/highlighted-code.css
@@ -31,15 +31,18 @@
     --shiki-token-embed: #ffffff;
   }
 
-  pre [data-highlighted-line] {
-    @apply bg-[rgba(0,85,255,0.08)] shadow-[inset_3px_0px_0px_0px_#0055ff] dark:bg-[rgba(0,229,153,0.08)] dark:shadow-[inset_3px_0px_0px_0px_#00E599];
+  pre .line {
+    &.highlighted,
+    &[data-highlighted-line] {
+      @apply bg-[rgba(0,85,255,0.08)] shadow-[inset_3px_0px_0px_0px_#0055ff] dark:bg-[rgba(0,229,153,0.08)] dark:shadow-[inset_3px_0px_0px_0px_#00E599];
+    }
   }
 
   [data-line-numbers='true'] pre {
     counter-reset: line;
   }
 
-  [data-line-numbers='true'] pre [data-line]::before {
+  [data-line-numbers='true'] pre .line::before {
     counter-increment: line;
     content: counter(line);
 
@@ -51,12 +54,16 @@
     color: gray;
   }
 
-  code [data-line] {
+  code .line {
     @apply px-4;
   }
 
-  code [data-line]::after {
+  code .line::after {
     @apply invisible overflow-hidden text-sm content-["'"];
+  }
+
+  .line .highlighted-word {
+    @apply -mx-[3px] -my-px rounded border border-[#c2c2c4] bg-[#f6f6f7] px-1 py-0.5 dark:border-[#3c3f44] dark:bg-[#202127];
   }
 
   .highlighted-code {
@@ -70,7 +77,7 @@
       counter-reset: line;
     }
 
-    pre code > [data-line]::before {
+    pre code > .line::before {
       counter-increment: line;
       content: counter(line);
 

--- a/src/styles/highlighted-code.css
+++ b/src/styles/highlighted-code.css
@@ -63,7 +63,7 @@
   }
 
   .line .highlighted-word {
-    @apply -mx-[3px] -my-px rounded border border-[#c2c2c4] bg-[#f6f6f7] px-1 py-0.5 dark:border-[#3c3f44] dark:bg-[#202127];
+    @apply -mx-[3px] rounded border border-[#c2c2c4] bg-[#f6f6f7] px-1 py-0.5 dark:border-[#3c3f44] dark:bg-[#202127];
   }
 
   .highlighted-code {


### PR DESCRIPTION
This pull request brings the highlight word for code snippets. It supports 4 types of transformers for now: 
- [transformerMetaHighlight](https://shiki.matsu.io/packages/transformers#transformermetahighlight),
- [transformerNotationHighlight](https://shiki.matsu.io/packages/transformers#transformernotationhighlight),
- [transformerNotationWordHighlight](https://shiki.matsu.io/packages/transformers#transformernotationwordhighlight)

**Changes**
- updated shiki dependency

**TODO**
- [x] remove test data in `/docs/guides/nextjs`

**Steps**
1. Open [preview](https://neon-next-git-shiki-transformers-neondatabase.vercel.app/docs/guides/nextjs)
2. Check the highlighted word
