### PR TITLE
fix: 404 error instead of 500

### DIFF
--- a/src/app/[slug]/page.jsx
+++ b/src/app/[slug]/page.jsx
@@ -85,6 +85,8 @@ const DinamicPage = async ({ params }) => {
 export async function generateViewport({ params }) {
   const page = await getWpPageBySlug(params.slug);
 
+  if (!page) return notFound();
+
   const {
     template: { templateName },
   } = page;


### PR DESCRIPTION
This pull request resolves the issue of a 500 error occurring when visiting a non-existent page.

Steps to verify:

- open the preview of a non-existent page;
- ensure that it returns a 404 error instead of a 500 error.
