### PR TITLE
Removing the ComingSoon admonition from GA features

### DIFF
--- a/content/docs/get-started-with-neon/query-with-neon-sql-editor.md
+++ b/content/docs/get-started-with-neon/query-with-neon-sql-editor.md
@@ -67,8 +67,6 @@ Understanding the information provided by the **Explain** and **Analyze** featur
 
 ## Time Travel
 
-<ComingSoon/>
-
 You can toggle Time Travel in the SQL Editor to switch from querying your current data to querying against a selected point within your [history retention window](/docs/manage/projects#configure-history-retention).
 
 ![time travel in SQL Editor](/docs/get-started-with-neon/time_travel_sql_editor.png "no-border")
@@ -78,8 +76,6 @@ For more details about using Time Travel queries, see:
 - [Time Travel tutorial](/docs/guides/time-travel-tutorial)
 
 ## Meta-commands
-
-<ComingSoon/>
 
 The Neon SQL Editor supports using Postgres meta-commands, which act like shortcuts for interacting with your database. If you are already familiar with using meta-commands from the `psql` command-line interface, you can use many of those same commands in the SQL Editor.
 

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -4,8 +4,6 @@ subtitle: Step-by-step guide showing you how to compare two development branches
 enableTableOfContents: true
 ---
 
-<ComingSoon/>
-
 In this guide we will create an initial schema on a new database called `people` on our `main` branch. We'll then create a development branch called `dev/jordan`, following our recommended convention for naming development branches. After making schema changes on `dev/jordan`, we'll use the **Schema Diff** tool on the **Branches** page to get a side-by-side, Github-style visual comparison between the `dev/jordan` development branch and `main`.
 
 ## Before you start

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -4,8 +4,6 @@ subtitle: Learn how to use Neon's Schema Diff tool to compare branches of your d
 enableTableOfContents: true
 ---
 
-<ComingSoon/>
-
 Neon's Schema Diff tool lets you compare an SQL script of the schemas for two selected branches in a side-by-side view (or line-by-line on mobile devices).
 
 ## How Schema Diff works

--- a/content/docs/guides/time-travel-assist.md
+++ b/content/docs/guides/time-travel-assist.md
@@ -42,8 +42,6 @@ Time Travel only allows non-destructive read-only queries. You cannot alter hist
 
 ### Time Travel with the SQL editor
 
-<ComingSoon/>
-
 Time Travel in the SQL Editor offers a non-destructive way to explore your database's historical data through read-only queries. By toggling Time Travel in the editor, you switch from querying your current data to querying against a selected point within your history retention window.
 
 You can use this feature to help with scenarios like:

--- a/content/docs/guides/time-travel-tutorial.md
+++ b/content/docs/guides/time-travel-tutorial.md
@@ -4,8 +4,6 @@ subtitle: Use Time Travel to analyze changes made to your database over time
 enableTableOfContents: true
 ---
 
-<ComingSoon/>
-
 This guide demonstrates how you could use Time Travel to address a common development scenario: debugging issues following a CI/CD deployment to production.
 
 In this scenario, your team has recently introduced a streamlined checkout process, managed by a `new_checkout_process` feature flag. Soon after this flag was enabled, customer support started receiving complaints related to the new feature. As a developer, you're tasked with investigating the issues to confirm whether they are directly linked to the feature's activation.


### PR DESCRIPTION
The FF is now open for all users for schema diff, time travel, and /d commands. Removing the <ComingSoon/> admonition from relevant locations.