### PR TITLE
chore: update pricing page links for plans

### DIFF
--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -95,7 +95,7 @@ const items = [
       { title: 'Standard Support' },
     ],
     button: {
-      url: `${LINKS.console}/?upgrade=launch`,
+      url: `${LINKS.console}/app/billing#plans`,
       text: 'Get started',
       theme: 'primary',
       event: 'Hero Launch Panel',
@@ -136,7 +136,7 @@ const items = [
       { title: 'Standard support' },
     ],
     button: {
-      url: `${LINKS.console}/?upgrade=scale`,
+      url: `${LINKS.console}/app/billing#plans`,
       text: 'Get started',
       theme: 'white-outline',
       event: 'Hero Scale Panel',
@@ -185,7 +185,7 @@ const items = [
       { title: 'Priority support' },
     ],
     button: {
-      url: `${LINKS.console}/?upgrade=business`,
+      url: `${LINKS.console}/app/billing#plans`,
       text: 'Get started',
       theme: 'white-outline',
       event: 'Hero Enterprise Panel',


### PR DESCRIPTION
This PR updates links for plans on Pricing page to 
https://console.neon.tech/app/billing#plans

![image](https://github.com/user-attachments/assets/c77fdb87-6576-4857-b58a-cd971e5184b8)

[Preview](https://neon-next-git-pricing-page-urls-neondatabase.vercel.app/pricing)