### PR TITLE
docs: Fix Laravel .env guidance for latest version

### DIFF
--- a/content/docs/guides/laravel.md
+++ b/content/docs/guides/laravel.md
@@ -33,8 +33,6 @@ DB_USERNAME=[user]
 DB_PASSWORD=[password]
 ```
 
-**Note:** For Laravel 10 and older add `DB_SSLMODE=require` to the `.env` file as well.
-
 You can find all of the connection details listed above in the **Connection Details** widget on the Neon **Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Connection issues

--- a/content/docs/guides/laravel.md
+++ b/content/docs/guides/laravel.md
@@ -31,8 +31,9 @@ DB_PORT=5432
 DB_DATABASE=[dbname]
 DB_USERNAME=[user]
 DB_PASSWORD=[password]
-DB_SSLMODE=require
 ```
+
+**Note:** For Laravel 10 and older add `DB_SSLMODE=require` to the `.env` file as well.
 
 You can find all of the connection details listed above in the **Connection Details** widget on the Neon **Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 


### PR DESCRIPTION
A developer on Discord pointed out that `DB_SSLMODE` is not needed. Removing it.