### PR TITLE
fix: add missing font weights

### DIFF
--- a/src/app/fonts.js
+++ b/src/app/fonts.js
@@ -2,7 +2,7 @@ import { Inter } from 'next/font/google';
 import localFont from 'next/font/local';
 
 const inter = Inter({
-  weight: ['300', '400', '500'],
+  weight: ['300', '400', '500', '600', '700'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-inter',


### PR DESCRIPTION
This PR brings global fixes for font weights in Safari and Firefox

<details><summary>Safari</summary>

![image](https://github.com/neondatabase/website/assets/22715126/e1eda4df-ad72-4843-83e7-e3d8591c7ba0)
</details>

<details><summary>Firefox</summary>

![image](https://github.com/neondatabase/website/assets/22715126/cfcc575d-19b0-4501-9e25-61f14f316d5a)
</details> 

[Preview](https://neon-next-git-fonts-fix-firefox-safari-neondatabase.vercel.app/docs/introduction)