### PR TITLE
fix: docs search cursor

### DIFF
--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -28,7 +28,7 @@
 }
 
 .DocSearch-Container {
-  @apply fixed left-0 top-0 z-[200] flex h-screen w-screen min-w-[320px] items-center justify-center bg-[rgba(12,13,13,0.2)] dark:bg-[rgba(12,13,13,0.8)] lg:p-4;
+  @apply fixed left-0 top-0 z-[200] flex h-screen w-screen min-w-[320px] cursor-default items-center justify-center bg-[rgba(12,13,13,0.2)] dark:bg-[rgba(12,13,13,0.8)] lg:p-4;
 
   .DocSearch-Modal {
     @apply relative w-full max-w-[564px] rounded-[10px] border border-gray-new-90 bg-white dark:border-gray-new-20 dark:bg-gray-new-8;

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -28,10 +28,10 @@
 }
 
 .DocSearch-Container {
-  @apply fixed left-0 top-0 z-[200] flex h-screen w-screen min-w-[320px] cursor-default items-center justify-center bg-[rgba(12,13,13,0.2)] dark:bg-[rgba(12,13,13,0.8)] lg:p-4;
+  @apply fixed left-0 top-0 z-[200] flex h-screen w-screen min-w-[320px] items-center justify-center bg-[rgba(12,13,13,0.2)] dark:bg-[rgba(12,13,13,0.8)] lg:p-4;
 
   .DocSearch-Modal {
-    @apply relative w-full max-w-[564px] rounded-[10px] border border-gray-new-90 bg-white dark:border-gray-new-20 dark:bg-gray-new-8;
+    @apply relative w-full max-w-[564px] cursor-default rounded-[10px] border border-gray-new-90 bg-white dark:border-gray-new-20 dark:bg-gray-new-8;
     box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.06);
   }
 


### PR DESCRIPTION
This PR brings fix for docs search cursor.
Before we had a bug with the Docs Search modal, it was whole with cursor-pointer. Now it's fixed. 

![image](https://github.com/neondatabase/website/assets/22715126/3f456401-bee6-4e01-b348-cb57db70f646)

[Preview](https://neon-next-git-fix-docs-search-cursor-neondatabase.vercel.app/docs/introduction)