### PR TITLE
Add underline to header, fix side menu

### DIFF
--- a/src/app/(home-page)/layout.jsx
+++ b/src/app/(home-page)/layout.jsx
@@ -2,7 +2,7 @@ import Layout from 'components/shared/layout';
 
 // eslint-disable-next-line react/prop-types
 const HomeLayout = ({ children }) => (
-  <Layout isHeaderSticky isHeaderStickyOverlay withOverflowHidden>
+  <Layout isHeaderSticky isHeaderStickyOverlay withOverflowHidden headerWithBorder>
     {children}
   </Layout>
 );

--- a/src/components/pages/doc/menu/menu.jsx
+++ b/src/components/pages/doc/menu/menu.jsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { LazyMotion, domAnimation, m, AnimatePresence } from 'framer-motion';
 import PropTypes from 'prop-types';
-import { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import Link from 'components/shared/link';
 import { DOCS_BASE_PATH, HOME_MENU_ITEM } from 'constants/docs';
@@ -10,7 +10,6 @@ import ArrowBackIcon from 'icons/docs/sidebar/arrow-back.inline.svg';
 import ChevronBackIcon from 'icons/docs/sidebar/chevron-back.inline.svg';
 import HomeIcon from 'icons/docs/sidebar/home.inline.svg';
 
-import Icon from './icon';
 import Item from './item';
 
 const Section = ({
@@ -92,7 +91,6 @@ const Menu = ({
   title,
   slug,
   basePath,
-  icon = null,
   parentMenu = null,
   items = null,
   closeMobileMenu = null,
@@ -160,7 +158,8 @@ const Menu = ({
             initial={false}
             animate={animateState}
             exit="close"
-            transition={{ ease: 'easeIn', duration: 0.3 }}
+            // NOTE: duration: 0 is needed to prevent the menu from animating out
+            transition={{ ease: 'easeIn', duration: 0 }}
             variants={{
               close: { opacity: 0 },
               open: { opacity: 1 },
@@ -199,10 +198,9 @@ const Menu = ({
                 </div>
 
                 <LinkTag
-                  className="mt-4 flex w-full items-start gap-1.5 text-left font-medium leading-tight tracking-extra-tight text-black-new dark:text-white md:hidden"
+                  className="mt-4 flex w-full items-start gap-1.5 pb-2.5 text-left font-medium leading-tight tracking-extra-tight text-black-new dark:text-white md:hidden"
                   to={slug ? `${basePath}${slug}` : undefined}
                 >
-                  {icon && <Icon title={icon} className="size-5" />}
                   {title}
                 </LinkTag>
               </>

--- a/src/components/pages/doc/menu/menu.jsx
+++ b/src/components/pages/doc/menu/menu.jsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { LazyMotion, domAnimation, m, AnimatePresence } from 'framer-motion';
 import PropTypes from 'prop-types';
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 import Link from 'components/shared/link';
 import { DOCS_BASE_PATH, HOME_MENU_ITEM } from 'constants/docs';

--- a/src/components/shared/header/header-wrapper/header-wrapper.jsx
+++ b/src/components/shared/header/header-wrapper/header-wrapper.jsx
@@ -40,7 +40,9 @@ const HeaderWrapper = ({
         isSticky ? 'sticky transition-[padding,background-color] duration-200' : 'absolute',
         isStickyOverlay ? '-mb-16' : bg,
         isSticky && isStickied && `${bg}`,
-        withBorder && 'border-b border-gray-new-94 dark:border-gray-new-10',
+        withBorder &&
+          'relative after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:bg-gray-new-94 after:opacity-0 after:transition-opacity after:duration-200 after:dark:bg-gray-new-10',
+        withBorder && isStickied && 'after:opacity-100',
         className
       )}
       ref={headerRef}

--- a/src/components/shared/header/header-wrapper/header-wrapper.jsx
+++ b/src/components/shared/header/header-wrapper/header-wrapper.jsx
@@ -41,8 +41,13 @@ const HeaderWrapper = ({
         isStickyOverlay ? '-mb-16' : bg,
         isSticky && isStickied && `${bg}`,
         withBorder &&
-          'relative after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:bg-gray-new-94 after:opacity-0 after:transition-opacity after:duration-200 after:dark:bg-gray-new-10',
-        withBorder && isStickied && 'after:opacity-100',
+          clsx(
+            'relative',
+            'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px',
+            'after:bg-gray-new-94 after:dark:bg-gray-new-10',
+            'after:transition-opacity after:duration-200',
+            isStickied ? 'after:opacity-100' : 'after:opacity-0'
+          ),
         className
       )}
       ref={headerRef}


### PR DESCRIPTION
This PR brings the following:
- New styles for Header bottom border
- Setting menu animation to zero
- Vanishing of menu headings icons

Preview is [here](https://neon-next-git-add-line-to-header-neondatabase.vercel.app/)