### PR TITLE
fix: code blocks scrollbars and copy buttons

### DIFF
--- a/src/components/pages/home/instant-provisioning/code-tabs/navigation/navigation.jsx
+++ b/src/components/pages/home/instant-provisioning/code-tabs/navigation/navigation.jsx
@@ -93,7 +93,7 @@ const Navigation = ({ codeSnippets, highlightedCodeSnippets }) => {
           })}
         </div>
       </div>
-      <div className="h-[342px]">
+      <div className="h-[342px] lg:h-[312px]">
         <LazyMotion features={domAnimation}>
           <AnimatePresence initial={false} mode="wait">
             {highlightedCodeSnippets.map(
@@ -106,7 +106,7 @@ const Navigation = ({ codeSnippets, highlightedCodeSnippets }) => {
                     animate={{ opacity: 1 }}
                     transition={{ duration: 0.3 }}
                   >
-                    <CodeBlockWrapper className="show-linenumbers highlighted-code h-[342px] overflow-auto [&_[data-line]]:px-3 [&_[data-line]]:text-xs [&_[data-line]]:leading-[1.21] lg:[&_[data-line]]:text-[11px] lg:[&_[data-line]]:leading-[1.09] [&_pre]:pt-3 [&_pre_code>.line::before]:mr-7">
+                    <CodeBlockWrapper className="show-linenumbers highlighted-code h-[342px] overflow-auto lg:h-[312px] [&_[data-line]]:px-3 [&_[data-line]]:text-xs [&_[data-line]]:leading-[1.21] lg:[&_[data-line]]:text-[11px] lg:[&_[data-line]]:leading-[1.09] [&_pre]:pt-3 [&_pre_code>.line::before]:mr-7">
                       {parse(code)}
                     </CodeBlockWrapper>
                   </m.div>

--- a/src/components/pages/partners/integration/api/code-tabs/code-tabs-navigation.jsx
+++ b/src/components/pages/partners/integration/api/code-tabs/code-tabs-navigation.jsx
@@ -45,7 +45,7 @@ const CodeTabsNavigation = ({ codeSnippets, highlightedCodeSnippets }) => {
           );
         })}
       </div>
-      <div className="min-h-[401px]">
+      <div className="h-[401px] lg:h-[386px]">
         <LazyMotion features={domAnimation}>
           <AnimatePresence initial={false} mode="wait">
             {highlightedCodeSnippets.map(
@@ -58,7 +58,7 @@ const CodeTabsNavigation = ({ codeSnippets, highlightedCodeSnippets }) => {
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ duration: 0.2 }}
                   >
-                    <CodeBlockWrapper className="show-linenumbers highlighted-code min-h-[401px] [&_[data-line]]:text-[15px]">
+                    <CodeBlockWrapper className="show-linenumbers highlighted-code h-[401px] lg:h-[386px] [&_[data-line]]:text-[15px]">
                       {parse(code)}
                     </CodeBlockWrapper>
                   </m.div>

--- a/src/components/pages/partners/integration/api/code-tabs/code-tabs-navigation.jsx
+++ b/src/components/pages/partners/integration/api/code-tabs/code-tabs-navigation.jsx
@@ -45,7 +45,7 @@ const CodeTabsNavigation = ({ codeSnippets, highlightedCodeSnippets }) => {
           );
         })}
       </div>
-      <div className="min-h-[383px]">
+      <div className="min-h-[401px]">
         <LazyMotion features={domAnimation}>
           <AnimatePresence initial={false} mode="wait">
             {highlightedCodeSnippets.map(
@@ -58,7 +58,7 @@ const CodeTabsNavigation = ({ codeSnippets, highlightedCodeSnippets }) => {
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ duration: 0.2 }}
                   >
-                    <CodeBlockWrapper className="show-linenumbers highlighted-code min-h-[383px] [&_[data-line]]:text-[15px]">
+                    <CodeBlockWrapper className="show-linenumbers highlighted-code min-h-[401px] [&_[data-line]]:text-[15px]">
                       {parse(code)}
                     </CodeBlockWrapper>
                   </m.div>

--- a/src/components/shared/code-block-wrapper/code-block-wrapper.jsx
+++ b/src/components/shared/code-block-wrapper/code-block-wrapper.jsx
@@ -47,11 +47,14 @@ const CodeBlockWrapper = ({
   const code = extractTextFromNode(children);
 
   return (
-    <Tag className={clsx('code-block group relative', className)} {...otherProps}>
+    <Tag
+      className={clsx('code-block group relative flex [&_pre]:min-w-full', className)}
+      {...otherProps}
+    >
       {children}
       <button
         className={clsx(
-          'invisible absolute right-2 top-2 rounded p-1.5 text-gray-new-80 opacity-0 transition-[background-color,opacity,visibility] duration-200 group-hover:visible group-hover:opacity-100 dark:border-gray-3 dark:bg-gray-new-10 dark:text-gray-8 lg:visible lg:opacity-100',
+          'invisible absolute right-5 top-2 rounded p-1.5 text-gray-new-80 opacity-0 transition-[background-color,opacity,visibility] duration-200 group-hover:visible group-hover:opacity-100 dark:border-gray-3 dark:bg-gray-new-10 dark:text-gray-8 lg:visible lg:opacity-100',
           copyButtonClassName
         )}
         type="button"


### PR DESCRIPTION
**Description**

This pull request brings fixes for code blocks scrollbars and copy buttons.

**Screenshots**

<details>
<summary>Code blocks scrollbars</summary>

[Partners](https://neon-next-git-fix-code-blocks-neondatabase.vercel.app/partners) - "Full automation with the Neon API" section - "Node" tab

Before

![image](https://github.com/neondatabase/website/assets/22715126/2c6405cb-8f80-4010-8694-2790e7112fd7)

After

![image](https://github.com/neondatabase/website/assets/22715126/5ae6f8db-9ff1-4b8d-946d-0ba44dcd38ef)
</details>

<details>
<summary>Copy buttons</summary>

[Homepage](https://neon-next-git-fix-code-blocks-neondatabase.vercel.app/) - "Works with your stack" section - "Go" tab

Before

![image](https://github.com/neondatabase/website/assets/22715126/7e0a1d3a-6152-47b8-bcd9-e43ab3cece31)

After

![image](https://github.com/neondatabase/website/assets/22715126/0dd3b8b8-1df4-46c9-9109-aa43edf6063c)
</details>

**References**

[Preview](https://neon-next-git-fix-code-blocks-neondatabase.vercel.app/)