### PR TITLE
chore: add gtag events for social share buttons

### DIFF
--- a/src/components/pages/blog-post/social-share/social-share.jsx
+++ b/src/components/pages/blog-post/social-share/social-share.jsx
@@ -50,7 +50,6 @@ const SocialShare = ({ className = null, slug, title, withTopBorder = false }) =
           key={index}
           onClick={() => {
             sendGtagEvent(eventName);
-            console.log(eventName);
           }}
         >
           <Icon className="h-4 w-4 text-white transition-colors duration-200 group-hover:text-[#47FFC2] lg:h-6 lg:w-6" />

--- a/src/components/pages/blog-post/social-share/social-share.jsx
+++ b/src/components/pages/blog-post/social-share/social-share.jsx
@@ -2,26 +2,30 @@
 
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { LinkedinShareButton, TwitterShareButton, FacebookShareButton } from 'react-share';
+import { FacebookShareButton, LinkedinShareButton, TwitterShareButton } from 'react-share';
 
 import LINKS from 'constants/links';
 import FacebookIcon from 'icons/facebook-sm.inline.svg';
 import LinkedinIcon from 'icons/linkedin-sm.inline.svg';
 import XIcon from 'icons/x.inline.svg';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const links = [
   {
     icon: XIcon,
     tag: TwitterShareButton,
     via: LINKS.twitter.split('/')[3],
+    eventName: 'share_twitter',
   },
   {
     icon: FacebookIcon,
     tag: FacebookShareButton,
+    eventName: 'share_facebook',
   },
   {
     icon: LinkedinIcon,
     tag: LinkedinShareButton,
+    eventName: 'share_linkedin',
   },
 ];
 
@@ -37,8 +41,18 @@ const SocialShare = ({ className = null, slug, title, withTopBorder = false }) =
   >
     <span className="leading-none text-gray-new-80">Share:</span>
     <div className="flex shrink-0 space-x-5">
-      {links.map(({ icon: Icon, tag: Tag, via }, index) => (
-        <Tag className="group" url={slug} title={title} via={via} key={index}>
+      {links.map(({ icon: Icon, tag: Tag, via, eventName }, index) => (
+        <Tag
+          className="group"
+          url={slug}
+          title={title}
+          via={via}
+          key={index}
+          onClick={() => {
+            sendGtagEvent(eventName);
+            console.log(eventName);
+          }}
+        >
           <Icon className="h-4 w-4 text-white transition-colors duration-200 group-hover:text-[#47FFC2] lg:h-6 lg:w-6" />
         </Tag>
       ))}


### PR DESCRIPTION
This PR brings GA events to track the Social Share buttons clicks on blog posts