### PR TITLE
fix: lost header sticky property

### DIFF
--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -30,6 +30,7 @@ const Header = async ({
   className = null,
   theme = null,
   isSticky = false,
+  isStickyOverlay = false,
   isBlogPage = false,
   isDocPage = false,
   withBorder = false,
@@ -42,6 +43,7 @@ const Header = async ({
       <HeaderWrapper
         className={className}
         isSticky={isSticky}
+        isStickyOverlay={isStickyOverlay}
         theme={theme}
         withBorder={withBorder}
       >
@@ -198,6 +200,7 @@ Header.propTypes = {
   className: PropTypes.string,
   theme: PropTypes.oneOf(['light', 'dark']),
   isSticky: PropTypes.bool,
+  isStickyOverlay: PropTypes.bool,
   isBlogPage: PropTypes.bool,
   isDocPage: PropTypes.bool,
   withBorder: PropTypes.bool,


### PR DESCRIPTION
This PR brings lost property for sticky header at #1738

<details><summary>Before</summary>

![image](https://github.com/neondatabase/website/assets/22715126/3c5cebe5-9220-4c0b-87c7-72e1913bd5f6)
</details> 

<details><summary>After</summary>

![image](https://github.com/neondatabase/website/assets/22715126/ec8e17f4-e300-4807-93a5-cc9c3fec5c67)
</details> 

[Preview](https://neon-next-git-fix-sticky-header-neondatabase.vercel.app/)