### PR TITLE
Clarified that some steps are specific to the private preview of Private Access

### DIFF
--- a/content/docs/guides/neon-private-access.md
+++ b/content/docs/guides/neon-private-access.md
@@ -51,6 +51,10 @@ To configure Neon Private Access, perform the following steps:
 
    Note the ID of the created endpoint and provide it to Neon. Neon will authorize this endpoint to access the Neon Private Access service and notify when the authorization is complete.
 
+   <Admonition type="note">
+    This step is specific to the Private Prereview. In the final version configuration of the allowed endpoint will be done through the Neon console without any manual involvement by Neon.
+   </Admonition>
+
 3. **Enable Private DNS**
 
    After Neon authorizes your endpoint (please wait for confirmation from Neon), you need to enable private DNS lookup for the endpoint.
@@ -95,4 +99,7 @@ To configure Neon Private Access, perform the following steps:
 
    ![Neon IP Allow configuration](/docs/guides/pl_neon_ip_allow.png)
 
+   <Admonition type="note">
+    Using the IP allowlist feature for blocking access from the public internet is only for the Private Preview. In the final version there will be a dedicated way in the Neon console for doing that!
+   </Admonition>
 <NeedHelp />

--- a/content/docs/guides/neon-private-access.md
+++ b/content/docs/guides/neon-private-access.md
@@ -93,13 +93,13 @@ To configure Neon Private Access, perform the following steps:
 
    Enter **0.0.0.0** in the allowlist to block all connections over the public internet, and click **Save changes**.
 
-   <Admonition type="note">
-    The Private Access connection is not affected by this IP Allow configuration.
-   </Admonition>
+      <Admonition type="note">
+       The Private Access connection is not affected by this IP Allow configuration.
+      </Admonition>
 
    ![Neon IP Allow configuration](/docs/guides/pl_neon_ip_allow.png)
 
-   <Admonition type="note">
-    Using the IP allowlist feature for blocking access from the public internet is only for the Private Preview. In the final version there will be a dedicated way in the Neon console for doing that!
-   </Admonition>
-<NeedHelp />
+      <Admonition type="note">
+       Using the IP allowlist feature for blocking access from the public internet is only for the Private Preview. In the final version there will be a dedicated way in the Neon console for doing that!
+      </Admonition>
+   <NeedHelp />

--- a/content/docs/guides/neon-private-access.md
+++ b/content/docs/guides/neon-private-access.md
@@ -52,7 +52,7 @@ To configure Neon Private Access, perform the following steps:
    Note the ID of the created endpoint and provide it to Neon. Neon will authorize this endpoint to access the Neon Private Access service and notify when the authorization is complete.
 
    <Admonition type="note">
-    This step is specific to the Private Prereview. In the final version configuration of the allowed endpoint will be done through the Neon console without any manual involvement by Neon.
+    This step is specific to the Private Preview. In the final version, the allowed endpoint will be configured through the Neon Console without any manual involvement by Neon.
    </Admonition>
 
 3. **Enable Private DNS**

--- a/content/docs/guides/neon-private-access.md
+++ b/content/docs/guides/neon-private-access.md
@@ -100,6 +100,6 @@ To configure Neon Private Access, perform the following steps:
    ![Neon IP Allow configuration](/docs/guides/pl_neon_ip_allow.png)
 
       <Admonition type="note">
-       Using the IP allowlist feature for blocking access from the public internet is only for the Private Preview. In the final version there will be a dedicated way in the Neon console for doing that!
+       Using the IP Allow feature to block access from the public internet is only for the Private Preview. In the final version, there will be a dedicated option for this provided in the Neon Console.
       </Admonition>
    <NeedHelp />


### PR DESCRIPTION
- It was not clear that the method for blocking internet access by using 0.0.0.0 as the IP allowlist is only temporary. Tried to make that clearer.
- Also clarified that manual acceptance of the VPC endpoint is only temporary as well.