### PR TITLE
docs: fix grammatical error in WHERE clause and equal example description

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-where.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-where.md
@@ -75,7 +75,7 @@ We will use the `customer` table from the [sample database](../postgresql-getti
 
 ### 1\)  Using WHERE clause with the equal (\=) operator example
 
-The following statement uses the `WHERE` clause to find customers with the first name is `Jamie`:
+The following statement uses the `WHERE` clause to find customers whose first name is `Jamie`:
 
 ```sql
 SELECT


### PR DESCRIPTION
Corrected the phrase "with the first name is Jamie" to "whose first name is Jamie" in the WHERE clause and equal example description.