### PR TITLE
docs: avoid child branches on preview branches

### DIFF
--- a/content/docs/guides/vercel.md
+++ b/content/docs/guides/vercel.md
@@ -143,7 +143,7 @@ The integration supports automatic deletion of obsolete preview branches when th
 5. Check **Automatically delete obsolete Neon branches**.
 
 <Admonition type="note">
-Avoid creating child branches on automatically created preview branches. This will prevent the preview branch from being automatically deleted. In Neon, child branches must be deleted before you can delete a parent branch. 
+Avoid creating child branches on automatically created preview branches, as it will prevent a preview branch from being automatically deleted. In Neon, child branches must be deleted before you can delete a parent branch. 
 </Admonition>
 
 <Admonition type="warning" title="Avoid manually renaming branches when using automatic branch deletion">

--- a/content/docs/guides/vercel.md
+++ b/content/docs/guides/vercel.md
@@ -142,6 +142,10 @@ The integration supports automatic deletion of obsolete preview branches when th
 4. In the **Vercel integration** drawer, select the **Branches** tab.
 5. Check **Automatically delete obsolete Neon branches**.
 
+<Admonition type="note">
+Avoid creating child branches on automatically created preview branches. This will prevent the preview branch from being automatically deleted. In Neon, child branches must be deleted before you can delete a parent branch. 
+</Admonition>
+
 <Admonition type="warning" title="Avoid manually renaming branches when using automatic branch deletion">
 The integration determines whether a preview branch created in Neon is obsolete by looking at its name and asking Vercel if a Git branch with the same exists.
 

--- a/content/docs/guides/vercel.md
+++ b/content/docs/guides/vercel.md
@@ -143,7 +143,7 @@ The integration supports automatic deletion of obsolete preview branches when th
 5. Check **Automatically delete obsolete Neon branches**.
 
 <Admonition type="note">
-Avoid creating child branches on automatically created preview branches, as it will prevent a preview branch from being automatically deleted. In Neon, child branches must be deleted before you can delete a parent branch. 
+Avoid creating child branches on automatically created preview branches. The presence of a child branch will prevent the parent preview branch from being automatically deleted. In Neon, child branches must be deleted before the parent branch can be deleted.
 </Admonition>
 
 <Admonition type="warning" title="Avoid manually renaming branches when using automatic branch deletion">


### PR DESCRIPTION
Add note to Vercel docs about obsolete branches not being deleted due to child branch
Support issue: https://neon.zendesk.com/agent/tickets/3601

Preview:
https://neon-next-git-dprice-avoid-child-branches-o-3513e5-neondatabase.vercel.app/docs/guides/vercel#automatic-deletion