### PR TITLE
docs: do not hide all the framework guides behind a toggle

### DIFF
--- a/content/docs/get-started-with-neon/frameworks.md
+++ b/content/docs/get-started-with-neon/frameworks.md
@@ -4,7 +4,7 @@ subtitle: Find detailed instructions for connecting to Neon from various framewo
 enableTableOfContents: true
 ---
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/nextjs-logo.svg" width="36" height="36" alt="Next.js" href="/docs/guides/nextjs" title="Connect a Next.js application to Neon" />
 

--- a/content/docs/get-started-with-neon/languages.md
+++ b/content/docs/get-started-with-neon/languages.md
@@ -6,7 +6,7 @@ redirectFrom:
   - /docs/guides/guides-intro
 ---
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/elixir-logo.svg" width="36" height="36" alt="Elixir" href="/docs/guides/elixir-ecto" title="Connect from Elixir with Ecto to Neon" />
 

--- a/content/docs/guides/integrations.md
+++ b/content/docs/guides/integrations.md
@@ -9,7 +9,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Deployment
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/vercel-logo.svg" width="36" height="36" alt="Vercel" href="/docs/guides/vercel" title="Connect with the Neon Vercel Integration" />
 
@@ -33,7 +33,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Serverless
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/neon-logo.svg"  width="42" height="36" alt="Neon" href="/docs/serverless/serverless-driver" title="Connect with the Neon serverless driver" />
 
@@ -44,7 +44,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Backend-as-a-service
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/exograph-logo.svg" width="36" height="36" alt="Exograph" href="/docs/guides/exograph" title="Use Exograph with Neon" />
 
@@ -64,7 +64,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Caching
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/cloudflare-logo.svg" width="36" height="36" alt="Cloudflare Hyperdrive" href="/docs/guides/cloudflare-hyperdrive" title="Use Neon with Cloudflare Hyperdrive" />
 
@@ -75,7 +75,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Replication
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/airbyte-logo.svg" width="36" height="36" alt="Airbyte" href="/docs/guides/logical-replication-airbyte" title="Replicate data from Neon with Airbyte" />
 
@@ -94,7 +94,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Migrations
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/django-logo.svg" width="29" height="36" alt="Django" href="/docs/guides/django-migrations" title="Connect a Django application to Neon" />
 
@@ -121,7 +121,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Tools
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/outerbase-logo.svg" width="36" height="36" alt="Outerbase" href="/docs/guides/outerbase" title="Connect Outerbase to Neon" />
 
@@ -132,7 +132,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Authentication
 
-<TechnologyNavigation>
+<TechnologyNavigation open={true}>
 
 <img src="/images/technology-logos/auth0-logo.svg" width="36" height="36" alt="Auth0" href="/docs/guides/auth-auth0" title="Authenticate Neon Postgres application users with Auth0" />
 

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -84,6 +84,7 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
 
 TechnologyNavigation.propTypes = {
   children: PropTypes.node,
+  open: PropTypes.bool
 };
 
 export default TechnologyNavigation;

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -65,8 +65,8 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
       </ul>
       {!open && (
         <button
-          type="button"
           onClick={handleClick}
+          type="button"
           className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"
         >
           <span>Show more</span>

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -63,7 +63,7 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
           );
         })}
       </ul>
-      {!open && (
+      {!isOpen && (
         <button
           type="button"
           className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -19,9 +19,7 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
     <>
       <ul className="not-prose !mb-2 !mt-9 grid grid-cols-12 gap-5 !p-0 xs:grid-cols-1">
         {React.Children.map(children, (child, index) => {
-          if (!child) {
-            return null;
-          }
+          if (!child) return null;
 
           const { href, src, alt, title, width, height } = child.props;
 
@@ -67,17 +65,12 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
       </ul>
       {!open && (
         <button
-          className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"
           type="button"
           onClick={handleClick}
+          className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"
         >
-          <span>{isOpen ? 'Hide' : 'Show more'}</span>
-          <ChevronRight
-            className={clsx(
-              'ml-2 block shrink-0 text-black-new transition-[transform,color] duration-200 dark:text-white',
-              isOpen ? '-rotate-90' : 'rotate-90'
-            )}
-          />
+          <span>Show more</span>
+          <ChevronRight className="rotate-90 ml-2 block shrink-0 text-black-new transition-[transform,color] duration-200 dark:text-white" />
         </button>
       )}
     </>

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -8,8 +8,8 @@ import React, { useState } from 'react';
 import ArrowRightIcon from 'icons/arrow-right.inline.svg';
 import ChevronRight from 'icons/chevron-right-sm.inline.svg';
 
-const TechnologyNavigation = ({ children = null }) => {
-  const [isOpen, setIsOpen] = useState(false);
+const TechnologyNavigation = ({ children = null, open = false }) => {
+  const [isOpen, setIsOpen] = useState(open);
 
   const handleClick = () => {
     setIsOpen((isOpen) => !isOpen);

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -65,9 +65,9 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
       </ul>
       {!open && (
         <button
-          onClick={handleClick}
           type="button"
           className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"
+          onClick={handleClick}
         >
           <span>Show more</span>
           <ChevronRight className="rotate-90 ml-2 block shrink-0 text-black-new transition-[transform,color] duration-200 dark:text-white" />


### PR DESCRIPTION
Helps get rid of the extra step required **always** to browse through the list of guides with neon: https://neon.tech/docs/get-started-with-neon/frameworks.