### PR TITLE
Add Rust deps under guides

### DIFF
--- a/content/docs/guides/rust.md
+++ b/content/docs/guides/rust.md
@@ -24,6 +24,10 @@ To create a Neon project:
 
 ## Configure the connection
 
+<Admonition type="note">
+To run the Rust solution below you have to install the required dependencies. You can do this by running `cargo add postgres postgres_openssl openssl`.
+</Admonition>
+
 Add the Neon connection details to your `main.rs` file, as in the following example:
 
 ```rust


### PR DESCRIPTION
Just wanted to run the code under the Rust guide but having the command to install the dependencies readily available for copy-pasting would be more convenient.