### PR TITLE
InKeep: filter search to current section

### DIFF
--- a/src/app/postgresql/layout.jsx
+++ b/src/app/postgresql/layout.jsx
@@ -18,10 +18,10 @@ const NeonPostgresLayout = async ({ children }) => {
     <Layout
       customType={customType}
       headerClassName="lg:border-none"
+      isPostgresPage
       burgerWithoutBorder
       showSearchInput
       isDocPage
-      isPostgresPage
       isHeaderSticky
       headerWithBorder
       hasThemesSupport

--- a/src/app/postgresql/layout.jsx
+++ b/src/app/postgresql/layout.jsx
@@ -21,6 +21,7 @@ const NeonPostgresLayout = async ({ children }) => {
       burgerWithoutBorder
       showSearchInput
       isDocPage
+      isPostgresPage
       isHeaderSticky
       headerWithBorder
       hasThemesSupport

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -191,6 +191,7 @@ const Header = async ({
   isStickyOverlay = false,
   showSearchInput = false,
   isDocPage = false,
+  isPostgresPage = false,
   withBorder = false,
   searchIndexName = null,
   customType = null,
@@ -230,7 +231,7 @@ const Header = async ({
                 </Link>
               </div>
               <div className="col-span-7 col-start-3 -ml-6 flex max-w-[832px] gap-3.5 3xl:col-span-8 3xl:col-start-2 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 xl:max-w-none lg:hidden">
-                <InkeepTrigger className="w-[272px]" showAIButton />
+                <InkeepTrigger className="w-[272px]" isPostgresPage={isPostgresPage} showAIButton />
               </div>
               <div className="col-span-2 col-start-11 -ml-12 h-full max-w-64 3xl:col-start-11 3xl:-ml-20 2xl:col-span-4 2xl:col-start-9 2xl:ml-6 xl:ml-0 lg:hidden">
                 <Sidebar />
@@ -271,6 +272,7 @@ Header.propTypes = {
   isStickyOverlay: PropTypes.bool,
   showSearchInput: PropTypes.bool,
   isDocPage: PropTypes.bool,
+  isPostgresPage: PropTypes.bool,
   withBorder: PropTypes.bool,
   searchIndexName: PropTypes.string,
   customType: PropTypes.shape({

--- a/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
+++ b/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
@@ -6,7 +6,7 @@ import { useTheme } from 'next-themes';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useState } from 'react';
 
-import { aiChatSettings, baseSettings, searchSettings } from 'lib/inkeep-settings';
+import { aiChatSettings, baseSettings } from 'lib/inkeep-settings';
 
 import InkeepAIButton from '../inkeep-ai-button';
 import InkeepSearch from '../inkeep-search';
@@ -27,13 +27,6 @@ const InkeepTrigger = ({
   const [isOpen, setIsOpen] = useState(false);
   const { theme, systemTheme } = useTheme();
   const [defaultModalView, setDefaultModalView] = useState('SEARCH');
-
-  // Override searchSettings with tabSettings
-  searchSettings.tabSettings = {
-    tabOrderByLabel: isPostgresPage
-      ? ['Postgres', 'Neon Docs', 'All']
-      : ['Neon Docs', 'Postgres', 'All'],
-  };
 
   const handleClose = useCallback(() => {
     setIsOpen(false);
@@ -79,7 +72,13 @@ const InkeepTrigger = ({
       defaultView: defaultModalView,
       askAILabel: 'Ask Neon AI',
     },
-    searchSettings,
+    searchSettings: {
+      tabSettings: {
+        tabOrderByLabel: isPostgresPage
+          ? ['Postgres', 'Neon Docs', 'All']
+          : ['Neon Docs', 'Postgres', 'All'],
+      },
+    },
     aiChatSettings,
   };
 

--- a/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
+++ b/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
@@ -22,10 +22,18 @@ const InkeepTrigger = ({
   isDarkTheme = false,
   topOffset,
   showAIButton = false,
+  isPostgresPage = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { theme, systemTheme } = useTheme();
   const [defaultModalView, setDefaultModalView] = useState('SEARCH');
+
+  // Override searchSettings with tabSettings
+  searchSettings.tabSettings = {
+    tabOrderByLabel: isPostgresPage
+      ? ['Postgres', 'Neon Docs', 'All']
+      : ['Neon Docs', 'Postgres', 'All'],
+  };
 
   const handleClose = useCallback(() => {
     setIsOpen(false);
@@ -99,6 +107,7 @@ InkeepTrigger.propTypes = {
   showAIButton: PropTypes.bool,
   isNotFoundPage: PropTypes.bool,
   isDarkTheme: PropTypes.bool,
+  isPostgresPage: PropTypes.bool,
 };
 
 export default InkeepTrigger;

--- a/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
+++ b/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
@@ -75,8 +75,8 @@ const InkeepTrigger = ({
     searchSettings: {
       tabSettings: {
         tabOrderByLabel: isPostgresPage
-          ? ['Postgres', 'Neon Docs', 'All']
-          : ['Neon Docs', 'Postgres', 'All'],
+          ? ['PostgreSQL Tutorial', 'Neon Docs', 'All']
+          : ['Neon Docs', 'PostgreSQL Tutorial', 'All'],
       },
     },
     aiChatSettings,

--- a/src/components/shared/layout/layout.jsx
+++ b/src/components/shared/layout/layout.jsx
@@ -19,6 +19,7 @@ const Layout = ({
   hasThemesSupport = false,
   showSearchInput = false,
   isDocPage = false,
+  isPostgresPage = false,
   searchIndexName = null,
   customType = null,
 }) => (
@@ -35,6 +36,7 @@ const Layout = ({
         hasThemesSupport={hasThemesSupport}
         showSearchInput={showSearchInput}
         isDocPage={isDocPage}
+        isPostgresPage={isPostgresPage}
         withBorder={headerWithBorder}
         searchIndexName={searchIndexName}
         customType={customType}
@@ -62,6 +64,7 @@ Layout.propTypes = {
   headerWithBorder: PropTypes.bool,
   showSearchInput: PropTypes.bool,
   isDocPage: PropTypes.bool,
+  isPostgresPage: PropTypes.bool,
   hasThemesSupport: PropTypes.bool,
   searchIndexName: PropTypes.string,
   customType: PropTypes.shape({

--- a/src/lib/inkeep-settings.js
+++ b/src/lib/inkeep-settings.js
@@ -26,7 +26,7 @@ const baseSettings = {
           partialUrl: 'https://neon.tech/postgresql',
         },
       },
-      searchTabLabel: 'Postgres',
+      searchTabLabel: 'PostgreSQL Tutorial',
     },
   ],
 };

--- a/src/lib/inkeep-settings.js
+++ b/src/lib/inkeep-settings.js
@@ -9,6 +9,26 @@ const baseSettings = {
   customIcons: {
     close: { custom: closeIcon },
   },
+  customCardSettings: [
+    {
+      filters: {
+        UrlMatch: {
+          ruleType: 'PartialUrl',
+          partialUrl: 'https://neon.tech/docs',
+        },
+      },
+      searchTabLabel: 'Neon Docs',
+    },
+    {
+      filters: {
+        UrlMatch: {
+          ruleType: 'PartialUrl',
+          partialUrl: 'https://neon.tech/postgresql',
+        },
+      },
+      searchTabLabel: 'Postgres',
+    },
+  ],
 };
 
 const searchSettings = {


### PR DESCRIPTION
When a user is on the PGT pages at neon.tech/postgresql/tutorial the search should default to filtering only to that section https://neon-next-git-ruf-io-inkeep-filters-neondatabase.vercel.app/postgresql/tutorial


When a user is on the docs at neon.tech/docs the search should default to filtering only docs. 
https://neon-next-git-ruf-io-inkeep-filters-neondatabase.vercel.app/docs/introduction