### PR TITLE
Move Prisma Pulse guide to the correct section

### DIFF
--- a/content/docs/guides/integrations.md
+++ b/content/docs/guides/integrations.md
@@ -108,6 +108,8 @@ updatedOn: '2024-08-22T02:18:02.644Z'
 
 <a href="/docs/guides/logical-replication-postgres" title="Neon to PostgreSQL" description="Replicate data from Neon to PostgreSQL" icon="postgresql"></a>
 
+<a href="/docs/guides/logical-replication-prisma-pulse" title="Prisma Pulse" description="Stream database changes in real-time with Prisma Pulse" icon="prisma"></a>
+
 <a href="/docs/guides/logical-replication-airbyte-snowflake" title="Snowflake" description="Replicate data from Neon to Snowflake with Airbyte" icon="snowflake"></a>
 
 </TechnologyNavigation>
@@ -129,8 +131,6 @@ updatedOn: '2024-08-22T02:18:02.644Z'
 <a href="/docs/guides/sequin" title="Sequin" description="Stream data from platforms like Stripe, Linear, and GitHub to Neon" icon="sequin"></a>
 
 <a href="/docs/guides/logical-replication-rds-to-neon" title="AWS RDS" description="Replicate data from AWS RDS PostgreSQL to Neon" icon="aws-rds"></a>
-
-<a href="/docs/guides/logical-replication-prisma-pulse" title="Prisma Pulse" description="Stream database changes in real-time with Prisma Pulse" icon="prisma"></a>
 
 <a href="/docs/guides/sequin" title="Sequin" description="Sync data from APIs to Neon in real time" icon="sequin"></a>
 


### PR DESCRIPTION
Hey @danieltprice 👋  just noticed that the Prisma Pulse guide was moved into the wrong section (I think) -- I believe it would fit better in the _Replicate data **from**_ section rather than the _**to**_ section. 