### PR TITLE
Small fixes for guides and costs fleets

### DIFF
--- a/src/app/cost-fleets/page.jsx
+++ b/src/app/cost-fleets/page.jsx
@@ -13,8 +13,8 @@ const CostFleetsPage = async () => (
     <Cta
       className="mt-[70px] py-[250px] xl:mt-14 xl:py-[184px] lg:mt-12 lg:py-[130px] md:mt-8 md:py-[105px]"
       title="Try it yourself"
-      buttonText="Request a free trial"
-      buttonUrl={LINKS.scaleTrial}
+      buttonText="Create an account"
+      buttonUrl={LINKS.signup}
     />
   </Layout>
 );

--- a/src/app/guides/(index)/page.jsx
+++ b/src/app/guides/(index)/page.jsx
@@ -29,7 +29,7 @@ const GuidesPage = async () => {
           size="1344"
         >
           <Sidebar />
-          <div className="col-span-7 col-start-4 flex flex-col 2xl:col-span-7 2xl:mx-5 xl:col-span-9 xl:ml-11 xl:mr-0 xl:max-w-[750px] lg:ml-0 lg:max-w-none lg:pt-0 md:mx-auto">
+          <div className="col-span-7 col-start-4 flex flex-col 2xl:col-span-7 2xl:mx-5 xl:col-span-9 xl:ml-11 xl:mr-0 xl:max-w-[750px] lg:mx-auto lg:pt-0">
             <ul>
               {posts.map(({ title, subtitle, author, createdAt, updatedOn, slug }) => (
                 <li

--- a/src/app/guides/(index)/page.jsx
+++ b/src/app/guides/(index)/page.jsx
@@ -34,7 +34,7 @@ const GuidesPage = async () => {
               {posts.map(({ title, subtitle, author, createdAt, updatedOn, slug }) => (
                 <li
                   key={slug}
-                  className="border-b border-gray-new-15/20 py-6 first:pt-0 last:border-none last:pb-0 dark:border-gray-new-15/80"
+                  className="border-b border-gray-new-15/20 pb-5 pt-6 first:pt-0 last:border-none last:pb-0 dark:border-gray-new-15/80"
                 >
                   <GuideCard
                     title={title}

--- a/src/app/guides/og/route.jsx
+++ b/src/app/guides/og/route.jsx
@@ -1,15 +1,15 @@
-import { ImageResponse } from 'next/server';
+import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
 export const preferredRegion = 'auto';
 
 export async function GET(request) {
-  const fontMedium = fetch(
-    new URL('../../../../public/fonts/ibm-plex-sans/ibm-plex-sans-medium.ttf', import.meta.url)
+  const fontTitle = fetch(
+    new URL('../../../fonts/esbuild/ESBuild-Medium.ttf', import.meta.url)
   ).then((res) => res.arrayBuffer());
-  const fontNormal = fetch(
-    new URL('../../../../public/fonts/ibm-plex-sans/ibm-plex-sans-regular.ttf', import.meta.url)
-  ).then((res) => res.arrayBuffer());
+  const fontText = fetch(new URL('../../../fonts/inter/Inter-Regular.ttf', import.meta.url)).then(
+    (res) => res.arrayBuffer()
+  );
   const logo = fetch(new URL('../../../../public/images/og-image/logo.png', import.meta.url)).then(
     (res) => res.arrayBuffer()
   );
@@ -17,9 +17,9 @@ export async function GET(request) {
     new URL('../../../../public/images/og-image/background.png', import.meta.url)
   ).then((res) => res.arrayBuffer());
 
-  const [fontDataMedium, fontDataNormal, logoData, backgroundData] = await Promise.all([
-    fontMedium,
-    fontNormal,
+  const [fontDataEsbuild, fontDataInter, logoData, backgroundData] = await Promise.all([
+    fontTitle,
+    fontText,
     logo,
     background,
   ]);
@@ -62,6 +62,7 @@ export async function GET(request) {
             <div
               style={{
                 fontSize: 76,
+                fontFamily: 'ESBuild',
                 fontWeight: 500,
                 color: 'white',
                 lineHeight: 1,
@@ -75,6 +76,7 @@ export async function GET(request) {
             </div>
             <div
               style={{
+                fontFamily: 'Inter',
                 fontSize: 30,
                 lineHeight: 1.25,
                 marginTop: 28,
@@ -93,14 +95,14 @@ export async function GET(request) {
         height: 630,
         fonts: [
           {
-            name: 'IBM Plex Sans',
-            data: fontDataMedium,
+            name: 'ESBuild',
+            data: fontDataEsbuild,
             style: 'normal',
             weight: 500,
           },
           {
-            name: 'IBM Plex Sans',
-            data: fontDataNormal,
+            name: 'Inter',
+            data: fontDataInter,
             style: 'normal',
             weight: 400,
           },

--- a/src/components/pages/guides/guide-card/guide-card.jsx
+++ b/src/components/pages/guides/guide-card/guide-card.jsx
@@ -13,7 +13,7 @@ const GuideCard = ({ title, subtitle, author, createdAt, slug }) => {
 
   return (
     <Link className="group" to={`${LINKS.guides}/${slug}`}>
-      <article className="flex items-end justify-between sm:block">
+      <article className="flex flex-col gap-y-[18px] sm:gap-y-4">
         <div className="max-w-[640px]">
           <h1 className="line-clamp-2 text-[20px] font-semibold leading-tight tracking-[-0.02em] transition-colors duration-200 group-hover:text-secondary-8 dark:group-hover:text-green-45">
             {title}
@@ -46,8 +46,10 @@ const GuideCard = ({ title, subtitle, author, createdAt, slug }) => {
             </time>
           </div>
         </div>
-        <div className="flex w-fit items-center gap-1 border-b border-transparent text-secondary-8 transition-colors duration-200 group-hover:border-secondary-8 dark:text-green-45 dark:group-hover:border-green-45 sm:mt-4">
-          <span className="text-[15px] leading-tight md:text-sm">Read guide</span>
+        <div className="flex w-fit items-center gap-1 border-b border-transparent text-secondary-8 transition-colors duration-200 group-hover:border-secondary-8 dark:text-green-45 dark:group-hover:border-green-45">
+          <span className="text-[15px] leading-tight tracking-extra-tight md:text-sm">
+            Read guide
+          </span>
           <ArrowIcon className="shrink-0" />
         </div>
       </article>


### PR DESCRIPTION
This pull request introduces several small updates, including:

- Updated button source in the CTA section of the costs fleets page (to sign up)
- Improved OG image generation for guides
- Aligned links on the guides cards

Steps to check:
- open preview ([guides](https://neon-next-git-small-fixes-070824-neondatabase.vercel.app/guides), [og](https://neon-next-git-small-fixes-070824-neondatabase.vercel.app/guides/og?title=SW1wbGVtZW50aW5nIFNvZnQgRGVsZXRlcyBpbiBMYXJhdmVsIGFuZCBQb3N0Z3Jlcw==), [costs fleets](https://neon-next-git-small-fixes-070824-neondatabase.vercel.app/cost-fleets))
- make sure that everything looks and works as expected