### PR TITLE
chore: update partners subline in header menu

### DIFF
--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -253,8 +253,8 @@ export default {
             light: partnersIcon,
             dark: partnersDarkIcon,
           },
-          text: 'Neon for platforms',
-          description: 'Postgres for your users',
+          text: 'Partners',
+          description: 'Add Neon to your platform',
           to: LINKS.partners,
         },
         {


### PR DESCRIPTION
This PR updates the title and description of partners link in the header menu.

Before | After
-- | --
Neon for Platforms | Partners
Postgres for your users | Add Neon to your platform


