### PR TITLE
docs: remove duplicate tools section from toc

### DIFF
--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -368,12 +368,6 @@
           slug: guides/sequelize
         - title: SQLAlchemy
           slug: guides/sqlalchemy-migrations
-    - title: Tools
-      items:
-        - title: Outerbase
-          slug: guides/outerbase
-        - title: Prisma
-          slug: guides/prisma
     - title: Authentication
       items:
         - title: Auth0


### PR DESCRIPTION
The "Integrations > Tools" section was duplicated in the TOC.