### PR TITLE
fix: broken landing metadata after plugins update

### DIFF
--- a/src/app/[slug]/page.jsx
+++ b/src/app/[slug]/page.jsx
@@ -130,7 +130,7 @@ export async function generateMetadata({ params }) {
     keywords: metaKeywords,
     robotsNoindex: metaRobotsNoindex,
     pathname: `/${params.slug}`,
-    imagePath: twitterImage.mediaItemUrl,
+    imagePath: twitterImage?.mediaItemUrl,
   });
 }
 


### PR DESCRIPTION
This PR brings fix for broken metadata for landing pages after plugins update

![image](https://github.com/neondatabase/website/assets/22715126/296aa312-06bb-4e60-bce4-164beb1c27da)

[Preview](https://neon-next-git-fix-landing-metadata-neondatabase.vercel.app/scale-trial)