### PR TITLE
docs: guides updates

### DIFF
--- a/content/docs/guides/django.md
+++ b/content/docs/guides/django.md
@@ -80,6 +80,16 @@ print("libpq version:", psycopg2._psycopg.libpq_version())
 
 The version number for `libpq` is presented in a different format, for example, version 14.1 will be shown as 140001. If your `libpq` version is less than version 14, you can either upgrade your `psycopg2` driver to get a newer `libpq` version or use one of the workarounds described in our [Connection errors](https://neon.tech/docs/connect/connection-errors#the-endpoint-id-is-not-specified) documentation. Upgrading your `psycopg2` driver may introduce compatibility issues with your Django or Python version, so you should test your application thoroughly.
 
+## Schema migration with Django
+
+For schema migration with Django, see our guide:
+
+<DetailIconCards>
+
+<a href="/docs/guides/django-migrations" description="Schema migration with Neon Postgres and Django" icon="app-store" icon="app-store">Django Migrations</a>
+
+</DetailIconCards>
+
 ## Django application blog post and sample application
 
 Learn how to use Django with Neon Postgres with this blog post and the accompanying sample application.

--- a/content/docs/guides/integrations.md
+++ b/content/docs/guides/integrations.md
@@ -7,7 +7,7 @@ redirectFrom:
 updatedOn: '2024-02-27T20:16:54.558Z'
 ---
 
-## Deployment
+## Deploy
 
 <TechnologyNavigation open>
 
@@ -41,8 +41,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 </TechnologyNavigation>
 
-
-## Backend-as-a-service
+## Query
 
 <TechnologyNavigation open>
 
@@ -54,25 +53,17 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 <img src="/images/technology-logos/hasura-logo.svg" width="35" height="36" alt="Hasura" href="/docs/guides/hasura" title="Connect from Hasura Cloud to Neon" />
 
-<img src="/images/technology-logos/sequin-logo.svg" width="29" height="36" alt="Sequin" href="/docs/guides/sequin" title="Sync data from APIs to Neon in real time" />
+<img src="/images/technology-logos/cloudflare-logo.svg" width="36" height="36" alt="Cloudflare Hyperdrive" href="/docs/guides/cloudflare-hyperdrive" title="Use Neon with Cloudflare Hyperdrive" />
 
 <img src="/images/technology-logos/stepzen-logo.svg" width="36" height="36" alt="StepZen" href="/docs/guides/stepzen" title="Use StepZen with Neon" />
 
 <img src="/images/technology-logos/wundergraph-logo.svg" width="36" height="36" alt="Wundergraph" href="/docs/guides/wundergraph" title="Use Wundergraph with Neon" />
 
-</TechnologyNavigation>
-
-## Caching
-
-<TechnologyNavigation open>
-
-<img src="/images/technology-logos/cloudflare-logo.svg" width="36" height="36" alt="Cloudflare Hyperdrive" href="/docs/guides/cloudflare-hyperdrive" title="Use Neon with Cloudflare Hyperdrive" />
-
-<img src="/images/technology-logos/polyscale-logo.svg" width="36" height="36" alt="PolyScale" href="/docs/guides/polyscale" title="Use PolyScale with Neon" />
+<img src="/images/technology-logos/outerbase-logo.svg" width="36" height="36" alt="Outerbase" href="/docs/guides/outerbase" title="Connect Outerbase to Neon" />
 
 </TechnologyNavigation>
 
-## CI/CD
+## Develop
 
 <TechnologyNavigation>
 
@@ -82,10 +73,11 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 <img src="/images/technology-logos/neosync-logo.svg" width="36" height="36" alt="Neosync" href="/docs/guides/neosync-generate" title="Seed data with Neosync" />
 
+<img src="/images/technology-logos/prisma-logo.svg" width="30" height="36" alt="Prisma" href="/docs/guides/prisma" title="Connect from Prisma to Neon" />
+
 </TechnologyNavigation>
 
-
-## Replication
+## Replicate
 
 <TechnologyNavigation open>
 
@@ -93,18 +85,19 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 <img src="/images/technology-logos/clickhouse-logo.svg" width="36" height="36" alt="ClickHouse" href="/docs/guides/logical-replication-clickhouse" title="Replicate data from Neon to ClickHouse (DoubleCloud)" />
 
-<img src="/images/technology-logos/fivetran-logo.svg" width="36" height="36" alt="Fivetran" href="/docs/guides/logical-replication-fivetran" title="Replicate data from Neon with Fivetran" />
-
 <img src="/images/technology-logos/kafka-logo.svg" width="36" height="36" alt="Kafka" href="/docs/guides/logical-replication-kafka-confluent" title="Replicate data from Neon with Kafka (Confluent)" />
+
+<img src="/images/technology-logos/fivetran-logo.svg" width="36" height="36" alt="Fivetran" href="/docs/guides/logical-replication-fivetran" title="Replicate data from Neon with Fivetran" />
 
 <img src="/images/technology-logos/materialize-logo.svg" width="36" height="36" alt="Materialize" href="/docs/guides/logical-replication-materialize" title="Replicate data from Neon to Materialize" />
 
 <img src="/images/technology-logos/postgresql-logo.svg" width="36" height="36" alt="Postgres" href="/docs/guides/logical-replication-postgres" title="Replicate data from Neon to PostgreSQL" />
 
+<img src="/images/technology-logos/sequin-logo.svg" width="29" height="36" alt="Sequin" href="/docs/guides/sequin" title="Sync data from APIs to Neon in real time" />
+
 </TechnologyNavigation>
 
-
-## Migrations
+## Schema Migration
 
 <TechnologyNavigation open>
 
@@ -130,19 +123,7 @@ updatedOn: '2024-02-27T20:16:54.558Z'
 
 </TechnologyNavigation>
 
-
-## Tools
-
-<TechnologyNavigation open>
-
-<img src="/images/technology-logos/outerbase-logo.svg" width="36" height="36" alt="Outerbase" href="/docs/guides/outerbase" title="Connect Outerbase to Neon" />
-
-<img src="/images/technology-logos/prisma-logo.svg" width="30" height="36" alt="Prisma" href="/docs/guides/prisma" title="Connect from Prisma to Neon" />
-
-</TechnologyNavigation>
-
-
-## Authentication
+## Authenticate
 
 <TechnologyNavigation open>
 

--- a/content/docs/guides/laravel.md
+++ b/content/docs/guides/laravel.md
@@ -60,4 +60,14 @@ If you run into this error, please see the following documentation for an explan
     DB_PASSWORD=endpoint=<endpoint_id>$<password>
     ```
 
+## Schema migration with Laravel
+
+For schema migration with Laravel, see our guide:
+
+<DetailIconCards>
+
+<a href="/docs/guides/laravel-migrations" description="Schema migration with Neon Postgres and Laravel" icon="app-store" icon="app-store">Laravel Migrations</a>
+
+</DetailIconCards>
+
 <NeedHelp/>

--- a/content/docs/guides/rails-migrations.md
+++ b/content/docs/guides/rails-migrations.md
@@ -351,7 +351,7 @@ In this guide, we demonstrated how to set up a Ruby on Rails project with Neon P
 
 ## Source code
 
-You can find the source code for the application describe in this guide on GitHub.
+You can find the source code for the application described in this guide on GitHub.
 
 <DetailIconCards>
 <a href="https://github.com/neondatabase/guide-neon-rails" description="Run migrations in a Neon-Rails project" icon="github">Migrations with Neon and Rails</a>

--- a/content/docs/guides/ruby-on-rails.md
+++ b/content/docs/guides/ruby-on-rails.md
@@ -113,4 +113,14 @@ Visit [localhost:3000/](http://localhost:3000/) in your web browser. Your Neon d
 PostgreSQL 15.5 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
 ```
 
+## Schema migration with Ruby on Rails
+
+For schema migration with Ruby on Rails, see our guide:
+
+<DetailIconCards>
+
+<a href="/docs/guides/rails-migrations" description="Schema migration with Neon Postgres and Ruby on Rails" icon="app-store" icon="app-store">Ruby on Rails Migrations</a>
+
+</DetailIconCards>
+
 <NeedHelp/>

--- a/content/docs/guides/sqlalchemy.md
+++ b/content/docs/guides/sqlalchemy.md
@@ -97,4 +97,14 @@ For additional information about connecting from SQLAlchemy, refer to the follow
 - [Establishing Connectivity - the Engine](https://docs.sqlalchemy.org/en/14/tutorial/engine.html)
 - [Connecting to PostgreSQL with SQLAlchemy](https://docs.sqlalchemy.org/en/14/core/engines.html#postgresql)
 
+## Schema migration with SQLAlchemy
+
+For schema migration with SQLAlchemy, see our guide:
+
+<DetailIconCards>
+
+<a href="/docs/guides/sqlalchemy-migrations" description="Schema migration with Neon Postgres and SQLAlchemy" icon="app-store" icon="app-store">SQLAlchemy Migrations</a>
+
+</DetailIconCards>
+
 <NeedHelp/>

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -43,7 +43,7 @@
           slug: guides/remix
         - title: Ruby on Rails
           slug: guides/ruby-on-rails
-        - title: SQL Alchemy
+        - title: SQLAlchemy
           slug: guides/sqlalchemy
         - title: Symfony
           slug: guides/symfony
@@ -262,7 +262,7 @@
 - title: Integration guides
   slug: guides/integrations
   items:
-    - title: Deployment
+    - title: Deploy
       items:
         - title: Vercel
           items:
@@ -298,7 +298,7 @@
           slug: serverless/serverless-driver
         - title: AWS Lambda
           slug: guides/aws-lambda
-    - title: Backend-as-a-service
+    - title: Query
       items:
         - title: Exograph
           slug: guides/exograph
@@ -308,19 +308,15 @@
           slug: guides/grafbase
         - title: Hasura
           slug: guides/hasura
-        - title: Sequin
-          slug: guides/sequin
+        - title: Cloudflare Hyperdrive
+          slug: guides/cloudflare-hyperdrive
+        - title: Outerbase
+          slug: guides/outerbase
         - title: StepZen
           slug: guides/stepzen
         - title: WunderGraph
           slug: guides/wundergraph
-    - title: Caching
-      items:
-        - title: Cloudflare Hyperdrive
-          slug: guides/cloudflare-hyperdrive
-        - title: PolyScale
-          slug: guides/polyscale
-    - title: CI/CD
+    - title: Develop
       items:
         - title: GitHub integration
           slug: guides/neon-github-app
@@ -332,21 +328,25 @@
             - title: Anonymize data
               slug: guides/neosync-anonymize
               tag: new
-    - title: Replication
+        - title: Prisma
+          slug: guides/prisma  
+    - title: Replicate
       items:
         - title: Airbyte
           slug: guides/logical-replication-airbyte
         - title: ClickHouse (DoubleCloud)
           slug: guides/logical-replication-clickhouse
-        - title: Fivetran
-          slug: guides/logical-replication-fivetran
         - title: Confluent
           slug: guides/logical-replication-kafka-confluent
+        - title: Fivetran
+          slug: guides/logical-replication-fivetran
         - title: Materialize
           slug: guides/logical-replication-materialize
         - title: Postgres
           slug: guides/logical-replication-postgres
-    - title: Migrations
+        - title: Sequin
+          slug: guides/sequin
+    - title: Schema Migration
       items:
         - title: Django
           slug: guides/django-migrations
@@ -384,12 +384,6 @@
           slug: guides/auth-clerk
         - title: Okta
           slug: guides/auth-okta
-    - title: Tools
-      items:
-        - title: Outerbase
-          slug: guides/outerbase
-        - title: Prisma
-          slug: guides/prisma
 - title: Postgres guides
   slug: postgresql/introduction
   items:


### PR DESCRIPTION
- drop polyscale guide
- reorganize integrations section to align with revised Integrations page categories 
- Add references to schema migration guides from framework guides (e.g. Django guide -> Django migration guide)