### PR TITLE
docs: add source code cards to deploy topics

### DIFF
--- a/content/docs/guides/cloudflare-pages.md
+++ b/content/docs/guides/cloudflare-pages.md
@@ -335,6 +335,14 @@ To delete your `Cloudflare Pages` application, you can use the Cloudflare dashbo
 
 To delete your Neon project, follow the steps outlined in the Neon documentation under [Delete a project](/docs/manage/projects#delete-a-project).
 
+## Source code
+
+You can find the source code for the application described in this guide on GitHub.
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/examples/tree/main/deploy-with-cloudflare-pages" description="Connect a Neon Postgres database to your Cloudflare Pages web application" icon="github">Use Neon with Cloudflare Pages</a>
+</DetailIconCards>
+
 ## Resources
 
 - [Cloudflare Pages](https://pages.cloudflare.com/)

--- a/content/docs/guides/cloudflare-workers.md
+++ b/content/docs/guides/cloudflare-workers.md
@@ -193,6 +193,14 @@ To delete your Worker, you can use the Cloudflare dashboard or run `wrangler del
 
 To delete your Neon project, follow the steps outlined in the Neon documentation under [Delete a project](/docs/manage/projects#delete-a-project).
 
+## Source code
+
+You can find the source code for the application described in this guide on GitHub.
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/examples/tree/main/deploy-with-cloudflare-workers" description="Connect a Neon Postgres database to your Cloudflare Workers application" icon="github">Use Neon with Cloudflare Workers</a>
+</DetailIconCards>
+
 ## Resources
 
 - [Cloudflare Workers](https://workers.cloudflare.com/)

--- a/content/docs/guides/deno.md
+++ b/content/docs/guides/deno.md
@@ -245,6 +245,14 @@ To delete the example application on Deno Deploy, follow these steps:
 
 To delete your Neon project, refer to [Delete a project](/docs/manage/projects#delete-a-project).
 
+## Source code
+
+You can find the source code for the application described in this guide on GitHub.
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/examples/tree/main/deploy-with-deno" description="Connect a Neon Postgres database to your Deno Deploy application" icon="github">Use Neon with Deno Deploy</a>
+</DetailIconCards>
+
 ## Resources
 
 - [Deno Deploy](https://deno.com/deploy)

--- a/content/docs/guides/heroku.md
+++ b/content/docs/guides/heroku.md
@@ -182,6 +182,14 @@ To remove your application from Heroku, select the app from your [Heroku dashboa
 
 To delete your Neon project, follow the steps outlined in the Neon documentation under [Delete a project](/docs/manage/projects#delete-a-project).
 
+## Source code
+
+You can find the source code for the application described in this guide on GitHub.
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/examples/tree/main/deploy-with-heroku" description="Deploying a Node application with a Neon Postgres database on Heroku" icon="github">Use Neon with Heroku</a>
+</DetailIconCards>
+
 ## Resources
 
 - [Heroku Documentation](https://devcenter.heroku.com/)

--- a/content/docs/guides/netlify-functions.md
+++ b/content/docs/guides/netlify-functions.md
@@ -220,6 +220,14 @@ For cleanup, delete your Netlify site and functions via the Netlify dashboard or
 
 To remove your Neon project, follow the deletion steps in Neon's documentation under [Manage Projects](https://neon.tech/docs/manage/projects#delete-a-project).
 
+## Source code
+
+You can find the source code for the application described in this guide on GitHub.
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/examples/tree/main/deploy-with-netlify-functions" description="Connect a Neon Postgres database to your Netlify Functions application" icon="github">Use Neon with Netlify Functions</a>
+</DetailIconCards>
+
 ## Resources
 
 - [Netlify Functions](https://www.netlify.com/products/functions/)

--- a/content/docs/guides/railway.md
+++ b/content/docs/guides/railway.md
@@ -157,6 +157,14 @@ To remove your application from Railway, select the project and navigate to the 
 
 To delete your Neon project, follow the steps outlined in the Neon documentation under [Delete a project](/docs/manage/projects#delete-a-project).
 
+## Source code
+
+You can find the source code for the application described in this guide on GitHub.
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/examples/tree/main/deploy-with-railway" description="Connect a Neon Postgres database to your Node application deployed with Railway" icon="github">Use Neon Postgres with Railway</a>
+</DetailIconCards>
+
 ## Resources
 
 - [Railway platform](https://railway.app/)

--- a/content/docs/guides/render.md
+++ b/content/docs/guides/render.md
@@ -155,6 +155,14 @@ To remove your application from Render, navigate to the dashboard, select `Setti
 
 To delete your Neon project, follow the steps outlined in the Neon documentation under [Delete a project](/docs/manage/projects#delete-a-project).
 
+## Source code
+
+You can find the source code for the application described in this guide on GitHub.
+
+<DetailIconCards>
+<a href="https://github.com/neondatabase/examples/tree/main/deploy-with-render" description="Connect a Neon Postgres database to your Node application deployed with Render" icon="github">Use Neon Postgres with Render</a>
+</DetailIconCards>
+
 ## Resources
 
 - [Render platform](https://render.com/)


### PR DESCRIPTION
Add source code cards to deploy topics so that users can access the source code for our deployment platform examples.