### PR TITLE
Neon cli updates

### DIFF
--- a/content/changelog/2024-06-14.md
+++ b/content/changelog/2024-06-14.md
@@ -76,6 +76,7 @@ To learn how to connect Outerbase to your Neon project, check out [this guide](/
 
 ### Fixes & improvements
 
+- The Neon CLI now supports a `--no-color` [global option](/docs/reference/neon-cli#global-options), which you can use to decolorize CLI command output when using Neon CLI commands in your CI/CD pipelines.
 - Fixed an issue with the dynamic rate limiter at the Neon Proxy that caused excessive CPU consumption and prevented new connections from being accepted.
 - Added a **Source** column to the **Branches** widget on the Project Dashboard, which shows icons that indicate the creation source for the branch. For example, you are now able to see if the branch was created in Neon, via the Neon Vercel Integration, or through our Hasura integration.
 - Added missing units of measure to the legends for several charts on the Neon **Monitoring** page in the Neon Console.

--- a/content/docs/reference/cli-auth.md
+++ b/content/docs/reference/cli-auth.md
@@ -28,6 +28,7 @@ The command launches a browser window where you can authorize the Neon CLI to ac
 An alternative to authenticating using `neon auth` is to provide an API key when running a CLI command. You can do this using the global `--api-key` option or by setting the `NEON_API_KEY` variable. See [Global options](/docs/reference/neon-cli#global-options) for instructions.
 
 <Admonition type="info">
+
 The authentication flow for the Neon CLI follows this order:
 
 - If the `--api-key` option is provided, it is used for authentication.

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -471,6 +471,20 @@ This setting is **optional**. If you leave it out, the operation uses either of 
 - `^parent` &#8212; compares the selected branch to the head of its parent branch. You can append `@timestamp` or `@lsn` to compare to an earlier point in the parent's history.
 - `<compare-branch-id|name>` &#8212; compares the selected branch to the head of another specified branch. Append `@timestamp` or `@lsn` to compare to an earlier point in the specified branch's history.
 
+#### Options
+
+In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-options), the `reset` subcommand supports these options:
+
+| Option                  | Description                                                                                   | Type    |                                 Required                                  |
+| ----------------------- | --------------------------------------------------------------------------------------------- | ------- | :-----------------------------------------------------------------------: |
+| `--context-file`        | [Context file](/docs/reference/cli-set-context#using-a-named-context-file) path and file name | string  |                                                                           |
+| `--project-id`          | Project ID                                                                                    | string  | Only if your Neon account has more than one project or context is not set |
+| `--database`, `--db`    | Name of the database for which the schema comparison is performed                             | string  |                                                                           |
+
+<Admonition type="note">
+The `--no-color` or `--color false` [global option](/docs/reference/neon-cli#global-options) can be used to decolorize the CLI command output when using CLI commands in CI/CD pipelines.
+</Admonition>
+
 #### Examples
 
 Examples of different kinds of schema diff operations you can do:

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -473,7 +473,7 @@ This setting is **optional**. If you leave it out, the operation uses either of 
 
 #### Options
 
-In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-options), the `reset` subcommand supports these options:
+In addition to the Neon CLI [global options](/docs/reference/neon-cli#global-options), the `schema-diff` subcommand supports these options:
 
 | Option                  | Description                                                                                   | Type    |                                 Required                                  |
 | ----------------------- | --------------------------------------------------------------------------------------------- | ------- | :-----------------------------------------------------------------------: |

--- a/content/docs/reference/cli-install.md
+++ b/content/docs/reference/cli-install.md
@@ -7,11 +7,17 @@ updatedOn: '2024-06-14T07:55:54.422Z'
 
 This section describes how to install the Neon CLI and connect via web authentication or API key.
 
-<Tabs labels={["npm", "Homebrew", "Binary"]}>
+<Tabs labels={["macOS", "Windows", "Linux"]}>
 
 <TabItem>
 
-To install the Neon CLI via [npm](https://www.npmjs.com/package/neonctl):
+**Install with [Homebrew](https://formulae.brew.sh/formula/neonctl)**
+
+```bash
+brew install neonctl
+```
+
+**Install via [npm](https://www.npmjs.com/package/neonctl)**
 
 ```shell
 npm i -g neonctl
@@ -19,79 +25,115 @@ npm i -g neonctl
 
 Requires [Node.js 18.0](https://nodejs.org/en/download/) or higher.
 
-</TabItem>
-
-<TabItem>
-
-To install the Neon CLI with [Homebrew](https://formulae.brew.sh/formula/neonctl):
+**Install with bun**
 
 ```bash
-brew install neonctl
+bun install -g neonctl
+```
+
+**macOS binary**
+
+Download the binary. No installation required.
+
+```bash shouldWrap
+curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-macos -o neonctl
+```
+
+Run the CLI from the download directory:
+
+```bash
+neonctl <command> [options]
 ```
 
 </TabItem>
 
 <TabItem>
 
-To install a [binary](https://github.com/neondatabase/neonctl/releases):
+**Install via [npm](https://www.npmjs.com/package/neonctl)**
 
-- **macOS**
+```shell
+npm i -g neonctl
+```
 
-  Download the macOS binary:
+Requires [Node.js 18.0](https://nodejs.org/en/download/) or higher.
 
-  ```bash shouldWrap
-  curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-macos -o neonctl
-  ```
+**Install with bun**
 
-  No installation is required. Run the Neon CLI as follows:
+```bash
+bun install -g neonctl
+```
 
-  ```bash
-  neonctl <command> [options]
-  ```
+**Windows binary**
 
-- **Linux**
+Download the binary. No installation required.
 
-  Download the Linux x64 or ARM64 binary:
+```bash shouldWrap
+curl -sL -O https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-win.exe
+```
 
-  x64:
+Run the CLI from the download directory:
 
-  ```bash shouldWrap
-  curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-x64 -o neonctl
-  ```
+```bash
+neonctl-win.exe <command> [options]
+```
 
-  ARM64:
+</TabItem>
 
-  ```bash shouldWrap
-  curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-arm64 -o neonctl
-  ```
+<TabItem>
 
-  No installation is required. Run the Neon CLI as follows:
+**Install via [npm](https://www.npmjs.com/package/neonctl)**
 
-  ```bash
-  neonctl <command> [options]
-  ```
+```shell
+npm i -g neonctl
+```
 
-- **Windows**
+**Install with bun**
 
-  Download the Windows binary:
+```bash
+bun install -g neonctl
+```
 
-  ```bash shouldWrap
-  curl -sL -O https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-win.exe
-  ```
+**Linux binary**
 
-  No installation is required. Run the Neon CLI as follows:
+Download the x64 or ARM64 binary, depending on your processor type. No installation required.
 
-  ```bash
-  neonctl-win.exe <command> [options]
-  ```
+x64:
+
+```bash shouldWrap
+curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-x64 -o neonctl
+```
+
+ARM64:
+
+```bash shouldWrap
+ curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-arm64 -o neonctl
+```
+
+Run the CLI from the download directory:
+
+```bash
+neonctl <command> [options]
+```
 
 </TabItem>
 
 </Tabs>
 
+<Admonition title="Use the Neon CLI without installing" type="note">
+You can run the Neon CLI without installing it using **npx** (Node Package eXecute) or the `bun` equivalent, **bunx**. For example:
+
+```shell
+# npx
+npx neonctl <command>
+
+# bunx
+bunx neonctl <command>
+```
+</Admonition>
+
 ### Upgrade
 
-When a new version is released, you can update your Neon CLI using the methods described below. To check for the latest version, refer to the **Releases** information on the [Neon CLI GitHub repository](https://github.com/neondatabase/neonctl) page. To check your installed version of the Neon CLI, run the following command:
+When a new version is released, you can update your Neon CLI using the methods described below, depending on how you installed the CLI initially. To check for the latest version, refer to the **Releases** information on the [Neon CLI GitHub repository](https://github.com/neondatabase/neonctl) page. To check your installed version of the Neon CLI, run the following command:
 
 ```bash
 neonctl --version

--- a/content/docs/reference/neon-cli.md
+++ b/content/docs/reference/neon-cli.md
@@ -9,11 +9,17 @@ The Neon CLI is a command-line interface that lets you manage Neon directly from
 
 ## Install
 
-<Tabs labels={["npm", "Homebrew", "Binary"]}>
+<Tabs labels={["macOS", "Windows", "Linux"]}>
 
 <TabItem>
 
-To install the Neon CLI via [npm](https://www.npmjs.com/package/neonctl):
+**Install with [Homebrew](https://formulae.brew.sh/formula/neonctl)**
+
+```bash
+brew install neonctl
+```
+
+**Install via [npm](https://www.npmjs.com/package/neonctl)**
 
 ```shell
 npm i -g neonctl
@@ -21,77 +27,113 @@ npm i -g neonctl
 
 Requires [Node.js 18.0](https://nodejs.org/en/download/) or higher.
 
-</TabItem>
-
-<TabItem>
-
-To install the Neon CLI with [Homebrew](https://formulae.brew.sh/formula/neonctl):
+**Install with bun**
 
 ```bash
-brew install neonctl
+bun install -g neonctl
+```
+
+**macOS binary**
+
+Download the binary. No installation required.
+
+```bash shouldWrap
+curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-macos -o neonctl
+```
+
+Run the CLI from the download directory:
+
+```bash
+neonctl <command> [options]
 ```
 
 </TabItem>
 
 <TabItem>
 
-To install a [binary](https://github.com/neondatabase/neonctl/releases):
+**Install via [npm](https://www.npmjs.com/package/neonctl)**
 
-- **macOS**
+```shell
+npm i -g neonctl
+```
 
-  Download the macOS binary:
+**Install with bun**
 
-  ```bash shouldWrap
-  curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-macos -o neonctl
-  ```
+```bash
+bun install -g neonctl
+```
 
-  No installation is required. Run the Neon CLI as follows:
+Requires [Node.js 18.0](https://nodejs.org/en/download/) or higher.
 
-  ```bash
-  neonctl <command> [options]
-  ```
+**Windows binary**
 
-- **Linux**
+Download the binary. No installation required.
 
-  Download the Linux x64 or ARM64 binary:
+```bash shouldWrap
+curl -sL -O https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-win.exe
+```
 
-  x64:
+Run the CLI from the download directory:
 
-  ```bash shouldWrap
-  curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-x64 -o neonctl
-  ```
+```bash
+neonctl-win.exe <command> [options]
+```
 
-  ARM64:
+</TabItem>
 
-  ```bash shouldWrap
-  curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-arm64 -o neonctl
-  ```
+<TabItem>
 
-  No installation is required. Run the Neon CLI as follows:
+**Install via [npm](https://www.npmjs.com/package/neonctl)**
 
-  ```bash
-  neonctl <command> [options]
-  ```
+```shell
+npm i -g neonctl
+```
 
-- **Windows**
+**Install with bun**
 
-  Download the Windows binary:
+```bash
+bun install -g neonctl
+```
 
-  ```bash shouldWrap
-  curl -sL -O https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-win.exe
-  ```
+**Linux binary**
 
-  No installation is required. Run the Neon CLI as follows:
+Download the x64 or ARM64 binary, depending on your processor type. No installation required.
 
-  ```bash
-  neonctl-win.exe <command> [options]
-  ```
+x64:
+
+```bash shouldWrap
+curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-x64 -o neonctl
+```
+
+ARM64:
+
+```bash shouldWrap
+ curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-arm64 -o neonctl
+```
+
+Run the CLI from the download directory:
+
+```bash
+neonctl <command> [options]
+```
 
 </TabItem>
 
 </Tabs>
 
 For more about installing, upgrading, and connecting, see [Neon CLI — Install and connect](/docs/reference/cli-install).
+
+<Admonition title="Use the Neon CLI without installing" type="note">
+You can run the Neon CLI without installing it using **npx** (Node Package eXecute) or the `bun` equivalent, **bunx**. For example:
+
+```shell
+# npx
+npx neonctl <command>
+
+# bunx
+bunx neonctl <command>
+```
+</Admonition>
 
 ## Synopsis
 
@@ -151,6 +193,7 @@ Global options are supported with any Neon CLI command.
 | [-o, --output](#output)     | Set the Neon CLI output format (`json`, `yaml`, or `table`) | string  | table                               |
 | [--config-dir](#config-dir) | Path to the Neon CLI configuration directory                | string  | `/home/<user>/.config/neonctl`      |
 | [--api-key](#api-key)       | Neon API key                                                | string  | `NEON_API_KEY` environment variable |
+| [--color](#color        )   | Colorize the output. Example: `--no-color`, `--color false` | boolean | true                                |
 | [--analytics](#analytics)   | Manage analytics                                            | boolean | true                                |
 | [-v, --version](#version)   | Show the Neon CLI version number                            | boolean | -                                   |
 | [-h, --help](#help)         | Show the Neon CLI help                                      | boolean | -                                   |
@@ -185,16 +228,18 @@ Global options are supported with any Neon CLI command.
   export NEON_API_KEY=<neon_api_key>
   ```
 
-  <Admonition type="info">
-    
-    The authentication flow for the Neon CLI follows this order:
+  <Admonition type="info">    
+  The authentication flow for the Neon CLI follows this order:
 
   - If the `--api-key` option is provided, it is used for authentication.
   - If the `--api-key` option is not provided, the `NEON_API_KEY` environment variable setting is used.
   - If there is no `--api-key` option or `NEON_API_KEY` environment variable setting, the CLI looks for the `credentials.json` file created by the `neonctl auth` command.
   - If the credentials file is not found, the Neon CLI initiates the `neonctl auth` web authentication process.
-
   </Admonition>
+
+- <a id="color"></a>`--color`
+
+  Colorize the output. This option is enabled by default, but you can disable it by specifying `--no-color` or `--color false`, which is useful when using Neon CLI commands in your automation pipelines. 
 
 - <a id="analytics"></a>`--analytics`
 

--- a/content/docs/reference/neon-cli.md
+++ b/content/docs/reference/neon-cli.md
@@ -237,7 +237,7 @@ Global options are supported with any Neon CLI command.
   - If the `--api-key` option is not provided, the `NEON_API_KEY` environment variable setting is used.
   - If there is no `--api-key` option or `NEON_API_KEY` environment variable setting, the CLI looks for the `credentials.json` file created by the `neonctl auth` command.
   - If the credentials file is not found, the Neon CLI initiates the `neonctl auth` web authentication process.
-  
+
   </Admonition>
 
 - <a id="color"></a>`--color`

--- a/content/docs/reference/neon-cli.md
+++ b/content/docs/reference/neon-cli.md
@@ -228,13 +228,15 @@ Global options are supported with any Neon CLI command.
   export NEON_API_KEY=<neon_api_key>
   ```
 
-  <Admonition type="info">    
+  <Admonition type="info">
+      
   The authentication flow for the Neon CLI follows this order:
 
   - If the `--api-key` option is provided, it is used for authentication.
   - If the `--api-key` option is not provided, the `NEON_API_KEY` environment variable setting is used.
   - If there is no `--api-key` option or `NEON_API_KEY` environment variable setting, the CLI looks for the `credentials.json` file created by the `neonctl auth` command.
   - If the credentials file is not found, the Neon CLI initiates the `neonctl auth` web authentication process.
+  
   </Admonition>
 
 - <a id="color"></a>`--color`


### PR DESCRIPTION
- mention new --no-color option in reference and changelog
- order install commands by platform (macOS, Windows, Linux) to be consistent with the website CLI page
- Add schema-diff command options table
- mention npx, bunx no-install usage options