### PR TITLE
docs: clarify import instructions

### DIFF
--- a/content/docs/import/import-from-neon.md
+++ b/content/docs/import/import-from-neon.md
@@ -31,17 +31,28 @@ To import your data from another Neon project:
    postgres://[user]:[password]@[neon_hostname]/[dbname]
    ```
 
-4. Prepare your import command to pipe data to from one Neon project to the other. The command will look similar to this:
+4. Prepare your import command to pipe data from one Neon project to the other. For the `pg_dump` command, specify the connection details for the source database. For the `pg_restore` command, specify the connection details for the destination database. The command should be defined as shown here:
 
    ```bash shouldWrap
-   pg_dump -Fc -v -d postgres://[user]:[password]@[neon_hostname]/[dbname] | pg_restore -v -d postgres://[user]:[password]@[neon_hostname]/[dbname]
+   pg_dump -Fc -v -d postgres://[user]:[password]@[source_neon_hostname]/[dbname] | pg_restore -v -d postgres://[user]:[password]@[destination_neon_hostname]/[dbname]
    ```
+
+   With actual source and destination connection details, the command will appear similar to this:
+
+   ```bash
+   pg_dump -Fc -v -d postgresql://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/my_source_db | pg_restore -v -d postgres://alex:AbC123dEf@square-shadow-654321.us-east-2.aws.neon.tech/my_destination_db     
+   ```
+
+   <Admonition type="note">
+   While your source and destination databases might have the same name, the hostnames will differ, as illustrated in the example above.
+   </Admonition>
 
    The command includes these arguments:
 
    - `-Fc`: Sends the output to a custom-format archive suitable for input into `pg_restore`.
    - `-v`: Runs commands in verbose mode, allowing you to monitor what happens during the operation.
    - `-d`: Specifies the database name or connection string.
+
 
 5. Run the command from your terminal or command window.
 6. If you no longer require the old project, you can remove it. See [Delete a project](/docs/manage/projects#delete-a-project) for instructions.


### PR DESCRIPTION
It was not clear that the source and destination database should have different connection strings (hostnames).