### PR TITLE
chore: admonition spacing, add aws label

### DIFF
--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -211,7 +211,7 @@ const Hero = () => {
                     }
                   }}
                 >
-                  {isScalePlan && (
+                  {(isScalePlan || type === 'Launch') && (
                     <a
                       className="group/aws absolute right-[18px] top-5 flex items-center gap-x-2"
                       href="https://aws.amazon.com/marketplace/saas/ordering?productId=prod-ro32fhzkkg7ya&offerId=offer-czr2a3vwvrtik"

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -214,7 +214,9 @@ const Hero = () => {
                   {(isScalePlan || type === 'Launch') && (
                     <a
                       className="group/aws absolute right-[18px] top-5 flex items-center gap-x-2"
-                      href="https://aws.amazon.com/marketplace/saas/ordering?productId=prod-ro32fhzkkg7ya&offerId=offer-czr2a3vwvrtik"
+                      href="https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa"
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       <span className="border-b border-gray-new-40 pb-0.5 text-sm font-light leading-none tracking-extra-tight text-gray-new-70 opacity-90 transition-colors duration-200 group-hover/aws:border-transparent group-hover/aws:text-gray-new-80">
                         Pay via marketplace

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -7,6 +7,10 @@
       @apply mt-0;
     }
 
+    p {
+      @apply my-3;
+    }
+
     p:last-child {
       @apply mb-0;
     }


### PR DESCRIPTION
This pull request brings small updates:

- spacing for admonition paragraphs
- adds aws label to launch card on pricing page

Steps to check:

- open previews ([docs](https://neon-next-git-fix-admonition-add-pricing-label-neondatabase.vercel.app/docs/guides/polyscale-integration), [pricing](https://neon-next-git-fix-admonition-add-pricing-label-neondatabase.vercel.app/pricing))
- make sure that everything looks and works as expected