### PR TITLE
fix: change branching link on main page

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -54,7 +54,7 @@ const ITEMS = [
     description:
       'Instantly branch your data and schema to access isolated DB copies for development, CI/CD, and schema migrations with copy-on-write storage.',
     linkLabel: 'Explore Branching',
-    linkUrl: LINKS.branching,
+    linkUrl: LINKS.docsBranching,
   },
 ];
 


### PR DESCRIPTION
This PR brings new link for Explore Branching on the Main Page

Preview is here

![Screenshot 2024-09-12 at 10 44 57 AM](https://github.com/user-attachments/assets/cb1ee833-f668-4afd-85d4-a6ff8f7a67a2)
