### PR TITLE
chore: fix typo on scalable-architecture page

### DIFF
--- a/src/components/pages/scalable-architecture/hero/hero.jsx
+++ b/src/components/pages/scalable-architecture/hero/hero.jsx
@@ -20,10 +20,10 @@ const Hero = () => {
           tag="h2"
           theme="white"
         >
-          Scalable SAAS architecture in Postgres with Neon & AWS
+          Scalable SaaS architecture in Postgres with Neon & AWS
         </Heading>
         <p className="z-20 col-span-6 col-start-4 mt-[18px] flex flex-col gap-5 text-center text-lg font-light leading-snug -tracking-[0.016em] text-[#898D95] xl:col-span-10 xl:col-start-2 xl:mt-6 xl:max-w-none xl:gap-4 lg:text-lg sm:col-span-12 sm:col-start-1">
-          Discover how to build and optimize scalable SAAS architectures in Postgres with Neon
+          Discover how to build and optimize scalable SaaS architectures in Postgres with Neon
           &&nbsp;AWS. Elevate your database management with expert insights in this video.
         </p>
         <div className="relative col-span-8 col-start-3 flex h-fit justify-center lg:col-span-10 lg:col-start-2 sm:col-span-12 sm:col-start-1">


### PR DESCRIPTION
This PR fixes the typo on page `/scalable-architecture` 
> SAAS to SaaS

[Preview](https://neon-next-git-fix-typo-neondatabase.vercel.app/scalable-architecture)