### PR TITLE
Update billing docs for "extra storage" on Launch plan

### DIFF
--- a/content/docs/introduction/billing-sample.md
+++ b/content/docs/introduction/billing-sample.md
@@ -89,4 +89,4 @@ _Total estimate_: $19 + $28 = $47 per month
 
 _Total estimate_: $69 per month
 
-The Launch plan is more economical in the short term, but you should consider upgrading to the [Scale](/docs/introduction/plans#scale) plan when purchasing extra storage on the Launch plan is no longer cheaper than the $69 per month Scale plan. The Scale plan has a higher monthly storage allowance (50 GiB) and a cheaper per-unit extra storage cost (10 GiB at $15 vs. 2 GiB at $3.5). The Scale plan also offers additional features and more projects, which may factor into your decision about when to upgrade from the Launch plan.
+The Launch plan is more economical in the short term, but you should consider upgrading to the [Scale](/docs/introduction/plans#scale) plan when purchasing extra storage on the Launch plan is no longer cheaper than the $69 per month Scale plan. The Scale plan has a higher monthly storage allowance (50 GiB) and a cheaper per-unit extra storage cost (10 GiB at $15 vs. 2 GiB at $3.5). The Scale plan also offers additional features and more projects, which may factor into your decision about when to upgrade.

--- a/content/docs/introduction/billing-sample.md
+++ b/content/docs/introduction/billing-sample.md
@@ -17,7 +17,7 @@ Roughly six months since launch, this high-traffic application attracts about 80
 
 ### Tech stack (user management portion of the app):
 * **Authentication**: [NextAuth.JS](https://next-auth.js.org/) for authentication with OAuth
-* **Database**: Neon Serverless PostgreSQL to store user info and session detail
+* **Database**: Neon Serverless Postgres to store user info and session detail
 * **ORM**: [Prisma ORM](https://www.prisma.io/) for database interactions
 * **Deployment Region**: US East (Ohio)
 
@@ -32,14 +32,8 @@ Given the high number of connections used by this application, [connection pooli
 
 ### Compute hours and storage:
 
-* **Compute hours.** This metric refers to the size of CPU required to handle your interactions plus the length of time your compute is active. The average daily compute usage is 23.94 hours, totaling 718.35 hours for the sample month. This indicates steady but low-intensity database usage.
+* **Compute hours.** This metric refers to the size of the CPU required to handle your interactions plus the length of time your compute is active (compute hours = compute size * active hours). The average daily compute usage is 23.94 hours, totaling 718.35 hours for the sample month. This indicates steady but low-intensity database usage.
 * **Storage.** The amount of database storage currently used by your project. It includes the total volume of data across all branches plus the shared history. The database is now over 25 GiB and growing steadily with new written data as the user base grows.
-
-### Which Pricing Plan fits best?
-
-With Neon pricing, two key metrics help you decide which [pricing plan](https://neon.tech/pricing) is right for you: compute hours and storage.
-
-At roughly 718 compute hours for the month, with a compute size of 0.25 vCPU, this application is well under the 1,200 active hours/month limit for the Launch plan. However, with a storage size of 25 GiB, the storage needs for this application are well over the Launch plan limit of 10 GiB. That makes the [Scale](/docs/introduction/plans#scale) plan the right choice: 3,000 active hours/month compute and 50 GiB storage.
 
 ## Consumption breakdown for the month
 
@@ -53,13 +47,9 @@ Compute usage is steady at almost 24 compute hours per day across the month.
 
 Daily average of 23.94 compute hours leads to a total of 713.35 compute hours for the month.
 
-This is well below the [Scale](/docs/introduction/plans#scale) plan limit of 3,000 hours/month, so there will be no charge for extra usage. The application is on track to be charged the set monthly rate for the Scale plan. The extra monthly compute allowance in this case could even be used to increase the size of your compute or enable Autoscaling for optimal performance. 
-
 ### Storage
 
 Project storage grew 4.4 GiB over the month, from 23.6 GiB to 28 GiB.
-
-This storage level is too high for the Launch plan but well under the 50 GiB limit for the [Scale](/docs/introduction/plans#scale) plan. No charge for extra storage.
 
 ![Sample storage graph](/docs/introduction/billing_storage_graph.png)
 
@@ -73,8 +63,30 @@ Here are the daily averages and monthly totals for the 2 key usage metrics that 
 
  Metric           | Start of billing period| End of billing period |
 |-----------------|---------------|---------------|
-| Data storage    | 23.6 GiB        | 28 GiB         |
+| Storage         | 23.6 GiB        | 28 GiB      |
 
-## Bill for the month
+### Which Neon pricing plan fits best?
 
-Since compute hours and storage size are well below the limits for the selected [Scale](/docs/introduction/plans#scale) plan, the bill for the month will come in at the set rate of **$69**.
+At roughly 718 compute hours for the month with a compute size of 0.25 vCPU, this application is well under the 1,200 active hours/month allowance for the [Launch](/docs/introduction/plans##launch) plan and 3000 active hours/month allowance for the [Scale](/docs/introduction/plans#scale) plan. However, with a storage size of 25 GiB, the storage requirements for the application are over the Launch plan allowance of 10 GiB. You could go with the Launch plan which offers 10 GiB of storage plus extra storage at $3.5 per 2 GiB unit or the Scale plan which offers 50 GiB storage. Let's do that math to compare monthly bills:
+
+**Launch plan**:
+
+- Base fee: $19
+- Storage usage: 25 GiB (15 GiB over the allowance)
+- Compute usage: 718 hours (within the 1200 hour allowance)
+- Extra storage fee: 8 * $3.5 = $28
+- Extra compute fee: $0
+
+_Total estimate_: $19 + $28 = $47 per month
+
+**Scale plan**:
+
+- Base fee: $69
+- Storage usage: 25 GiB (within the 50 GiB allowance)
+- Compute usage: 718 hours (within the 3000 allowance)
+- Extra storage fee: $0
+- Extra compute fee: $0
+
+_Total estimate_: $69 per month
+
+The Launch plan is more economical in the short term, but you should consider upgrading to the [Scale](/docs/introduction/plans#scale) plan when purchasing extra storage on the Launch plan is no longer cheaper than the $69 per month Scale plan. The Scale plan has a higher monthly storage allowance (50 GiB) and a cheaper per-unit extra storage cost (10 GiB at $15 vs. 2 GiB at $3.5). The Scale plan also offers additional features and more projects, which may factor into your decision about when to upgrade from the Launch plan.

--- a/content/docs/introduction/how-billing-works.md
+++ b/content/docs/introduction/how-billing-works.md
@@ -39,11 +39,11 @@ The [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/pl
 
 |                | Launch   | Scale    |
 |----------------|----------|----------|
+| Extra Storage  | &check;  | &check;  |
 | Extra Compute  | &check;  | &check;  |
 | Extra Projects |          | &check;  |
-| Extra Storage  |          | &check;  |
 
-The Launch plan only supports extra compute usage. If you are on the Launch plan and require extra projects or storage, you must upgrade to the Scale plan, which provides higher storage and project allowances. Once on the Scale plan, you have access to all extra usage types (storage, compute, and project) should you require it.
+The Launch plan does not support extra projects. If you are on the Launch plan and require extra projects, you must upgrade to the Scale plan, which provides higher project allowances.
 
 ## How does extra usage work?
 
@@ -51,7 +51,11 @@ Taking advantage of extra usage requires no user action. Extra usage, if support
 
 ### Storage
 
-Extra storage is available with the [Scale](/docs/introduction/plans##scale) plan. Extra storage is billed in increments of 10 GiB at $15 per increment. For example, the Scale plan includes an allowance of 50 GiB in the plan's monthly fee. If you exceed 50 GiB of storage, you are automatically billed for an extra storage increment of 10 GiB at $15 per increment. If you exceed 60 GiB, you are billed for 2 increments of 10 GiB (an extra $30), and so on. 
+Extra storage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans.
+- On the Launch plan, extra storage is billed for in units of 2 GiB at $3.5 each.
+- On the Scale plan, extra storage is billed for in units of 10 GiB at $15 each.
+
+For example, the Launch plan includes an allowance of 10 GiB in the plan's monthly fee. If you exceed 10 GiB of storage, you are automatically billed for an extra storage unit of 2 GiB at $3.5 per unit. If you exceed 12 GiB, you are billed for 2 units of 2 GiB (an extra $7), and so on. It works the same way on the Storage plan, but with 10 GiB units of storage at $15 per unit.
 
 ### Compute
 

--- a/content/docs/introduction/how-billing-works.md
+++ b/content/docs/introduction/how-billing-works.md
@@ -135,7 +135,7 @@ Total Monthly Estimate = Monthly Base Fee + Extra Storage Fee + Extra Compute Fe
 - Extra storage fee: 2 * $3.5 = $7
 - Extra compute fee: 50 hours * $0.04 = $2
 
-_Total estimate_: $19 + 7 + $2 = $28 per month
+_Total estimate_: $19 + $7 + $2 = $28 per month
 
 **Scale plan example**:
 

--- a/content/docs/introduction/how-billing-works.md
+++ b/content/docs/introduction/how-billing-works.md
@@ -51,9 +51,9 @@ Taking advantage of extra usage requires no user action. Extra usage, if support
 
 ### Storage
 
-Extra storage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans.
-- On the Launch plan, extra storage is billed for in units of 2 GiB at $3.5 each.
-- On the Scale plan, extra storage is billed for in units of 10 GiB at $15 each.
+Extra storage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans:
+- On the Launch plan, extra storage is billed for in units of 2 GiB at $3.5 each
+- On the Scale plan, extra storage is billed for in units of 10 GiB at $15 each
 
 For example, the Launch plan includes an allowance of 10 GiB in the plan's monthly fee. If you exceed 10 GiB of storage, you are automatically billed for an extra storage unit of 2 GiB at $3.5 per unit. If you exceed 12 GiB, you are billed for 2 units of 2 GiB (an extra $7), and so on. It works the same way on the Storage plan, but with 10 GiB units of storage at $15 per unit.
 
@@ -106,8 +106,9 @@ Each [plan](/docs/introduction/plans) comes with base allowances for **Storage**
 
 #### For the Launch plan:
 
-The Launch plan supports extra compute usage. If you need extra storage or projects, you'll need to move up to the Scale plan.
+The Launch plan supports extra **Storage** and **Compute**. If you need extra projects, you'll need to move up to the Scale plan.
 
+- **Extra Storage**: If you exceed 10 GiB, extra storage is billed in units of 2 GiB at $3.5 per unit.
 - **Extra Compute**: If you exceed 300 compute hours, extra compute is billed at $0.04/hour.
 
 #### For the Scale plan:
@@ -129,10 +130,12 @@ Total Monthly Estimate = Monthly Base Fee + Extra Storage Fee + Extra Compute Fe
 **Launch plan example**:
 
 - Base fee: $19
+- Storage usage: 14 GiB (4 GiB over the allowance)
 - Compute usage: 350 hours (50 hours over the allowance)
+- Extra storage fee: 2 * $3.5 = $7
 - Extra compute fee: 50 hours * $0.04 = $2
 
-_Total estimate_: $19 + $2 = $21 per month
+_Total estimate_: $19 + 7 + $2 = $28 per month
 
 **Scale plan example**:
 

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -59,14 +59,14 @@ The Launch plan provides all of the resources, features, and support you need to
 | **Storage**                             | Up to 10 GiB of data storage                                  |
 | **Compute**                             | Up to  300 compute hours (1,200 _active hours_)/month for all computes in all projects |
 
-Launch plan users can access extra compute hours beyond the 300 compute hours/month included in the Launch plan. Extra compute hours are billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour cost.
+Launch plan users can access extra compute hours beyond the 300 compute hours/month included in the Launch plan. Extra compute hours are billed automatically.
 
 In addition, Launch plan users have access to the following Neon features:
 
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 4 vCPUs and 16 GB RAM, _Autosuspend_ (**5 minutes+** or never).
 - [Advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, and 60+ Postgres extensions.
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **7 days** in the past, time travel connections, and more.
-- [Extra usage](/docs/introduction/how-billing-works#extra-usage): Launch plan users can access extra compute usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute cost.
+- [Extra usage](/docs/introduction/how-billing-works#extra-usage): Launch plan users can access extra compute and storage usage, which is billed automatically.
 - [Standard support](/docs/introduction/support): Launch plan users have access to **Standard** Neon support, which offers access to the Neon Support team via support tickets.
 
 ### Scale
@@ -86,7 +86,7 @@ In addition, Scale plan users have access to the following Neon features:
 - [All compute features](#compute-features): Includes [compute sizes](#compute-size) up to 8 vCPUs and 32 GB RAM, _Autosuspend_ (**1 minute+** or never).
 - [All advanced Postgres features](#advanced-postgres-features): Connection pooling, logical replication, 60+ Postgres extensions, and customer-provided custom extensions.
 - [All additional features](#additional-features): Includes [point-in-time restore](#point-in-time-recovery) up to **30 days** in the past, time travel connections, and more.
-- [Extra usage](/docs/introduction/how-billing-works#extra-usage): Scale plan users can access extra compute and storage usage, which is billed automatically. Please refer to our [pricing](https://neon.tech/pricing) page for the per-hour compute and extra storage prices.
+- [Extra usage](/docs/introduction/how-billing-works#extra-usage): Scale plan users can access extra compute and storage usage, which is billed automatically.
 - [Priority support](/docs/introduction/support): Scale plan users have access to **Priority** Neon support, which offers _priority_ access to the Neon Support team via support tickets.
 
 ### Enterprise

--- a/content/docs/introduction/usage-metrics.md
+++ b/content/docs/introduction/usage-metrics.md
@@ -23,9 +23,9 @@ The following table outlines data storage allowances per month for each Neon pla
 | Scale      | 50 GiB     |
 | Enterprise | Larger sizes |
 
-Extra storage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans.
-- On the Launch plan, extra storage is billed for in units of 2 GiB at $3.5 each.
-- On the Scale plan, extra storage is billed for in units of 10 GiB at $15 each.
+Extra storage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans:
+- On the Launch plan, extra storage is billed for in units of 2 GiB at $3.5 each
+- On the Scale plan, extra storage is billed for in units of 10 GiB at $15 each
 
 ### Storage details
 

--- a/content/docs/introduction/usage-metrics.md
+++ b/content/docs/introduction/usage-metrics.md
@@ -23,7 +23,9 @@ The following table outlines data storage allowances per month for each Neon pla
 | Scale      | 50 GiB     |
 | Enterprise | Larger sizes |
 
-Extra storage is available with the [Scale](/docs/introduction/plans##scale) plan and is billed for in units of 10 GiB at $15 each.
+Extra storage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans.
+- On the Launch plan, extra storage is billed for in units of 2 GiB at $3.5 each.
+- On the Scale plan, extra storage is billed for in units of 10 GiB at $15 each.
 
 ### Storage details
 


### PR DESCRIPTION
We now allow extra storage to be purchased on the Launch plan @ $3.5 per 2 GiB
- Extra storage:
https://neon-next-git-dprice-launch-plan-update-neondatabase.vercel.app/docs/introduction/how-billing-works#extra-usage
- Revisions throughout billing content for this change