### PR TITLE
chore: remove hero image from careers page

### DIFF
--- a/src/components/pages/careers/hero/hero.jsx
+++ b/src/components/pages/careers/hero/hero.jsx
@@ -1,32 +1,19 @@
-import Image from 'next/image';
-
 import Container from 'components/shared/container';
 
-import illustration from './images/hero-illustration.jpg';
-
 const Hero = () => (
-  <section className="safe-paddings bg-black-pure pt-40 text-white xl:pt-36 lg:pt-12 md:pt-6">
-    <Container className="grid grid-cols-12 gap-x-10 3xl:gap-x-0" size="1344">
+  <section className="safe-paddings bg-black-pure pb-24 pt-40 text-white xl:pt-36 lg:pb-16 lg:pt-12 md:pb-12 md:pt-6">
+    <Container size="1152">
       <div className="col-span-10 col-start-2 3xl:col-span-full 3xl:col-start-1">
         <h1 className="t-5xl text-center font-title font-medium leading-tight">
           Become a part of our team{' '}
         </h1>
-        <p className="t-lg mx-auto mt-8 max-w-[1160px] text-center leading-normal tracking-extra-tight 3xl:max-w-[860px] 2xl:mt-7 xl:mt-6">
+        <p className="t-lg mx-auto mt-8 max-w-[1160px] text-center leading-normal tracking-extra-tight 3xl:max-w-[800px] 2xl:mt-7 xl:mt-6">
           Neon is a distributed team building open-source, cloud-native Postgres. We are a
           well-funded startup with deep knowledge of Postgres internals and decades of experience
           building databases. Our storage layer is written in Rust, and our cloud control plane is
           written in Go. We are on a mission to create a cloud-native database service for every
           developer.
         </p>
-        <div className="-mt-16 translate-y-32 lg:-mt-12 lg:translate-y-24 md:-mt-8 md:flex md:translate-y-16 md:justify-center">
-          <Image
-            className="rounded-md md:min-w-[600px] sm:min-w-0"
-            src={illustration}
-            alt=""
-            priority
-            aria-hidden
-          />
-        </div>
       </div>
     </Container>
   </section>

--- a/src/components/pages/careers/jobs-list/jobs-list.jsx
+++ b/src/components/pages/careers/jobs-list/jobs-list.jsx
@@ -36,7 +36,7 @@ const JobsList = () => {
   }, []);
 
   return (
-    <section className="safe-paddings pt-64 3xl:pt-60 2xl:pt-52 xl:pt-48 lg:pt-40 md:pt-32">
+    <section className="safe-paddings pt-24 lg:pt-16 md:pt-12">
       <Container size="xs">
         <h2 className="t-5xl font-title font-medium leading-tight">Job Openings</h2>
         <ul className="mb-16 mt-14 space-y-16 lg:mb-12 lg:mt-10 lg:space-y-12 md:mb-8 md:mt-6 md:space-y-8">


### PR DESCRIPTION
This PR removes image from careers page

<img width="858" alt="image" src="https://github.com/user-attachments/assets/69b3708f-5b20-4617-a118-178fe8859bc1">

[Preview](https://neon-next-git-careers-page-hero-neondatabase.vercel.app/careers)