### PR TITLE
feat: add retry graphql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@segment/analytics-next": "^1.67.0",
         "@splinetool/react-spline": "^2.2.6",
         "@tailwindcss/typography": "github:tailwindcss/typography",
+        "async-retry": "^1.3.3",
         "clsx": "^2.1.1",
         "copy-to-clipboard": "^3.3.3",
         "date-fns": "^3.6.0",
@@ -10916,6 +10917,14 @@
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
       "dev": true
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -20458,6 +20467,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@segment/analytics-next": "^1.67.0",
     "@splinetool/react-spline": "^2.2.6",
     "@tailwindcss/typography": "github:tailwindcss/typography",
+    "async-retry": "^1.3.3",
     "clsx": "^2.1.1",
     "copy-to-clipboard": "^3.3.3",
     "date-fns": "^3.6.0",

--- a/src/lib/graphQLClient.js
+++ b/src/lib/graphQLClient.js
@@ -1,3 +1,4 @@
+import retry from 'async-retry';
 import { GraphQLClient } from 'graphql-request';
 
 export { gql } from 'graphql-request';
@@ -10,3 +11,17 @@ export const graphQLClientAdmin = (authToken) =>
       Authorization: `Bearer ${authToken}`,
     },
   });
+
+export const fetchGraphQL = (client, retries = 3) => {
+  const request = async (query, variables = {}) =>
+    retry(async () => await client.request(query, variables), {
+      retries,
+      factor: 2,
+      minTimeout: 1000,
+      onRetry: (error, attempt) => {
+        console.log(`Attempt ${attempt} failed. Retrying...`);
+      },
+    });
+
+  return { request };
+};

--- a/src/utils/api-auth.js
+++ b/src/utils/api-auth.js
@@ -1,4 +1,4 @@
-import { gql, graphQLClient } from 'lib/graphQLClient';
+import { fetchGraphQL, gql, graphQLClient } from 'lib/graphQLClient';
 
 const getAuthToken = async () => {
   const authQuery = gql`
@@ -9,7 +9,9 @@ const getAuthToken = async () => {
     }
   `;
 
-  return graphQLClient.request(authQuery, { refreshToken: process.env.WP_GRAPHQL_AUTH_TOKEN });
+  return fetchGraphQL(graphQLClient).request(authQuery, {
+    refreshToken: process.env.WP_GRAPHQL_AUTH_TOKEN,
+  });
 };
 
 export default getAuthToken;

--- a/src/utils/api-auth.js
+++ b/src/utils/api-auth.js
@@ -1,4 +1,4 @@
-import { fetchGraphQL, gql, graphQLClient } from 'lib/graphQLClient';
+import { gql, graphQLClient } from 'lib/graphQLClient';
 
 const getAuthToken = async () => {
   const authQuery = gql`
@@ -9,9 +9,7 @@ const getAuthToken = async () => {
     }
   `;
 
-  return fetchGraphQL(graphQLClient).request(authQuery, {
-    refreshToken: process.env.WP_GRAPHQL_AUTH_TOKEN,
-  });
+  return graphQLClient.request(authQuery, { refreshToken: process.env.WP_GRAPHQL_AUTH_TOKEN });
 };
 
 export default getAuthToken;

--- a/src/utils/api-pages.js
+++ b/src/utils/api-pages.js
@@ -1,4 +1,4 @@
-import { gql, graphQLClient } from 'lib/graphQLClient';
+import { fetchGraphQL, gql, graphQLClient } from 'lib/graphQLClient';
 
 const PAGE_SEO_FRAGMENT = gql`
   fragment wpPageSeo on Page {
@@ -30,7 +30,7 @@ const getLandingPages = async () => {
       }
     }
   `;
-  const data = await graphQLClient.request(allLandingPagesQuery);
+  const data = await fetchGraphQL(graphQLClient).request(allLandingPagesQuery);
 
   return data?.pages.nodes.filter((node) => node.template.templateName === 'Landing');
 };
@@ -48,7 +48,7 @@ const getStaticPages = async () => {
       }
     }
   `;
-  const data = await graphQLClient.request(allStaticPagesQuery);
+  const data = await fetchGraphQL(graphQLClient).request(allStaticPagesQuery);
 
   return data?.pages.nodes.filter((node) => node.template.templateName === 'Static');
 };
@@ -67,7 +67,7 @@ const getWpPageBySlug = async (slug) => {
     }
     ${PAGE_SEO_FRAGMENT}
   `;
-  const data = await graphQLClient.request(wpPageBySlugQuery, { slug });
+  const data = await fetchGraphQL(graphQLClient).request(wpPageBySlugQuery, { slug });
 
   return data?.page;
 };
@@ -82,7 +82,7 @@ const getAboutPage = async () => {
     }
     ${PAGE_SEO_FRAGMENT}
   `;
-  const data = await graphQLClient.request(aboutPageQuery);
+  const data = await fetchGraphQL(graphQLClient).request(aboutPageQuery);
 
   return data?.page;
 };

--- a/src/utils/api-posts.js
+++ b/src/utils/api-posts.js
@@ -581,7 +581,6 @@ const getWpPreviewPostData = async (id, status) => {
   const {
     refreshJwtAuthToken: { authToken },
   } = await getAuthToken();
-  const adminClient = graphQLClientAdmin(authToken);
 
   const isDraft = status === 'draft';
   const isRevision = status === 'publish';
@@ -669,7 +668,7 @@ const getWpPreviewPostData = async (id, status) => {
       ${POST_SEO_FRAGMENT}
     `;
 
-    const data = await fetchGraphQL(adminClient).request(query, { id });
+    const data = await graphQLClientAdmin(authToken).request(query, { id });
 
     const sortedPosts = data?.posts?.nodes
       .filter((post) => post.slug !== data?.post?.slug)
@@ -765,7 +764,7 @@ const getWpPreviewPostData = async (id, status) => {
       }
       ${POST_SEO_FRAGMENT}
     `;
-    const revisionPostData = await fetchGraphQL(adminClient).request(query, {
+    const revisionPostData = await graphQLClientAdmin(authToken).request(query, {
       id,
     });
     // TODO: Pass seo data to head component
@@ -785,7 +784,6 @@ const getWpPreviewPost = async (id) => {
   const {
     refreshJwtAuthToken: { authToken },
   } = await getAuthToken();
-  const adminClient = graphQLClientAdmin(authToken);
 
   const findPreviewPostQuery = gql`
     query PreviewPost($id: ID!) {
@@ -797,7 +795,7 @@ const getWpPreviewPost = async (id) => {
     }
   `;
 
-  return fetchGraphQL(adminClient).request(findPreviewPostQuery, { id });
+  return graphQLClientAdmin(authToken).request(findPreviewPostQuery, { id });
 };
 
 const getAllWpCaseStudiesPosts = async () => {


### PR DESCRIPTION
This pull request adds a wrapper for GraphQL requests to include retry logic. The wrapper ensures that requests are automatically retried in case of failure, enhancing the reliability of our GraphQL operations.

**Steps to check:**

- open the preview environment (including [blog](https://neon-next-git-retry-gql-neondatabase.vercel.app/blog) and other pages with WordPress functionality);
- ensure that all pages and functionalities are working correctly.