### PR TITLE
Added VPC endpoint service name for us-east-2 to documentation

### DIFF
--- a/content/docs/guides/neon-private-access.md
+++ b/content/docs/guides/neon-private-access.md
@@ -37,6 +37,7 @@ To configure Neon Private Access, perform the following steps:
    1. Specify the **Service name**. It must be one of the following names, depending on your region:
 
       - **us-east-1**: `com.amazonaws.vpce.us-east-1.vpce-svc-0ccf08d7888526333`
+      - **us-east-2**: `com.amazonaws.vpce.us-east-2.vpce-svc-0fa555394e26593be`
       - **eu-central-1**: `com.amazonaws.vpce.eu-central-1.vpce-svc-0fa74d33d011f0803`
 
       ![Select the endpoint service](/docs/guides/pl_select_endpoint_service.png)


### PR DESCRIPTION
Added name of the VPC endpoint service for us-east-2 to the documentation. The region was requested by a POC customer.
See https://github.com/neondatabase/cloud/issues/18304.
See [the POC definition](https://www.notion.so/neondatabase/Neon-Private-Access-POC-Proposal-8f707754e1ab4190ad5709da7832f020?d=887495c15e884aa4973f973a8a0a582a#7ac6ec249b524a74adbeddc4b84b8f5f) for details about the POC scope.