### PR TITLE
chore: edit-on-github link

### DIFF
--- a/src/components/pages/doc/edit-on-github/edit-on-github.jsx
+++ b/src/components/pages/doc/edit-on-github/edit-on-github.jsx
@@ -16,7 +16,7 @@ const EditOnGithub = ({ fileOriginPath }) => (
     rel="noopener noreferrer"
   >
     <GitHubIcon className="h-3.5 w-3.5" />
-    <span className="text-sm leading-tight tracking-tight">Edit this page on Github</span>
+    <span className="text-sm leading-tight tracking-tight">Edit this page on GitHub</span>
     <ArrowExternalIcon className="text-gray-new-90 dark:text-gray-new-15 lg:hidden" />
   </Link>
 );


### PR DESCRIPTION
This PR updates "Edit this page on GitHub" link

![image](https://github.com/user-attachments/assets/310097eb-965a-4cd0-84f2-7a0a1106694c)

[Preview](https://neon-next-git-update-github-link-neondatabase.vercel.app/docs)