### PR TITLE
Docs: tweak to extensions and support in docs

### DIFF
--- a/content/changelog/2024-01-19-console.md
+++ b/content/changelog/2024-01-19-console.md
@@ -4,7 +4,7 @@ description: Neon API updates, CLI updates, and more
 
 ### Custom extension support
 
-Neon supports custom-built Postgres extensions for exclusive use with your Neon account. If you developed your own Postgres extension and want to use it with Neon, paid plan users can [open a support ticket](https://console.neon.tech/app/projects?modal=support). Free plan users can submit a request via the feedback channel on [Discord server](https://discord.com/invite/92vNTzKDGp). To learn more about how we support custom extensions, check out this blog post: [Bring Your Own Extensions to Serverless PostgreSQL](https://neon.tech/blog/bring-your-own-extensions-to-serverless-postgresql).
+Neon supports custom-built Postgres extensions for exclusive use with your Neon account. If you developed your own Postgres extension and want to use it with Neon, [Scale](/docs/introduction/plans#scale) and [Enterprise](/docs/introduction/plans#enterprise) plan users can [open a support ticket](https://console.neon.tech/app/projects?modal=support). To learn more about how we support custom extensions, check out this blog post: [Bring Your Own Extensions to Serverless PostgreSQL](https://neon.tech/blog/bring-your-own-extensions-to-serverless-postgresql).
 
 ### Neon API updates
 

--- a/content/docs/extensions/pg-extensions.md
+++ b/content/docs/extensions/pg-extensions.md
@@ -119,11 +119,11 @@ When Neon releases a new extension or new extension version, a compute restart i
 
 ## Request extension support
 
-To request support for a Postgres extension, paid plan users can [open a support ticket](https://console.neon.tech/app/projects?modal=support). Free plan users can submit a request via the **feedback** channel on our [Discord Server](https://discord.com/invite/92vNTzKDGp).
+To request support for a Postgres extension, paid plan users can [open a support ticket](https://console.neon.tech/app/projects?modal=support). Free plan users can submit a request via the **feedback** channel on our [Discord Server](https://neon.tech/discord).
 
 ### Custom-built extensions
 
-Neon supports custom-built Postgres extensions for exclusive use with your Neon account. If you developed your own Postgres extension and want to use it with Neon, please reach out to us as described above. Please include the following information in your request:
+On Scale and Enterprise plans, Neon supports custom-built Postgres extensions for exclusive use with your Neon account. If you developed your own Postgres extension and want to use it with Neon, please reach out to us as described above. Please include the following information in your request:
 
 - A repository link or archive file containing the source code for your extension
 - A description of what the extension does, instructions for compiling it, and any prerequisites

--- a/content/docs/extensions/pg-extensions.md
+++ b/content/docs/extensions/pg-extensions.md
@@ -123,7 +123,7 @@ To request support for a Postgres extension, paid plan users can [open a support
 
 ### Custom-built extensions
 
-On Scale and Enterprise plans, Neon supports custom-built Postgres extensions for exclusive use with your Neon account. If you developed your own Postgres extension and want to use it with Neon, please reach out to us as described above. Please include the following information in your request:
+On [Scale](/docs/introduction/plans#scale) and [Enterprise](/docs/introduction/plans#enterprise) plans, Neon supports custom-built Postgres extensions for exclusive use with your Neon account. If you developed your own Postgres extension and want to use it with Neon, please reach out to us as described above. Please include the following information in your request:
 
 - A repository link or archive file containing the source code for your extension
 - A description of what the extension does, instructions for compiling it, and any prerequisites

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -38,9 +38,9 @@ In addition, Free Tier users have access to the following Neon features:
 - [Autosuspend](#autosuspend): Compute scales to zero after 5 minutes of inactivity.
 - [Region availabilty](#region-availability): The Free Tier is available in all supported regions.
 - [Project sharing](#project-sharing): Share your project with any Neon user account.
-- [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, Postgres extensions, and custom extensions.
-- [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **24 hours** in the past.
-- [Community support](/docs/introduction/support): Free Tier plan users have access to **Community** support, which includes the [Neon Discord Server](/discord) or the [Neon Discourse Community](https://community.neon.tech/).
+- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and Standard extensions
+- [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **24 hours** in the past
+- [Community support](/docs/introduction/support): Free Tier plan users have access to **Community** support, which includes the [Neon Discord Server](/discord).
 
 <Admonition type="tip" title="Free Tier Compute Allowances">
 On the Free Tier, your primary branch compute is always available — it will never be suspended due to running out of compute hours, which means you can always access the data on the primary branch in your Neon project. Branch computes have 20 hours of [active time](/docs/reference/glossary#active-time) (5 [compute hours](/docs/reference/glossary#compute-hour)) per month. If your branch computes exceed this allowance, they are suspended until the allowance resets at the beginning of the month. You can monitor branch compute hours on the [Billing page](/docs/introduction/manage-billing#view-the-billing-page) in the Neon Console. The compute hour allowance for branch computes resets at the beginning of each month. For instance, if you enrolled in the Neon Free Tier in January, the allowance for branch computes resets on February 1st.
@@ -58,15 +58,15 @@ The Launch plan provides all of the resources, features, and support you need to
 | **Storage**                             | Up to 10 GiB of data storage                                  |
 | **Compute**                             | Up to 1,200 _active hours_/month (300 compute hours) for all computes in all projects |
 
-Launch plan users can access extra compute hours beyond the 1200 compute hours/month included in the Launch plan. Extra compute hours are billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour cost.
+Launch plan users can access extra compute hours beyond the 1,200 compute hours/month included in the Launch plan. Extra compute hours are billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour cost.
 
 In addition, Launch plan users have access to the following Neon features:
 
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**5 minutes+** or never)
-- [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, Postgres extensions, and custom extensions
+- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and Standard extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **7 days** in the past
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Launch plan users can access extra compute usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute cost.
-- [Expert support](/docs/introduction/support): Launch plan users have access to **Expert** Neon support, which includes access to the Neon Support team via support tickets.
+- [Standard support](/docs/introduction/support): Launch plan users have access to **Standard** Neon support, which includes access to the Neon Support team via support tickets.
 
 ### Scale
 
@@ -80,13 +80,13 @@ The Scale plan provides full platform and support access, and is designed for sc
 | **Storage**                             | Up to 50 GiB of data storage                                  |
 | **Compute**                             | Up to 3,000 _active hours_/month (750 compute hours) for all computes in all projects |
 
-In addition, Sacle plan users have access to the following Neon features:
+In addition, Scale plan users have access to the following Neon features:
 
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**1 minute+** or never)
 - [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, Postgres extensions, and custom extensions.
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **30 days** in the past.
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Scale plan users can access extra compute and storage usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute and extra storage prices.
-- [Expert support](/docs/introduction/support): Scale plan users have access to **Priority** Neon support, which includes _priority_ access to the Neon Support team via support tickets.
+- [Priority support](/docs/introduction/support): Scale plan users have access to **Priority** Neon support, which includes _priority_ access to the Neon Support team via support tickets.
 
 ### Enterprise
 
@@ -110,7 +110,7 @@ Additionally, the _Enterprise_ plan can be tailored to your specific requirement
 
 Enterprise plan users have access to **Enterprise** support, which includes everything offered with the **Priority** plan plus retail customer support, Customer Success Team support, and SLAs. For more information, Neon support plans are outlined on our [Support](/docs/introduction/support) page.
 
-If you are interested in exploring an _Enterprise_ plan with Neon, please reach out to our [Sales team](https://neon.tech/contact-sales).
+If you are interested in exploring an _Enterprise_ plan with Neon, you can  [request an enterprise trial](/enterprise#request-trial) or [get in touch with our sales team](/contact-sales).
 
 ## Features
 
@@ -120,7 +120,7 @@ This section describes the features available with one or more of the Neon plans
 
 #### Compute size
 
-Neon supports compute sizes from .25 vCPU with 1 GB RAM up to 7 vCPU with 28 GB RAM.
+Neon supports compute sizes from 0.25 vCPU with 1 GB RAM up to 7 vCPU with 28 GB RAM.
 
 #### Read replicas
 
@@ -156,7 +156,7 @@ Neon uses [PgBouncer](https://www.pgbouncer.org/) to offer connection pooling su
 
 Logical replication enables replicating data from your Neon database to external destinations, allowing for Change Data Capture (CDC) and real-time analytics. Stream your data to data warehouses, analytical database services, messaging platforms, event-streaming platforms, external Postgres databases, and more. To learn more, see [Get started with logical replication](/docs/guides/logical-replication-guide).
 
-#### Postgres extensions
+#### Standard extensions
 
 Neon supports a large number of Postgres extensions letting you extend the capabilities of Postgres. See [Supported extensions](/docs/extensions/pg-extensions).
 
@@ -176,7 +176,7 @@ Paid plan users can request access to Neon's SOC 2 report on our [Neon Trust Cen
 
 #### Customer-owned S3
 
-The Neon Enterprise plan supports data storage on customer-owned S3. If you are interested in this feature, please contact [Sales](https://neon.tech/contact-sales).
+The Neon Enterprise plan supports data storage on customer-owned S3. If you are interested in this feature, please [contact Sales](https://neon.tech/contact-sales).
 
 ### Additional features
 

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -38,7 +38,7 @@ In addition, Free Tier users have access to the following Neon features:
 - [Autosuspend](#autosuspend): Compute scales to zero after 5 minutes of inactivity.
 - [Region availabilty](#region-availability): The Free Tier is available in all supported regions.
 - [Project sharing](#project-sharing): Share your project with any Neon user account.
-- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ standard Postgres extensions
+- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **24 hours** in the past
 - [Community support](/docs/introduction/support): Free Tier plan users have access to **Community** support, which includes the [Neon Discord Server](/discord).
 
@@ -63,7 +63,7 @@ Launch plan users can access extra compute hours beyond the 1,200 compute hours/
 In addition, Launch plan users have access to the following Neon features:
 
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**5 minutes+** or never)
-- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ standard Postgres extensions
+- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **7 days** in the past
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Launch plan users can access extra compute usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute cost.
 - [Standard support](/docs/introduction/support): Launch plan users have access to **Standard** Neon support, which includes access to the Neon Support team via support tickets.
@@ -83,7 +83,7 @@ The Scale plan provides full platform and support access, and is designed for sc
 In addition, Scale plan users have access to the following Neon features:
 
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**1 minute+** or never)
-- [All advanced Postgres features](#advanced-postgres-features): - [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ standard Postgres extensions, and your own custom extensions
+- [All advanced Postgres features](#advanced-postgres-features): - [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions, and customer-provided custom extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **30 days** in the past.
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Scale plan users can access extra compute and storage usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute and extra storage prices.
 - [Priority support](/docs/introduction/support): Scale plan users have access to **Priority** Neon support, which includes _priority_ access to the Neon Support team via support tickets.
@@ -156,7 +156,7 @@ Neon uses [PgBouncer](https://www.pgbouncer.org/) to offer connection pooling su
 
 Logical replication enables replicating data from your Neon database to external destinations, allowing for Change Data Capture (CDC) and real-time analytics. Stream your data to data warehouses, analytical database services, messaging platforms, event-streaming platforms, external Postgres databases, and more. To learn more, see [Get started with logical replication](/docs/guides/logical-replication-guide).
 
-#### Standard Postgres extensions
+#### Postgres extensions
 
 Neon supports a large number of open-source Postgres extensions letting you extend the capabilities of Postgres. See [Supported extensions](/docs/extensions/pg-extensions).
 

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -38,7 +38,7 @@ In addition, Free Tier users have access to the following Neon features:
 - [Autosuspend](#autosuspend): Compute scales to zero after 5 minutes of inactivity.
 - [Region availabilty](#region-availability): The Free Tier is available in all supported regions.
 - [Project sharing](#project-sharing): Share your project with any Neon user account.
-- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and Standard extensions
+- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ standard Postgres extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **24 hours** in the past
 - [Community support](/docs/introduction/support): Free Tier plan users have access to **Community** support, which includes the [Neon Discord Server](/discord).
 
@@ -63,7 +63,7 @@ Launch plan users can access extra compute hours beyond the 1,200 compute hours/
 In addition, Launch plan users have access to the following Neon features:
 
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**5 minutes+** or never)
-- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and Standard extensions
+- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ standard Postgres extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **7 days** in the past
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Launch plan users can access extra compute usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute cost.
 - [Standard support](/docs/introduction/support): Launch plan users have access to **Standard** Neon support, which includes access to the Neon Support team via support tickets.
@@ -83,7 +83,7 @@ The Scale plan provides full platform and support access, and is designed for sc
 In addition, Scale plan users have access to the following Neon features:
 
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**1 minute+** or never)
-- [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, Postgres extensions, and custom extensions.
+- [All advanced Postgres features](#advanced-postgres-features): - [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ standard Postgres extensions, and your own custom extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **30 days** in the past.
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Scale plan users can access extra compute and storage usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute and extra storage prices.
 - [Priority support](/docs/introduction/support): Scale plan users have access to **Priority** Neon support, which includes _priority_ access to the Neon Support team via support tickets.
@@ -156,9 +156,9 @@ Neon uses [PgBouncer](https://www.pgbouncer.org/) to offer connection pooling su
 
 Logical replication enables replicating data from your Neon database to external destinations, allowing for Change Data Capture (CDC) and real-time analytics. Stream your data to data warehouses, analytical database services, messaging platforms, event-streaming platforms, external Postgres databases, and more. To learn more, see [Get started with logical replication](/docs/guides/logical-replication-guide).
 
-#### Standard extensions
+#### Standard Postgres extensions
 
-Neon supports a large number of Postgres extensions letting you extend the capabilities of Postgres. See [Supported extensions](/docs/extensions/pg-extensions).
+Neon supports a large number of open-source Postgres extensions letting you extend the capabilities of Postgres. See [Supported extensions](/docs/extensions/pg-extensions).
 
 #### Custom extensions
 

--- a/content/docs/introduction/support.md
+++ b/content/docs/introduction/support.md
@@ -4,9 +4,9 @@ enableTableOfContents: true
 updatedOn: '2024-02-16T18:37:19.448Z'
 ---
 
-Neon's Community, Expert, Priority, and Enterprise support plans are outlined below.
+Neon's Community, Standard, Priority, and Enterprise support plans are outlined below.
 
-| Support channels                         | Community | Expert   | Priority | Enterprise |
+| Support channels                         | Community | Standard | Priority | Enterprise |
 | :--------------------------------------- | :-------: | :------: | :------: | :--------: |
 | Neon Discord Server                      |  &check;  | &check;  | &check;  | &check;    |
 | Neon Discourse Community                 |  &check;  | &check;  | &check;  | &check;    |
@@ -21,9 +21,9 @@ Neon's Community, Expert, Priority, and Enterprise support plans are outlined be
 
 Community support includes the [Neon Discord Server](/discord) or the [Neon Discourse Community](https://community.neon.tech/), where you can ask questions or see what others are doing with Neon. You will find Neon users and members of the Neon team actively engaged in both communities. 
 
-## Expert support
+## Standard support
 
-Expert support includes access to the Neon Support team via support tickets. 
+Standard support includes access to the Neon Support team via support tickets. 
 
 You can open support tickets in the Neon Console. Look for the **Support** link in the sidebar. It opens the **Create Support Ticket** modal, where you can describe your issue. To access the modal directly, [click here](https://console.neon.tech/app/projects?modal=support).
 


### PR DESCRIPTION
This makes a couple updates to align docs and pricing page:

- Only Scale and Enterprise plans can load custom extensions. So we need to update a few places, including changelog, billing/plans, and pg-extensions
- `s/Expert/Standard/` Support - All support is expert support, based on Slack discussion, renaming "Expert" to "Standard" and aligning it with pricing page.