### PR TITLE
Clarify pooled and unpooled connections for Postgres import docs

### DIFF
--- a/content/docs/import/import-from-postgres.md
+++ b/content/docs/import/import-from-postgres.md
@@ -10,7 +10,7 @@ updatedOn: '2024-02-08T15:20:54.293Z'
 This topic describes migrating data from another Postgres database to Neon using the `pg_dump` and `pg_restore` command line utilities.
 
 <Admonition type="important">
-Avoid using `pg_dump` over a [pooled Neon connection](https://neon.tech/docs/connect/connection-pooling) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an unpooled connection instead.
+Avoid using `pg_dump` over a [pooled connection string](/docs/reference/glossary#pooled-connection-string) (see PgBouncer issues [452](https://github.com/pgbouncer/pgbouncer/issues/452) & [976](https://github.com/pgbouncer/pgbouncer/issues/976) for details). Use an [unpooled connection string](/docs/reference/glossary#unpooled-connection-string) instead.
 </Admonition>
 
 Repeat the `pg_dump` and `pg_restore` process for each database you want to migrate.

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -291,6 +291,14 @@ A custom volume-based paid plan offered by Neon that includes support for resale
 
 Restoration of data to a state that existed at an earlier time. Neon retains a history of changes in the form of Write-Ahead-Log (WAL) records, which allows you to restore data to an earlier time. A point-in-time restore is performed by creating a branch using the **Time** or **LSN** option. By default, Neon retains a history of changes for all branches in a project. The supported limits are 24 hours for [Neon Free Tier](/docs/introduction/plans#free-tier) users, 7 days for [Launch](/docs/introduction/plans#launch) plan users, and 30 days for [Scale](/docs/introduction/plans#scale) plan users. For more information about this feature, see [Branching — Point-in-time restore](https://neon.tech/docs/guides/branching-pitr).
 
+## pooled connection string
+
+A pooled connection string in Neon includes a `-pooler` option, which directs your connection to a pooled connection port, where it is able to obtain a connection from a pool of connections. This is an example of a pooled connection:
+
+```text
+
+```
+
 ## PostgreSQL
 
 An open-source relational database management system (RDBMS) emphasizing extensibility and SQL compliance.

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -293,11 +293,15 @@ Restoration of data to a state that existed at an earlier time. Neon retains a h
 
 ## pooled connection string
 
-A pooled connection string in Neon includes a `-pooler` option, which directs your connection to a pooled connection port, where it is able to obtain a connection from a pool of connections. This is an example of a pooled connection:
+A pooled connection string in Neon includes a `-pooler` option, which directs your connection to a pooled connection port at the Neon Proxy. This is an example of a pooled connection:
 
 ```text
-
+postgres://alex:AbC123dEf@ep-cool-darkness-123456-pooler.us-east-2.aws.neon.tech/dbname
 ```
+
+A pooled connection can support a high number of concurrent users and is recommended for use with serverless and edge functions. For more information, see [Connection pooling](/docs/connect/connection-pooling).
+
+You can obtain a pooled connection string for your database from the **Connection Details** widget on the Neon Dashboard. Select the **Pooled connection** option to add the `-pooler` option to the connection string. For further instructions, see [Enable connection pooling](/docs/connect/connection-pooling#enable-connection-pooling).
 
 ## PostgreSQL
 
@@ -410,6 +414,16 @@ An encrypted access token that enables you to authenticate with Neon using the N
 ## tmpfs
 
 A temporary file storage system that uses a portion of a system's RAM to store files, improving performance by reducing disk usage.
+
+## unpooled connection string
+
+An unpooled connection string connects to your Neon database directly. It does not use [connection pooling](#connection-pooling), and it looks similar to this:
+
+```text
+postgres://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/dbname
+```
+
+You can obtain an unpooled connection string for your database from the **Connection Details** widget on the Neon Dashboard. Ensure that the **Pooled connection** option is **not** selected. A direct connection is subject to the `max_connections` limit for your compute. For more information, see [How to size your compute](/docs/manage/endpoints#how-to-size-your-compute).
 
 ## User
 


### PR DESCRIPTION
This was a user request. We advise using an unpooled connection when performing a dump and restore. It was unclear to the user what pooled and unpooled connections are. This PR adds links to newly added glossary terms for pooled and unpooled connection strings.
Preview:
https://neon-next-git-dprice-clarify-pooled-unpooled-neondatabase.vercel.app/docs/import/import-from-postgres