### PR TITLE
chore: add classnames for algolia search for blog and guides

### DIFF
--- a/src/app/blog/[slug]/page.jsx
+++ b/src/app/blog/[slug]/page.jsx
@@ -65,7 +65,7 @@ const BlogPage = async ({ params }) => {
       <div className="safe-paddings">
         <article className="dark mx-auto grid max-w-[1472px] grid-cols-12 gap-x-10 pb-40 pt-16 2xl:px-10 xl:gap-x-6 xl:pb-32 xl:pt-12 lg:max-w-none lg:px-8 lg:pb-28 lg:pt-10 md:gap-x-0 md:px-4 md:pb-20 md:pt-8">
           <Hero
-            className="post-title col-start-4 col-end-10 xl:col-start-1 xl:col-end-9 lg:col-span-full"
+            className="col-start-4 col-end-10 xl:col-start-1 xl:col-end-9 lg:col-span-full"
             title={title}
             date={formattedDate}
             category={categories.nodes[0]}
@@ -73,7 +73,7 @@ const BlogPage = async ({ params }) => {
           />
 
           <Content
-            className="col-start-4 col-end-10 row-start-2 mt-10 xl:col-start-1 xl:col-end-9 lg:col-span-full lg:row-start-3"
+            className="post-content col-start-4 col-end-10 row-start-2 mt-10 xl:col-start-1 xl:col-end-9 lg:col-span-full lg:row-start-3"
             html={contentWithLazyBlocks}
           />
           <Aside

--- a/src/components/pages/blog-post/aside/aside.jsx
+++ b/src/components/pages/blog-post/aside/aside.jsx
@@ -38,7 +38,7 @@ const Aside = ({ className, title, slug, authors, posts }) => (
                 <div className="flex flex-col">
                   <span
                     className={clsx(
-                      'font-semibold leading-dense tracking-[-0.02em] transition-colors duration-200',
+                      'post-author font-semibold leading-dense tracking-[-0.02em] transition-colors duration-200',
                       { 'group-hover:text-green-45': author.postAuthor?.url }
                     )}
                   >

--- a/src/components/pages/blog-post/hero/hero.jsx
+++ b/src/components/pages/blog-post/hero/hero.jsx
@@ -24,7 +24,7 @@ const Hero = ({ title, description, date, category, className = null }) => (
         {date}
       </time>
     </div>
-    <h1 className="mt-3 font-title text-5xl font-medium leading-dense tracking-tighter xl:text-[44px] md:text-4xl sm:text-[32px] sm:tracking-[0.02em] xs:text-3xl">
+    <h1 className="post-title mt-3 font-title text-5xl font-medium leading-dense tracking-tighter xl:text-[44px] md:text-4xl sm:text-[32px] sm:tracking-[0.02em] xs:text-3xl">
       {title}
     </h1>
     <p className="mt-3 text-2xl leading-snug text-gray-new-90 xl:text-xl md:text-lg">

--- a/src/components/pages/guides/post/author/author.jsx
+++ b/src/components/pages/guides/post/author/author.jsx
@@ -20,7 +20,7 @@ const Author = ({ data, className = null }) => (
         />
       )}
       <div>
-        <span className="block leading-tight">{data.name}</span>
+        <span className="post-author block leading-tight">{data.name}</span>
         {data.position && (
           <span className="mt-1 block text-[14px] leading-none text-gray-new-50 dark:text-gray-new-60">
             {data.position}

--- a/src/components/pages/guides/post/post.jsx
+++ b/src/components/pages/guides/post/post.jsx
@@ -25,7 +25,7 @@ const Post = ({
 
     <div className="col-span-6 col-start-4 -mx-[26px] flex flex-col xl:col-span-8 xl:col-start-1 xl:mx-0">
       <article>
-        <h1 className="font-title text-[36px] font-medium leading-tight tracking-tighter xl:text-3xl">
+        <h1 className="post-title font-title text-[36px] font-medium leading-tight tracking-tighter xl:text-3xl">
           {title}
         </h1>
         {subtitle && (
@@ -34,7 +34,7 @@ const Post = ({
           </p>
         )}
         {author && <Author data={author} className="mt-5 hidden lg:block" />}
-        <Content className="mt-5" content={content} />
+        <Content className="post-content mt-5" content={content} />
       </article>
 
       <NavigationLinks


### PR DESCRIPTION
This PR brings new classNames for algolia search for blog and guides:

- post-title
- post-content
- post-author

Preview Blog Post
Preview Guides Post