### PR TITLE
chore: trust link fix

### DIFF
--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -52,7 +52,7 @@ export default {
   terms: '/terms-of-service',
   termsOfService: '/terms-of-service',
   thankYou: '/thank-you',
-  trust: '/trust',
+  trust: 'https://trust.neon.tech',
   variable: '/variable',
   twitter: 'https://twitter.com/neondatabase/',
   youtube: 'https://www.youtube.com/channel/UCoMzQTJSIr7-RU1QbomQI2w',


### PR DESCRIPTION
This PR changes Trust constant link to external to resolve CORS issue

![image](https://github.com/user-attachments/assets/16204251-db8d-4ef0-94dc-29216276709e)

[Preview](https://neon-next-git-trust-link-fix-neondatabase.vercel.app/)