### PR TITLE
fix: add target blank for footer external links

### DIFF
--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -72,6 +72,7 @@ const Footer = ({ isDocPage = false, theme = 'white' }) => {
                         to={to}
                         theme={isDarkTheme ? 'gray-70' : 'gray-30'}
                         rel={isExternalUrl ? 'noopener noreferrer' : null}
+                        target={isExternalUrl ? '_blank' : null}
                       >
                         {icon && (
                           <span


### PR DESCRIPTION
**Description**

This pull request adds target blank for footer external links.

**References**

[Preview](https://neon-next-git-fix-footer-external-links-neondatabase.vercel.app/)