### PR TITLE
Update message

### DIFF
--- a/content/docs/serverless/serverless-driver.md
+++ b/content/docs/serverless/serverless-driver.md
@@ -96,7 +96,7 @@ export default async function handler(request: NextApiRequest, res: NextApiRespo
 </CodeTabs>
 
 <Admonition type="note">
-The maximum request size and response size for queries over HTTP is 10 MB.
+The maximum request size and response size for queries over HTTP is 64 MB.
 </Admonition>
 
 ### neon function configuration options


### PR DESCRIPTION
The request/response size limit is now 64 MB

[Context on Discord](https://discord.com/channels/1176467419317940276/1176467419938701375/1303450302292430848)