### PR TITLE
chore: add azure icon for docs sidebar

### DIFF
--- a/src/components/pages/doc/menu/icon/icon.jsx
+++ b/src/components/pages/doc/menu/icon/icon.jsx
@@ -4,6 +4,7 @@ import AiIcon from 'icons/docs/sidebar/ai.inline.svg';
 import ApiIcon from 'icons/docs/sidebar/api.inline.svg';
 import ArchitectureIcon from 'icons/docs/sidebar/architecture.inline.svg';
 import AuthIcon from 'icons/docs/sidebar/auth.inline.svg';
+import AzureIcon from 'icons/docs/sidebar/azure.inline.svg';
 import BillingIcon from 'icons/docs/sidebar/billing.inline.svg';
 import ChangelogIcon from 'icons/docs/sidebar/changelog.inline.svg';
 import CliIcon from 'icons/docs/sidebar/cli.inline.svg';
@@ -37,6 +38,7 @@ const icons = {
   api: ApiIcon,
   architecture: ArchitectureIcon,
   auth: AuthIcon,
+  azure: AzureIcon,
   billing: BillingIcon,
   changelog: ChangelogIcon,
   cli: CliIcon,

--- a/src/icons/docs/sidebar/azure.inline.svg
+++ b/src/icons/docs/sidebar/azure.inline.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.64917 3L5.52115 6.59982L2 12.958H5.17542L9.64917 3ZM10.1981 3.84214L8.43662 8.83554L11.8138 13.1035L5.2612 14.2359H16L10.1981 3.84214Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
This PR brings Azure icon for docs sidebar

![image](https://github.com/user-attachments/assets/1c852a77-f6b0-4f92-8a11-ac3c2985852e)
