### PR TITLE
Fix data types prev and next urls

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-array.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-array.md
@@ -7,11 +7,11 @@ ogImage: ''
 updatedOn: '2024-02-01T12:38:39+00:00'
 enableTableOfContents: true
 previousLink:
-  title: 'PostgreSQL UUID Data Type'
-  slug: 'postgresql-tutorial/postgresql-uuid'
-nextLink:
   title: 'PostgreSQL hstore'
   slug: 'postgresql-tutorial/postgresql-hstore'
+nextLink:
+  title: 'User-defined Data Types'
+  slug: 'postgresql-tutorial/postgresql-user-defined-data-types'
 ---
 
 **Summary**: in this tutorial, you will learn how to work with **PostgreSQL array** and how to use some handy functions for array manipulation.

--- a/content/postgresql/postgresql-tutorial/postgresql-hstore.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-hstore.md
@@ -7,11 +7,11 @@ ogImage: '/postgresqltutorial/postgresql-hstore-query.jpg'
 updatedOn: '2024-02-01T12:53:20+00:00'
 enableTableOfContents: true
 previousLink:
-  title: 'PostgreSQL Array'
-  slug: 'postgresql-tutorial/postgresql-array'
-nextLink:
   title: 'PostgreSQL JSON'
   slug: 'postgresql-tutorial/postgresql-json'
+nextLink:
+  title: 'PostgreSQL Array'
+  slug: 'postgresql-tutorial/postgresql-array'
 ---
 
 **Summary**: in this tutorial, you’ll learn how to work with **PostgreSQL hstore** data type.

--- a/content/postgresql/postgresql-tutorial/postgresql-json.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-json.md
@@ -7,11 +7,11 @@ ogImage: ''
 updatedOn: '2024-02-23T10:29:43+00:00'
 enableTableOfContents: true
 previousLink:
-  title: 'PostgreSQL hstore'
-  slug: 'postgresql-tutorial/postgresql-hstore'
+  title: 'UUID'
+  slug: 'postgresql-tutorial/postgresql-uuid'
 nextLink:
-  title: 'A Look at PostgreSQL User-defined Data Types'
-  slug: 'postgresql-tutorial/postgresql-user-defined-data-types'
+ title: 'PostgreSQL hstore'
+ slug: 'postgresql-tutorial/postgresql-hstore'
 ---
 
 **Summary**: in this tutorial, you will learn about JSON and how to work with JSON data in PostgreSQL using the PostgreSQL JSON and JSONB data types.

--- a/content/postgresql/postgresql-tutorial/postgresql-user-defined-data-types.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-user-defined-data-types.md
@@ -7,10 +7,10 @@ ogImage: '/postgresqltutorial/PostgreSQL-User-defined-Type-Example.png'
 updatedOn: '2020-07-10T01:18:36+00:00'
 enableTableOfContents: true
 previousLink:
-  title: 'PostgreSQL JSON'
-  slug: 'postgresql-tutorial/postgresql-json'
+  title: 'PostgreSQL Array'
+  slug: 'postgresql-tutorial/postgresql-array'
 nextLink:
-  title: 'PostgreSQL enum'
+  title: 'PostgreSQL Enum'
   slug: 'postgresql-tutorial/postgresql-enum'
 ---
 

--- a/content/postgresql/postgresql-tutorial/postgresql-uuid.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-uuid.md
@@ -10,8 +10,8 @@ previousLink:
   title: 'PostgreSQL TIME Data Type'
   slug: 'postgresql-tutorial/postgresql-time'
 nextLink:
-  title: 'PostgreSQL Array'
-  slug: 'postgresql-tutorial/postgresql-array'
+  title: 'PostgreSQL JSON'
+  slug: 'postgresql-tutorial/postgresql-json'
 ---
 
 **Summary**: in this tutorial, you will learn about the PostgreSQL UUID data type and how to generate UUID values using a supplied module.


### PR DESCRIPTION
Some previous and next urls were not pointing to the correct pages as per the index. This pull requests fixes all these pages which have incorrect previous and next linking in data types category.