### PR TITLE
style: new color for blog category

### DIFF
--- a/src/constants/blog.js
+++ b/src/constants/blog.js
@@ -9,13 +9,6 @@ const CATEGORY_COLORS = {
   'case-study': 'text-pink-90',
 };
 
-const CATEGORY_HOVER_COLORS = {
-  company: 'hover:text-[#4DFFC4]',
-  engineering: 'hover:text-[#CAC2F0]',
-  community: 'hover:text-[#F7F7B6]',
-  ai: 'hover:text-[#C1E8FF]',
-};
-
 const CATEGORY_BG_COLORS = {
   company: 'bg-green-45/10',
   engineering: 'bg-purple-70/10',
@@ -28,7 +21,6 @@ export {
   BLOG_BASE_PATH,
   BLOG_POSTS_PER_PAGE,
   CATEGORY_COLORS,
-  CATEGORY_HOVER_COLORS,
   CATEGORY_BG_COLORS,
   BLOG_CATEGORY_BASE_PATH,
 };

--- a/src/constants/blog.js
+++ b/src/constants/blog.js
@@ -6,6 +6,7 @@ const CATEGORY_COLORS = {
   engineering: 'text-purple-70',
   community: 'text-yellow-70',
   ai: 'text-blue-80',
+  'case-study': 'text-pink-90',
 };
 
 const CATEGORY_HOVER_COLORS = {
@@ -20,6 +21,7 @@ const CATEGORY_BG_COLORS = {
   engineering: 'bg-purple-70/10',
   community: 'bg-yellow-70/10',
   ai: 'bg-blue-80/10',
+  'case-study': 'bg-pink-90/10',
 };
 
 export {


### PR DESCRIPTION
This PR adds pink color for the category "case studies" on Blog page and remove old not-usable constant. 

[preview 1](https://neon-next-git-color-neondatabase.vercel.app/blog/category/all-posts)
[preview 2](https://neon-next-git-color-neondatabase.vercel.app/blog/how-recrowd-uses-neon-autoscaling-to-meet-fluctuating-demand)