### PR TITLE
Spelling: Github -> GitHub

### DIFF
--- a/content/docs/get-started-with-neon/signing-up.md
+++ b/content/docs/get-started-with-neon/signing-up.md
@@ -40,7 +40,7 @@ After signing up, you'll start with a `main` branch and the empty database `neon
 
     [https://console.neon.tech/signup](https://console.neon.tech/signup)
 
-    Sign up with your email, Github, Google, or other partner account.
+    Sign up with your email, GitHub, Google, or other partner account.
 
     For information about what's included with the free plan, see
     [Neon Free Plan](/docs/introduction/plans#free-plan). For information about Neon's paid options, see
@@ -255,7 +255,7 @@ With `psql` available, let's work from the terminal to connect to your `dev/deve
 
 ## Step 7 - Check your changes with Schema Diff
 
-After making the schema changes to your development branch, you can use the [Schema Diff](/docs/guides/schema-diff) feature to compare your branch against its parent branch. Schema Diff is a Github-style code-comparison tool used to visualize differences between different branch's databases.
+After making the schema changes to your development branch, you can use the [Schema Diff](/docs/guides/schema-diff) feature to compare your branch against its parent branch. Schema Diff is a GitHub-style code-comparison tool used to visualize differences between different branch's databases.
 
 For this tutorial, Schema Diff helps with validating isolation: it confirms that schema changes made in your isolated development branch remain separate from the main branch.
 

--- a/content/docs/guides/auth-clerk.md
+++ b/content/docs/guides/auth-clerk.md
@@ -79,7 +79,7 @@ DATABASE_URL=NEON_DB_CONNECTION_STRING
 ### Create a Clerk application
 
 1. Log in to your Clerk account and navigate to the [Dashboard](https://dashboard.clerk.dev/). From the left sidebar, select `Create Application` to create a new app.
-2. In the dialog that appears, provide a name for your application and a few sign-in options. For this tutorial, we'll use `Email`, `Google` and `Github` as allowed sign-in methods.
+2. In the dialog that appears, provide a name for your application and a few sign-in options. For this tutorial, we'll use `Email`, `Google` and `GitHub` as allowed sign-in methods.
 
 ### Retrieve your API keys
 

--- a/content/docs/guides/branch-restore.md
+++ b/content/docs/guides/branch-restore.md
@@ -9,7 +9,7 @@ redirectFrom:
 updatedOn: '2024-10-18T17:17:53.242Z'
 ---
 
-With Neon's branch restore capability, you can easily restore a branch to an earlier state in its own or another branch's history. You can use Time Travel Assist to connect to a specific point in your history retention window, where you can run read-only queries to pinpoint the exact moment you need to restore to. You can also use Schema Diff to get a side-by-side, Github-style visual comparison of your selected branches before restoring.
+With Neon's branch restore capability, you can easily restore a branch to an earlier state in its own or another branch's history. You can use Time Travel Assist to connect to a specific point in your history retention window, where you can run read-only queries to pinpoint the exact moment you need to restore to. You can also use Schema Diff to get a side-by-side, GitHub-style visual comparison of your selected branches before restoring.
 
 ## How branch restore works
 

--- a/content/docs/guides/deno.md
+++ b/content/docs/guides/deno.md
@@ -231,9 +231,9 @@ $ curl https://cloudy-otter-57.deno.dev/books
 
 To check the health of the deployment or modify settings, navigate to the [Project Overview](https://dash.deno.com/account/projects) page and select your project from the **Projects** list.
 
-### Deploying using Github
+### Deploying using GitHub
 
-When deploying a more complex Deno application, with custom build steps, you can use Deno's Github integration. The integration lets you link a Deno Deploy project to a GitHub repository. For more information, see [Deploying with GitHub](https://docs.deno.com/deploy/manual/how-to-deploy).
+When deploying a more complex Deno application, with custom build steps, you can use Deno's GitHub integration. The integration lets you link a Deno Deploy project to a GitHub repository. For more information, see [Deploying with GitHub](https://docs.deno.com/deploy/manual/how-to-deploy).
 
 ## Removing the example application and Neon project
 

--- a/content/docs/guides/netlify-functions.md
+++ b/content/docs/guides/netlify-functions.md
@@ -14,7 +14,7 @@ This guide will show you how to connect to a Neon Postgres database from your Ne
 Before starting, ensure you have:
 
 - A Neon account. If you do not have one, sign up at [Neon](https://neon.tech). Your Neon project comes with a ready-to-use Postgres database named `neondb`. We'll use this database in the following examples.
-- A Netlify account for deploying your site with `Functions`. Sign up at [Netlify](https://netlify.com) if necessary. While Netlify can deploy directly from a Github repository, we'll use the `Netlify` CLI tool to deploy our project manually.
+- A Netlify account for deploying your site with `Functions`. Sign up at [Netlify](https://netlify.com) if necessary. While Netlify can deploy directly from a GitHub repository, we'll use the `Netlify` CLI tool to deploy our project manually.
 - [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/) installed locally for developing and deploying your Functions.
 
 ## Setting up your Neon database

--- a/content/docs/guides/railway.md
+++ b/content/docs/guides/railway.md
@@ -139,7 +139,7 @@ You can visit the GitHub repository to verify that your code has been pushed suc
 
 ### Creating a new Railway project
 
-Log in to your Railway account and navigate to the dashboard. Click on the `New Project` button and select the `Deploy from Github repo` option. Pick the repository you created above, which sets off a Railway deployment.
+Log in to your Railway account and navigate to the dashboard. Click on the `New Project` button and select the `Deploy from GitHub repo` option. Pick the repository you created above, which sets off a Railway deployment.
 
 Railway automatically figures out the type of application you're deploying and sets up the necessary build and start commands. However, we still need to add the `DATABASE_URL` environment variable to connect to our Neon database.
 

--- a/content/docs/guides/render.md
+++ b/content/docs/guides/render.md
@@ -15,7 +15,7 @@ To follow along with this guide, you will need:
 
 - A Neon account. If you do not have one, sign up at [Neon](https://neon.tech). Your Neon project comes with a ready-to-use Postgres database named `neondb`. We'll use this database in the following examples.
 - A Render account. If you do not have one, sign up at [Render](https://render.com) to get started.
-- A GitHub account. Render integrates with public Github providers for continuous deployment. So, you'd need a GitHub account to upload your application code.
+- A GitHub account. Render integrates with public GitHub providers for continuous deployment. So, you'd need a GitHub account to upload your application code.
 - [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/) installed on your local machine. We'll use Node.js to build and test the application locally.
 
 ## Setting up your Neon database

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -6,7 +6,7 @@ enableTableOfContents: true
 updatedOn: '2024-08-07T21:36:52.665Z'
 ---
 
-In this guide we will create an initial schema on a new database called `people` on our `main` branch. We'll then create a development branch called `dev/jordan`, following our recommended convention for naming development branches. After making schema changes on `dev/jordan`, we'll use the **Schema Diff** tool on the **Branches** page to get a side-by-side, Github-style visual comparison between the `dev/jordan` development branch and `main`.
+In this guide we will create an initial schema on a new database called `people` on our `main` branch. We'll then create a development branch called `dev/jordan`, following our recommended convention for naming development branches. After making schema changes on `dev/jordan`, we'll use the **Schema Diff** tool on the **Branches** page to get a side-by-side, GitHub-style visual comparison between the `dev/jordan` development branch and `main`.
 
 ## Before you start
 

--- a/content/docs/guides/wundergraph.md
+++ b/content/docs/guides/wundergraph.md
@@ -280,7 +280,7 @@ const Home: NextPage = () => {
               target="_blank"
               href="https://github.com/wundergraph/wundergraph"
             >
-              Github
+              GitHub
             </a>{' '}
             to learn more about WunderGraph.
           </p>

--- a/content/guides/fastapi-async.md
+++ b/content/guides/fastapi-async.md
@@ -792,4 +792,4 @@ Using this guide, you have built a fully functional API for managing products us
 
 This stack provides a solid foundation for building high-performance and scalable web services. `FastAPI`'s asynchronous support, combined with `Pydantic`'s robust data validation and `asyncpg`'s efficient database interactions, allows for fast and reliable API development.
 
-As a next step, you can look at deploying this application in the cloud using scalable technologies like `Docker` and `Kubernetes`, or implementing automated test, build, and deployment workflows using `Github CI`
+As a next step, you can look at deploying this application in the cloud using scalable technologies like `Docker` and `Kubernetes`, or implementing automated test, build, and deployment workflows using `GitHub CI`

--- a/src/components/pages/about/investors/investors.jsx
+++ b/src/components/pages/about/investors/investors.jsx
@@ -68,7 +68,7 @@ const investors = {
       image: natFriedman,
       name: 'Nat Friedman',
       role: 'CEO at',
-      company: 'Github',
+      company: 'GitHub',
     },
     {
       image: guillermoRauch,

--- a/src/components/pages/variable/efficiency/efficiency.jsx
+++ b/src/components/pages/variable/efficiency/efficiency.jsx
@@ -35,7 +35,7 @@ const items = [
   },
   {
     icon: openSourceIcon,
-    text: 'Transparency with open-source architecture. <a href="https://github.com/neondatabase/neon" target="_blank" rel="noopener noreferrer">Explore our code in&nbsp;Github</a>.',
+    text: 'Transparency with open-source architecture. <a href="https://github.com/neondatabase/neon" target="_blank" rel="noopener noreferrer">Explore our code in&nbsp;GitHub</a>.',
   },
 ];
 

--- a/src/scripts/update-frontmatter.js
+++ b/src/scripts/update-frontmatter.js
@@ -6,7 +6,7 @@ const fs = require('fs').promises;
 const matter = require('gray-matter');
 
 // The function below is for getting the last update date from GitHub,
-// as Github has the rate limit for unauthenticated requests (60 requests per hour),
+// as GitHub has the rate limit for unauthenticated requests (60 requests per hour),
 // the script was run manually and the date was hardcoded in the frontmatter of the docs.
 
 // const octokit = new Octokit({


### PR DESCRIPTION
This PR fixes the spelling for the word "GitHub" (it makes "h" capitalised).
I've split changes into 2 commits — changes in markdown files (I did it automatically) and changes in js(x) files (I did apply them manually)