### PR TITLE
refactor: themes support for docs and guides

### DIFF
--- a/src/app/docs/(neon)/layout.jsx
+++ b/src/app/docs/(neon)/layout.jsx
@@ -16,6 +16,7 @@ const NeonDocsLayout = async ({ children }) => {
       isDocPage
       isHeaderSticky
       headerWithBorder
+      hasThemesSupport
     >
       <div className="safe-paddings flex flex-1 dark:bg-black-pure dark:text-white lg:block">
         <MobileNav

--- a/src/app/docs/(postgres)/layout.jsx
+++ b/src/app/docs/(postgres)/layout.jsx
@@ -16,6 +16,7 @@ const PostgresDocsLayout = async ({ children }) => {
       isDocPage
       isHeaderSticky
       headerWithBorder
+      hasThemesSupport
     >
       <div className="safe-paddings flex flex-1 dark:bg-black-pure dark:text-white lg:block">
         <MobileNav

--- a/src/app/guides/(index)/page.jsx
+++ b/src/app/guides/(index)/page.jsx
@@ -22,7 +22,7 @@ const GuidesPage = async () => {
   if (!posts) return <div className="text-18">No guides yet</div>;
 
   return (
-    <Layout headerWithBorder burgerWithoutBorder isHeaderSticky>
+    <Layout headerWithBorder burgerWithoutBorder isHeaderSticky hasThemesSupport>
       <div className="safe-paddings flex flex-1 flex-col dark:bg-black-pure dark:text-white lg:block">
         <Container
           className="grid w-full flex-1 grid-cols-12 gap-x-10 pb-20 pt-16 xl:gap-x-7 lg:block lg:gap-x-5 lg:pt-11 md:pt-10 sm:pt-8"

--- a/src/app/guides/[slug]/page.jsx
+++ b/src/app/guides/[slug]/page.jsx
@@ -65,7 +65,7 @@ const GuidePost = async ({ params }) => {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
-      <Layout headerWithBorder burgerWithoutBorder isHeaderSticky>
+      <Layout headerWithBorder burgerWithoutBorder isHeaderSticky hasThemesSupport>
         <div className="safe-paddings flex flex-1 flex-col dark:bg-black-pure dark:text-white lg:block">
           <Container
             className="grid w-full flex-1 grid-cols-12 gap-x-10 pb-20 pt-12 xl:gap-x-7 lg:block lg:gap-x-5 md:pt-10 sm:pt-8"

--- a/src/app/provider.jsx
+++ b/src/app/provider.jsx
@@ -19,13 +19,13 @@ const whiteThemePages = [
 const ThemeProvider = ({ children }) => {
   const pathname = usePathname();
   const isWhiteThemePage = whiteThemePages.some((page) => pathname.startsWith(page));
-  const isDocPage = pathname.startsWith('/docs') || pathname.startsWith('/guides');
+  const hasThemesSupport = pathname.startsWith('/docs') || pathname.startsWith('/guides');
   const forcedTheme = isWhiteThemePage ? 'light' : 'dark';
 
   return (
     <PreferredProvider
       attribute="class"
-      forcedTheme={isDocPage ? null : forcedTheme}
+      forcedTheme={hasThemesSupport ? null : forcedTheme}
       storageKey="neon-theme"
       disableTransitionOnChange
     >

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -9,7 +9,7 @@ import Logo from 'components/shared/logo';
 import MENUS from 'constants/menus.js';
 
 // TODO: add responsive styles for black-pure theme, fix logo size
-const Footer = ({ isDocPage = false, theme = null }) => {
+const Footer = ({ hasThemesSupport = false, theme = null }) => {
   const isDarkTheme = theme === 'dark';
 
   return (
@@ -40,8 +40,8 @@ const Footer = ({ isDocPage = false, theme = null }) => {
                   height={32}
                 />
               </Link>
-              <StatusBadge isDocPage={isDocPage} isDarkTheme={isDarkTheme} />
-              {isDocPage && <ThemeSelect className="mt-7 xl:mt-6 md:mt-3" />}
+              <StatusBadge hasThemesSupport={hasThemesSupport} isDarkTheme={isDarkTheme} />
+              {hasThemesSupport && <ThemeSelect className="mt-7 xl:mt-6 md:mt-3" />}
             </div>
           </div>
           <div className="flex flex-col gap-x-1 gap-y-3 text-[13px] leading-none tracking-extra-tight text-gray-new-40 lg:flex-row lg:self-end lg:leading-tight sm:flex-col sm:self-start">
@@ -98,7 +98,7 @@ const Footer = ({ isDocPage = false, theme = null }) => {
 };
 
 Footer.propTypes = {
-  isDocPage: PropTypes.bool,
+  hasThemesSupport: PropTypes.bool,
   theme: PropTypes.oneOf(['light', 'dark']),
 };
 

--- a/src/components/shared/footer/status-badge/status-badge.jsx
+++ b/src/components/shared/footer/status-badge/status-badge.jsx
@@ -41,7 +41,7 @@ const fetchStatus = async () => {
   return 'UP';
 };
 
-const StatusBadge = ({ isDocPage = false, isDarkTheme = true }) => {
+const StatusBadge = ({ hasThemesSupport = false, isDarkTheme = true }) => {
   const [currentStatus, setCurrentStatus] = useState(null);
   const [ref, inView] = useInView({ triggerOnce: true, rootMargin: '0px 0px 200px 0px' });
 
@@ -64,7 +64,7 @@ const StatusBadge = ({ isDocPage = false, isDarkTheme = true }) => {
       rel="noopener noreferrer"
       className={clsx(
         'flex items-center justify-center gap-x-1.5',
-        isDocPage ? 'mt-12 lg:mt-8' : 'mt-auto lg:mt-8 md:mt-8'
+        hasThemesSupport ? 'mt-12 lg:mt-8' : 'mt-auto lg:mt-8 md:mt-8'
       )}
       ref={ref}
     >
@@ -86,6 +86,6 @@ const StatusBadge = ({ isDocPage = false, isDarkTheme = true }) => {
   );
 };
 
-StatusBadge.propTypes = { isDocPage: PropTypes.bool, isDarkTheme: PropTypes.bool };
+StatusBadge.propTypes = { hasThemesSupport: PropTypes.bool, isDarkTheme: PropTypes.bool };
 
 export default StatusBadge;

--- a/src/components/shared/layout/layout.jsx
+++ b/src/components/shared/layout/layout.jsx
@@ -18,6 +18,7 @@ const Layout = ({
   isHeaderStickyOverlay = false,
   isDocPage = false,
   isBlogPage = false,
+  hasThemesSupport = false,
 }) => (
   <>
     <Topbar isDarkTheme={headerTheme === 'dark'} />
@@ -38,7 +39,7 @@ const Layout = ({
       >
         {children}
       </main>
-      <Footer isDocPage={isDocPage} theme={footerTheme} />
+      <Footer hasThemesSupport={hasThemesSupport} theme={footerTheme} />
       <CookieConsent />
     </div>
   </>
@@ -56,6 +57,7 @@ Layout.propTypes = {
   headerWithBorder: PropTypes.bool,
   isDocPage: PropTypes.bool,
   isBlogPage: PropTypes.bool,
+  hasThemesSupport: PropTypes.bool,
 };
 
 export default Layout;


### PR DESCRIPTION
This PR brings refactor for themes support for docs and guides

- [Docs](https://neon-next-git-add-themes-for-guides-neondatabase.vercel.app/docs)
- [Guides](https://neon-next-git-add-themes-for-guides-neondatabase.vercel.app/guides)

[Preview](https://neon-next-git-add-themes-for-guides-neondatabase.vercel.app/)