### PR TITLE
Add request trial to Scale plan.jsx

### DIFF
--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -79,8 +79,8 @@ const items = [
       { title: 'IP Allow Rules' },
     ],
     button: {
-      url: `${LINKS.console}/?upgrade=scale`,
-      text: 'Get started',
+      url: `https://neon.tech/scale-trial`,
+      text: 'Request trial',
       theme: 'white-outline',
       event: 'Hero Scale Panel',
     },


### PR DESCRIPTION
We'll be running an experiment for the next 2-4 weeks, using a "Request trial" CTA for the Scale plan. We still should be able to track clicks on this button, please (I think I have messed this up with my original commit 😶) 

DON'T MERGE YET -- request trial landing page still needs a fix 🙏