### PR TITLE
docs: modify cli page to show install command only

### DIFF
--- a/src/components/pages/cli/hero/code-tabs/code-tabs-navigation.jsx
+++ b/src/components/pages/cli/hero/code-tabs/code-tabs-navigation.jsx
@@ -64,7 +64,7 @@ const CodeTabsNavigation = ({ codeSnippets, highlightedCodeSnippets }) => {
           );
         })}
       </div>
-      <div className="h-[138px]">
+      <div className="h-[72px]">
         <LazyMotion features={domAnimation}>
           <AnimatePresence initial={false} mode="wait">
             {highlightedCodeSnippets.map(
@@ -77,7 +77,7 @@ const CodeTabsNavigation = ({ codeSnippets, highlightedCodeSnippets }) => {
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ duration: 0.2 }}
                   >
-                    <CodeBlockWrapper className="highlighted-code h-[138px] [&_[data-line]]:text-[15px]">
+                    <CodeBlockWrapper className="highlighted-code h-[72px] [&_[data-line]]:text-[15px]">
                       {parse(code)}
                     </CodeBlockWrapper>
                   </m.div>

--- a/src/components/pages/cli/hero/code-tabs/code-tabs.jsx
+++ b/src/components/pages/cli/hero/code-tabs/code-tabs.jsx
@@ -10,28 +10,19 @@ const codeSnippets = [
     name: 'macOS',
     iconName: 'macos',
     language: 'text',
-    code: `brew install neonctl
-neonctl auth
-neonctl branches create --name dev/alex
-neonctl branches list`,
+    code: `brew install neonctl`,
   },
   {
     name: 'Windows',
     iconName: 'windows',
     language: 'text',
-    code: `npm install -g neonctl
-neonctl auth
-neonctl branches create --name dev/alex
-neonctl branches list`,
+    code: `npm install -g neonctl`,
   },
   {
     name: 'Linux',
     iconName: 'linux',
     language: 'text',
-    code: `npm install -g neonctl
-neonctl auth
-neonctl branches create --name dev/alex
-neonctl branches list`,
+    code: `npm install -g neonctl`,
   },
 ];
 


### PR DESCRIPTION
We'd like to show only the CLI installation command, which was suggested by @m-abdelwahab (mockup shown below)
![image](https://github.com/neondatabase/website/assets/10074684/78b8f016-f074-4205-961b-bca544b6973e)

The change in the PR fails to shrink the height of the tabbed codeblock. 