### PR TITLE
docs: add info about using set in transaction mode

### DIFF
--- a/content/docs/connect/connection-errors.md
+++ b/content/docs/connect/connection-errors.md
@@ -19,6 +19,7 @@ This topic describes how to resolve connection errors you may encounter when usi
 - [Unsupported startup parameter](#unsupported-startup-parameter)
 - [You have exceeded the limit of concurrently active endpoints](#you-have-exceeded-the-limit-of-concurrently-active-endpoints)
 - [Remaining connection slots are reserved for roles with the SUPERUSER attribute](#remaining-connection-slots-are-reserved-for-roles-with-the-superuser-attribute)
+- [Relation not found](#relation-not-found)
 
 <Admonition type="info">
 Connection problems are sometimes related to a system issue. To check for system issues, please refer to the [Neon status page](https://neonstatus.com/).  
@@ -216,6 +217,6 @@ If you are already using connection pooling, you may need to reach out to Neon S
 
 ## Relation not found
 
-This error is often encountered when attempting to set set the Postgres `search_path` session variable using a `SET search_path` statement over a pooled connection. For more information and workarounds, please see [Connection pooling in transaction mode](/docs/connect/connection-pooling#connection-pooling-in-transaction-mode).
+This error is often encountered when attempting to set the Postgres `search_path` session variable using a `SET search_path` statement over a pooled connection. For more information and workarounds, please see [Connection pooling in transaction mode](/docs/connect/connection-pooling#connection-pooling-in-transaction-mode).
 
 <NeedHelp/>

--- a/content/docs/connect/connection-errors.md
+++ b/content/docs/connect/connection-errors.md
@@ -214,4 +214,8 @@ To resolve this issue, you have several options:
 
 If you are already using connection pooling, you may need to reach out to Neon Support to request a higher `default_pool_size` setting for PgBouncer. See [Neon PgBouncer configuration settings for more information](/docs/connect/connection-pooling#neon-pgbouncer-configuration-settings).
 
+## Relation not found
+
+This error is often encountered when attempting to set set the Postgres `search_path` session variable using a `SET search_path` statement over a pooled connection. For more information and workarounds, please see [Connection pooling in transaction mode](/docs/connect/connection-pooling#connection-pooling-in-transaction-mode).
+
 <NeedHelp/>

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -115,18 +115,20 @@ As mentioned above, Neon uses PgBouncer in _transaction mode_ (`pool_mode=transa
 - `LOAD` statement
 - Session-level advisory locks
 
-These features are not supported due to the nature of transaction-mode pooling, which does not maintain a persistent session state across transactions.
+These session-level features are not supported _transaction mode_ because:
+1. In this mode, database connections are allocated from the pool on a per-transaction basis
+2. Session states are not persisted across transactions
 
 <Admonition type="warning" title="Avoid using SET statements over a pooled connection">
-Due to the transaction mode limitation described above, users often encounter issues when running `SET` statements over a pooled connection. For example, if you set the Postgres `search_path` session variable using a `SET search_path` statement over a pooled connection, the setting is only valid for the duration of the transaction. This is because database connections are allocated to clients from the connection pool on a per-transaction basis. As a result, a session variable like `search_path` will not remain set for subsequent transactions.
+Due to the transaction mode limitation described above, users often encounter issues when running `SET` statements over a pooled connection. For example, if you set the Postgres `search_path` session variable using a `SET search_path` statement over a pooled connection, the setting is only valid for the duration of the transaction. As a result, a session variable like `search_path` will not remain set for subsequent transactions.
 
 This particular `search_path` issue often shows up as a `relation does not exist` error. To avoid this error, you can:
 
 - Use a direct connection string when you need to set the search path and have it persist across multiple transactions.
-- Explicitly specify the schema in your queries, so you don’t need to set the search path.
-- Use an `ALTER ROLE your_role_name SET search_path TO <schema1>, <schema2>, <schema3>;` command to set a persistent search path for the role executing queries. See the [ALTER ROLE documentation](https://www.postgresql.org/docs/current/sql-alterrole.html).
+- Explicitly specify the schema in your queries so that you don’t need to set the search path.
+- Use an `ALTER ROLE your_role_name SET search_path TO <schema1>, <schema2>, <schema3>;` command to set a persistent search path for the role executing queries. See the [ALTER ROLE](https://www.postgresql.org/docs/current/sql-alterrole.html).
 
-Similar issues can occur when attempting to use `pg_dump` over a pooled connection. A `pg_dump` operation typically executes several `SET` statements during data ingestion, which will not persist over a pool connection. For these reasons, we always recommend using `pg_dump` only over a direct connection.
+Similar issues can occur when attempting to use `pg_dump` over a pooled connection. A `pg_dump` operation typically executes several `SET` statements during data ingestion, and these settings will not persist over a pool connection. For these reasons, we recommend using `pg_dump` only over a direct connection.
   </Admonition>
 
 For the official list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -134,7 +134,7 @@ Similar issues can occur when attempting to use `pg_dump` over a pooled connecti
 
 For the official list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
 
-## Connection polling with schema migration tools
+## Connection pooling with schema migration tools
 
 We recommend using a direct (non-pooled) connection string when performing migrations using Object Relational Mappers (ORMs) and similar schema migration tools. With the exception of recent versions of [Prisma ORM, which support using a pooled connection string with Neon](https://neon.tech/docs/guides/prisma#using-a-pooled-connection-with-prisma-migrate), using a pooled connection string for migrations is likely not supported or prone to errors. Before attempting to perform migrations over a pooled connection string, please refer to your tool's documentation to determine if pooled connections are supported.
 

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -115,15 +115,16 @@ As mentioned above, Neon uses PgBouncer in _transaction mode_ (`pool_mode=transa
 - `LOAD` statement
 - Session-level advisory locks
 
- These features are not supported due to the nature of transaction-mode pooling, which does not maintain a persistent session state across transactions.
+These features are not supported due to the nature of transaction-mode pooling, which does not maintain a persistent session state across transactions.
 
 <Admonition type="important" title="Avoid using SET statements over a pooled connection">
-Due to the transaction mode limitation, users often encounter issues when running `SET` statements over a pooled connection. For example, if you set the Postgres search path using a `SET search_path` statement over a pooled connection, the setting is only valid for the duration of the transaction. This is because database connections are allocated to clients from the connection pool on a per-transaction basis. 
+Due to the transaction mode limitation, users often encounter issues when running `SET` statements over a pooled connection. For example, if you set the Postgres search path using a `SET search_path` statement over a pooled connection, the setting is only valid for the duration of the transaction. This is because database connections are allocated to clients from the connection pool on a per-transaction basis.
 
 This issue often shows up as a `relation does not exist` error. To avoid this particular `SET search_path` issue, you can either:
+
 - Use a direct connection string when you need to set the search path, or
 - Explicitly specify the schema in your queries.
-</Admonition>
+  </Admonition>
 
 For the official list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
 

--- a/content/docs/connect/connection-pooling.md
+++ b/content/docs/connect/connection-pooling.md
@@ -103,10 +103,33 @@ The following list describes each setting. For a full explanation of each parame
 - `max_prepared_statements=0`: Maximum number of prepared statements a connection is allowed to have at the same time. `0` means prepared statements are disabled.
 - `query_wait_timeout=120`: Maximum time queries are allowed to spend waiting for execution. Neon uses the default setting of `120` seconds.
 
-## Connection pooling notes
+## Connection pooling in transaction mode
 
-- Neon uses PgBouncer in _transaction mode_, which limits some functionality in Postgres. For a complete list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
-- We recommend using a direct (non-pooled) connection string when performing migrations using Object Relational Mappers (ORMs). With the exception of recent versions of [Prisma ORM, which support using a pooled connection string with Neon](https://neon.tech/docs/guides/prisma#using-a-pooled-connection-with-prisma-migrate), using a pooled connection string for migrations can be prone to errors.
+As mentioned above, Neon uses PgBouncer in _transaction mode_ (`pool_mode=transaction`), which limits some functionality in Postgres. Functionality **NOT supported** in transaction mode includes:
+
+- `SET`/`RESET`
+- `LISTEN`
+- `WITH HOLD CURSOR`
+- `PREPARE / DEALLOCATE`
+- `PRESERVE` / `DELETE ROWS` temp tables
+- `LOAD` statement
+- Session-level advisory locks
+
+ These features are not supported due to the nature of transaction-mode pooling, which does not maintain a persistent session state across transactions.
+
+<Admonition type="important" title="Avoid using SET statements over a pooled connection">
+Due to the transaction mode limitation, users often encounter issues when running `SET` statements over a pooled connection. For example, if you set the Postgres search path using a `SET search_path` statement over a pooled connection, the setting is only valid for the duration of the transaction. This is because database connections are allocated to clients from the connection pool on a per-transaction basis. 
+
+This issue often shows up as a `relation does not exist` error. To avoid this particular `SET search_path` issue, you can either:
+- Use a direct connection string when you need to set the search path, or
+- Explicitly specify the schema in your queries.
+</Admonition>
+
+For the official list of limitations, refer to the "_SQL feature map for pooling modes_" section in the [pgbouncer.org Features](https://www.pgbouncer.org/features.html) documentation.
+
+## Connection polling with schema migration tools
+
+We recommend using a direct (non-pooled) connection string when performing migrations using Object Relational Mappers (ORMs) and similar schema migration tools. With the exception of recent versions of [Prisma ORM, which support using a pooled connection string with Neon](https://neon.tech/docs/guides/prisma#using-a-pooled-connection-with-prisma-migrate), using a pooled connection string for migrations is likely not supported or prone to errors. Before attempting to perform migrations over a pooled connection string, please refer to your tool's documentation to determine if pooled connections are supported.
 
 ## Optimize queries with PgBouncer and prepared statements
 


### PR DESCRIPTION
Connection pooling section about transaction mode and SET:
https://neon-next-git-dprice-set-transaction-mode-neondatabase.vercel.app/docs/connect/connection-pooling#connection-pooling-in-transaction-mode

Relation not found error:
https://neon-next-git-dprice-set-transaction-mode-neondatabase.vercel.app/docs/connect/connection-errors#relation-not-found
