### PR TITLE
docs: add missing /api prefix to stack-auth jwks example route

### DIFF
--- a/content/docs/guides/neon-authorize-stack-auth.md
+++ b/content/docs/guides/neon-authorize-stack-auth.md
@@ -46,7 +46,7 @@ https://api.stack-auth.com/api/v1/projects/{YOUR_PROJECT_ID}/.well-known/jwks.js
 Replace `{YOUR_PROJECT_ID}` with your actual Stack Auth project ID. For example, if your project ID is `my-awesome-project`, your JWKS URL would be:
 
 ```plaintext shouldWrap
-https://api.stack-auth.com/v1/projects/my-awesome-project/.well-known/jwks.json
+https://api.stack-auth.com/api/v1/projects/my-awesome-project/.well-known/jwks.json
 ```
 
 ### 2. Add Stack Auth as an authorization provider in the Neon Console


### PR DESCRIPTION
The example route is missing the `/api` prefix, causing a 404 Not Found error (after substituting a valid project ID)