### PR TITLE
Billing updates

### DIFF
--- a/content/docs/introduction/how-billing-works.md
+++ b/content/docs/introduction/how-billing-works.md
@@ -59,7 +59,7 @@ For example, the Launch plan includes an allowance of 10 GiB in the plan's month
 
 ### Compute
 
-Extra compute usage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans. Extra compute usage is billed by _compute hour_ at $0.16 per hour. For example, the Launch plan has an allowance of 300 compute hours included in the plan's monthly fee. If you use 100 additional compute hours over the billing period, you are billed an extra $16.00 (100 x $0.16).
+Extra compute usage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans. Extra compute usage is billed by _compute hour_ at $0.16 per hour. For example, the Launch plan has an allowance of 300 compute hours included in the plan's monthly fee. If you use 100 additional compute hours over the billing period, you are billed an extra $16 (100 x $0.16).
 
 ### Projects
 
@@ -133,9 +133,9 @@ Total Monthly Estimate = Monthly Base Fee + Extra Storage Fee + Extra Compute Fe
 - Storage usage: 14 GiB (4 GiB over the allowance)
 - Compute usage: 350 hours (50 hours over the allowance)
 - Extra storage fee: 2 * $3.5 = $7
-- Extra compute fee: 50 hours * $0.16 = $2
+- Extra compute fee: 50 hours * $0.16 = $8
 
-_Total estimate_: $19 + $7 + $2 = $28 per month
+_Total estimate_: $19 + $7 + $8 = $34 per month
 
 **Scale plan example**:
 

--- a/content/docs/introduction/how-billing-works.md
+++ b/content/docs/introduction/how-billing-works.md
@@ -59,7 +59,7 @@ For example, the Launch plan includes an allowance of 10 GiB in the plan's month
 
 ### Compute
 
-Extra compute usage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans. Extra compute usage is billed by _compute hour_ at $0.04 per hour. For example, the Launch plan has an allowance of 300 compute hours included in the plan's monthly fee. If you use 100 additional compute hours over the billing period, you are billed an extra $4 (100 x $0.04).
+Extra compute usage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans. Extra compute usage is billed by _compute hour_ at $0.16 per hour. For example, the Launch plan has an allowance of 300 compute hours included in the plan's monthly fee. If you use 100 additional compute hours over the billing period, you are billed an extra $16.00 (100 x $0.16).
 
 ### Projects
 
@@ -109,14 +109,14 @@ Each [plan](/docs/introduction/plans) comes with base allowances for **Storage**
 The Launch plan supports extra **Storage** and **Compute**. If you need extra projects, you'll need to move up to the Scale plan.
 
 - **Extra Storage**: If you exceed 10 GiB, extra storage is billed in units of 2 GiB at $3.5 per unit.
-- **Extra Compute**: If you exceed 300 compute hours, extra compute is billed at $0.04/hour.
+- **Extra Compute**: If you exceed 300 compute hours, extra compute is billed at $0.16/hour.
 
 #### For the Scale plan:
 
 The Scale plan supports extra **Storage**, **Compute**, and **Projects**.
 
 - **Extra Storage**: If you exceed 50 GiB, extra storage is billed in increments of 10 GiB at $15 per increment.
-- **Extra Compute**: If you exceed 750 compute hours, extra compute is billed at $0.04/hour.
+- **Extra Compute**: If you exceed 750 compute hours, extra compute is billed at $0.16/hour.
 - **Extra Projects**: If you exceed 50 projects, extra projects are billed in units of 10 projects at $50 per unit.
 
 ### Step 5: Total monthly estimate
@@ -133,7 +133,7 @@ Total Monthly Estimate = Monthly Base Fee + Extra Storage Fee + Extra Compute Fe
 - Storage usage: 14 GiB (4 GiB over the allowance)
 - Compute usage: 350 hours (50 hours over the allowance)
 - Extra storage fee: 2 * $3.5 = $7
-- Extra compute fee: 50 hours * $0.04 = $2
+- Extra compute fee: 50 hours * $0.16 = $2
 
 _Total estimate_: $19 + $7 + $2 = $28 per month
 
@@ -144,10 +144,10 @@ _Total estimate_: $19 + $7 + $2 = $28 per month
 - Compute usage: 800 hours (50 hours over the allowance)
 - Project usage: 55 projects (5 projects over the allowance)
 - Extra storage fee: 1 * $15 = $15
-- Extra compute fee: 50 * $0.04 = $2
+- Extra compute fee: 50 * $0.16 = $8
 - Extra project fee: 1 * $50 = $50
 
-_Total estimate_: $69 + $15 + $2 + $50 = $136 per month
+_Total estimate_: $69 + $15 + $8 + $50 = $142 per month
 
 <Admonition type="note" title="Notes">
 - Adjust your usage estimates as needed to reflect your actual or projected usage.

--- a/content/docs/introduction/usage-metrics.md
+++ b/content/docs/introduction/usage-metrics.md
@@ -58,7 +58,7 @@ The following table outlines compute allowances per month for each Neon plan.
 | Scale      | 750 compute hours (3,000 _active hours_)/month                                                                                            |
 | Enterprise | Custom                                                                                                            |
 
-Extra compute usage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans. Extra compute usage is billed for at $0.04 per compute hour. For example, the Launch plan has an allowance of 300 compute hours included in the plan's monthly fee. If you use 100 additional compute hours over the monthly billing period, you are billed an extra $4 (100 x $0.04) for the month.
+Extra compute usage is available with the [Launch](/docs/introduction/plans##launch) and [Scale](/docs/introduction/plans##scale) plans. Extra compute usage is billed for at $0.16 per compute hour. For example, the Launch plan has an allowance of 300 compute hours included in the plan's monthly fee. If you use 100 additional compute hours over the monthly billing period, you are billed an extra $16 (100 x $0.16) for the month.
 
 <Admonition type="tip" title="What are active hours and compute hours?">
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -124,7 +124,6 @@ A unit that measures the processing power of a Neon compute or the "compute size
 | 7             | 7    | 28 GB  |
 | 8             | 8    | 32 GB  |
 
-
 ## Compute hours
 
 A usage metric for tracking compute usage. 1 compute hour is equal to 1 [active hour](#active-hours) for a compute with 1 vCPU. If you have a compute with .25 vCPU, as you would on the Neon Free Tier, it would require 4 _active hours_ to use 1 compute hour. On the other hand, if you have a compute with 4 vCPU, it would only take 15 minutes to use 1 compute hour.

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -15,6 +15,8 @@ See [Token](#token).
 
 A usage metric that tracks the amount of time a compute is active, rather than idle when suspended due to inactivity. The time that your compute is idle is not counted toward compute usage.
 
+Also see [Compute hours](#compute-hours).
+
 ## Activity Monitor
 
 A process that monitors a Neon compute instance for activity. During periods of inactivity, the Activity Monitor gracefully places the compute into an `Idle` state to save energy and resources. The Activity Monitor closes idle connections after 5 minutes of inactivity. When a connection is made to an idle compute, the Activity Monitor reactivates the compute.
@@ -109,9 +111,9 @@ The number of Compute Units (CU) assigned to a Neon compute. One CU is defined a
 
 A unit that measures the processing power of a Neon compute. A Neon compute can have anywhere from .25 CUs to 7 CUs.
 
-## Compute hour
+## Compute hours
 
-A usage metric for tracking compute usage. 1 compute hour is equal to one _active hour_ for a compute with 1 vCPU. If you have a compute with .25 vCPU, as you would on the Neon Free Tier, it would require 4 _active hours_ to use 1 compute hour. On the other hand, if you have a compute with 4 vCPU, it would only take 15 minutes to use 1 compute hour.
+A usage metric for tracking compute usage. 1 compute hour is equal to 1 [active hour](#active-hours) for a compute with 1 vCPU. If you have a compute with .25 vCPU, as you would on the Neon Free Tier, it would require 4 _active hours_ to use 1 compute hour. On the other hand, if you have a compute with 4 vCPU, it would only take 15 minutes to use 1 compute hour.
 
 To calculate compute hour usage, you would use the following formula:
 
@@ -120,6 +122,8 @@ compute hours = active hours x compute size
 ```
 
 For more information, see [Compute](/docs/introduction/usage-metrics#compute).
+
+Also see [Active hours](#active-hours).
 
 ## Console
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -109,7 +109,21 @@ The number of Compute Units (CU) assigned to a Neon compute. One CU is defined a
 
 ## Compute Unit (CU)
 
-A unit that measures the processing power of a Neon compute. A Neon compute can have anywhere from .25 CUs to 7 CUs.
+A unit that measures the processing power of a Neon compute or the "compute size". A Compute Unit (CU) includes vCPU and RAM. A Neon compute can have anywhere from .25 CUs to 8 CUs. The following table shows the vCPU and RAM for each CU:
+
+| Compute Unit (CU)  | vCPU | RAM    |
+|:--------------|:-----|:-------|
+| .25           | .25  | 1 GB   |
+| .5            | .5   | 2 GB   |
+| 1             | 1    | 4 GB   |
+| 2             | 2    | 8 GB   |
+| 3             | 3    | 12 GB  |
+| 4             | 4    | 16 GB  |
+| 5             | 5    | 20 GB  |
+| 6             | 6    | 24 GB  |
+| 7             | 7    | 28 GB  |
+| 8             | 8    | 32 GB  |
+
 
 ## Compute hours
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -109,7 +109,7 @@ The number of Compute Units (CU) assigned to a Neon compute. One CU is defined a
 
 ## Compute Unit (CU)
 
-A unit that measures the processing power of a Neon compute or the "compute size". A Compute Unit (CU) includes vCPU and RAM. A Neon compute can have anywhere from .25 CUs to 8 CUs. The following table shows the vCPU and RAM for each CU:
+A unit that measures the processing power or "size" of a Neon compute. A Compute Unit (CU) includes vCPU and RAM. A Neon compute can have anywhere from .25 to 8 CUs. The following table shows the vCPU and RAM for each CU:
 
 | Compute Unit (CU)  | vCPU | RAM    |
 |:--------------|:-----|:-------|


### PR DESCRIPTION
- Change compute hours costs. $0.04 was for .25 vCPU. It's $0.16 for 1 vCPU.
- Link glossary terms for compute hours and active hours