### PR TITLE
Adjust compute sizes

### DIFF
--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -62,9 +62,9 @@ Launch plan users can access extra compute hours beyond the 1,200 compute hours/
 
 In addition, Launch plan users have access to the following Neon features:
 
-- [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**5 minutes+** or never)
-- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions
-- [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **7 days** in the past
+- [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**5 minutes+** or never).
+- [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions.
+- [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **7 days** in the past.
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Launch plan users can access extra compute usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute cost.
 - [Standard support](/docs/introduction/support): Launch plan users have access to **Standard** Neon support, which includes access to the Neon Support team via support tickets.
 
@@ -82,8 +82,8 @@ The Scale plan provides full platform and support access and is designed for sca
 
 In addition, Scale plan users have access to the following Neon features:
 
-- [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 8 vCPUs and 32 GB RAM, _Autosuspend_ (**1 minute+** or never)
-- [All advanced Postgres features](#advanced-postgres-features): - [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions, and customer-provided custom extensions
+- [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 8 vCPUs and 32 GB RAM, _Autosuspend_ (**1 minute+** or never).
+- [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, 60+ Postgres extensions, and customer-provided custom extensions.
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **30 days** in the past.
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Scale plan users can access extra compute and storage usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute and extra storage prices.
 - [Priority support](/docs/introduction/support): Scale plan users have access to **Priority** Neon support, which includes _priority_ access to the Neon Support team via support tickets.

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -70,7 +70,7 @@ In addition, Launch plan users have access to the following Neon features:
 
 ### Scale
 
-The Scale plan provides full platform and support access, and is designed for scaling production workloads. It includes the following usage:
+The Scale plan provides full platform and support access and is designed for scaling production workloads. It includes the following usage:
 
 |                                         |                                                               |
 |-----------------------------------------|---------------------------------------------------------------|

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -82,7 +82,7 @@ The Scale plan provides full platform and support access, and is designed for sc
 
 In addition, Scale plan users have access to the following Neon features:
 
-- [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**1 minute+** or never)
+- [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 8 vCPUs and 32 GB RAM, _Autosuspend_ (**1 minute+** or never)
 - [All advanced Postgres features](#advanced-postgres-features): - [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions, and customer-provided custom extensions
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **30 days** in the past.
 - [Extra usage](/docs/introduction/how-billing-works#extra-usage): Scale plan users can access extra compute and storage usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute and extra storage prices.

--- a/content/docs/introduction/usage-metrics.md
+++ b/content/docs/introduction/usage-metrics.md
@@ -161,6 +161,7 @@ The following table outlines project allowances for each Neon plan.
 | Enterprise | Unlimited |
 
 - When you reach your limit on the [Free Tier](/docs/introduction/plans#free-tier) or [Launch](/docs/introduction/plans#launch) plan, you cannot create additional projects. Instead, you can upgrade to the [Launch](/docs/introduction/plans#launch) or [Scale](/docs/introduction/plans#scale) plan, which offer allowances of 10 and 50 projects, respectively.
-- Extra projects are available with the [Scale](/docs/introduction/plans#scale) plan in increments of 10. If you use more than 50 projects, you are automatically billed for an extra package of 10 projects for the price stated on our [pricing](https://neon.tech/pricing) page. For example, if you use 51 projects, you are billed for a package of 10 projects. If you use 61 projects, you are billed for two packages of 10 projects, and so on. 
+- Extra projects are available with the [Scale](/docs/introduction/plans#scale) plan in increments of 10. If you use more than 50 projects, you are automatically billed for an extra package of 10 projects for the price stated on our [pricing](https://neon.tech/pricing) page. For example, if you use 51 projects, you are billed for a package of 10 projects. If you use 61 projects, you are billed for two packages of 10 projects, and so on.
+- There is a soft compute size limit of 7 vCPU. For computes with 8 vCPU, please contact [Support](/docs/introduction/support).
 
 <NeedHelp/>   

--- a/content/docs/introduction/usage-metrics.md
+++ b/content/docs/introduction/usage-metrics.md
@@ -162,6 +162,5 @@ The following table outlines project allowances for each Neon plan.
 
 - When you reach your limit on the [Free Tier](/docs/introduction/plans#free-tier) or [Launch](/docs/introduction/plans#launch) plan, you cannot create additional projects. Instead, you can upgrade to the [Launch](/docs/introduction/plans#launch) or [Scale](/docs/introduction/plans#scale) plan, which offer allowances of 10 and 50 projects, respectively.
 - Extra projects are available with the [Scale](/docs/introduction/plans#scale) plan in increments of 10. If you use more than 50 projects, you are automatically billed for an extra package of 10 projects for the price stated on our [pricing](https://neon.tech/pricing) page. For example, if you use 51 projects, you are billed for a package of 10 projects. If you use 61 projects, you are billed for two packages of 10 projects, and so on.
-- There is a soft limit of 7 vCPU for compute sizes in the Neon Console. For computes with 8 vCPU, please contact [Support](/docs/introduction/support).
 
 <NeedHelp/>   

--- a/content/docs/introduction/usage-metrics.md
+++ b/content/docs/introduction/usage-metrics.md
@@ -162,6 +162,6 @@ The following table outlines project allowances for each Neon plan.
 
 - When you reach your limit on the [Free Tier](/docs/introduction/plans#free-tier) or [Launch](/docs/introduction/plans#launch) plan, you cannot create additional projects. Instead, you can upgrade to the [Launch](/docs/introduction/plans#launch) or [Scale](/docs/introduction/plans#scale) plan, which offer allowances of 10 and 50 projects, respectively.
 - Extra projects are available with the [Scale](/docs/introduction/plans#scale) plan in increments of 10. If you use more than 50 projects, you are automatically billed for an extra package of 10 projects for the price stated on our [pricing](https://neon.tech/pricing) page. For example, if you use 51 projects, you are billed for a package of 10 projects. If you use 61 projects, you are billed for two packages of 10 projects, and so on.
-- There is a soft compute size limit of 7 vCPU. For computes with 8 vCPU, please contact [Support](/docs/introduction/support).
+- There is a soft limit of 7 vCPU for compute sizes in the Neon Console. For computes with 8 vCPU, please contact [Support](/docs/introduction/support).
 
 <NeedHelp/>   

--- a/content/docs/manage/endpoints.md
+++ b/content/docs/manage/endpoints.md
@@ -78,7 +78,7 @@ Some key points to understand about how your endpoint responds when you make cha
 
 Users on paid plans can change compute size settings when [editing a compute endpoint](#edit-a-compute-endpoint).
 
-_Compute size_ is the number of Compute Units (CUs) assigned to a Neon compute endpoint. The number of CUs determines the processing capacity of the compute endpoint. One CU has 1 vCPU and 4 GB of RAM, 2 CUs have 2 vCPUs and 8 GB of RAM, and so on. The amount of RAM in GB is always 4 times the vCPUs, as shown in the table below. Currently, a Neon compute can have anywhere from 1/4 (.25) to 7 CUs.
+_Compute size_ is the number of Compute Units (CUs) assigned to a Neon compute endpoint. The number of CUs determines the processing capacity of the compute endpoint. One CU has 1 vCPU and 4 GB of RAM, 2 CUs have 2 vCPUs and 8 GB of RAM, and so on. The amount of RAM in GB is always 4 times the vCPUs, as shown in the table below.
 
 | Compute size (in CUs)  | vCPU | RAM    |
 |:--------------|:-----|:-------|
@@ -91,11 +91,13 @@ _Compute size_ is the number of Compute Units (CUs) assigned to a Neon compute e
 | 5             | 5    | 20 GB  |
 | 6             | 6    | 24 GB  |
 | 7             | 7    | 28 GB  |
+| 8             | 8    | 32 GB  |
+
 
 Neon supports fixed-size and autoscaling compute configurations.
 
-- **Fixed size:** You can use the slider to select a fixed compute size ranging from .25 CUs to 7 CUs. A fixed-size compute does not scale to meet workload demand.
-- **Autoscaling:** You can also use the slider to specify a minimum and maximum compute size. Neon scales the compute size up and down within the selected compute size boundaries to meet workload demand. _Autoscaling_ currently supports a range of 1/4 (.25) to 7 CUs. For information about how Neon implements the _Autoscaling_ feature, see [Autoscaling](/docs/introduction/autoscaling).
+- **Fixed size:** You can use the slider to select a fixed compute size. A fixed-size compute does not scale to meet workload demand.
+- **Autoscaling:** You can also use the slider to specify a minimum and maximum compute size. Neon scales the compute size up and down within the selected compute size boundaries to meet workload demand. For information about how Neon implements the _Autoscaling_ feature, see [Autoscaling](/docs/introduction/autoscaling).
 
 <Admonition type="info">
 The `neon_utils` extension provides a `num_cpus()` function you can use to monitor how the _Autoscaling_ feature allocates compute resources in response to workload. For more information, see [The neon_utils extension](/docs/extensions/neon-utils).
@@ -122,6 +124,7 @@ The following table outlines the vCPU, RAM, `shared_buffer` limit (50 % of RAM),
 | 5            | 5    | 20 GB | 10 GB          | 2253            |
 | 6            | 6    | 24 GB | 12 GB          | 2703            |
 | 7            | 7    | 28 GB | 14 GB          | 3154            |
+| 8            | 8    | 32 GB | 16 GB          | 3,604           |
 
 
 <Admonition type="note">

--- a/content/docs/manage/endpoints.md
+++ b/content/docs/manage/endpoints.md
@@ -93,7 +93,6 @@ _Compute size_ is the number of Compute Units (CUs) assigned to a Neon compute e
 | 7             | 7    | 28 GB  |
 | 8             | 8    | 32 GB  |
 
-
 Neon supports fixed-size and autoscaling compute configurations.
 
 - **Fixed size:** You can use the slider to select a fixed compute size. A fixed-size compute does not scale to meet workload demand.

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -111,7 +111,7 @@ A unit that measures the processing power of a Neon compute. A Neon compute can 
 
 ## Compute hour
 
-A usage metric for tracking that amount of compute usage. A compute hour is 1 hour of [active time](#active-time) for a compute with 1 vCPU. Neon supports computes ranging in size from 1 vCPU to 7 vCPU. If you have a compute with .25 vCPU, as you would on the Neon Free Tier, it would take 4 hours of active time to use 1 compute hour. On the other hand, If you have a compute with 4 vCPU, it would only take 15 minutes of active time to use 1 compute hour.
+A usage metric for tracking that amount of compute usage. A compute hour is 1 hour of [active time](#active-time) for a compute with 1 vCPU. Neon supports computes ranging in size from 1 vCPU to 8 vCPU. If you have a compute with .25 vCPU, as you would on the Neon Free Tier, it would take 4 hours of active time to use 1 compute hour. On the other hand, If you have a compute with 4 vCPU, it would only take 15 minutes of active time to use 1 compute hour.
 
 To calculate compute hour usage, you would use the following formula:
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -111,7 +111,7 @@ A unit that measures the processing power of a Neon compute. A Neon compute can 
 
 ## Compute hour
 
-A usage metric for tracking that amount of compute usage. A compute hour is 1 hour of [active time](#active-time) for a compute with 1 vCPU. Neon supports computes ranging in size from 1 vCPU to 8 vCPU. If you have a compute with .25 vCPU, as you would on the Neon Free Tier, it would take 4 hours of active time to use 1 compute hour. On the other hand, If you have a compute with 4 vCPU, it would only take 15 minutes of active time to use 1 compute hour.
+A usage metric for tracking that amount of compute usage. A compute hour is 1 hour of [active time](#active-time) for a compute with 1 vCPU. Neon supports computes ranging in size from 1 vCPU to 8 vCPU. If you have a compute with .25 vCPU, as you would on the Neon Free Tier, it would take 4 hours of active time to use 1 compute hour. On the other hand, if you have a compute with 4 vCPU, it would only take 15 minutes of active time to use 1 compute hour.
 
 To calculate compute hour usage, you would use the following formula:
 


### PR DESCRIPTION
Add compute size soft limit of 7vCPU. Contact support if you want to use 8 vCPU.
Some adjustments to content where we mentioned/implied only supporting up to 7 vCPU.
We mention 8 on the Pricing page now. 