### PR TITLE
fix: code transformers colors

### DIFF
--- a/src/styles/highlighted-code.css
+++ b/src/styles/highlighted-code.css
@@ -115,10 +115,10 @@
 
     &.diff {
       &.add {
-        @apply bg-code-green-1/10 before:absolute before:left-2 before:text-code-green-1 before:content-['+'];
+        @apply bg-[#00E599]/10 before:absolute before:left-2 before:text-code-green-1 before:content-['+'];
       }
       &.remove {
-        @apply bg-code-red-1/10 before:absolute before:left-2 before:text-code-red-1/50 before:content-['—'];
+        @apply bg-[#FF275D]/10 before:absolute before:left-2 before:text-code-red-1/50 before:content-['—'];
       }
     }
   }


### PR DESCRIPTION
**Description**
This PR brings slight color updates for the new shiki code transformers

**Screenshot**
![image](https://github.com/neondatabase/website/assets/22715126/1c080b4a-caa4-4acd-9a39-f4682d4794ad)

[Preview](https://neon-next-git-fix-code-transformers-styles-neondatabase.vercel.app/guides/feature-flags-sveltekit#optional-adding-tailwind-css-to-the-application)