### PR TITLE
refactor: docs sidebar menu without animations

### DIFF
--- a/src/components/pages/doc/menu/menu.jsx
+++ b/src/components/pages/doc/menu/menu.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { LazyMotion, domAnimation, m, AnimatePresence } from 'framer-motion';
 import PropTypes from 'prop-types';
 import { useRef, useEffect } from 'react';
 
@@ -116,18 +115,10 @@ const Menu = ({
 
   // update menu height and scroll menu to top
   useEffect(() => {
-    let timeout;
-
     if (isLastActive && menuRef.current && menuRef.current.scrollHeight > 0 && setMenuHeight) {
-      timeout = setTimeout(() => {
-        setMenuHeight(menuRef.current.scrollHeight);
-        menuWrapperRef.current?.scrollTo(0, 0);
-      }, 200);
+      setMenuHeight(menuRef.current.scrollHeight);
+      menuWrapperRef.current?.scrollTo(0, 0);
     }
-
-    return () => {
-      clearTimeout(timeout);
-    };
   }, [isLastActive, setMenuHeight, menuWrapperRef]);
 
   const handleClose = () => {
@@ -139,139 +130,122 @@ const Menu = ({
     setActiveMenuList([HOME_MENU_ITEM]);
   };
 
-  const animateState = () => {
-    if (isRootMenu) return 'moveMenu';
-    return isActive ? 'open' : 'close';
-  };
+  if (!isRootMenu && !isActive) return null;
 
   return (
-    <LazyMotion features={domAnimation}>
-      <AnimatePresence initial={false}>
-        {(isRootMenu || isActive) && (
-          <m.div
-            className={clsx(
-              'absolute left-0 top-0 w-full pb-16',
-              !isActive && 'pointer-events-none',
-              !isRootMenu && 'translate-x-full',
-              'lg:px-8 lg:pb-8 lg:pt-4 md:px-5'
+    <div
+      className={clsx(
+        'absolute left-0 top-0 w-full pb-16',
+        !isActive && 'pointer-events-none',
+        !isRootMenu && 'translate-x-full',
+        'lg:px-8 lg:pb-8 lg:pt-4 md:px-5',
+        (isActive || isRootMenu) && 'opacity-1'
+      )}
+      style={isRootMenu ? { transform: `translateX(${lastDepth * -100}%)` } : undefined}
+      ref={menuRef}
+    >
+      {/* breadcrumbs, menu title and home link */}
+      {!isRootMenu && (
+        <>
+          <div className="flex flex-col gap-7 border-b border-gray-new-94 pb-4 dark:border-gray-new-10 md:pb-3.5">
+            {depth > 0 && (
+              <BackLinkTag
+                className="flex items-center gap-2 text-sm font-medium leading-tight tracking-extra-tight text-secondary-8 dark:text-green-45"
+                type={parentMenu.slug ? undefined : 'button'}
+                to={parentMenu.slug ? `${basePath}${parentMenu.slug}` : undefined}
+                onClick={handleClose}
+              >
+                <ChevronBackIcon className="size-4.5" />
+                Back to {parentMenu.title}
+              </BackLinkTag>
             )}
-            initial={false}
-            animate={animateState}
-            exit="close"
-            // NOTE: duration: 0 is needed to prevent the menu from animating out
-            transition={{ ease: 'easeIn', duration: 0 }}
-            variants={{
-              close: { opacity: 0 },
-              open: { opacity: 1 },
-              moveMenu: { opacity: 1, x: `${lastDepth * -100}%` },
-            }}
-            ref={menuRef}
+            {depth !== 1 && (
+              <Link
+                className={clsx(
+                  'flex w-full items-start gap-2 text-left text-sm leading-tight tracking-extra-tight transition-colors duration-200',
+                  'text-gray-new-40 hover:text-black-new dark:text-gray-new-80 dark:hover:text-white'
+                )}
+                to={homePath}
+                onClick={handleClickHome}
+              >
+                <HomeIcon className="size-4.5" />
+                Home
+              </Link>
+            )}
+          </div>
+
+          <LinkTag
+            className="mt-4 flex w-full items-start gap-1.5 pb-2.5 text-left font-medium leading-tight tracking-extra-tight text-black-new dark:text-white md:hidden"
+            to={slug ? `${basePath}${slug}` : undefined}
           >
-            {/* breadcrumbs, menu title and home link */}
-            {!isRootMenu && (
-              <>
-                <div className="flex flex-col gap-7 border-b border-gray-new-94 pb-4 dark:border-gray-new-10 md:pb-3.5">
-                  {depth > 0 && (
-                    <BackLinkTag
-                      className="flex items-center gap-2 text-sm font-medium leading-tight tracking-extra-tight text-secondary-8 dark:text-green-45"
-                      type={parentMenu.slug ? undefined : 'button'}
-                      to={parentMenu.slug ? `${basePath}${parentMenu.slug}` : undefined}
-                      onClick={handleClose}
-                    >
-                      <ChevronBackIcon className="size-4.5" />
-                      Back to {parentMenu.title}
-                    </BackLinkTag>
-                  )}
-                  {depth !== 1 && (
-                    <Link
-                      className={clsx(
-                        'flex w-full items-start gap-2 text-left text-sm leading-tight tracking-extra-tight transition-colors duration-200',
-                        'text-gray-new-40 hover:text-black-new dark:text-gray-new-80 dark:hover:text-white'
-                      )}
-                      to={homePath}
-                      onClick={handleClickHome}
-                    >
-                      <HomeIcon className="size-4.5" />
-                      Home
-                    </Link>
-                  )}
-                </div>
+            {title}
+          </LinkTag>
+        </>
+      )}
 
-                <LinkTag
-                  className="mt-4 flex w-full items-start gap-1.5 pb-2.5 text-left font-medium leading-tight tracking-extra-tight text-black-new dark:text-white md:hidden"
-                  to={slug ? `${basePath}${slug}` : undefined}
-                >
-                  {title}
-                </LinkTag>
-              </>
-            )}
-
-            {/* menu sections and items */}
-            <ul className={clsx('w-full', !isRootMenu && 'py-2.5')}>
-              {items.map((item, index) =>
-                item.section ? (
-                  <Section
-                    key={index}
-                    depth={depth}
-                    {...item}
-                    title={title}
-                    slug={slug}
-                    basePath={basePath}
-                    closeMobileMenu={closeMobileMenu}
-                    setMenuHeight={setMenuHeight}
-                    menuWrapperRef={menuWrapperRef}
-                    activeMenuList={activeMenuList}
-                    setActiveMenuList={setActiveMenuList}
-                  />
-                ) : (
-                  <Item
-                    key={index}
-                    {...item}
-                    basePath={basePath}
-                    activeMenuList={activeMenuList}
-                    setActiveMenuList={setActiveMenuList}
-                    closeMobileMenu={closeMobileMenu}
-                  >
-                    {item.items && (
-                      <Menu
-                        depth={depth + 1}
-                        title={item.title}
-                        slug={item.slug}
-                        icon={item.icon}
-                        items={item.items}
-                        basePath={basePath}
-                        parentMenu={{ title, slug }}
-                        setMenuHeight={setMenuHeight}
-                        menuWrapperRef={menuWrapperRef}
-                        activeMenuList={activeMenuList}
-                        setActiveMenuList={setActiveMenuList}
-                        closeMobileMenu={closeMobileMenu}
-                      />
-                    )}
-                  </Item>
-                )
+      {/* menu sections and items */}
+      <ul className={clsx('w-full', !isRootMenu && 'py-2.5')}>
+        {items.map((item, index) =>
+          item.section ? (
+            <Section
+              key={index}
+              depth={depth}
+              {...item}
+              title={title}
+              slug={slug}
+              basePath={basePath}
+              closeMobileMenu={closeMobileMenu}
+              setMenuHeight={setMenuHeight}
+              menuWrapperRef={menuWrapperRef}
+              activeMenuList={activeMenuList}
+              setActiveMenuList={setActiveMenuList}
+            />
+          ) : (
+            <Item
+              key={index}
+              {...item}
+              basePath={basePath}
+              activeMenuList={activeMenuList}
+              setActiveMenuList={setActiveMenuList}
+              closeMobileMenu={closeMobileMenu}
+            >
+              {item.items && (
+                <Menu
+                  depth={depth + 1}
+                  title={item.title}
+                  slug={item.slug}
+                  icon={item.icon}
+                  items={item.items}
+                  basePath={basePath}
+                  parentMenu={{ title, slug }}
+                  setMenuHeight={setMenuHeight}
+                  menuWrapperRef={menuWrapperRef}
+                  activeMenuList={activeMenuList}
+                  setActiveMenuList={setActiveMenuList}
+                  closeMobileMenu={closeMobileMenu}
+                />
               )}
-            </ul>
-
-            {/* back to docs link */}
-            {isRootMenu && basePath !== DOCS_BASE_PATH && (
-              <div className="border-t border-gray-new-94 pt-4 dark:border-gray-new-10">
-                <Link
-                  className={clsx(
-                    'flex w-full items-start gap-2 text-left text-sm leading-tight tracking-extra-tight transition-colors duration-200',
-                    'text-gray-new-60 hover:text-black-new dark:hover:text-white'
-                  )}
-                  to={isRootMenu ? backLinkPath : homePath}
-                >
-                  <ArrowBackIcon className="size-4.5" />
-                  Back to docs
-                </Link>
-              </div>
-            )}
-          </m.div>
+            </Item>
+          )
         )}
-      </AnimatePresence>
-    </LazyMotion>
+      </ul>
+
+      {/* back to docs link */}
+      {isRootMenu && basePath !== DOCS_BASE_PATH && (
+        <div className="border-t border-gray-new-94 pt-4 dark:border-gray-new-10">
+          <Link
+            className={clsx(
+              'flex w-full items-start gap-2 text-left text-sm leading-tight tracking-extra-tight transition-colors duration-200',
+              'text-gray-new-60 hover:text-black-new dark:hover:text-white'
+            )}
+            to={isRootMenu ? backLinkPath : homePath}
+          >
+            <ArrowBackIcon className="size-4.5" />
+            Back to docs
+          </Link>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/pages/doc/mobile-nav/mobile-nav.jsx
+++ b/src/components/pages/doc/mobile-nav/mobile-nav.jsx
@@ -136,10 +136,7 @@ const MobileNav = ({ className = null, sidebar, slug, basePath }) => {
           style={{ height: wrapperHeight }}
         >
           <InkeepTrigger className="lg:hidden" topOffset={wrapperHeight || menuHeight} />
-          <div
-            className="relative w-full overflow-hidden transition-[height] duration-300"
-            style={{ height: menuHeight }}
-          >
+          <div className="relative w-full overflow-hidden" style={{ height: menuHeight }}>
             <Menu
               depth={0}
               title="Home"

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -96,10 +96,7 @@ const Sidebar = ({ className = null, sidebar, slug, basePath }) => {
           className="no-scrollbars z-10 mt-5 h-[calc(100vh-70px)] overflow-x-hidden overflow-y-scroll pt-[46px]"
           ref={menuWrapperRef}
         >
-          <div
-            className="relative w-full overflow-hidden transition-[height] duration-300"
-            style={{ height: menuHeight }}
-          >
+          <div className="relative w-full overflow-hidden" style={{ height: menuHeight }}>
             <Menu
               depth={0}
               title="Home"


### PR DESCRIPTION
This PR brings refactor for docs sidebar menu without animations

- fix issue with menu height change delay for nested menus
- optimize code, remove Framer Motion from menu

[Preview](https://neon-next-git-docs-sidebar-no-animations-neondatabase.vercel.app/docs/introduction)