### PR TITLE
Adjust CLI reset and restore examples

### DIFF
--- a/content/docs/guides/branching-neon-cli.md
+++ b/content/docs/guides/branching-neon-cli.md
@@ -148,7 +148,7 @@ neonctl branches reset dev/alex --parent
 ┌────────────────────────────┬──────────┬─────────┬──────────────────────┬──────────────────────┐
 │ Id                         │ Name     │ Primary │ Created At           │ Last Reset At        │
 ├────────────────────────────┼──────────┼─────────┼──────────────────────┼──────────────────────┤
-│ br-twilight-smoke-123456 │ dev/alex │ false   │ 2024-04-23T17:01:49Z │ 2024-04-23T17:57:35Z │
+│ br-twilight-smoke-123456   │ dev/alex │ false   │ 2024-04-23T17:01:49Z │ 2024-04-23T17:57:35Z │
 ```
 
 If the branch you want to reset has child branches, you need to include the `preserve-under-name` parameter. This will save the current state of your branch under a new name before performing the reset. The child branches will then show this newly named branch as their parent. This step ensures that your original branch can be reset cleanly, as all child branches will have been transferred to the new parent name.
@@ -171,6 +171,30 @@ Using the CLI, you can restore a branch to an earlier point in its history or an
 
 ``` bash shouldWrap
 neonctl branches restore <target id|name> <source id|name @ timestamp|lsn>
+```
+
+This command restores the branch `main` to an earlier timestamp in it's own history, saving to a backup branch called `main_restore_backup_2024-02-20`
+
+```bash shouldWrap
+neonctl branches restore main ^self@2024-05-06T10:00:00.000Z --preserve-under-name main_restore_backup_2024-05-06   
+```
+
+Results of the operation:
+
+```bash shouldWrap
+INFO: Restoring branch br-purple-dust-a5hok5mk to the branch br-purple-dust-a5hok5mk timestamp 2024-05-06T10:00:00.000Z
+Restored branch
+┌─────────────────────────┬──────┬──────────────────────┐
+│ Id                      │ Name │ Last Reset At        │
+├─────────────────────────┼──────┼──────────────────────┤
+│ br-purple-dust-a5hok5mk │ main │ 2024-05-07T09:45:21Z │
+└─────────────────────────┴──────┴──────────────────────┘
+Backup branch
+┌─────────────────────────┬────────────────────────────────┐
+│ Id                      │ Name                           │
+├─────────────────────────┼────────────────────────────────┤
+│ br-flat-forest-a5z016gm │ main_restore_backup_2024-05-06 │
+└─────────────────────────┴────────────────────────────────┘
 ```
 
 For full details about the different restore options available with this command, see [Restoring using the CLI](/docs/guides/branch-restore#how-to-use-branch-restore).

--- a/content/docs/guides/branching-neon-cli.md
+++ b/content/docs/guides/branching-neon-cli.md
@@ -143,6 +143,8 @@ neonctl branches reset <id|name> --parent
 
 Example:
 
+This example resets a developer's branch to match the latest state of its parent branch:
+
 ``` bash
 neonctl branches reset dev/alex --parent
 ┌────────────────────────────┬──────────┬─────────┬──────────────────────┬──────────────────────┐
@@ -153,7 +155,7 @@ neonctl branches reset dev/alex --parent
 
 If the branch you want to reset has child branches, you need to include the `preserve-under-name` parameter. This will save the current state of your branch under a new name before performing the reset. The child branches will then show this newly named branch as their parent. This step ensures that your original branch can be reset cleanly, as all child branches will have been transferred to the new parent name.
 
-For example, here we are resetting `dev/alex` to its parent, while preserving its latest state under the branch name `dev/alex_backup`:
+For example, here we are resetting `dev/alex` to its parent while preserving its latest state under the branch name `dev/alex_backup`:
 
 ```bash
 neon branches reset dev/alex --parent --preserve-under-name dev/alex_backup

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -302,13 +302,14 @@ In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-opt
 #### Example
 
 ```bash
-neonctl branches reset mybranch --parent
-┌──────────────────────────┬─────────────┬─────────┬──────────────────────┬──────────────────────┐
-│ Id                       │ Name        │ Primary │ Created At           │ Last Reset At        │
-├──────────────────────────┼─────────────┼─────────┼──────────────────────┼──────────────────────┤
-│ br-raspy-meadow-26349337 │ development │ false   │ 2023-11-28T19:19:11Z │ 2023-11-28T19:29:26Z │
-└──────────────────────────┴─────────────┴─────────┴──────────────────────┴──────────────────────┘
+neonctl branches reset dev/alex --parent
+┌──────────────────────┬──────────┬─────────┬──────────────────────┬──────────────────────┐
+│ Id                   │ Name     │ Primary │ Created At           │ Last Reset At        │
+├──────────────────────┼──────────┼─────────┼──────────────────────┼──────────────────────┤
+│ br-aged-sun-a5qowy01 │ dev/alex │ false   │ 2024-05-07T09:31:59Z │ 2024-05-07T09:36:32Z │
+└──────────────────────┴──────────┴─────────┴──────────────────────┴──────────────────────┘
 ```
+
 ## restore
 
 This command restores a branch to a specified point in time in its own or another branch's history.
@@ -346,28 +347,28 @@ Examples of the different kinds of restore operations you can do:
 
 #### Restoring a branch to an earlier point in its own history (with backup)
 
-This command restores the branch `dev/alex` to an earlier timestamp, saving to a backup branch called `restore_backup_2024-02-20`
+This command restores the branch `main` to an earlier timestamp, saving to a backup branch called `main_restore_backup_2024-02-20`
 
 ```bash shouldWrap
-neonctl branches restore dev/alex ^self@2024-02-21T10:00:00.000Z --preserve-under-name restore_backup_2024-02-20
+neonctl branches restore main ^self@2024-05-06T10:00:00.000Z --preserve-under-name main_restore_backup_2024-05-06   
 ```
 
 Results of the operation:
 
 ```bash shouldWrap
-INFO: Restoring branch br-restless-frost-69810125 to the branch br-restless-frost-69810125 timestamp 2024-02-21T10:00:00.000Z
+INFO: Restoring branch br-purple-dust-a5hok5mk to the branch br-purple-dust-a5hok5mk timestamp 2024-05-06T10:00:00.000Z
 Restored branch
-┌────────────────────────────┬──────────┬──────────────────────┐
-│ Id                         │ Name     │ Last Reset At        │
-├────────────────────────────┼──────────┼──────────────────────┤
-│ br-restless-frost-69810125 │ dev/alex │ 2024-02-21T15:48:05Z │
-└────────────────────────────┴──────────┴──────────────────────┘
+┌─────────────────────────┬──────┬──────────────────────┐
+│ Id                      │ Name │ Last Reset At        │
+├─────────────────────────┼──────┼──────────────────────┤
+│ br-purple-dust-a5hok5mk │ main │ 2024-05-07T09:45:21Z │
+└─────────────────────────┴──────┴──────────────────────┘
 Backup branch
-┌───────────────────────────┬───────────────────────────┐
-│ Id                        │ Name                      │
-├───────────────────────────┼───────────────────────────┤
-│ br-patient-union-a5s838zf │ restore_backup_2024-02-20 │
-└───────────────────────────┴───────────────────────────┘
+┌─────────────────────────┬────────────────────────────────┐
+│ Id                      │ Name                           │
+├─────────────────────────┼────────────────────────────────┤
+│ br-flat-forest-a5z016gm │ main_restore_backup_2024-05-06 │
+└─────────────────────────┴────────────────────────────────┘
 ```
 
 #### Restoring a branch (target) to the head of another branch (source)


### PR DESCRIPTION
Adjust CLI examples, as suggested:

<img width="1146" alt="image" src="https://github.com/neondatabase/website/assets/10074684/80376df8-7a9f-482c-9bc4-0e26851c64a8">

Reset branch example:
https://neon-next-git-dprice-update-cli-reset-resto-b97477-neondatabase.vercel.app/docs/reference/cli-branches#example

Restore branch example:
https://neon-next-git-dprice-update-cli-reset-resto-b97477-neondatabase.vercel.app/docs/reference/cli-branches#restoring-a-branch-to-an-earlier-point-in-its-own-history-with-backup
