### PR TITLE
fix(docs): remove duplicate the from sentences in documentation

### DIFF
--- a/content/docs/guides/liquibase.md
+++ b/content/docs/guides/liquibase.md
@@ -125,7 +125,7 @@ jdbc:postgresql://ep-cool-darkness-123456.us-east-2.aws.neon.tech/blog?user=alex
    touch liquibase.properties
    ```
 
-3. Open the the `liquibase.properties` file in an editor and add entries for a [liquibase changelog file](https://docs.liquibase.com/concepts/changelogs/home.html) and your database `url`. We'll call the changelog file `dbchangelog.xml`. You will use this file to define schema changes. For the `url`, specify the Neon connection string you retrieved previously.
+3. Open the `liquibase.properties` file in an editor and add entries for a [liquibase changelog file](https://docs.liquibase.com/concepts/changelogs/home.html) and your database `url`. We'll call the changelog file `dbchangelog.xml`. You will use this file to define schema changes. For the `url`, specify the Neon connection string you retrieved previously.
 
    ```bash shouldWrap
    changeLogFile:dbchangelog.xml

--- a/content/docs/guides/logical-replication-alloydb.md
+++ b/content/docs/guides/logical-replication-alloydb.md
@@ -151,7 +151,7 @@ pg_dump --schema-only \
 	> schema_dump.sql
 ```
 
-- With the the `--schema-only` option, only object definitions are dumped. Data is excluded.
+- With the `--schema-only` option, only object definitions are dumped. Data is excluded.
 - The `--no-privileges` option prevents dumping privileges. Neon may not support the privileges you've defined elsewhere, or if dumping a schema from Neon, there maybe Neon-specific privileges that cannot be restored to another database.
 
 #### Review and modify the dumped schema

--- a/content/docs/guides/logical-replication-kafka-confluent.md
+++ b/content/docs/guides/logical-replication-kafka-confluent.md
@@ -35,7 +35,7 @@ To enable logical replication in Neon:
 3. Select **Logical Replication**.
 4. Click **Enable** to enable logical replication.
 
-You can verify that logical replication is enabled by running the following query from the the [Neon SQL Editor](/docs/get-started-with-neon/query-with-neon-sql-editor):
+You can verify that logical replication is enabled by running the following query from the [Neon SQL Editor](/docs/get-started-with-neon/query-with-neon-sql-editor):
 
 ```sql
 SHOW wal_level;

--- a/content/docs/guides/neon-features.md
+++ b/content/docs/guides/neon-features.md
@@ -49,7 +49,7 @@ Branch data the same way you branch your code.
 
 <a href="/docs/guides/branch-refresh" description="Refresh a development branch with the Neon API" icon="split-branch">Refresh a branch</a>
 
-<a href="/docs/guides/branch-promote" description="Promote a branch to default with the the Neon API" icon="split-branch">Promote a branch to default</a>
+<a href="/docs/guides/branch-promote" description="Promote a branch to default with the Neon API" icon="split-branch">Promote a branch to default</a>
 
 </DetailIconCards>
 

--- a/content/docs/import/import-sample-data.md
+++ b/content/docs/import/import-sample-data.md
@@ -69,7 +69,7 @@ A table containing data about the periodic table of elements.
    psql postgresql://[user]:[password]@[neon_hostname]/periodic_table
    ```
 
-5. Look up the the element with the Atomic Number 10:
+5. Look up the element with the Atomic Number 10:
 
    ```sql
    SELECT * FROM periodic_table WHERE "AtomicNumber" = 10;

--- a/content/docs/import/migrate-aws-dms.md
+++ b/content/docs/import/migrate-aws-dms.md
@@ -107,7 +107,7 @@ To verify that data was migrated to your Neon database:
 
 This section contains notes from our experience using AWS DMS to migrate data to Neon from an RDS Postgres database.
 
-- When testing migration steps, the the [Getting started with AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_GettingStarted.html) tutorial was our primary reference. As recommended in the tutorial, we created a VPC and created all resources within the VPC.
+- When testing migration steps, the [Getting started with AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_GettingStarted.html) tutorial was our primary reference. As recommended in the tutorial, we created a VPC and created all resources within the VPC.
 - We created all resources in the same region (`us-east-2a`)
 - We created an RDS PostgreSQL 15 database called `dms_sample` as the source database. The Neon target database was also Postgres 15.
 - We populated the RDS PostgreSQL source database using the [AWS DMS sample Postgres database](https://github.com/aws-samples/aws-database-migration-samples/blob/master/PostgreSQL/sampledb/v1/README.md). To do this, we created an EC2 instance to connect to the database following the steps in this topic: [Create an Amazon EC2 Client](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_GettingStarted.Prerequisites.html#CHAP_GettingStarted.Prerequisites.client).

--- a/content/docs/import/migrate-schema-only.md
+++ b/content/docs/import/migrate-schema-only.md
@@ -22,7 +22,7 @@ pg_dump --schema-only \
 	> schema_dump.sql
 ```
 
-- With the the `--schema-only` option, only object definitions are dumped. Data is excluded.
+- With the `--schema-only` option, only object definitions are dumped. Data is excluded.
 - The `--no-privileges` option prevents dumping privileges. Neon may not support the privileges you've defined elsewhere, or if dumping a schema from Neon, there maybe Neon-specific privileges that cannot be restored to another database.
 
 <Admonition type="tip">

--- a/content/docs/introduction/monitoring-page.md
+++ b/content/docs/introduction/monitoring-page.md
@@ -142,7 +142,7 @@ The **Working set size** graph provides a visual representation of how much data
 - **5m** (5 minutes): This line shows how much data has been accessed in the last 5 minutes.
 - **15m** (15 minutes): Similar to the 5-minute window, this metric tracks data accessed over the last 15 minutes.
 - **1h** (1 hour): This line represents the amount of data accessed in the last hour.
-- **Local file cache size**: This is the size of the the LFC, which is determined by the size of your compute. Larger computes have larger caches. For cache sizes, see [How to size your compute](/docs/manage/endpoints#how-to-size-your-compute).
+- **Local file cache size**: This is the size of the LFC, which is determined by the size of your compute. Larger computes have larger caches. For cache sizes, see [How to size your compute](/docs/manage/endpoints#how-to-size-your-compute).
 For optimal performance the local file cache should be larger than your working set size for a given time interval.
 If your working set size is larger than the LFC size it is recommended to increase the maximum size of the compute to improve the LFC hit rate and achieve good performance.
 

--- a/content/docs/reference/feeds.md
+++ b/content/docs/reference/feeds.md
@@ -81,6 +81,6 @@ To receive updates in Slack, enter the `/feed subscribe` command with the desire
 
 ## Remove feeds from Slack
 
-To remove feeds from Slack, enter the the `/feed list` command and note the feed ID number.
+To remove feeds from Slack, enter the `/feed list` command and note the feed ID number.
 
 Enter `/feed remove [ID number]` to remove the feed.

--- a/content/docs/reference/sdk.md
+++ b/content/docs/reference/sdk.md
@@ -60,7 +60,7 @@ To get started with the `@neondatabase/api-client` library, follow these steps:
 The following is a list of community-created SDKs for interacting with the Neon API.
 
 <Admonition type="note">
-Community SDKs are not maintained or officially supported by Neon. Some features may be out of date, so use these SDKs at your own discretion. If you have questions about these SDKs, please contact the the project maintainers.
+Community SDKs are not maintained or officially supported by Neon. Some features may be out of date, so use these SDKs at your own discretion. If you have questions about these SDKs, please contact the project maintainers.
 </Admonition>
 
 - [Node and Deno TypeScript SDK](https://github.com/paambaati/neon-js-sdk)

--- a/content/guides/chatbot-astro-postgres-llamaindex.md
+++ b/content/guides/chatbot-astro-postgres-llamaindex.md
@@ -74,7 +74,7 @@ postgres://<user>:<password>@<endpoint_hostname>.neon.tech:<port>/<dbname>?sslmo
 - `dbname` is the name of the database. `neondb` is the default database created with a Neon project if you do not define your own database.
 - `?sslmode=require` an optional query parameter that enforces [SSL](https://www.cloudflare.com/en-gb/learning/ssl/what-is-ssl/) mode for better security when connecting to the Postgres instance.
 
-Save the connection string somewhere safe. It will be used to set the the **POSTGRES_URL** variable later.
+Save the connection string somewhere safe. It will be used to set the **POSTGRES_URL** variable later.
 
 ## Create a new Astro application
 

--- a/content/guides/next-server-actions.md
+++ b/content/guides/next-server-actions.md
@@ -7,7 +7,7 @@ createdAt: '2024-05-13T13:24:36.612Z'
 updatedOn: '2024-05-13T13:24:36.612Z'
 ---
 
-In this guide, you will learn the the process of creating a simple web application using Next.js Server Actions that allows you to capture user input via forms, and insert them into Postgres via `@neondatabase/serverless` and `pg`.
+In this guide, you will learn the process of creating a simple web application using Next.js Server Actions that allows you to capture user input via forms, and insert them into Postgres via `@neondatabase/serverless` and `pg`.
 
 To create a Neon project and access it from an Next.js application:
 

--- a/content/postgresql/postgresql-csharp/postgresql-csharp-import-csv-file.md
+++ b/content/postgresql/postgresql-csharp/postgresql-csharp-import-csv-file.md
@@ -271,7 +271,7 @@ Output:
 (11 rows)
 ```
 
-The output indicates that the program has successfully imported 10 rows from the the `students.csv` file into the `students` table.
+The output indicates that the program has successfully imported 10 rows from the `students.csv` file into the `students` table.
 
 ## Summary
 

--- a/content/postgresql/postgresql-php/postgresql-blob.md
+++ b/content/postgresql/postgresql-php/postgresql-blob.md
@@ -68,7 +68,7 @@ The following `insert()` method reads data from a file specified by the `$pathTo
             $fileData = $this->pdo->pgsqlLOBCreate();
             $stream = $this->pdo->pgsqlLOBOpen($fileData, 'w');
 
-            // read data from the file and copy the the stream
+            // read data from the file and copy the stream
             $fh = fopen($pathToFile, 'rb');
             stream_copy_to_stream($fh, $stream);
             //

--- a/content/postgresql/postgresql-string-functions/postgresql-chr.md
+++ b/content/postgresql/postgresql-string-functions/postgresql-chr.md
@@ -36,7 +36,7 @@ It could be a Unicode code point which is converted to a UTF8 character.
 
 ## Return Value
 
-The `CHR()` function returns a character that corresponds the the ASCII code value or Unicode code point.
+The `CHR()` function returns a character that corresponds the ASCII code value or Unicode code point.
 
 ## Examples
 

--- a/content/postgresql/postgresql-tutorial/postgresql-cube.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-cube.md
@@ -39,7 +39,7 @@ GROUP BY
 
 In this syntax:
 
-- First, specify the `CUBE` subclause in the the [`GROUP BY`](postgresql-group-by) clause of the [`SELECT`](postgresql-select) statement.
+- First, specify the `CUBE` subclause in the [`GROUP BY`](postgresql-group-by) clause of the [`SELECT`](postgresql-select) statement.
 - Second, in the select list, specify the columns (dimensions or dimension columns) which you want to analyze and [aggregation function](../postgresql-aggregate-functions) expressions.
 - Third, in the `GROUP BY` clause, specify the dimension columns within the parentheses of the `CUBE` subclause.
 

--- a/content/postgresql/postgresql-tutorial/postgresql-rename-table.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-rename-table.md
@@ -32,7 +32,7 @@ In this statement:
 
 If you rename a table that does not exist, PostgreSQL will issue an error.
 
-To avoid the error, you can use the the `IF EXISTS` option:
+To avoid the error, you can use the `IF EXISTS` option:
 
 ```sql
 ALTER TABLE IF EXISTS table_name

--- a/content/postgresql/postgresql-tutorial/postgresql-union.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-union.md
@@ -35,7 +35,7 @@ In this syntax, the queries must conform to the following rules:
 - The number and the order of the columns in the select list of both queries must be the same.
 - The data types of the columns in select lists of the queries must be compatible.
 
-The `UNION` operator removes all duplicate rows from the combined data set. To retain the duplicate rows, you use the the `UNION ALL` instead.
+The `UNION` operator removes all duplicate rows from the combined data set. To retain the duplicate rows, you use the `UNION ALL` instead.
 
 Here’s the syntax of the `UNION ALL` operator:
 


### PR DESCRIPTION
Corrected instances of duplicated "the" across multiple files to improve readability.