### PR TITLE
fix: footer compliance section icons

### DIFF
--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -87,7 +87,7 @@ const Footer = ({ hasThemesSupport = false, theme = null }) => {
                             className={clsx(
                               icon,
                               'inline-block dark:bg-gray-new-70',
-                              to ? 'mr-2.5 size-4' : 'mr-1.5 size-3',
+                              heading === 'Compliance' ? 'mr-1.5 size-3' : 'mr-2.5 size-4',
                               isDarkTheme ? 'bg-gray-new-70' : 'bg-gray-new-30',
                               to && 'transition-colors duration-200 group-hover/link:bg-green-45'
                             )}


### PR DESCRIPTION
This PR brings fix for Compliance section icons to inline with other menus

![image](https://github.com/user-attachments/assets/3860d3eb-af84-4d77-95cd-8680c408e126)

Reference PR: https://github.com/neondatabase/website/pull/2481

[Preview](https://neon-next-git-fix-footer-styles-neondatabase.vercel.app/)