### PR TITLE
fix: docs technology navigation toggler

### DIFF
--- a/content/docs/get-started-with-neon/frameworks.md
+++ b/content/docs/get-started-with-neon/frameworks.md
@@ -4,7 +4,7 @@ subtitle: Find detailed instructions for connecting to Neon from various framewo
 enableTableOfContents: true
 ---
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/nextjs-logo.svg" width="36" height="36" alt="Next.js" href="/docs/guides/nextjs" title="Connect a Next.js application to Neon" />
 

--- a/content/docs/get-started-with-neon/frameworks.md
+++ b/content/docs/get-started-with-neon/frameworks.md
@@ -4,7 +4,7 @@ subtitle: Find detailed instructions for connecting to Neon from various framewo
 enableTableOfContents: true
 ---
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/nextjs-logo.svg" width="36" height="36" alt="Next.js" href="/docs/guides/nextjs" title="Connect a Next.js application to Neon" />
 

--- a/content/docs/get-started-with-neon/languages.md
+++ b/content/docs/get-started-with-neon/languages.md
@@ -6,7 +6,7 @@ redirectFrom:
   - /docs/guides/guides-intro
 ---
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/elixir-logo.svg" width="36" height="36" alt="Elixir" href="/docs/guides/elixir-ecto" title="Connect from Elixir with Ecto to Neon" />
 

--- a/content/docs/get-started-with-neon/languages.md
+++ b/content/docs/get-started-with-neon/languages.md
@@ -6,7 +6,7 @@ redirectFrom:
   - /docs/guides/guides-intro
 ---
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/elixir-logo.svg" width="36" height="36" alt="Elixir" href="/docs/guides/elixir-ecto" title="Connect from Elixir with Ecto to Neon" />
 

--- a/content/docs/guides/integrations.md
+++ b/content/docs/guides/integrations.md
@@ -9,7 +9,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Deployment
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/vercel-logo.svg" width="36" height="36" alt="Vercel" href="/docs/guides/vercel" title="Connect with the Neon Vercel Integration" />
 
@@ -33,7 +33,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Serverless
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/neon-logo.svg"  width="42" height="36" alt="Neon" href="/docs/serverless/serverless-driver" title="Connect with the Neon serverless driver" />
 
@@ -44,7 +44,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Backend-as-a-service
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/exograph-logo.svg" width="36" height="36" alt="Exograph" href="/docs/guides/exograph" title="Use Exograph with Neon" />
 
@@ -64,7 +64,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Caching
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/cloudflare-logo.svg" width="36" height="36" alt="Cloudflare Hyperdrive" href="/docs/guides/cloudflare-hyperdrive" title="Use Neon with Cloudflare Hyperdrive" />
 
@@ -87,7 +87,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Replication
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/airbyte-logo.svg" width="36" height="36" alt="Airbyte" href="/docs/guides/logical-replication-airbyte" title="Replicate data from Neon with Airbyte" />
 
@@ -106,7 +106,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Migrations
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/django-logo.svg" width="29" height="36" alt="Django" href="/docs/guides/django-migrations" title="Connect a Django application to Neon" />
 
@@ -133,7 +133,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Tools
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/outerbase-logo.svg" width="36" height="36" alt="Outerbase" href="/docs/guides/outerbase" title="Connect Outerbase to Neon" />
 
@@ -144,7 +144,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Authentication
 
-<TechnologyNavigation open={true}>
+<TechnologyNavigation noToggler>
 
 <img src="/images/technology-logos/auth0-logo.svg" width="36" height="36" alt="Auth0" href="/docs/guides/auth-auth0" title="Authenticate Neon Postgres application users with Auth0" />
 

--- a/content/docs/guides/integrations.md
+++ b/content/docs/guides/integrations.md
@@ -9,7 +9,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Deployment
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/vercel-logo.svg" width="36" height="36" alt="Vercel" href="/docs/guides/vercel" title="Connect with the Neon Vercel Integration" />
 
@@ -33,7 +33,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Serverless
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/neon-logo.svg"  width="42" height="36" alt="Neon" href="/docs/serverless/serverless-driver" title="Connect with the Neon serverless driver" />
 
@@ -44,7 +44,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Backend-as-a-service
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/exograph-logo.svg" width="36" height="36" alt="Exograph" href="/docs/guides/exograph" title="Use Exograph with Neon" />
 
@@ -64,7 +64,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Caching
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/cloudflare-logo.svg" width="36" height="36" alt="Cloudflare Hyperdrive" href="/docs/guides/cloudflare-hyperdrive" title="Use Neon with Cloudflare Hyperdrive" />
 
@@ -87,7 +87,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Replication
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/airbyte-logo.svg" width="36" height="36" alt="Airbyte" href="/docs/guides/logical-replication-airbyte" title="Replicate data from Neon with Airbyte" />
 
@@ -106,7 +106,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Migrations
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/django-logo.svg" width="29" height="36" alt="Django" href="/docs/guides/django-migrations" title="Connect a Django application to Neon" />
 
@@ -133,7 +133,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Tools
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/outerbase-logo.svg" width="36" height="36" alt="Outerbase" href="/docs/guides/outerbase" title="Connect Outerbase to Neon" />
 
@@ -144,7 +144,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 ## Authentication
 
-<TechnologyNavigation noToggler>
+<TechnologyNavigation open>
 
 <img src="/images/technology-logos/auth0-logo.svg" width="36" height="36" alt="Auth0" href="/docs/guides/auth-auth0" title="Authenticate Neon Postgres application users with Auth0" />
 

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -8,8 +8,8 @@ import React, { useState } from 'react';
 import ArrowRightIcon from 'icons/arrow-right.inline.svg';
 import ChevronRight from 'icons/chevron-right-sm.inline.svg';
 
-const TechnologyNavigation = ({ children = null, noToggler = false }) => {
-  const [isOpen, setIsOpen] = useState(noToggler);
+const TechnologyNavigation = ({ children = null, open = false }) => {
+  const [isOpen, setIsOpen] = useState(open);
 
   const handleClick = () => {
     setIsOpen((isOpen) => !isOpen);
@@ -63,10 +63,10 @@ const TechnologyNavigation = ({ children = null, noToggler = false }) => {
           );
         })}
       </ul>
-      {!noToggler && (
+      {!open && (
         <button
-          className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"
           type="button"
+          className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"
           onClick={handleClick}
         >
           <span>{isOpen ? 'Hide' : 'Show more'}</span>
@@ -84,7 +84,7 @@ const TechnologyNavigation = ({ children = null, noToggler = false }) => {
 
 TechnologyNavigation.propTypes = {
   children: PropTypes.node,
-  noToggler: PropTypes.bool,
+  open: PropTypes.bool,
 };
 
 export default TechnologyNavigation;

--- a/src/components/pages/doc/technology-navigation/technology-navigation.jsx
+++ b/src/components/pages/doc/technology-navigation/technology-navigation.jsx
@@ -8,8 +8,8 @@ import React, { useState } from 'react';
 import ArrowRightIcon from 'icons/arrow-right.inline.svg';
 import ChevronRight from 'icons/chevron-right-sm.inline.svg';
 
-const TechnologyNavigation = ({ children = null, open = false }) => {
-  const [isOpen, setIsOpen] = useState(open);
+const TechnologyNavigation = ({ children = null, noToggler = false }) => {
+  const [isOpen, setIsOpen] = useState(noToggler);
 
   const handleClick = () => {
     setIsOpen((isOpen) => !isOpen);
@@ -63,14 +63,19 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
           );
         })}
       </ul>
-      {!isOpen && (
+      {!noToggler && (
         <button
-          type="button"
           className="mx-auto flex items-center rounded-full bg-gray-new-98 px-5 py-2 text-sm font-medium text-black-new transition-colors duration-200 hover:bg-gray-new-94 dark:bg-gray-new-15 dark:text-white dark:hover:bg-gray-2"
+          type="button"
           onClick={handleClick}
         >
-          <span>Show more</span>
-          <ChevronRight className="ml-2 block shrink-0 rotate-90 text-black-new transition-[transform,color] duration-200 dark:text-white" />
+          <span>{isOpen ? 'Hide' : 'Show more'}</span>
+          <ChevronRight
+            className={clsx(
+              'ml-2 block shrink-0 text-black-new transition-[transform,color] duration-200 dark:text-white',
+              isOpen ? '-rotate-90' : 'rotate-90'
+            )}
+          />
         </button>
       )}
     </>
@@ -79,7 +84,7 @@ const TechnologyNavigation = ({ children = null, open = false }) => {
 
 TechnologyNavigation.propTypes = {
   children: PropTypes.node,
-  open: PropTypes.bool,
+  noToggler: PropTypes.bool,
 };
 
 export default TechnologyNavigation;


### PR DESCRIPTION
**Description**
This PR brings fix for docs technology navigation toggler https://github.com/neondatabase/website/pull/1719

**Steps to test**
- [x]  [Default state](https://neon-next-git-fix-docs-tech-toggler-neondatabase.vercel.app/docs/introduction) should have Show more/Hide toggler
- [x] [No toggler state](https://neon-next-git-fix-docs-tech-toggler-neondatabase.vercel.app/docs/get-started-with-neon/frameworks) shouldn't have toggler and list should always be open

**Previews**
[Preview](https://neon-next-git-fix-docs-tech-toggler-neondatabase.vercel.app/docs/introduction) (default state)
[Preview](https://neon-next-git-fix-docs-tech-toggler-neondatabase.vercel.app/docs/get-started-with-neon/frameworks) (no toggler state)