### PR TITLE
Fix a typo in logical replication guide

### DIFF
--- a/content/docs/guides/logical-replication-guide.md
+++ b/content/docs/guides/logical-replication-guide.md
@@ -13,7 +13,7 @@ updatedOn: '2024-08-22T15:15:07.639Z'
 Neon's logical replication feature, available to all Neon users, allows you to replicate data to and from your Neon Postgres database:
 
 - Perform live migrations to Neon from external sources such as AWS RDS, Aurora, and Google Cloud SQL &#8212; or any platform that runs Postgres.
-- Stream data from your Neon database to external destinations, enabling Change Data Capture (CDC) and real-time analytics. External sources might might include data warehouses, analytical database services, real-time stream processing systems, messaging and event-streaming platforms, and external Postgres databases, among others.
+- Stream data from your Neon database to external destinations, enabling Change Data Capture (CDC) and real-time analytics. External sources might include data warehouses, analytical database services, real-time stream processing systems, messaging and event-streaming platforms, and external Postgres databases, among others.
 - Replicate data from one Neon project to another for Neon project, account, Postgres version, or region migration.
 
 ![Neon logical replication subscribers image](/docs/guides/logical_replication_publishers_subscribers.jpg)

--- a/content/docs/introduction/logical-replication.md
+++ b/content/docs/introduction/logical-replication.md
@@ -8,7 +8,7 @@ updatedOn: '2024-08-20T23:55:48.551Z'
 Neon's logical replication feature, available to all Neon users, allows you to replicate data to and from your Neon Postgres database:
 
 - Perform live migrations to Neon from external sources such as AWS RDS, Aurora, and Google Cloud SQL &#8212; or any platform that runs Postgres.
-- Stream data from your Neon database to external destinations, enabling Change Data Capture (CDC) and real-time analytics. External sources might might include data warehouses, analytical database services, real-time stream processing systems, messaging and event-streaming platforms, and external Postgres databases, among others.
+- Stream data from your Neon database to external destinations, enabling Change Data Capture (CDC) and real-time analytics. External sources might include data warehouses, analytical database services, real-time stream processing systems, messaging and event-streaming platforms, and external Postgres databases, among others.
 - Replicate data from one Neon project to another for Neon project, account, Postgres version, or region migration.
 
 ![Neon logical replication subscribers image](/docs/guides/logical_replication_publishers_subscribers.jpg)


### PR DESCRIPTION
I've noticed a typо while reading a guide on logical replication https://neon.tech/docs/guides/logical-replication-guide 

<img width="735" alt="image" src="https://github.com/user-attachments/assets/7a8915a8-b1c4-41f1-b013-429945e6366c">
