### PR TITLE
Docs: Clarify where neonConfig comes from in serverless driver docs

### DIFF
--- a/content/docs/serverless/serverless-driver.md
+++ b/content/docs/serverless/serverless-driver.md
@@ -372,6 +372,7 @@ export default async function handler(
 - In Node.js and some other environments, there's no built-in WebSocket support. In these cases, supply a WebSocket constructor function.
 
   ```javascript
+  import { Pool, neonConfig } from '@neondatabase/serverless';
   import ws from 'ws';
   neonConfig.webSocketConstructor = ws;
   ```


### PR DESCRIPTION
We currently have this callout in Serverless Driver docs: 

![image](https://github.com/neondatabase/website/assets/11527560/3ce328c1-be9d-44b7-9213-a7133b9e1525)

But it was confusing... Where is neonConfig coming from? Other examples in the page and GitHub led me to the answer but I think it's clearer to explicitly demonstrate how everything works together