### PR TITLE
feat: add rewrite for latency dashboard

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -245,6 +245,13 @@ const defaultConfig = {
         source: '/developer-days/:path*',
         destination: 'https://neon-dev-days-next.vercel.app/developer-days/:path*',
       },
+      { source: '/regional-latency',
+        destination: 'https://latencies-ui.vercel.app/regional-latency'
+      },
+      {
+        source: '/regional-latency/:asset*',
+        destination: 'https://latencies-ui.vercel.app/regional-latency/:asset*'
+      }
     ];
   },
   webpack(config) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "rewrites": [
+    { "source": "/regional-latency", "destination": "https://latencies-ui.vercel.app/regional-latency" },
+    { "source": "/regional-latency/:asset*", "destination": "https://latencies-ui.vercel.app/regional-latency/:asset*" },
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "rewrites": [
-    { "source": "/regional-latency", "destination": "https://latencies-ui.vercel.app/regional-latency" },
-    { "source": "/regional-latency/:asset*", "destination": "https://latencies-ui.vercel.app/regional-latency/:asset*" },
-    { "source": "/(.*)", "destination": "/" }
-  ]
-}


### PR DESCRIPTION
This PR makes /regional-latency a path on neon.tech. It points to: https://latencies-ui.vercel.app/