### PR TITLE
fix: remove next-client-cookies to enable sitemap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "lottie-web": "^5.12.2",
         "markdownlint-cli": "^0.39.0",
         "next": "^14.2.2",
-        "next-client-cookies": "^1.1.1",
         "next-mdx-remote": "^4.4.1",
         "next-sitemap": "^4.2.3",
         "next-themes": "^0.3.0",
@@ -16790,26 +16789,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-client-cookies": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/next-client-cookies/-/next-client-cookies-1.1.1.tgz",
-      "integrity": "sha512-7/wiTI5RPJcP7c1zh5a9XNkvChihtattUG9dHMvfijtvzgEQXotr6E3AHYD1aXyVqGiZA95y/cWlcEI5EJ31tw==",
-      "dependencies": {
-        "js-cookie": "^3.0.5"
-      },
-      "peerDependencies": {
-        "next": ">= 13.0.0",
-        "react": ">= 16.8.0"
-      }
-    },
-    "node_modules/next-client-cookies/node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/next-mdx-remote": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "lottie-web": "^5.12.2",
     "markdownlint-cli": "^0.39.0",
     "next": "^14.2.2",
-    "next-client-cookies": "^1.1.1",
     "next-mdx-remote": "^4.4.1",
     "next-sitemap": "^4.2.3",
     "next-themes": "^0.3.0",

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,7 +1,6 @@
 import 'styles/globals.css';
 
 import Script from 'next/script';
-import { CookiesProvider } from 'next-client-cookies/server';
 
 import 'swiper/css';
 
@@ -30,13 +29,11 @@ const RootLayout = ({ children }) => (
       <link rel="preconnect" href="https://console.neon.tech" />
     </head>
     <body>
-      <CookiesProvider>
-        <ThemeProvider>
-          <HomepageVisitProvider>
-            <ActiveLabelProvider>{children}</ActiveLabelProvider>
-          </HomepageVisitProvider>
-        </ThemeProvider>
-      </CookiesProvider>
+      <ThemeProvider>
+        <HomepageVisitProvider>
+          <ActiveLabelProvider>{children}</ActiveLabelProvider>
+        </HomepageVisitProvider>
+      </ThemeProvider>
     </body>
   </html>
 );

--- a/src/components/shared/region-request/region-request.jsx
+++ b/src/components/shared/region-request/region-request.jsx
@@ -172,6 +172,7 @@ const DEFAULT_DATA = {
 };
 
 function getCookie(name) {
+  if (typeof document === 'undefined') return null;
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
   if (parts.length === 2) return parts.pop().split(';').shift();

--- a/src/components/shared/region-request/region-request.jsx
+++ b/src/components/shared/region-request/region-request.jsx
@@ -8,7 +8,6 @@ import {
   ComboboxOptions,
 } from '@headlessui/react';
 import clsx from 'clsx';
-import { useCookies } from 'next-client-cookies';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 
@@ -172,14 +171,21 @@ const DEFAULT_DATA = {
   ],
 };
 
+function getCookie(name) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop().split(';').shift();
+  return null;
+}
+
 const RegionRequest = ({
   title = DEFAULT_DATA.title,
   description = DEFAULT_DATA.description,
   buttonText = DEFAULT_DATA.buttonText,
   options = DEFAULT_DATA.regions,
 }) => {
-  const cookies = useCookies();
-  const isRecognized = !!cookies.get('ajs_user_id');
+  const isRecognized = !!getCookie('ajs_user_id');
+
   const [selected, setSelected] = useState();
   const [email, setEmail] = useState();
   const [requestComplete, setRequestComplete] = useState(false);


### PR DESCRIPTION
This pull request brings the sitemap fix by getting rid of `next-client-cookies`, checking cookie using a function on client side. 

https://github.com/iamvishnusankar/next-sitemap/pull/812#issuecomment-2231707718

Preview: https://neon-next-git-sitemap-fix-neondatabase.vercel.app/sitemap-0.xml