### PR TITLE
docs: add error list and links to top of page

### DIFF
--- a/content/docs/guides/neon-authorize-troubleshooting.md
+++ b/content/docs/guides/neon-authorize-troubleshooting.md
@@ -10,7 +10,7 @@ This page covers common errors you might encounter when implementing Row-Level S
 Errors:
 - [`NeonDbError: password authentication failed for user 'jwk not found'`](#password-authentication-error)
 - [`NeonDbError: permission denied for table X`](#permission-denied-error)
-- [`Invalid RSA Signing Algorithm`](#invalid-rsa-signing-algorithm)
+- [`invalid RSA Signing Algorithm`](#invalid-rsa-signing-algorithm)
 
 ---
 <a id="password-authentication-error"></a>

--- a/content/docs/guides/neon-authorize-troubleshooting.md
+++ b/content/docs/guides/neon-authorize-troubleshooting.md
@@ -7,7 +7,13 @@ updatedOn: '2024-10-29T23:35:22.437Z'
 
 This page covers common errors you might encounter when implementing Row-Level Security (RLS) policies with Neon Authorize and your authentication provider.
 
+Errors:
+- [`NeonDbError: password authentication failed for user 'jwk not found'`](#password-authentication-error)
+- [`NeonDbError: permission denied for table X`](#permission-denied-error)
+- [`Invalid RSA Signing Algorithm`](#invalid-rsa-signing-algorithm)
+
 ---
+<a id="password-authentication-error"></a>
 
 ```bash
 NeonDbError: password authentication failed for user 'jwk not found'
@@ -41,6 +47,7 @@ This issue typically occurs when:
 - [JSON Web Key (JWK) Specification](https://datatracker.ietf.org/doc/html/rfc7517)
 
 ---
+<a id="permission-denied-error"></a>
 
 ```bash
 NeonDbError: permission denied for table X
@@ -82,6 +89,7 @@ Neon Authorize prompts you to run these commands when you first set up your auth
 </Admonition>
 
 ---
+<a id="invalid-rsa-signing-algorithm"></a>
 
 ```bash
 invalid RSA signing algorithm


### PR DESCRIPTION
Preference is to use error messages as heading equivalent on this page, which breaks the rightnav.

This is a workaround to give a list of errors a the top of the page; each error links to an anchor in the relevant section. 