### PR TITLE
docs: remove default mention

### DIFF
--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -11,7 +11,7 @@ updatedOn: '2024-11-15T17:09:41.650Z'
 
 ## Postgres versions
 
-Neon supports Postgres 14, 15, 16, 17. You can select the Postgres version you want to use when creating a Neon project. Postgres 16 is selected by default. For information about creating a Neon project, See [Manage projects](/docs/manage/projects). Minor Postgres point releases are rolled out by Neon after extensive validation as part of regular platform maintenance.
+Neon supports Postgres 14, 15, 16, 17. You can select the Postgres version you want to use when creating a Neon project. For information about creating a Neon project, See [Manage projects](/docs/manage/projects). Minor Postgres point releases are rolled out by Neon after extensive validation as part of regular platform maintenance.
 
 ## Postgres extensions
 


### PR DESCRIPTION
The default Postgres version is visible in the UI. We don't need to mention it in this one place in the docs. This avoids having to update it with each default change.