### PR TITLE
docs: fix typo in postgres-select-distinct page

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-select-distinct.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-select-distinct.md
@@ -139,7 +139,7 @@ Output:
 (4 rows)
 ```
 
-The `bcolor` column has 3 red values, two NULL, 1 green value, and two blue values. The `DISTINCT` removes two read values, 1 NULL, and one blue.
+The `bcolor` column has 3 red values, two NULL, 1 green value, and two blue values. The `DISTINCT` removes two red values, 1 NULL, and one blue.
 
 Note that PostgreSQL treats `NULL`s as duplicates so that it keeps one `NULL` for all `NULL`s when you apply the `SELECT DISTINCT` clause.
 


### PR DESCRIPTION
The description of the `bcolor` column mistakenly referred to "read" instead of "red." This commit corrects the typo for clarity and accuracy in the documentation.