### PR TITLE
feat: open pricing table by #plans anchor in url

### DIFF
--- a/src/components/pages/pricing/plans/table/table.jsx
+++ b/src/components/pages/pricing/plans/table/table.jsx
@@ -102,6 +102,12 @@ const Table = () => {
   const [tableRows, setTableRows] = useState(tableData.cols.slice(0, DEFAULT_ROWS_TO_SHOW));
 
   useEffect(() => {
+    if (window.location.hash === '#plans') {
+      setTableRows(tableData.cols);
+    }
+  }, []);
+
+  useEffect(() => {
     const cells = document.querySelectorAll(`[data-row-id]`);
 
     cells.forEach((cell) => {


### PR DESCRIPTION
This PR brings feature for Pricing Page by auto-opening pricing table if we have #plans anchor in url

[Preview](https://neon-next-git-pricing-page-anchor-link-neondatabase.vercel.app/pricing#plans)