### PR TITLE
docs: fixed guide formatting issues caused by prettier

### DIFF
--- a/content/guides/react-fastapi-rag-portfolio.md
+++ b/content/guides/react-fastapi-rag-portfolio.md
@@ -54,23 +54,23 @@ Follow these steps to set up your backend for the full-stack portfolio website:
 
 3.  Set up the virtual environment.
 
-                You will now create and activate a virtual environment in which your project's dependencies will be installed.
+        You will now create and activate a virtual environment in which your project's dependencies will be installed.
 
-                <CodeTabs labels={["Linux/macOS", "Windows"]}>
-                `bash
+        <CodeTabs labels={["Linux/macOS", "Windows"]}>
 
+            ```bash
             uv venv
             source .venv/bin/activate
-            `
+            ```
 
-        `bash
+            ```bash
+            uv venv
+            .venv\Scripts\activate
+            ```
 
-    uv venv
-    .venv\Scripts\activate
-    `
-    </CodeTabs>
+        </CodeTabs>
 
-                You should see `(portfolio_backend)` in your terminal now, this means that your virtual environment is activated.
+        You should see `(portfolio_backend)` in your terminal now, this means that your virtual environment is activated.
 
 4.  Install dependencies.
 

--- a/content/guides/timescale-fastapi.md
+++ b/content/guides/timescale-fastapi.md
@@ -42,23 +42,23 @@ Follow these steps to set up your project and virtual environment:
 
 2.  Set up the virtual environment.
 
-                You will now create and activate a virtual environment in which your project's dependencies will beinstalled.
+        You will now create and activate a virtual environment in which your project's dependencies will beinstalled.
 
-                <CodeTabs labels={["Linux/macOS", "Windows"]}>
-                `bash
+        <CodeTabs labels={["Linux/macOS", "Windows"]}>
 
+            ```bash
             uv venv
             source .venv/bin/activate
-            `
+            ```
 
-        `bash
+            ```bash
+            uv venv
+            .venv\Scripts\activate
+            ```
 
-    uv venv
-    .venv\Scripts\activate
-    `
-    </CodeTabs>
+        </CodeTabs>
 
-                You should see `(timescale_fastapi)` in your terminal now, this means that your virtual environment is activated.
+        You should see `(timescale_fastapi)` in your terminal now, this means that your virtual environment is activated.
 
 3.  Install dependencies.
 


### PR DESCRIPTION
Weird issue where when the Prettier bot formats the md guides, it undoes the <CodeTabs> block triple backticks, and replaces them with oddly formatted single backticks. If I indent the CodeTabe block once more than it should be, Prettier leaves it as is, and it still renders the same on the website