### PR TITLE
fix: replace inkeep search placeholder

### DIFF
--- a/src/lib/inkeep-settings.js
+++ b/src/lib/inkeep-settings.js
@@ -13,6 +13,7 @@ const baseSettings = {
 
 const searchSettings = {
   searchMode: 'KEYWORD',
+  placeholder: 'Search',
 };
 
 const aiChatSettings = {


### PR DESCRIPTION
This PR replaces Inkeep search placeholder from "Search for anything" to "Search"

**Screenshot**
<img width="391" alt="image" src="https://github.com/user-attachments/assets/8feb6943-5631-4e4a-9eea-ae9995d0e3f6">
