### PR TITLE
fix: pricing page hero plans links

### DIFF
--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -35,7 +35,7 @@
       "features": [{ "title": "Read replicas" }, { "title": "90+ Postgres extensions" }]
     },
     "button": {
-      "url": "LINKS.signup",
+      "url": "https://console.neon.tech/signup",
       "text": "Start for free",
       "theme": "white-outline",
       "event": "Hero Free Tier Panel"
@@ -90,7 +90,7 @@
       ]
     },
     "button": {
-      "url": "LINKS.console/app/billing#plans",
+      "url": "https://console.neon.tech/app/billing#plans",
       "text": "Get started",
       "theme": "primary",
       "event": "Hero Launch Panel"
@@ -143,7 +143,7 @@
       ]
     },
     "button": {
-      "url": "LINKS.console/app/billing#plans",
+      "url": "https://console.neon.tech/app/billing#plans",
       "text": "Get started",
       "theme": "white-outline",
       "event": "Hero Scale Panel"
@@ -203,7 +203,7 @@
       ]
     },
     "button": {
-      "url": "LINKS.console/app/billing#plans",
+      "url": "https://console.neon.tech/app/billing#plans",
       "text": "Get started",
       "theme": "white-outline",
       "event": "Hero Enterprise Panel"


### PR DESCRIPTION
This PR brings fix for pricing page hero plans links

[Preview](https://neon-next-git-pricing-page-links-neondatabase.vercel.app/pricing)