### PR TITLE
fix: redudant scroll

### DIFF
--- a/src/components/pages/blog/sidebar/sidebar.jsx
+++ b/src/components/pages/blog/sidebar/sidebar.jsx
@@ -26,7 +26,7 @@ const Sidebar = ({ categories }) => {
             />
             <ul className="mt-8 flex flex-col gap-y-3.5 lt:mt-0 lt:flex-row lt:gap-x-7 md:after:shrink-0 md:after:grow-0 md:after:basis-px md:after:content-['']">
               {allCategories.map(({ name, slug }, index) => (
-                <li key={index}>
+                <li className="inline-flex" key={index}>
                   <BlogNavLink name={name} slug={slug} />
                 </li>
               ))}


### PR DESCRIPTION
This pull request implements a fix that resolves the redundant vertical scrolling for blog categories on mobile devices.

Steps to check:

- open the [preview](https://neon-next-git-fix-blog-category-scroll-neondatabase.vercel.app/blog) on a mobile device
- ensure that the categories can only be scrolled horizontally (X-axis)