### PR TITLE
Update vercel.md to show correct neon branch prefix for preview branches

### DIFF
--- a/content/docs/guides/vercel.md
+++ b/content/docs/guides/vercel.md
@@ -123,7 +123,7 @@ After you add the integration to a Vercel project, Neon creates a database branc
 
    - The commit triggers a preview deployment in Vercel, as would occur without the Neon integration.
      ![Neon preview deployment branch](/docs/guides/vercel_deployments.png)
-   - The integration creates a branch in Neon. This branch is an isolated copy-on-write clone of your default branch, with its own dedicated compute. The branch is created with the same name as your `git` branch but includes a `/preview` prefix.
+   - The integration creates a branch in Neon. This branch is an isolated copy-on-write clone of your default branch, with its own dedicated compute. The branch is created with the same name as your `git` branch but includes a `preview/` prefix.
      ![Neon preview deployment branch](/docs/guides/vercel_neon_app_update.png)
    - The integration sets Vercel preview environment variables to connect the preview deployment to the new branch.
      ![Vercel preview settings](/docs/guides/vercel_preview_settings.png)


### PR DESCRIPTION
I was using the Inkeep ask AI functionality on the neon docs and noticed this issue with the documentation.

Hopefully this docs fix will help others with their Neon-Vercel Integration understanding and setup.