### PR TITLE
Add 1 day default for history retention configuration

### DIFF
--- a/content/docs/get-started-with-neon/production-checklist.md
+++ b/content/docs/get-started-with-neon/production-checklist.md
@@ -83,7 +83,7 @@ The `-pooler` flag directs connections to a connection pooling port at the Neon 
 
 ## Configure your history retention period
 
-Neon retains a history of changes for all branches, enabling features like: point-in-time restore, time travel queries, and no-cost branching. This history is invaluable for recovering lost data, investigating issues, viewing the past state of your database, and adding database branching to developer workflows. It can also function as part of your database backup strategy.
+Neon retains a history of changes for all branches, enabling features like point-in-time restore and time travel queries. It can also function as part of your database backup strategy.
 
 By default, Neon's history retention window is set to **1 day** across all plans to help you avoid unexpected storage costs.
 

--- a/content/docs/get-started-with-neon/production-checklist.md
+++ b/content/docs/get-started-with-neon/production-checklist.md
@@ -83,7 +83,7 @@ The `-pooler` flag directs connections to a connection pooling port at the Neon 
 
 ## Configure your history retention period
 
-Neon retains a history of changes for all branches, enabling features like point-in-time restore and time travel queries. It can also function as part of your database backup strategy.
+Neon retains a history of changes for all branches. This history enables point-in-time restore and time travel queries, among other development-focused features. Keeping a history enables recovering lost data or viewing the past state of your database, which is helpful when trying to determine when an issue occurred or find a restore point. Neon's history can also function as a database backup strategy.
 
 By default, Neon's history retention window is set to **1 day** across all plans to help you avoid unexpected storage costs.
 

--- a/content/docs/get-started-with-neon/production-checklist.md
+++ b/content/docs/get-started-with-neon/production-checklist.md
@@ -83,13 +83,13 @@ The `-pooler` flag directs connections to a connection pooling port at the Neon 
 
 ## Configure your history retention period
 
-Neon retains a history of changes for all branches. This history enables point-in-time restore and time travel queries among other development-focussed features. Keeping a history enables recovering lost data or viewing the past state of your database, which is helpful when trying to determine when an issue occurred or find a restore point. Neon's history can also function as a database backup strategy.
+Neon retains a history of changes for all branches, enabling features like: point-in-time restore, time travel queries, and no-cost branching. This history is invaluable for recovering lost data, investigating issues, viewing the past state of your database, and adding database branching to developer workflows. It can also function as part of your database backup strategy.
 
-The history retention limit is 24 hours for Neon Free Plan users, 7 days for Launch plan users, and 30 days for Scale and Business plan users. Before going into production, select a history retention period that suits your operational requirements.
+By default, Neon's history retention window is set to **1 day** across all plans to help you avoid unexpected storage costs.
+
+If you choose to extend your retention window beyond the default &#8212; to take full advantage of the features that this history enables &#8212; keep in mind that this will increase your storage usage and may lead to higher costs, especially if you have many active branches. Make sure you select a history retention period that aligns with your goals.
 
 ![History retention setting](/docs/get-started-with-neon/history_retention_setting.png)
-
-A longer history retention period expands your point-in-time restore and time travel query horizons at the cost of increased storage usage.
 
 For more, see [Branch reset and restore](/docs/introduction/point-in-time-restore).
 

--- a/content/docs/guides/logical-replication-tips.md
+++ b/content/docs/guides/logical-replication-tips.md
@@ -3,7 +3,7 @@ title: Logical replication tips
 subtitle: Learn how to optimize for logical replication
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2024-09-04T18:53:01.155Z'
+updatedOn: '2024-09-05T13:51:32.866Z'
 ---
 
 The following tips are based on actual customer data migrations to Neon using logical replication:

--- a/content/docs/introduction/point-in-time-restore.md
+++ b/content/docs/introduction/point-in-time-restore.md
@@ -9,7 +9,7 @@ Neon retains a history of changes for all branches. This shared history provides
 
 ## History retention
 
-The history retention limit is up to 24 hours for [Neon Free Plan](/docs/introduction/plans#free-plan) users, 7 days for [Launch](/docs/introduction/plans#launch), 14 days for [Scale](/docs/introduction/plans#scale), and 30 days for [Business](/docs/introduction/plans#business) plan users.
+By default, Neon's history retention window is set to **1 day** across all plans to help you avoid unexpected storage costs. The history retention limit is up to 24 hours for [Neon Free Plan](/docs/introduction/plans#free-plan) users, 7 days for [Launch](/docs/introduction/plans#launch), 14 days for [Scale](/docs/introduction/plans#scale), and 30 days for [Business](/docs/introduction/plans#business) plan users.
 
 You can configure the **History retention** setting in the Neon Console, under **Project settings** > **Storage**. For further instructions, see [Configure history retention](/docs/manage/projects#configure-history-retention).
 ![History retention configuration](/docs/relnotes/history_retention.png)

--- a/content/docs/introduction/point-in-time-restore.md
+++ b/content/docs/introduction/point-in-time-restore.md
@@ -9,7 +9,7 @@ Neon retains a history of changes for all branches. This shared history provides
 
 ## History retention
 
-By default, Neon's history retention window is set to **1 day** across all plans to help you avoid unexpected storage costs. The history retention limit is up to 24 hours for [Neon Free Plan](/docs/introduction/plans#free-plan) users, 7 days for [Launch](/docs/introduction/plans#launch), 14 days for [Scale](/docs/introduction/plans#scale), and 30 days for [Business](/docs/introduction/plans#business) plan users.
+By default, Neon's history retention window is set to **1 day** across all plans to help you avoid unexpected storage costs. Increasing your retention window gives you a better range for your reset and restore operations, but it can also increase storage costs. The history retention limit is up to 24 hours for [Neon Free Plan](/docs/introduction/plans#free-plan) users, 7 days for [Launch](/docs/introduction/plans#launch), 14 days for [Scale](/docs/introduction/plans#scale), and 30 days for [Business](/docs/introduction/plans#business) plan users.
 
 You can configure the **History retention** setting in the Neon Console, under **Project settings** > **Storage**. For further instructions, see [Configure history retention](/docs/manage/projects#configure-history-retention).
 ![History retention configuration](/docs/relnotes/history_retention.png)

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -157,7 +157,11 @@ _Example: default minimum and maximum autoscale settings_
 
 ### Configure history retention
 
-By default, Neon retains a history of changes for all branches in a Neon project, which allows you to create a branch that restores data to any point within the defined retention period. The supported limits are 24 hours for [Neon Free Plan](/docs/introduction/plans#free-plan) users, 7 days for [Launch](/docs/introduction/plans#launch) plan users, and 30 days for [Scale](/docs/introduction/plans#scale) and [Business](/docs/introduction/plans#business) plan users. Please be aware that increasing the history retention period affects all branches in your project and increases [project storage](/docs/introduction/usage-metrics#storage).
+By default, Neon retains a history of changes for all branches in your project, enabling features like point-in-time restore, time travel queries, and database branching. These features are invaluable for recovering lost data, investigating issues, and adding database branching to development workflows.
+
+The default retention window is **1 day** across all plans to help manage storage costs. If you extend the retention window, you'll expand the range of data recovery and query options, but be aware that this will also increase your storage usage, especially with multiple active branches.
+
+Also note that adjusting the history retention period affects _all_ branches in your project and increases [project storage](/docs/introduction/usage-metrics#storage).
 
 To configure the history retention period for a project:
 
@@ -167,6 +171,8 @@ To configure the history retention period for a project:
    ![History retention configuration](/docs/manage/history_retention.png)
 4. Use the slider to select the history retention period.
 5. Click **Save**.
+
+For more information about available plan limits, see [Neon plans](/docs/introduction/plans).
 
 ## Enable logical replication
 

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -162,7 +162,7 @@ By default, Neon retains a history of changes for all branches in your project, 
 - [Point-in-time restore](/docs/introduction/point-in-time-restore) for recovering lost data
 - [Time Travel](/docs/guides/time-travel-assist) queries for investingating data issues
 
-The default retention window is **1 day** across all plans to help manage storage costs. If you extend this retention window, you'll expand the range of data recovery and query options, but note that this will also increase your [storage](/docs/introduction/usage-metrics#storage) usage, especially with multiple active branches.
+The default retention window is **1 day** across all plans to help avoid unexpected storage costs. If you extend this retention window, you'll expand the range of data recovery and query options, but note that this will also increase your [storage](/docs/introduction/usage-metrics#storage) usage, especially with multiple active branches.
 
 Also note that adjusting the history retention period affects _all_ branches in your project.
 

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -157,11 +157,14 @@ _Example: default minimum and maximum autoscale settings_
 
 ### Configure history retention
 
-By default, Neon retains a history of changes for all branches in your project, enabling features like point-in-time restore, time travel queries, and database branching. These features are invaluable for recovering lost data, investigating issues, and adding database branching to development workflows.
+By default, Neon retains a history of changes for all branches in your project, enabling features like:
 
-The default retention window is **1 day** across all plans to help manage storage costs. If you extend the retention window, you'll expand the range of data recovery and query options, but be aware that this will also increase your storage usage, especially with multiple active branches.
+- [Database branching](/docs/guides/branching-intro), a fundamental Neon feature that lets you integrate your database into developer workflows, create isolated environments for your team, among other use cases
+- [Time Travel](/docs/guides/time-travel-assist) queries and [Point-in-time restore](/docs/introduction/point-in-time-restore) for investingating issues and recovering lost data
 
-Also note that adjusting the history retention period affects _all_ branches in your project and increases [project storage](/docs/introduction/usage-metrics#storage).
+The default retention window is **1 day** across all plans to help manage storage costs. If you extend this retention window, you'll expand the range of data recovery and query options, but note that this will also increase your [storage](/docs/introduction/usage-metrics#storage) usage, especially with multiple active branches.
+
+Also note that adjusting the history retention period affects _all_ branches in your project.
 
 To configure the history retention period for a project:
 

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -159,8 +159,8 @@ _Example: default minimum and maximum autoscale settings_
 
 By default, Neon retains a history of changes for all branches in your project, enabling features like:
 
-- [Database branching](/docs/guides/branching-intro), a fundamental Neon feature that lets you integrate your database into developer workflows, create isolated environments for your team, among other use cases
-- [Time Travel](/docs/guides/time-travel-assist) queries and [Point-in-time restore](/docs/introduction/point-in-time-restore) for investingating issues and recovering lost data
+- [Point-in-time restore](/docs/introduction/point-in-time-restore) for recovering lost data
+- [Time Travel](/docs/guides/time-travel-assist) queries for investingating data issues
 
 The default retention window is **1 day** across all plans to help manage storage costs. If you extend this retention window, you'll expand the range of data recovery and query options, but note that this will also increase your [storage](/docs/introduction/usage-metrics#storage) usage, especially with multiple active branches.
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -326,9 +326,13 @@ The Pageserver uploads immutable files to cloud storage, which is the final, hig
 
 The ability to authenticate without providing a password. Neon’s [Passwordless auth](#passwordless-auth) feature supports passwordless authentication.
 
-## point-in-time restore
 
-Restoration of data to a state that existed at an earlier time. Neon retains a history of changes in the form of Write-Ahead-Log (WAL) records, which allows you to restore data to an earlier time. A point-in-time restore is performed by creating a branch using the **Time** or **LSN** option. By default, Neon retains a history of changes for all branches in a project. The supported limits are 24 hours for [Neon Free Plan](/docs/introduction/plans#free-plan) users, 7 days for [Launch](/docs/introduction/plans#launch) plan users, and 30 days for [Scale](/docs/introduction/plans#scale) plan users. For more information about this feature, see [Branching — Point-in-time restore](https://neon.tech/docs/guides/branching-pitr).
+## point-in-time restore
+Restoration of data to a state that existed at an earlier time. Neon retains a history of changes in the form of Write-Ahead-Log (WAL) records, which allows you to restore data to an earlier point. A point-in-time restore is performed by creating a branch using the **Time** or **LSN** option. 
+
+By default, Neon retains a history of changes for **1 day** across all plans to help avoid unexpected storage costs. You can increase the retention window to 24 hours for [Neon Free Plan](/docs/introduction/plans#free-plan) users, 7 days for [Launch](/docs/introduction/plans#launch), 14 days for [Scale](/docs/introduction/plans#scale), and 30 days for [Business](/docs/introduction/plans#business) plan users. Keep in mind that this will increase your storage usage and may lead to higher costs, especially if you have many active branches.
+
+For more information about this feature, see [Branching — Point-in-time restore](/docs/introduction/point-in-time-restore).
 
 ## pooled connection string
 


### PR DESCRIPTION
Preview:
- [Configure history retention (production checklist page)](https://neon-next-git-bgrenon-history-retention-default-neondatabase.vercel.app/docs/get-started-with-neon/production-checklist#configure-your-history-retention-period)
- [Configure history retention (manage computes page)](https://neon-next-git-bgrenon-history-retention-default-neondatabase.vercel.app/docs/manage/projects#configure-history-retention)
- [Branch reset and restore](https://neon-next-git-bgrenon-history-retention-default-neondatabase.vercel.app/docs/introduction/point-in-time-restore)
- [Point-in-time-restore (glossary)](https://neon-next-git-bgrenon-history-retention-default-neondatabase.vercel.app/docs/reference/glossary#point-in-time-restore)