### PR TITLE
docs: replace old pg_embedding link

### DIFF
--- a/src/app/ai/page.jsx
+++ b/src/app/ai/page.jsx
@@ -84,11 +84,11 @@ const AIPage = () => (
       className="mt-[180px] 2xl:mt-40 xl:mt-[125px] lg:mt-16"
       buttonClassName="px-14 xl:px-10 lg:px-9 sm:px-14"
       title="Build your next AI app now with Neon"
-      description="Neon offers flexible usage and volume-based plans. Contact our Sales team to learn more."
-      buttonText="Contact Sales"
-      buttonUrl={LINKS.contactSales}
-      linkText="Learn more on GitHub"
-      linkUrl="https://github.com/neondatabase/pg_embedding"
+      description="Build your AI app on our Free Tier. Upgrade to a paid plan when you're ready to scale."
+      buttonText="Start for Free"
+      buttonUrl={LINKS.signup}
+      linkText="View the docs"
+      linkUrl="https://neon.tech/docs/ai/ai-intro"
       linkTarget="_blank"
     />
   </Layout>


### PR DESCRIPTION
Replace old pg_embedding link and text about our old usage based plans