### PR TITLE
style: mobile text size for h3 for blog article

### DIFF
--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -2,7 +2,7 @@
   .prose-blog {
     @apply max-w-none leading-normal text-gray-new-90 prose-p:my-4 prose-p:text-gray-new-90 prose-strong:text-gray-new-90 prose-ol:my-5 prose-ul:my-5 prose-li:my-4;
     @apply prose-headings:font-medium prose-headings:leading-tight prose-headings:tracking-tighter prose-headings:text-white;
-    @apply prose-h2:mb-5 prose-h2:mt-10 prose-h2:text-[36px] prose-h3:mb-4 prose-h3:mt-7 prose-h3:text-[28px] prose-h4:mb-4 prose-h4:mt-6 prose-h4:text-2xl prose-h5:mb-4 prose-h5:mt-5 prose-h5:text-xl md:prose-h2:text-[32px] sm:prose-h2:text-[26px];
+    @apply prose-h2:mb-5 prose-h2:mt-10 prose-h2:text-[36px] prose-h3:mb-4 prose-h3:mt-7 prose-h3:text-[28px] prose-h4:mb-4 prose-h4:mt-6 prose-h4:text-2xl prose-h5:mb-4 prose-h5:mt-5 prose-h5:text-xl md:prose-h2:text-[32px] sm:prose-h2:text-[26px] sm:prose-h3:text-[20px];
     @apply prose-a:font-normal prose-a:text-green-45 prose-a:no-underline prose-a:transition-colors prose-a:duration-200 prose-a:ease-in-out hover:prose-a:text-[#47FFC2] sm:prose-a:break-words;
     @apply prose-figure:my-10 prose-img:my-10 md:prose-figure:my-8 md:prose-img:my-8;
     @apply prose-pre:my-0 prose-pre:px-2;


### PR DESCRIPTION
Adjust the text size of H3 headings for a mobile view in a blog article.

[Preview](https://neon-next-git-heading-size-neondatabase.vercel.app/blog/easily-anonymize-production-data-in-postgres) 