### PR TITLE
docs: fix typos

### DIFF
--- a/content/docs/get-started-with-neon/production-checklist.md
+++ b/content/docs/get-started-with-neon/production-checklist.md
@@ -127,7 +127,7 @@ To learn more about monitoring resources and metrics in Neon, check out our [Mon
 
 ## Create staging or test branches
 
-With Neon branching, you can easily create an isolated copy of your production database for est schema changes and application updates before deploying to production. To get an idea of how easily you can create a branch for testing, see our [Branching — Testing queries](/docs/guides/branching-test-queries) guide.
+With Neon branching, you can easily create an isolated copy of your production database for test schema changes and application updates before deploying to production. To get an idea of how easily you can create a branch for testing, see our [Branching — Testing queries](/docs/guides/branching-test-queries) guide.
 
 The [Neon CLI](/docs/reference/neon-cli) and [Neon API](https://api-docs.neon.tech/reference/getting-started-with-neon-api) enable you to automate testing and build CI/CD pipelines to streamline your testing processes.
 

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -9,7 +9,7 @@ redirectFrom:
 updatedOn: '2024-09-22T10:36:04.266Z'
 ---
 
-Our development teams are focused on helping you ship faster with Postgres. This roadmap describes committed features that we're working on right now, plus a peak at some of the upcoming features we'll be taking on next.
+Our development teams are focused on helping you ship faster with Postgres. This roadmap describes committed features that we're working on right now, plus a peek at some of the upcoming features we'll be taking on next.
 
 ## What we've just launched
 


### PR DESCRIPTION
A candidate for the support role found these typos when reading through the docs.