### PR TITLE
fix: docs sidebar scrolling issue

### DIFF
--- a/src/components/pages/doc/menu/menu.jsx
+++ b/src/components/pages/doc/menu/menu.jsx
@@ -103,7 +103,8 @@ const Menu = ({
   const BackLinkTag = parentMenu?.slug ? Link : 'button';
 
   const isActive = isRootMenu || activeMenuList.some((item) => item.title === title);
-  const isLastActive = activeMenuList[lastDepth]?.title === title;
+  const isLastActive =
+    activeMenuList[lastDepth]?.title === title || (isRootMenu && lastDepth === 0);
 
   const backLinkPath = basePath === DOCS_BASE_PATH ? '/' : LINKS.docs;
   const docsHomePath = LINKS.docsHome;
@@ -127,10 +128,10 @@ const Menu = ({
   return (
     <div
       className={clsx(
-        'absolute left-0 top-0 w-full px-[52px] pb-16 xl:px-8',
+        'absolute left-0 top-0 w-full px-[52px] pb-8 xl:px-8',
         !isActive && 'pointer-events-none',
         !isRootMenu && 'translate-x-full',
-        'lg:px-8 lg:pb-8 lg:pt-4 md:px-5',
+        'lg:px-8 lg:pt-4 md:px-5',
         (isActive || isRootMenu) && 'opacity-100'
       )}
       style={isRootMenu ? { transform: `translateX(${lastDepth * -100}%)` } : undefined}

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -102,10 +102,10 @@ const Sidebar = ({ className = null, sidebar, slug, basePath }) => {
           </Link>
         </div>
         <nav
-          className="no-scrollbars z-10 mt-5 h-[calc(100vh-70px)] overflow-y-scroll pt-10"
+          className="no-scrollbars z-10 mt-5 h-[calc(100vh-100px)] overflow-y-scroll pt-10"
           ref={menuWrapperRef}
         >
-          <div className="relative w-full" style={{ height: menuHeight }}>
+          <div className="relative w-full overflow-hidden" style={{ height: menuHeight }}>
             <Menu
               depth={0}
               basePath={basePath}


### PR DESCRIPTION
This PR brings fix for docs sidebar scrolling issue

**Steps to test:**
- open different sidebar menus and make sure they don't have an extra scrolling
- open mobile menu and make sure it scrolls as expected as well

[Preview](https://neon-next-git-docs-sidebar-scroll-fix-neondatabase.vercel.app/docs)