### PR TITLE
Fix MySQL migration docs card title

### DIFF
--- a/content/docs/import/import-intro.md
+++ b/content/docs/import/import-intro.md
@@ -23,6 +23,6 @@ Find instructions for importing data from Postgres, CSV, other Neon projects, an
 
 <a href="/docs/import/import-sample-data" description="Load one of several sample datasets for exploration and testing" icon="import">Load sample data</a>
 
-<a href="/docs/import/migrate-mysql" description="Learn how to migrate your MySQL database to Neon Postgres using pgloader." icon="import">Load sample data</a>
+<a href="/docs/import/migrate-mysql" description="Learn how to migrate your MySQL database to Neon Postgres using pgloader." icon="import">Migrate from MySQL</a>
 
 </DetailIconCards>


### PR DESCRIPTION
Fix the title of the MySQL migration card. Copy-paste error.