### PR TITLE
feat: update docs home cta styles

### DIFF
--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -5,7 +5,7 @@ updatedOn: '2024-08-15T17:23:10.558Z'
 
 Neon is a serverless Postgres platform designed to help you build reliable and scalable applications faster. We separate compute and storage to offer modern developer features such as autoscaling, branching, point-in-time restore, and more. Get started today with our [generous free plan](https://console.neon.tech).
 
-<CTA title="Branch your data like code" description="Learn how Neon's database branching can help you integrate Postgres into your development workflow." buttonText="Read our primer" buttonUrl="/docs/get-started-with-neon/workflow-primer"></CTA>
+<CTA title="Did you know?" description="Neon's database branching can help you integrate Postgres into your development workflow. Branch your data like code. <a href='/docs/get-started-with-neon/workflow-primer'>Read our primer</a> to learn&nbsp;how." noButton></CTA>
 
 ## Get started
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -5,7 +5,7 @@ updatedOn: '2024-08-15T17:23:10.558Z'
 
 Neon is a serverless Postgres platform designed to help you build reliable and scalable applications faster. We separate compute and storage to offer modern developer features such as autoscaling, branching, point-in-time restore, and more. Get started today with our [generous free plan](https://console.neon.tech).
 
-<CTA title="Did you know?" description="Neon's database branching can help you integrate Postgres into your development workflow. Branch your data like code. <a href='/docs/get-started-with-neon/workflow-primer'>Read our primer</a> to learn&nbsp;how." noButton></CTA>
+<CTA title="Did you know?" description="Neon's database branching can help you integrate Postgres into your development workflow. Branch your data like code. <a href='/docs/get-started-with-neon/workflow-primer'>Read our primer</a> to learn&nbsp;how." isIntro></CTA>
 
 ## Get started
 

--- a/src/components/shared/doc-cta/doc-cta.jsx
+++ b/src/components/shared/doc-cta/doc-cta.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
 import LINKS from 'constants/links';
@@ -17,17 +18,39 @@ const DocCta = ({
   description = DEFAULT_DATA.description,
   buttonText = DEFAULT_DATA.buttonText,
   buttonUrl = DEFAULT_DATA.buttonUrl,
+  noButton = false,
 }) => (
-  <figure className="doc-cta not-prose my-5 flex items-end gap-x-16 rounded-[10px] border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA_0%,rgba(250,250,250,0)100%)] px-7 py-6 dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_28.86%,#131415_74.18%)] md:flex-col md:items-start sm:p-6">
+  <figure
+    className={clsx(
+      'doc-cta not-prose my-12 flex items-end gap-x-16 rounded-[10px] px-6 py-5',
+      'border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA_0%,rgba(250,250,250,0)100%)]',
+      'dark:border-gray-new-15 dark:bg-[linear-gradient(to_right,#18191B_28.86%,#131415_74.18%)]',
+      'md:flex-col md:items-start'
+    )}
+  >
     <div>
-      <h2 className="!my-0 font-title text-2xl font-medium leading-dense">{title}</h2>
-      <p className="mt-2 text-sm font-light text-gray-new-20 dark:text-gray-new-80">
-        {description}
-      </p>
+      <h2 className="!my-0 font-title text-xl font-semibold leading-tight tracking-extra-tight">
+        {title}
+      </h2>
+      <p
+        className={clsx(
+          'mt-2 tracking-extra-tight text-gray-new-20 dark:text-gray-new-80',
+          '[&_a]:border-b [&_a]:border-transparent [&_a]:text-secondary-8 [&_a]:no-underline',
+          '[&_a]:transition-[border-color] [&_a]:duration-200 [&_a]:ease-in-out hover:[&_a]:border-secondary-8',
+          'dark:[&_a]:text-primary-1 dark:hover:[&_a]:border-primary-1'
+        )}
+        dangerouslySetInnerHTML={{ __html: description }}
+      />
     </div>
-    <Button className="px-6 py-3 font-semibold leading-none md:mt-4" to={buttonUrl} theme="primary">
-      {buttonText}
-    </Button>
+    {!noButton && (
+      <Button
+        className="px-6 py-3 font-semibold leading-none md:mt-4"
+        to={buttonUrl}
+        theme="primary"
+      >
+        {buttonText}
+      </Button>
+    )}
   </figure>
 );
 
@@ -36,6 +59,7 @@ DocCta.propTypes = {
   description: PropTypes.node,
   buttonText: PropTypes.string,
   buttonUrl: PropTypes.string,
+  noButton: PropTypes.bool,
 };
 
 export default DocCta;

--- a/src/components/shared/doc-cta/doc-cta.jsx
+++ b/src/components/shared/doc-cta/doc-cta.jsx
@@ -18,23 +18,33 @@ const DocCta = ({
   description = DEFAULT_DATA.description,
   buttonText = DEFAULT_DATA.buttonText,
   buttonUrl = DEFAULT_DATA.buttonUrl,
-  noButton = false,
+  isIntro = false,
 }) => (
   <figure
     className={clsx(
-      'doc-cta not-prose my-12 flex items-end gap-x-16 rounded-[10px] px-6 py-5',
+      'doc-cta not-prose rounded-[10px]',
+      isIntro
+        ? 'my-12 px-6 py-5 md:my-8'
+        : 'my-5 flex items-end gap-x-16 px-7 py-6 md:flex-col md:items-start',
       'border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA_0%,rgba(250,250,250,0)100%)]',
-      'dark:border-gray-new-15 dark:bg-[linear-gradient(to_right,#18191B_28.86%,#131415_74.18%)]',
-      'md:flex-col md:items-start'
+      'dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_28.86%,#131415_74.18%)]'
     )}
   >
     <div>
-      <h2 className="!my-0 font-title text-xl font-semibold leading-tight tracking-extra-tight">
+      <h2
+        className={clsx(
+          '!my-0',
+          isIntro
+            ? 'text-xl font-semibold leading-tight tracking-extra-tight'
+            : 'font-title text-2xl font-medium leading-dense'
+        )}
+      >
         {title}
       </h2>
       <p
         className={clsx(
-          'mt-2 tracking-extra-tight text-gray-new-20 dark:text-gray-new-80',
+          'mt-2 text-gray-new-20 dark:text-gray-new-80',
+          isIntro ? 'tracking-extra-tight' : 'text-sm font-light',
           '[&_a]:border-b [&_a]:border-transparent [&_a]:text-secondary-8 [&_a]:no-underline',
           '[&_a]:transition-[border-color] [&_a]:duration-200 [&_a]:ease-in-out hover:[&_a]:border-secondary-8',
           'dark:[&_a]:text-primary-1 dark:hover:[&_a]:border-primary-1'
@@ -42,7 +52,7 @@ const DocCta = ({
         dangerouslySetInnerHTML={{ __html: description }}
       />
     </div>
-    {!noButton && (
+    {!isIntro && (
       <Button
         className="px-6 py-3 font-semibold leading-none md:mt-4"
         to={buttonUrl}
@@ -59,7 +69,7 @@ DocCta.propTypes = {
   description: PropTypes.node,
   buttonText: PropTypes.string,
   buttonUrl: PropTypes.string,
-  noButton: PropTypes.bool,
+  isIntro: PropTypes.bool,
 };
 
 export default DocCta;


### PR DESCRIPTION
This PR updates Docs home page CTA section styles

![image](https://github.com/user-attachments/assets/a8dceeaa-96dc-4e08-8529-def8aeccab88)

CTA blocks on other pages (for example [AI](https://neon-next-git-docs-home-cta-neondatabase.vercel.app/docs/ai/ai-intro) page) are not changed

[Preview](https://neon-next-git-docs-home-cta-neondatabase.vercel.app/docs/introduction)