### PR TITLE
feat/twin-thing-rewrite

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -231,6 +231,14 @@ const defaultConfig = {
         destination: 'https://dfv3qgd2ykmrx.cloudfront.net/api_spec/release/v2.json',
       },
       {
+        source: '/demos/twin-thing',
+        destination: 'https://twin-thing.vercel.app/demos/twin-thing',
+      },
+      {
+        source: '/demos/twin-thing/:path*',
+        destination: 'https://twin-thing.vercel.app/demos/twin-thing/:path*',
+      },
+      {
         source: '/demos/ping-thing',
         destination: 'https://ping-thing.vercel.app/demos/ping-thing',
       },


### PR DESCRIPTION
This PR adds a rewrite / proxy redirect for a new demo named twin-thing. The setup is the same as previous demo named ping-thing.  More information about why rewrites are used for demos can be found here: [What Is a Proxy Redirect?](https://www.paulie.dev/posts/2023/10/what-is-a-proxy-redirect)

