### PR TITLE
fix: add pull script to workflow actions

### DIFF
--- a/.github/workflows/format-markdown.yml
+++ b/.github/workflows/format-markdown.yml
@@ -35,7 +35,7 @@ jobs:
         git config user.email "action@github.com"
         export HUSKY=0
         git add -A
-        # Check for meaningful changes before committing
+        # Check for meaningful changes before committing 
         if [ -n "$(git status --porcelain)" ]; then
           # Commit only modified markdown files, not all changes
           git commit -m "chore: format content markdown files with Prettier"

--- a/.github/workflows/format-markdown.yml
+++ b/.github/workflows/format-markdown.yml
@@ -45,6 +45,9 @@ jobs:
           exit 0
         fi
 
+    - name: Pull latest changes
+      run: git pull --rebase
+
     - name: Push changes
       run: git push
       env:

--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -61,6 +61,9 @@ jobs:
           exit 0
         fi
 
+    - name: Pull latest changes
+      run: git pull --rebase
+
     - name: Push changes
       run: git push origin HEAD:main
       env:

--- a/content/README.md
+++ b/content/README.md
@@ -39,6 +39,6 @@ This section contains reference information such as the glossary, API reference,
 
 This section describes how Neon handles security.
 
-  ## Changelog
+## Changelog
 
 This section describes the latest features and fixes from Neon. Changelog is categorized as either "Console" or "Storage". Within each category, changelog is organized under "What's new" and "Bug fixes" subcategories. Subcategories are further classified with tags. For example, each Console release note is tagged as "API", "Control Plane", "Integrations", or "UI". Storage changelog is tagged as "Compute", "Pageserver", "Proxy", or "Safekeeper". Write changelog from the user's perspective. Give context. Describe why each feature was introduced and the issue that a bug fix resolves. Provide links to the documentation or website for more details where applicable. Changelog should tell the story of Neon's development journey.

--- a/content/README.md
+++ b/content/README.md
@@ -39,6 +39,6 @@ This section contains reference information such as the glossary, API reference,
 
 This section describes how Neon handles security.
 
-## Changelog
+  ## Changelog
 
 This section describes the latest features and fixes from Neon. Changelog is categorized as either "Console" or "Storage". Within each category, changelog is organized under "What's new" and "Bug fixes" subcategories. Subcategories are further classified with tags. For example, each Console release note is tagged as "API", "Control Plane", "Integrations", or "UI". Storage changelog is tagged as "Compute", "Pageserver", "Proxy", or "Safekeeper". Write changelog from the user's perspective. Give context. Describe why each feature was introduced and the issue that a bug fix resolves. Provide links to the documentation or website for more details where applicable. Changelog should tell the story of Neon's development journey.

--- a/content/docs/community/contribution-guide.md
+++ b/content/docs/community/contribution-guide.md
@@ -197,7 +197,7 @@ To comment out content in a markdown file use this construction:
 [comment]: <> (Single line comment.)
 
 [comment]: <> (
-Multiline comment.
+Multiline comment. 
 You can't use line breaks or () parentheses here.
 )
 ```


### PR DESCRIPTION
This PR brings fix for workflow actions by adding the `pull` script

![image](https://github.com/neondatabase/website/assets/22715126/5b8516f8-ad7c-4c64-9f38-91224471ad06)

[Test trigger](https://github.com/neondatabase/website/actions/runs/9513632933/job/26224146845) with no significant changes to commit

