### PR TITLE
feat: add authors info for guides metadata for algolia search

### DIFF
--- a/src/app/guides/[slug]/page.jsx
+++ b/src/app/guides/[slug]/page.jsx
@@ -22,11 +22,16 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }) {
   const { slug } = params;
   const post = getPostBySlug(slug, GUIDES_DIR_PATH);
+
   if (!post) return notFound();
+
   const {
     data: { title, subtitle },
+    author,
   } = post;
+
   const encodedTitle = Buffer.from(title).toString('base64');
+
   return getMetadata({
     title: `${title} - Neon Guides`,
     description: subtitle,
@@ -37,6 +42,7 @@ export async function generateMetadata({ params }) {
     pathname: `${LINKS.guides}/${slug}`,
     rssPathname: null,
     type: 'article',
+    authors: [author.name],
   });
 }
 


### PR DESCRIPTION
This PR adds authors info for guides metadata for algolia search

![image](https://github.com/user-attachments/assets/23857027-2562-4e2d-a915-9a99db2871cf)

[Preview](https://neon-next-git-guides-metadata-authors-neondatabase.vercel.app/guides/vercel-sdk-migration)