### PR TITLE
Add /home clone in preparation for console redirect

### DIFF
--- a/src/app/(home-page)/home/page.jsx
+++ b/src/app/(home-page)/home/page.jsx
@@ -1,0 +1,36 @@
+import AiIndex from 'components/pages/home/ai-index';
+import Bento from 'components/pages/home/bento';
+import GetStarted from 'components/pages/home/get-started';
+import Hero from 'components/pages/home/hero/hero';
+import Industry from 'components/pages/home/industry';
+import InstantProvisioning from 'components/pages/home/instant-provisioning';
+import Lightning from 'components/pages/home/lightning';
+import Logos from 'components/pages/home/logos';
+import Multitenancy from 'components/pages/home/multitenancy';
+import Trusted from 'components/pages/home/trusted';
+import SEO_DATA from 'constants/seo-data';
+import getMetadata from 'utils/get-metadata';
+
+export const metadata = getMetadata({
+  ...SEO_DATA.index,
+  robotsNoindex: 'noindex',
+});
+
+const HomePage = () => (
+  <>
+    <Hero />
+    <Logos />
+    <InstantProvisioning />
+    <Lightning />
+    <Bento />
+    <AiIndex />
+    <Multitenancy />
+    <Industry />
+    <Trusted />
+    <GetStarted />
+  </>
+);
+
+export default HomePage;
+
+export const revalidate = 60;


### PR DESCRIPTION
Instead of deploying the console redirect in a single step, let's first add the `neon.tech/home` page so that console can add a link back to it here https://github.com/neondatabase/cloud/pull/13441