### PR TITLE
fix: changelog single page layout

### DIFF
--- a/src/app/docs/(neon)/changelog/[...slug]/page.jsx
+++ b/src/app/docs/(neon)/changelog/[...slug]/page.jsx
@@ -2,7 +2,6 @@
 import { notFound, redirect } from 'next/navigation';
 
 import Hero from 'components/pages/changelog/hero';
-import Container from 'components/shared/container';
 import Content from 'components/shared/content';
 import Link from 'components/shared/link';
 import {
@@ -102,35 +101,31 @@ const ChangelogPost = async ({ currentSlug }) => {
         />
       )}
 
-      <div className="col-span-6 -mr-12 ml-[-33px] flex flex-col 2xl:-ml-4 xl:col-span-9 xl:ml-10 xl:mr-0 xl:max-w-[750px] lg:ml-0 lg:max-w-none lg:pt-0 md:mx-auto md:pb-[70px] sm:pb-8">
+      <div className="col-span-7 col-start-3 -ml-6 flex max-w-[832px] flex-col 3xl:col-span-8 3xl:col-start-2 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 lg:ml-0 lg:max-w-none lg:pt-0 md:mx-auto md:pb-[70px] sm:pb-8">
         <Hero
           className="flex justify-center lg:pt-16 md:py-10 sm:py-7"
           date={label}
           withContainer
         />
-        <div className="flex grow pb-28 lg:pb-20 md:pb-16">
-          <Container size="xs" className="relative flex w-full pb-10">
-            <article className="relative flex w-full max-w-full flex-col items-start">
-              <h2>
-                <time
-                  className="mt-3 whitespace-nowrap text-gray-new-20 dark:text-gray-new-70"
-                  dateTime={datetime}
-                >
-                  {label}
-                </time>
-              </h2>
-              <Content className="mt-8 w-full max-w-full prose-h3:text-xl" content={content} />
-              <Link
-                className="mt-10 font-semibold lg:mt-8"
-                to={CHANGELOG_BASE_PATH}
-                size="sm"
-                theme="black-primary-1"
-              >
-                Back to all changelog posts
-              </Link>
-            </article>
-          </Container>
-        </div>
+        <article className="relative flex w-full max-w-full flex-col items-start">
+          <h2>
+            <time
+              className="mt-3 whitespace-nowrap text-gray-new-20 dark:text-gray-new-70"
+              dateTime={datetime}
+            >
+              {label}
+            </time>
+          </h2>
+          <Content className="mt-8 w-full max-w-full prose-h3:text-xl" content={content} />
+          <Link
+            className="mt-10 font-semibold lg:mt-8"
+            to={CHANGELOG_BASE_PATH}
+            size="sm"
+            theme="black-primary-1"
+          >
+            Back to all changelog posts
+          </Link>
+        </article>
       </div>
     </>
   );


### PR DESCRIPTION
This PR brings fix for Changelog single page layout on updated docs

[Preview](https://neon-next-git-fix-changelog-layout-neondatabase.vercel.app/docs/changelog/2024-08-16)