### PR TITLE
docs: hint switch to pg-native for performance improvement with pg-wrapped libraries

### DIFF
--- a/content/docs/guides/typeorm.md
+++ b/content/docs/guides/typeorm.md
@@ -22,8 +22,8 @@ To establish a basic connection from TypeORM to Neon, perform the following step
 2. Update the TypeORM's DataSource initialization in your application to the following:
 
    ```typescript {4,5,6}
-   import { DataSource } from 'typeorm'
-   
+   import { DataSource } from 'typeorm';
+
    export const AppDataSource = new DataSource({
      type: 'postgres',
      url: process.env.DATABASE_URL,

--- a/content/docs/guides/typeorm.md
+++ b/content/docs/guides/typeorm.md
@@ -21,7 +21,9 @@ To establish a basic connection from TypeORM to Neon, perform the following step
 
 2. Update the TypeORM's DataSource initialization in your application to the following:
 
-   ```typescript {2,3,4}
+   ```typescript {4,5,6}
+   import { DataSource } from 'typeorm'
+   
    export const AppDataSource = new DataSource({
      type: 'postgres',
      url: process.env.DATABASE_URL,
@@ -39,6 +41,8 @@ To establish a basic connection from TypeORM to Neon, perform the following step
    ```text shouldWrap
    DATABASE_URL="postgres://[user]:[password]@[neon_hostname]/[dbname]?sslmode=require"
    ```
+
+<PgHint />
 
 ## Use connection pooling with TypeORM
 

--- a/content/docs/shared-content/index.js
+++ b/content/docs/shared-content/index.js
@@ -4,6 +4,7 @@ const sharedMdxComponents = {
   NewPricing: 'shared-content/NewPricing',
   LRNotice: 'shared-content/lr-notice',
   ComingSoon: 'shared-content/coming-soon',
+  PgHint: 'shared-content/pg-hint'
 };
 
 module.exports = sharedMdxComponents;

--- a/content/docs/shared-content/pg-hint.md
+++ b/content/docs/shared-content/pg-hint.md
@@ -3,5 +3,5 @@ updatedOn: '2024-07-31T07:55:54.426Z'
 ---
 
 <Admonition type="tip">
-TypeORM leverages [node-postgres](https://node-postgres.com) Pool instance underneath to connect to your Postgres. Configuring the `NODE_PG_FORCE_NATIVE` environment variable to `true` [switches the pg driver to pg-native one](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/index.js#L31-L34), which in some cases, seem to bring noticeable faster response times.
+TypeORM leverages a [node-postgres](https://node-postgres.com) Pool instance to connect to your Postgres database. Setting the `NODE_PG_FORCE_NATIVE` environment variable to `true` [switches the `pg` driver to `pg-native`](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/index.js#L31-L34), which, according to some users, produces noticeably faster response times.
 </Admonition>

--- a/content/docs/shared-content/pg-hint.md
+++ b/content/docs/shared-content/pg-hint.md
@@ -3,5 +3,5 @@ updatedOn: '2024-07-31T07:55:54.426Z'
 ---
 
 <Admonition type="tip">
-TypeORM leverages a [node-postgres](https://node-postgres.com) Pool instance to connect to your Postgres database. Setting the `NODE_PG_FORCE_NATIVE` environment variable to `true` [switches the `pg` driver to `pg-native`](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/index.js#L31-L34), which, according to some users, produces noticeably faster response times.
+TypeORM leverages a [node-postgres](https://node-postgres.com) Pool instance to connect to your Postgres database. Installing [pg-native](https://npmjs.com/package/pg-native), and setting the `NODE_PG_FORCE_NATIVE` environment variable to `true` [switches the `pg` driver to `pg-native`](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/index.js#L31-L34), which, according to some users, produces noticeably faster response times.
 </Admonition>

--- a/content/docs/shared-content/pg-hint.md
+++ b/content/docs/shared-content/pg-hint.md
@@ -3,5 +3,5 @@ updatedOn: '2024-07-31T07:55:54.426Z'
 ---
 
 <Admonition type="tip">
-TypeORM leverages a [node-postgres](https://node-postgres.com) Pool instance to connect to your Postgres database. Installing [pg-native](https://npmjs.com/package/pg-native), and setting the `NODE_PG_FORCE_NATIVE` environment variable to `true` [switches the `pg` driver to `pg-native`](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/index.js#L31-L34), which, according to some users, produces noticeably faster response times.
+TypeORM leverages a [node-postgres](https://node-postgres.com) Pool instance to connect to your Postgres database. Installing [pg-native](https://npmjs.com/package/pg-native) and setting the `NODE_PG_FORCE_NATIVE` environment variable to `true` [switches the `pg` driver to `pg-native`](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/index.js#L31-L34), which, according to some users, produces noticeably faster response times.
 </Admonition>

--- a/content/docs/shared-content/pg-hint.md
+++ b/content/docs/shared-content/pg-hint.md
@@ -1,0 +1,7 @@
+---
+updatedOn: '2024-07-31T07:55:54.426Z'
+---
+
+<Admonition type="tip">
+TypeORM leverages [node-postgres](https://node-postgres.com) Pool instance underneath to connect to your Postgres. Configuring the `NODE_PG_FORCE_NATIVE` environment variable to `true` [switches the pg driver to pg-native one](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/index.js#L31-L34), which in some cases, seem to bring noticeable faster response times.
+</Admonition>


### PR DESCRIPTION
I'm looking to add a hint for all the users (**it's not a 100% verified claim**) using pg-wrapped libraries to use this environment variable, such as in TypeORM (already existing doc) and Knex (an upcoming PR).