### PR TITLE
Add event tracking for button clicks site-wide

### DIFF
--- a/src/components/pages/home/get-started/get-started.jsx
+++ b/src/components/pages/home/get-started/get-started.jsx
@@ -37,6 +37,7 @@ const GetStarted = () => (
         theme="primary"
         to={LINKS.signup}
         target="_blank"
+        tag_name="Footer"
       >
         Get Started
       </Button>

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -119,7 +119,7 @@ const Hero = () => {
           <h1 className="font-title text-[72px] font-medium leading-none -tracking-[0.03em] text-white xl:text-[64px] lg:text-[48px] md:text-[40px] sm:text-[32px]">
             Ship faster with Postgres
           </h1>
-          <p className="lg:text-balance mx-auto mt-3.5 max-w-xl text-[19px] font-light leading-snug -tracking-[0.04em] text-gray-new-80 lg:mt-2.5 lg:max-w-lg lg:text-base sm:max-w-xs">
+          <p className="mx-auto mt-3.5 max-w-xl text-[19px] font-light leading-snug -tracking-[0.04em] text-gray-new-80 lg:mt-2.5 lg:max-w-lg lg:text-balance lg:text-base sm:max-w-xs">
             The database you love, on a serverless platform designed to help you build reliable and
             scalable applications faster.
           </p>
@@ -128,6 +128,7 @@ const Hero = () => {
             theme="primary"
             to={LINKS.signup}
             target="_blank"
+            tag_name="Hero"
           >
             Get Started
           </Button>

--- a/src/components/shared/button/button.jsx
+++ b/src/components/shared/button/button.jsx
@@ -1,7 +1,12 @@
+'use client';
+
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
 import Link from 'components/shared/link';
+import getNodeText from 'utils/get-node-text';
+import sendGtagEvent from 'utils/send-gtag-event';
+
 
 const styles = {
   base: 'inline-flex items-center justify-center font-bold !leading-none text-center whitespace-nowrap rounded-full transition-colors duration-200 outline-none',
@@ -45,6 +50,7 @@ const Button = ({
   to = null,
   size = null,
   theme = null,
+  tag_name = null,
   children,
   ...otherProps
 }) => {
@@ -53,7 +59,18 @@ const Button = ({
   const Tag = to ? Link : 'button';
 
   return (
-    <Tag className={className} to={to} {...otherProps}>
+    <Tag
+      className={className}
+      to={to}
+      onClick={() => {
+        sendGtagEvent('Button Clicked', {
+          style: theme,
+          text: getNodeText(children),
+          tag_name,
+        });
+      }}
+      {...otherProps}
+    >
       {children}
     </Tag>
   );
@@ -65,6 +82,7 @@ Button.propTypes = {
   size: PropTypes.oneOf(Object.keys(styles.size)),
   theme: PropTypes.oneOf(Object.keys(styles.theme)),
   children: PropTypes.node.isRequired,
+  tag_name: PropTypes.string,
 };
 
 export default Button;

--- a/src/utils/get-node-text.js
+++ b/src/utils/get-node-text.js
@@ -1,0 +1,22 @@
+export default function getNodeText(node) {
+  if (node == null) return '';
+
+  switch (typeof node) {
+    case 'string':
+    case 'number':
+      return node.toString();
+
+    case 'boolean':
+      return '';
+
+    case 'object': {
+      if (node instanceof Array) return node.map(getNodeText).join('');
+
+      if ('props' in node) return getNodeText(node.props.children);
+    } // eslint-ignore-line no-fallthrough
+
+    default:
+      console.warn('Unresolved `node` of type:', typeof node, node);
+      return '';
+  }
+}

--- a/src/utils/send-gtag-event.js
+++ b/src/utils/send-gtag-event.js
@@ -1,7 +1,5 @@
 export default function sendGtagEvent(eventName, properties) {
-  window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push({
-    event: eventName,
-    ...properties,
-  });
+  if (window.zaraz) {
+    window.zaraz.track(eventName, properties);
+  }
 }


### PR DESCRIPTION
Please review this PR closely, I don't want to break button clicks in any way.

This adds event tracking to _every_ <Button> on the site, the structure of the event is:
```
track("Button Clicked" {"style": "<theme>", "tag_name": "<optional extra tag to help disambiguate buttons", "text": "<text of button>"})
```

For example the homepage CTA is 
```
track("Button Clicked" {"style": "primary", "tag_name": "Hero", "text": "Get Started"});
```

FYI I've also switched from the legacy compatibility-mode usage of `window.datalayer.push` to the better-supported Zaraz-native, window.zaraz.track https://developers.cloudflare.com/zaraz/web-api/track/