### PR TITLE
fix: line illustrations for forms

### DIFF
--- a/src/components/pages/landing/hero/form/form.jsx
+++ b/src/components/pages/landing/hero/form/form.jsx
@@ -264,7 +264,7 @@ const Form = ({
             )}
           </div>
           <LinesIllustration
-            className="-top-8 z-10 h-[130px] !w-[125%]"
+            className="-!top-8 z-10 h-[150px] !w-[125%]"
             color={state === FORM_STATES.ERROR ? '#FF4C79' : '#00E599'}
             bgColor="#000"
           />

--- a/src/components/shared/lines-illustration/lines-illustration.jsx
+++ b/src/components/shared/lines-illustration/lines-illustration.jsx
@@ -12,7 +12,7 @@ const LinesIllustration = ({ className: additionalClassName, color, bgColor }) =
     <LazyMotion features={domAnimation}>
       <m.span
         className={clsx(
-          'pointer-events-none absolute left-1/2 -z-10 block h-[150px] w-[113%] -translate-x-1/2',
+          'pointer-events-none absolute -top-1/2 left-1/2 -z-10 block h-[130px] w-[113%] -translate-x-1/2',
           additionalClassName
         )}
         initial={{ opacity: 0 }}


### PR DESCRIPTION
**Description**
This PR brings fix for line illustrations for forms

**Screenshots**
![image](https://github.com/neondatabase/website/assets/22715126/de9d2d65-788b-49e3-8d78-02b961cbb138)

**Previews**
[Preview Blog](https://neon-next-git-fix-line-illustrations-neondatabase.vercel.app/blog)
[Preview Landing 1](https://neon-next-git-fix-line-illustrations-neondatabase.vercel.app/early-access-program)
[Preview Landing 2](https://neon-next-git-fix-line-illustrations-neondatabase.vercel.app/scale-trial)