### PR TITLE
Add Launch storage pricing

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -93,7 +93,7 @@
         "title": "Storage"
       },
       "free": false,
-      "launch": "$3.5 <span>per 2 GiB</span>",
+      "launch": "$3.50 <span>per 2 GiB</span>",
       "scale": "$15 <span>per 10 GiB</span>",
       "enterprise": "Custom"
     },

--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -93,7 +93,7 @@
         "title": "Storage"
       },
       "free": false,
-      "launch": false,
+      "launch": "$3.5 <span>per 2 GiB</span>",
       "scale": "$15 <span>per 10 GiB</span>",
       "enterprise": "Custom"
     },


### PR DESCRIPTION
This adds an overage rate of $3.5 per 10 GiB for the launch tier in the pricing details table.
![image](https://github.com/neondatabase/website/assets/11527560/f5117b8b-03c0-49af-951f-4c2a19d2af03)
