### PR TITLE
Update hero.jsx

### DIFF
--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -25,7 +25,6 @@ const items = [
     description: 'Always-available free tier, no credit card required.',
     features: [
       { title: '0.5 GiB storage' },
-      { title: '10 branches', info: 'All within 1 project' },
       {
         title: '24/7 database at 0.25 CU',
         info: 'Plus 20h of usage for additional branches. 0.25 CU = 0.25 vCPU, 1 GB RAM',
@@ -83,10 +82,6 @@ const items = [
     description: 'Full platform access for scaling production workloads.',
     features: [
       { title: '50 GiB storage included', info: 'Additional storage: $15 per 10 GiB' },
-      {
-        title: '500 branches per project',
-        info: '50 projects included. Additional 10 projects: $50/month',
-      },
       {
         title: '750 <a href="#compute-hour">compute hours</a> included',
         info: 'Additional usage: $0.16 per compute hour',

--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -238,7 +238,7 @@
       },
       "free": false,
       "launch": false,
-      "scale": true,
+      "scale": false,
       "business": true
     },
     {


### PR DESCRIPTION
- Fix a mistake in the hero (number of branches should be off for all plans, now it shows in 2 / 4) 
- Fix a mistake in the detailed table (IP Allow is not available in Scale no more)