### PR TITLE
docs: remove duplicate links

### DIFF
--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -247,10 +247,6 @@
               slug: guides/logical-replication-schema-changes
             - title: Logical replication tips
               slug: guides/logical-replication-tips
-        - title: Organizations
-          slug: manage/organizations
-        - title: Project sharing
-          slug: guides/project-sharing-guide
         - title: Read replicas
           slug: introduction/read-replicas
           items:


### PR DESCRIPTION
Linking to content from a different section in the sidebar causes navigation issues. Revert changes.