### PR TITLE
Add sparkline img api for emails

### DIFF
--- a/src/pages/api/sparkline.jsx
+++ b/src/pages/api/sparkline.jsx
@@ -18,7 +18,7 @@ export default async function handler(req) {
     paths.push(
       <path
         key={i}
-        stroke={`rgba(0,191,131,${alpha})`}
+        stroke={`rgba(162,162,162,${alpha})`}
         strokeWidth={i === 0 ? 1 : 2}
         d={series.reduce(
           (acc, v, k) =>

--- a/src/pages/api/sparkline.jsx
+++ b/src/pages/api/sparkline.jsx
@@ -7,8 +7,8 @@ export const config = {
 export default async function handler(req) {
   const { searchParams } = req.nextUrl;
   const series = searchParams.get('series')?.split(',') || [1, 1];
-  const w = searchParams.get('w') || 140;
-  const h = searchParams.get('h') || 32;
+  const w = parseInt(searchParams.get('w'), 10) || 140;
+  const h = parseInt(searchParams.get('h'), 10) || 32;
   const normalizer = Math.max(...series);
 
   const fade = 10;
@@ -20,10 +20,13 @@ export default async function handler(req) {
         key={i}
         stroke={`rgba(0,191,131,${alpha})`}
         strokeWidth={i === 0 ? 1 : 2}
-        d={series.reduce((acc, v, k) => (
-            `${acc 
-            }${k == 0 ? 'M' : 'L'}${k * (w / (series.length - 1))} ${h + i * 2 - (v / normalizer) * h} `
-          ), '')}
+        d={series.reduce(
+          (acc, v, k) =>
+            `${
+              acc
+            }${k == 0 ? 'M' : 'L'}${k * (w / (series.length - 1))} ${h + i * 2 - (v / normalizer) * h} `,
+          ''
+        )}
       />
     );
     alpha = i === 0 ? 0.25 : alpha / 1.25;

--- a/src/pages/api/sparkline.jsx
+++ b/src/pages/api/sparkline.jsx
@@ -1,0 +1,54 @@
+import { ImageResponse } from 'next/og';
+
+export const config = {
+  runtime: 'edge',
+};
+
+export default async function handler(req) {
+  const { searchParams } = req.nextUrl;
+  const series = searchParams.get('series')?.split(',') || [1, 1];
+  const w = searchParams.get('w') || 140;
+  const h = searchParams.get('h') || 32;
+  const normalizer = Math.max(...series);
+
+  const fade = 10;
+  let alpha = 1;
+  const paths = [];
+  for (let i = 0; i < fade; i++) {
+    paths.push(
+      <path
+        key={i}
+        stroke={`rgba(0,191,131,${alpha})`}
+        strokeWidth={i === 0 ? 1 : 2}
+        d={series.reduce((acc, v, k) => (
+            `${acc 
+            }${k == 0 ? 'M' : 'L'}${k * (w / (series.length - 1))} ${h + i * 2 - (v / normalizer) * h} `
+          ), '')}
+      />
+    );
+    alpha = i === 0 ? 0.25 : alpha / 1.25;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          position: 'relative',
+          display: 'flex',
+          width: '100%',
+          height: '100%',
+          padding: '0',
+          backgroundColor: 'transparent',
+        }}
+      >
+        <svg stroke="red" fill="none" viewBox="0 0 320 80">
+          {paths}
+        </svg>
+      </div>
+    ),
+    {
+      width: w,
+      height: h,
+    }
+  );
+}


### PR DESCRIPTION
Adds a image generator API for creating sparklines like this: https://neon.tech/api/sparkline?series=10,20,10,0,15,25&w=120&h=24

should generate something like this 
![image](https://github.com/user-attachments/assets/4e97aee3-b5e6-479e-b2f9-9267f5ea19a6)
