### PR TITLE
fix: remove duplicate slugs causing incorrect navigation links

### DIFF
--- a/src/utils/api-docs.js
+++ b/src/utils/api-docs.js
@@ -86,7 +86,9 @@ const getFlatSidebar = (sidebar, path = []) =>
   }, []);
 
 const getNavigationLinks = (slug, flatSidebar) => {
-  const posts = flatSidebar.filter((item) => item.slug !== undefined);
+  const posts = [
+    ...new Map(flatSidebar.filter((item) => item.slug).map((item) => [item.slug, item])).values(),
+  ];
   const currentItemIndex = posts.findIndex((item) => item.slug === slug);
 
   const previousItem = posts[currentItemIndex - 1];


### PR DESCRIPTION
This PR fixes #2081 where clicking the “Next Page” link on the “Why-Neon” & ”1 - Playing with Neon” pages incorrectly redirected the user back to the same page. The bug was caused by an issue in the `getNavigationLinks` function. In this function, the `posts` array has duplicated slug values in it, after constructed.