### PR TITLE
Add Blog post redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -114,6 +114,11 @@ const defaultConfig = {
 
     return [
       {
+        source: '/blog/the-non-obviousness-of-postgres-roles',
+        destination: '/blog/postgres-roles',
+        permanent: true,
+      },
+      {
         source: '/2024-plan-updates',
         destination: '/pricing',
         permanent: true,


### PR DESCRIPTION
Renamed the slug of this blog post: https://neon.tech/blog/the-non-obviousness-of-postgres-roles to https://neon.tech/blog/postgres-roles

and need to manually add a redirect