### PR TITLE
Better link for supported extensions

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -202,7 +202,7 @@
       "rows": "2",
       "feature": {
         "title": "Standard Extensions",
-        "subtitle": "View <a href='/docs/extensions/pg-extensions' class='underline'>Supported Extensions</a>"
+        "subtitle": "View <a href='/docs/extensions/extensions-intro' class='underline'>Supported Extensions</a>"
       },
       "free": true,
       "launch": true,


### PR DESCRIPTION
Update the link to Postgres extensions on the Pricing page.
This link provides a nicer categorized view of supported extensions:
[/docs/extensions/extensions-intro](https://neon.tech/docs/extensions/extensions-intro)