### PR TITLE
docs: fix grammar in BETWEEN example conclusion

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-where.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-where.md
@@ -243,7 +243,7 @@ first_name | name_length
 ...
 ```
 
-In this example, we use the [`LENGTH()`](../postgresql-string-functions/postgresql-length-function) function gets the number of characters of an input string.
+In this example, we use the [`LENGTH()`](../postgresql-string-functions/postgresql-length-function) function to get the number of characters of an input string.
 
 ### 7\) Using the WHERE clause with the not equal operator (\<\>) example
 


### PR DESCRIPTION
The example description for the LENGTH() function incorrectly used "gets" instead of "to get". This commit improves the grammar for enhanced clarity.

Before:
"In this example, we use the LENGTH() function gets the number of characters of an input string."

After:
"In this example, we use the LENGTH() function to get the number of characters of an input string."