### PR TITLE
Add a signup redirect that logs a pageview

### DIFF
--- a/src/app/signup/page.jsx
+++ b/src/app/signup/page.jsx
@@ -1,0 +1,7 @@
+import Script from 'next/script';
+
+const SignupPage = async () => (
+    <Script id="zwait-redirector">{`zwait = setInterval(function(){if(window.zaraz) {clearInterval(zwait); window.location = "https://console.neon.tech/signup";}}, 50)`}</Script>
+  );
+
+export default SignupPage;


### PR DESCRIPTION
This is a little page that we can use like https://neon.tech/signup?ref=psql.sh and it will log a pageview before redirecting to https://console.neon.tech/signup so we can properly attribute signups.