### PR TITLE
chore: variable traffic page updates

### DIFF
--- a/src/app/variable-load/page.jsx
+++ b/src/app/variable-load/page.jsx
@@ -13,104 +13,9 @@ import Layout from 'components/shared/layout';
 import TableOfContents from 'components/shared/table-of-contents';
 import LINKS from 'constants/links';
 import SEO_DATA from 'constants/seo-data';
-import evolutionOfPostgres from 'images/pages/variable-load/relevant-articles/evolution-of-postgres.jpg';
-import { getWpPostBySlug } from 'utils/api-posts';
-import getFormattedDate from 'utils/get-formatted-date';
 import getMetadata from 'utils/get-metadata';
 
 export const metadata = getMetadata(SEO_DATA.variable);
-
-const blogArticlesData = [
-  {
-    slug: '/blog/autoscaling-in-action-postgres-load-testing-with-pgbench',
-    order: 2,
-  },
-  {
-    slug: '/blog/1-year-of-autoscaling-postgres-at-neon',
-    order: 3,
-  },
-  {
-    slug: '/blog/white-widgets-secret-to-scalable-postgres-neon',
-    order: 9,
-  },
-  {
-    slug: '/blog/how-recrowd-uses-neon-autoscaling-to-meet-fluctuating-demand',
-    order: 10,
-  },
-  {
-    slug: '/blog/why-you-want-a-database-that-scales-to-zero',
-    order: 11,
-  },
-];
-
-const docsArticlesData = [
-  {
-    slug: '/docs/introduction/autoscaling',
-    title: 'Autoscaling',
-    order: 6,
-  },
-  {
-    slug: '/docs/extensions/neon-utils',
-    title: 'The neon_utils extension',
-    order: 7,
-  },
-];
-
-const externalArticlesData = [
-  {
-    url: 'https://www.outerbase.com/blog/the-evolution-of-serverless-postgres/',
-    title: 'The Evolution of Serverless Postgres',
-    image: evolutionOfPostgres,
-    date: 'May 29, 2024',
-    order: 1,
-  },
-  {
-    url: 'https://medium.com/@carlotasotos/database-economics-an-amazon-rds-reflection-5d7a35638b20',
-    title: 'Database economics: an Amazon RDS reflection',
-    date: 'May 31, 2024',
-    order: 4,
-  },
-  {
-    url: 'https://dev.to/rsiv/auto-scaling-apps-by-default-neon-api-gateway-nitric-34id',
-    title: 'Architectural choices that scale',
-    date: 'Jun 6, 2023',
-    order: 5,
-  },
-  {
-    url: 'https://github.com/prisma/read-replicas-demo',
-    title: 'Read Replicas Demo',
-    order: 8,
-  },
-];
-
-const fetchBlogArticles = async (articles) =>
-  Promise.all(
-    articles.map(async (article) => {
-      const { post } = await getWpPostBySlug(article.slug);
-      if (post) {
-        return {
-          ...article,
-          title: post.title,
-          date: getFormattedDate(post.date),
-          image: post.seo?.twitterImage?.mediaItemUrl,
-        };
-      }
-      return article;
-    })
-  );
-
-const articlesWithImages = (articles) =>
-  articles.map((article) => {
-    if (article.image) {
-      return article;
-    }
-    const encodedTitle = Buffer.from(article.title).toString('base64');
-    const imagePath = `/docs/og?title=${encodedTitle}&show-logo=${article.url ? 'false' : 'true'}`;
-    return {
-      ...article,
-      image: imagePath,
-    };
-  });
 
 const titles = [
   'Variable traffic, fixed costs?',
@@ -120,11 +25,6 @@ const titles = [
 ];
 
 const VariableLoadPage = async () => {
-  const blogArticles = await fetchBlogArticles(blogArticlesData);
-  const docsArticles = articlesWithImages(docsArticlesData);
-  const externalArticles = articlesWithImages(externalArticlesData);
-  const allArticles = [...blogArticles, ...docsArticles, ...externalArticles];
-
   const tableOfContents = titles.map((title) => ({
     title,
     id: slugify(title.replace(/&nbsp;/g, ' '), {
@@ -150,7 +50,6 @@ const VariableLoadPage = async () => {
               <Unique title={tableOfContents[3]} />
             </article>
           </div>
-
           <div className="col-start-10 col-end-13 ml-[50px] h-full xl:hidden">
             <nav
               className={clsx(
@@ -162,8 +61,7 @@ const VariableLoadPage = async () => {
             </nav>
           </div>
         </Container>
-
-        <RelevantArticles articles={allArticles} />
+        <RelevantArticles />
         <Cta
           className="pb-[290px] pt-[285px] xl:py-[230px] lg:pb-[156px] lg:pt-[179px] sm:pb-[110px] sm:pt-[116px]"
           title="Try it yourself"

--- a/src/app/variable-traffic/page.jsx
+++ b/src/app/variable-traffic/page.jsx
@@ -1,0 +1,182 @@
+import clsx from 'clsx';
+import slugify from 'slugify';
+
+import Budget from 'components/pages/variable/budget';
+import Efficiency from 'components/pages/variable/efficiency';
+import Hero from 'components/pages/variable/hero';
+import Load from 'components/pages/variable/load';
+import RelevantArticles from 'components/pages/variable/relevant-articles';
+import Unique from 'components/pages/variable/unique';
+import Container from 'components/shared/container';
+import Cta from 'components/shared/cta';
+import Layout from 'components/shared/layout';
+import TableOfContents from 'components/shared/table-of-contents';
+import LINKS from 'constants/links';
+import SEO_DATA from 'constants/seo-data';
+import evolutionOfPostgres from 'images/pages/variable-load/relevant-articles/evolution-of-postgres.jpg';
+import { getWpPostBySlug } from 'utils/api-posts';
+import getFormattedDate from 'utils/get-formatted-date';
+import getMetadata from 'utils/get-metadata';
+
+export const metadata = getMetadata(SEO_DATA.variable);
+
+const blogArticlesData = [
+  {
+    slug: '/blog/autoscaling-in-action-postgres-load-testing-with-pgbench',
+    order: 2,
+  },
+  {
+    slug: '/blog/1-year-of-autoscaling-postgres-at-neon',
+    order: 3,
+  },
+  {
+    slug: '/blog/white-widgets-secret-to-scalable-postgres-neon',
+    order: 9,
+  },
+  {
+    slug: '/blog/how-recrowd-uses-neon-autoscaling-to-meet-fluctuating-demand',
+    order: 10,
+  },
+  {
+    slug: '/blog/why-you-want-a-database-that-scales-to-zero',
+    order: 11,
+  },
+];
+
+const docsArticlesData = [
+  {
+    slug: '/docs/introduction/autoscaling',
+    title: 'Autoscaling',
+    order: 6,
+  },
+  {
+    slug: '/docs/extensions/neon-utils',
+    title: 'The neon_utils extension',
+    order: 7,
+  },
+];
+
+const externalArticlesData = [
+  {
+    url: 'https://www.outerbase.com/blog/the-evolution-of-serverless-postgres/',
+    title: 'The Evolution of Serverless Postgres',
+    image: evolutionOfPostgres,
+    date: 'May 29, 2024',
+    order: 1,
+  },
+  {
+    url: 'https://medium.com/@carlotasotos/database-economics-an-amazon-rds-reflection-5d7a35638b20',
+    title: 'Database economics: an Amazon RDS reflection',
+    date: 'May 31, 2024',
+    order: 4,
+  },
+  {
+    url: 'https://dev.to/rsiv/auto-scaling-apps-by-default-neon-api-gateway-nitric-34id',
+    title: 'Architectural choices that scale',
+    date: 'Jun 6, 2023',
+    order: 5,
+  },
+  {
+    url: 'https://github.com/prisma/read-replicas-demo',
+    title: 'Read Replicas Demo',
+    order: 8,
+  },
+];
+
+const fetchBlogArticles = async (articles) =>
+  Promise.all(
+    articles.map(async (article) => {
+      const { post } = await getWpPostBySlug(article.slug);
+      if (post) {
+        return {
+          ...article,
+          title: post.title,
+          date: getFormattedDate(post.date),
+          image: post.seo?.twitterImage?.mediaItemUrl,
+        };
+      }
+      return article;
+    })
+  );
+
+const articlesWithImages = (articles) =>
+  articles.map((article) => {
+    if (article.image) {
+      return article;
+    }
+    const encodedTitle = Buffer.from(article.title).toString('base64');
+    const imagePath = `/docs/og?title=${encodedTitle}&show-logo=${article.url ? 'false' : 'true'}`;
+    return {
+      ...article,
+      image: imagePath,
+    };
+  });
+
+const titles = [
+  'Variable traffic, fixed costs?',
+  'Pay only for what you use with Neon',
+  'How much money are you wasting on&nbsp;unused compute?',
+  'Why Neon vs Aurora Serverless',
+];
+
+const VariableLoadPage = async () => {
+  const blogArticles = await fetchBlogArticles(blogArticlesData);
+  const docsArticles = articlesWithImages(docsArticlesData);
+  const externalArticles = articlesWithImages(externalArticlesData);
+  const allArticles = [...blogArticles, ...docsArticles, ...externalArticles];
+
+  const tableOfContents = titles.map((title) => ({
+    title,
+    id: slugify(title.replace(/&nbsp;/g, ' '), {
+      lower: true,
+      strict: true,
+      remove: /[*+~.()'"!:@]/g,
+    }),
+  }));
+
+  return (
+    <Layout headerWithBorder burgerWithoutBorder isHeaderSticky>
+      <div className="safe-paddings flex flex-1 flex-col dark:bg-black-pure dark:text-white lg:block">
+        <Container
+          className="grid w-full flex-1 grid-cols-12 gap-x-10 pt-[88px] xl:gap-x-7 xl:pt-14 lg:block lg:gap-x-5 lg:pt-11 md:pt-8"
+          size="1344"
+        >
+          <div className="col-span-6 col-start-4 -mx-[26px] flex flex-col 2xl:col-span-9 2xl:col-start-2 2xl:mx-5 xl:col-span-8 xl:col-start-3 lg:ml-0 md:mx-auto">
+            <article>
+              <Hero />
+              <Load title={tableOfContents[0]} />
+              <Efficiency title={tableOfContents[1]} />
+              <Budget title={tableOfContents[2]} />
+              <Unique title={tableOfContents[3]} />
+            </article>
+          </div>
+
+          <div className="col-start-10 col-end-13 ml-[50px] h-full xl:hidden">
+            <nav
+              className={clsx(
+                'no-scrollbars sticky bottom-10 top-[104px] -mt-2 max-h-[calc(100vh-80px)]',
+                'before:absolute before:-inset-5 before:-z-10 before:bg-black-pure before:bg-gradient-to-b before:blur'
+              )}
+            >
+              <TableOfContents items={tableOfContents} />
+            </nav>
+          </div>
+        </Container>
+
+        <RelevantArticles articles={allArticles} />
+        <Cta
+          className="pb-[290px] pt-[285px] xl:py-[230px] lg:pb-[156px] lg:pt-[179px] sm:pb-[110px] sm:pt-[116px]"
+          title="Try it yourself"
+          description="You can experiment with autoscaling for free during 14 days"
+          buttonClassName="mt-9 h-12 w-[201px] lg:mt-7 lg:h-11 lg:w-[186px] lg:text-sm md:mt-4.5 md:h-10 md:w-[183px]"
+          buttonText="Request a Scale trial"
+          buttonUrl={LINKS.scaleTrial}
+        />
+      </div>
+    </Layout>
+  );
+};
+
+export default VariableLoadPage;
+
+export const revalidate = 60;

--- a/src/app/variable-traffic/page.jsx
+++ b/src/app/variable-traffic/page.jsx
@@ -13,104 +13,9 @@ import Layout from 'components/shared/layout';
 import TableOfContents from 'components/shared/table-of-contents';
 import LINKS from 'constants/links';
 import SEO_DATA from 'constants/seo-data';
-import evolutionOfPostgres from 'images/pages/variable-load/relevant-articles/evolution-of-postgres.jpg';
-import { getWpPostBySlug } from 'utils/api-posts';
-import getFormattedDate from 'utils/get-formatted-date';
 import getMetadata from 'utils/get-metadata';
 
 export const metadata = getMetadata(SEO_DATA.variable);
-
-const blogArticlesData = [
-  {
-    slug: '/blog/autoscaling-in-action-postgres-load-testing-with-pgbench',
-    order: 2,
-  },
-  {
-    slug: '/blog/1-year-of-autoscaling-postgres-at-neon',
-    order: 3,
-  },
-  {
-    slug: '/blog/white-widgets-secret-to-scalable-postgres-neon',
-    order: 9,
-  },
-  {
-    slug: '/blog/how-recrowd-uses-neon-autoscaling-to-meet-fluctuating-demand',
-    order: 10,
-  },
-  {
-    slug: '/blog/why-you-want-a-database-that-scales-to-zero',
-    order: 11,
-  },
-];
-
-const docsArticlesData = [
-  {
-    slug: '/docs/introduction/autoscaling',
-    title: 'Autoscaling',
-    order: 6,
-  },
-  {
-    slug: '/docs/extensions/neon-utils',
-    title: 'The neon_utils extension',
-    order: 7,
-  },
-];
-
-const externalArticlesData = [
-  {
-    url: 'https://www.outerbase.com/blog/the-evolution-of-serverless-postgres/',
-    title: 'The Evolution of Serverless Postgres',
-    image: evolutionOfPostgres,
-    date: 'May 29, 2024',
-    order: 1,
-  },
-  {
-    url: 'https://medium.com/@carlotasotos/database-economics-an-amazon-rds-reflection-5d7a35638b20',
-    title: 'Database economics: an Amazon RDS reflection',
-    date: 'May 31, 2024',
-    order: 4,
-  },
-  {
-    url: 'https://dev.to/rsiv/auto-scaling-apps-by-default-neon-api-gateway-nitric-34id',
-    title: 'Architectural choices that scale',
-    date: 'Jun 6, 2023',
-    order: 5,
-  },
-  {
-    url: 'https://github.com/prisma/read-replicas-demo',
-    title: 'Read Replicas Demo',
-    order: 8,
-  },
-];
-
-const fetchBlogArticles = async (articles) =>
-  Promise.all(
-    articles.map(async (article) => {
-      const { post } = await getWpPostBySlug(article.slug);
-      if (post) {
-        return {
-          ...article,
-          title: post.title,
-          date: getFormattedDate(post.date),
-          image: post.seo?.twitterImage?.mediaItemUrl,
-        };
-      }
-      return article;
-    })
-  );
-
-const articlesWithImages = (articles) =>
-  articles.map((article) => {
-    if (article.image) {
-      return article;
-    }
-    const encodedTitle = Buffer.from(article.title).toString('base64');
-    const imagePath = `/docs/og?title=${encodedTitle}&show-logo=${article.url ? 'false' : 'true'}`;
-    return {
-      ...article,
-      image: imagePath,
-    };
-  });
 
 const titles = [
   'Variable traffic, fixed costs?',
@@ -120,11 +25,6 @@ const titles = [
 ];
 
 const VariableLoadPage = async () => {
-  const blogArticles = await fetchBlogArticles(blogArticlesData);
-  const docsArticles = articlesWithImages(docsArticlesData);
-  const externalArticles = articlesWithImages(externalArticlesData);
-  const allArticles = [...blogArticles, ...docsArticles, ...externalArticles];
-
   const tableOfContents = titles.map((title) => ({
     title,
     id: slugify(title.replace(/&nbsp;/g, ' '), {
@@ -150,7 +50,6 @@ const VariableLoadPage = async () => {
               <Unique title={tableOfContents[3]} />
             </article>
           </div>
-
           <div className="col-start-10 col-end-13 ml-[50px] h-full xl:hidden">
             <nav
               className={clsx(
@@ -162,8 +61,7 @@ const VariableLoadPage = async () => {
             </nav>
           </div>
         </Container>
-
-        <RelevantArticles articles={allArticles} />
+        <RelevantArticles />
         <Cta
           className="pb-[290px] pt-[285px] xl:py-[230px] lg:pb-[156px] lg:pt-[179px] sm:pb-[110px] sm:pt-[116px]"
           title="Try it yourself"

--- a/src/components/pages/variable/budget/budget.jsx
+++ b/src/components/pages/variable/budget/budget.jsx
@@ -9,40 +9,29 @@ import Section from '../section';
 
 const items = [
   {
-    text: 'You&apos;ll need at least <strong>one production database</strong>, but also separate instances for development, testing, and staging.',
+    text: 'You&apos;ll need at least one production database, but also separate instances for development, testing, and staging.',
   },
   {
-    text: 'Your <strong>production database will run 24/7</strong>, but only run <strong>at peak capacity</strong> when you reach peak load.',
+    text: 'Your production database will run 24/7, but only run at peak capacity when you reach peak load.',
   },
   {
-    text: 'Your <strong>non-prod databases</strong> will only run a few hours per day.',
+    text: 'Your non-prod databases will only run a few hours per day.',
   },
   {
-    text: 'But for each one of these databases, <strong>you&apos;ll be paying for peak compute</strong>, 100% of the time - even if you don&apos;t use it.',
+    text: 'But for each one of these databases, you&apos;ll be paying for peak compute, 100% of the time - even if you don&apos;t use it.',
   },
 ];
 
 const Budget = ({ title }) => (
   <Section className="budget" title={title}>
-    <div className="prose-variable">
-      <p>
-        <strong>Provisioning for peak load is highly inefficient cost-wise,</strong> especially
-        taking into consideration that you will most likely be running not only one database
-        instance but many.
-      </p>
-      <List items={items} />
-      <p>
-        To grasp how much money is typically wasted on unused compute resources,{' '}
-        <strong>play with the calculator below using Amazon RDS prices.</strong>
-      </p>
-    </div>
     <Example />
     <div className="prose-variable">
       <p>
-        If you wanted to <strong>avoid this wasted budget</strong>, you would have to regularly
-        resize and restart your instances. In practice, this is a manual process that not only takes
-        time from your engineers but in many cases, it also causes downtime for your end-users.
+        Provisioning for peak load is highly inefficient cost-wise, especially taking into
+        consideration that you will most likely be running not only one database instance,
+        but&nbsp;many.
       </p>
+      <List items={items} />
     </div>
     <Cta
       text="Want a price estimation for your particular use case?"

--- a/src/components/pages/variable/example/calculator/calculator.jsx
+++ b/src/components/pages/variable/example/calculator/calculator.jsx
@@ -9,7 +9,7 @@ import ChevronIcon from 'icons/chevron-down.inline.svg';
 
 const instancePrices = {
   prod: 2.25,
-  staging: 1.125,
+  // staging: 1.125,
   testing: 0.0376,
   dev: 0.016,
 };
@@ -72,11 +72,11 @@ const inputParamsBlock = [
         title: 'How many hrs/day are dev databases&nbsp;running?',
         values: [1, 2, 3, 5, 8],
       },
-      {
-        name: 'staging_databases_daily_hrs',
-        title: 'How many hrs/day is staging running?',
-        values: [2, 5, 8],
-      },
+      // {
+      //   name: 'staging_databases_daily_hrs',
+      //   title: 'How many hrs/day is staging running?',
+      //   values: [2, 5, 8],
+      // },
       {
         name: 'peak_traffic_hrs',
         title: 'How many hrs/ day do you hit&nbsp;peak&nbsp;traffic?',
@@ -111,7 +111,7 @@ const Calculator = () => {
     dev_databases_num: 10,
     test_databases_daily_hrs: 1,
     dev_databases_daily_hrs: 1,
-    staging_databases_daily_hrs: 2,
+    // staging_databases_daily_hrs: 2,
     peak_traffic_hrs: 0.5,
   });
 
@@ -122,7 +122,7 @@ const Calculator = () => {
   const instanceCost = useMemo(
     () => ({
       production: instancePrices.prod * 730,
-      staging: instancePrices.staging * 730,
+      // staging: instancePrices.staging * 730,
       testing: instancePrices.testing * 730 * inputParams.test_databases_num,
       development: instancePrices.dev * 730 * inputParams.dev_databases_num,
     }),

--- a/src/components/pages/variable/example/example.jsx
+++ b/src/components/pages/variable/example/example.jsx
@@ -32,7 +32,7 @@ const databases = [
 ];
 
 const Example = () => (
-  <div className="relative my-10 w-full overflow-hidden rounded-lg bg-[#0D0E10] px-8 py-6 xl:my-9 lg:my-8 sm:my-6 sm:p-6">
+  <div className="relative w-full overflow-hidden rounded-lg bg-[#0D0E10] px-8 py-6 sm:p-6">
     <div className="relative z-10 pb-[18px]">
       <h3 className="mb-5 text-2xl font-medium leading-snug tracking-tighter xl:text-xl sm:mb-4 sm:text-lg">
         Example deployment in RDS

--- a/src/components/pages/variable/load/load.jsx
+++ b/src/components/pages/variable/load/load.jsx
@@ -15,48 +15,25 @@ import loadGraphicNeon from './images/load-graphic-neon.jpg';
 const items = [
   {
     icon: productivityIcon,
-    text: '<strong>A productivity application</strong> might have increased demand during working hours as teams collaborate and complete tasks.',
+    text: 'A productivity application might have increased demand during working hours as teams collaborate and complete tasks.',
   },
   {
     icon: aiIcon,
-    text: '<strong>An AI analytics startup</strong> could face heavy processing loads during off-peak hours when batch data jobs are run.',
+    text: 'An AI analytics startup could face heavy processing loads during off-peak hours when batch data jobs are run.',
   },
   {
     icon: gamingIcon,
-    text: '<strong>A gaming platform</strong> might experience surges in user activity during evenings when players are most active.',
+    text: 'A gaming platform might experience surges in user activity during evenings when players are most active.',
   },
   {
     icon: shopsIcon,
-    text: '<strong>Online shops</strong> might see spikes when certain sales are run… And so on.',
+    text: 'Online shops might see spikes when certain sales are run… And so on.',
   },
 ];
 
 const Load = ({ title }) => (
   <Section className="load" title={title}>
-    <div className="prose-variable">
-      <p>
-        No real-world database has constant demand. To some extent, all modern applications
-        experience variable traffic patterns; for some applications, demand is clearly variable. For
-        example:
-      </p>
-      <List items={items} />
-      <p>
-        Variable load patterns are common, but <strong>traditional managed databases</strong>{' '}
-        require provisioning a fixed amount of CPU and memory. To avoid degraded performance or even
-        outages, it is standard practice to provision for peak traffic, which means{' '}
-        <strong>
-          paying for peak capacity 24/7 — even though it&apos;s needed only a fraction of the time.
-        </strong>
-      </p>
-      <p>
-        <strong>Neon&apos;s serverless architecture</strong> eliminates the need for provisioning a
-        fixed amount of CPU and memory. Instead of overpaying for peak capacity that is rarely
-        needed, Neon dynamically adjusts compute resources to match actual workload demands.{' '}
-        <strong>This means you only pay for what you use.</strong>
-      </p>
-    </div>
-
-    <div className="mt-10 flex items-center justify-center gap-5 xl:mt-9 lg:mt-8 lg:flex-col md:gap-3.5 sm:mt-6">
+    <div className="flex items-center justify-center gap-5 lg:flex-col md:gap-3.5">
       <Image
         className="w-[470px] shrink-0 rounded-lg lg:w-full lg:max-w-xl md:rounded"
         src={loadGraphicAWS}
@@ -77,6 +54,22 @@ const Load = ({ title }) => (
         aria-hidden
         priority
       />
+    </div>
+    <div className="prose-variable">
+      <p>
+        No real-world database has constant demand. To some extent, all modern applications
+        experience variable traffic patterns; for some applications, demand is clearly variable. For
+        example:
+      </p>
+      <List items={items} />
+      <p>
+        Variable load patterns are common, but <strong>traditional managed databases</strong>{' '}
+        require provisioning a fixed amount of CPU and memory. To avoid degraded performance or even
+        outages, it is standard practice to provision for peak traffic, which means{' '}
+        <strong>
+          paying for peak capacity 24/7 — even though it&apos;s needed only a fraction of the time.
+        </strong>
+      </p>
     </div>
   </Section>
 );

--- a/src/components/pages/variable/relevant-articles/relevant-articles.jsx
+++ b/src/components/pages/variable/relevant-articles/relevant-articles.jsx
@@ -1,19 +1,115 @@
-import { PropTypes } from 'prop-types';
-
 import Container from 'components/shared/container';
+import evolutionOfPostgres from 'images/pages/variable-load/relevant-articles/evolution-of-postgres.jpg';
+import { getWpPostBySlug } from 'utils/api-posts';
+import getFormattedDate from 'utils/get-formatted-date';
 
 import Slider from './slider';
 
-const RelevantArticles = ({ articles }) => (
-  <section className="viewed-articles mt-[72px] xl:mt-16 lg:mt-14 md:mt-11">
-    <Container size="1220" className="md:px-5">
-      <Slider articles={articles} />
-    </Container>
-  </section>
-);
+const blogArticlesData = [
+  {
+    slug: '/blog/autoscaling-in-action-postgres-load-testing-with-pgbench',
+    order: 5,
+  },
+  {
+    slug: '/blog/1-year-of-autoscaling-postgres-at-neon',
+    order: 6,
+  },
+  {
+    slug: '/blog/white-widgets-secret-to-scalable-postgres-neon',
+    order: 1,
+  },
+  {
+    slug: '/blog/how-recrowd-uses-neon-autoscaling-to-meet-fluctuating-demand',
+    order: 2,
+  },
+  {
+    slug: '/blog/why-you-want-a-database-that-scales-to-zero',
+    order: 3,
+  },
+];
 
-RelevantArticles.propTypes = {
-  articles: PropTypes.arrayOf(PropTypes.object).isRequired,
+const docsArticlesData = [
+  {
+    slug: '/docs/introduction/autoscaling',
+    title: 'Autoscaling',
+    order: 9,
+  },
+  {
+    slug: '/docs/extensions/neon-utils',
+    title: 'The neon_utils extension',
+    order: 10,
+  },
+];
+
+const externalArticlesData = [
+  {
+    url: 'https://www.outerbase.com/blog/the-evolution-of-serverless-postgres/',
+    title: 'The Evolution of Serverless Postgres',
+    image: evolutionOfPostgres,
+    date: 'May 29, 2024',
+    order: 4,
+  },
+  {
+    url: 'https://medium.com/@carlotasotos/database-economics-an-amazon-rds-reflection-5d7a35638b20',
+    title: 'Database economics: an Amazon RDS reflection',
+    date: 'May 31, 2024',
+    order: 7,
+  },
+  {
+    url: 'https://dev.to/rsiv/auto-scaling-apps-by-default-neon-api-gateway-nitric-34id',
+    title: 'Architectural choices that scale',
+    date: 'Jun 6, 2023',
+    order: 8,
+  },
+  {
+    url: 'https://github.com/prisma/read-replicas-demo',
+    title: 'Read Replicas Demo',
+    order: 11,
+  },
+];
+
+const fetchBlogArticles = async (articles) =>
+  Promise.all(
+    articles.map(async (article) => {
+      const { post } = await getWpPostBySlug(article.slug);
+      if (post) {
+        return {
+          ...article,
+          title: post.title,
+          date: getFormattedDate(post.date),
+          image: post.seo?.twitterImage?.mediaItemUrl,
+        };
+      }
+      return article;
+    })
+  );
+
+const articlesWithImages = (articles) =>
+  articles.map((article) => {
+    if (article.image) {
+      return article;
+    }
+    const encodedTitle = Buffer.from(article.title).toString('base64');
+    const imagePath = `/docs/og?title=${encodedTitle}&show-logo=${article.url ? 'false' : 'true'}`;
+    return {
+      ...article,
+      image: imagePath,
+    };
+  });
+
+const RelevantArticles = async () => {
+  const blogArticles = await fetchBlogArticles(blogArticlesData);
+  const docsArticles = articlesWithImages(docsArticlesData);
+  const externalArticles = articlesWithImages(externalArticlesData);
+  const allArticles = [...blogArticles, ...docsArticles, ...externalArticles];
+
+  return (
+    <section className="viewed-articles mt-[72px] xl:mt-16 lg:mt-14 md:mt-11">
+      <Container size="1220" className="md:px-5">
+        <Slider articles={allArticles} />
+      </Container>
+    </section>
+  );
 };
 
 export default RelevantArticles;

--- a/src/components/pages/variable/testimonial/testimonial.jsx
+++ b/src/components/pages/variable/testimonial/testimonial.jsx
@@ -9,9 +9,9 @@ import BgDecor from '../bg-decor';
 const Testimonial = ({ text, author, url }) => (
   <figure
     className={clsx(
-      'relative mt-14 w-full rounded-lg bg-[#0D0E10] p-14 pb-8 pr-11',
+      'relative w-full rounded-lg bg-[#0D0E10] p-14 pb-8 pr-11',
       'before:absolute before:left-6 before:top-6 before:size-16 before:bg-[url("/images/pages/variable-load/blockquote.svg")] before:bg-contain before:bg-no-repeat',
-      'xl:mt-12 lg:mt-11 lg:p-12 lg:pb-7 lg:pr-10 sm:mt-8 sm:p-6 sm:pb-7',
+      'lg:p-12 lg:pb-7 lg:pr-10 sm:p-6 sm:pb-7',
       'lg:before:left-[22px] lg:before:top-[22px] lg:before:size-14 sm:before:hidden'
     )}
   >

--- a/src/components/pages/variable/unique/unique.jsx
+++ b/src/components/pages/variable/unique/unique.jsx
@@ -9,34 +9,30 @@ import Testimonial from '../testimonial';
 
 const items = [
   {
-    text: 'Neon compute costs are <a href="https://www.outerbase.com/blog/the-evolution-of-serverless-postgres/" target="_blank" rel="noopener noreferrer">up to 75% cheaper</a> vs Aurora Serverless v2.',
+    text: 'Neon compute costs are <a href="https://www.outerbase.com/blog/the-evolution-of-serverless-postgres/" target="_blank" rel="noopener noreferrer">up to 75% cheaper</a> vs Aurora&nbsp;Serverless&nbsp;v2.',
   },
   {
-    text: 'Neon <strong>scales to zero</strong>, Aurora Serverless does not.',
+    text: 'Neon scales to zero, Aurora Serverless does not.',
   },
   {
-    text: 'Neon <strong>provisions instances in < 1 s</strong>, compared to Aurora&apos;s up to&nbsp;20&nbsp;min.',
+    text: 'Neon provisions instances in < 1 s, compared to Aurora&apos;s up to&nbsp;20&nbsp;min.',
   },
   {
-    text: 'Neon uses <strong>transparent compute units</strong>, vs the ACU abstraction in&nbsp;Aurora&nbsp;Serverless.',
+    text: 'Neon uses transparent compute units, vs the ACU abstraction in&nbsp;Aurora&nbsp;Serverless.',
   },
   {
-    text: 'Neon supports <strong>database branching with data and schema via copy-on-write,</strong> <a href="/flow">improving development workflows.</a>',
+    text: 'Neon supports database branching with data and schema via copy-on-write, <a href="/flow">improving development workflows.</a>',
   },
   {
-    text: 'Neon&apos;s <strong>read replicas don&apos;t require storage redundancy</strong>, differently than Aurora&apos;s.',
+    text: 'Neon&apos;s read replicas don&apos;t require storage redundancy, differently than Aurora&apos;s.',
   },
   {
-    text: '<strong>Connection pooling is built-in in Neon,</strong> vs Aurora&apos;s RDS Proxy.',
+    text: 'Connection pooling is built-in in Neon, vs Aurora&apos;s RDS Proxy.',
   },
 ];
 
 const Unique = ({ title }) => (
   <Section className="unique" title={title}>
-    <div className="prose-variable">
-      <p>The Neon architecture is inspired in Amazon&nbsp;Aurora, but with some key differences:</p>
-      <List items={items} />
-    </div>
     <Testimonial
       text="Before choosing Neon, we also considered Aurora, but the opacity of&nbsp;the pricing model did not convince us and costs seemed to&nbsp;rise&nbsp;quickly."
       author={{
@@ -46,6 +42,10 @@ const Unique = ({ title }) => (
       }}
       url={`${LINKS.blog}/white-widgets-secret-to-scalable-postgres-neon`}
     />
+    <div className="prose-variable">
+      <p>The Neon architecture is inspired in Amazon&nbsp;Aurora, but with some key differences:</p>
+      <List items={items} />
+    </div>
   </Section>
 );
 


### PR DESCRIPTION
This PR brings chore updates for variable traffic page:
- copy page to variable-traffic url
- text updates
- replace posts order
- move up blocks in sections

Preview