### PR TITLE
chore: add Azure to pricing plans payment methods

### DIFF
--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -2,7 +2,6 @@
   {
     "type": "Free Plan",
     "price": 0,
-    "headerLink": null,
     "description": "To kickstart your projects, no credit card required.",
     "features": [
       {
@@ -46,10 +45,7 @@
     "highlighted": true,
     "price": 19,
     "priceFrom": true,
-    "headerLink": {
-      "url": "https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa",
-      "text": "Pay via AWS marketplace"
-    },
+    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a> or <a href='#' target='_blank' rel='noopener noreferrer'>Azure</a>",
     "description": "The resources, features, and support you need to launch.",
     "features": [
       {
@@ -95,10 +91,7 @@
     "type": "Scale",
     "price": 69,
     "priceFrom": true,
-    "headerLink": {
-      "url": "https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa",
-      "text": "Pay via AWS marketplace"
-    },
+    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a> or <a href='#' target='_blank' rel='noopener noreferrer'>Azure</a>",
     "description": "More capacity and functionality for scaling production workloads.",
     "features": [
       {
@@ -131,10 +124,7 @@
     ],
     "otherFeatures": {
       "title": "Everything in Launch, plus...",
-      "features": [
-        { "title": "IP Allow Rules" },
-        { "title": "Datadog integration" }
-      ]
+      "features": [{ "title": "IP Allow Rules" }, { "title": "Datadog integration" }]
     },
     "button": {
       "url": "https://console.neon.tech/app/billing#plans",
@@ -147,10 +137,7 @@
     "type": "Business",
     "price": 700,
     "priceFrom": true,
-    "headerLink": {
-      "url": "/migration-assistance",
-      "text": "Get migration help"
-    },
+    "headerLinks": "<a href='/migration-assistance'>Get migration help</a>",
     "description": "For larger workloads, with best compliance and security. ",
     "features": [
       {

--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -45,7 +45,7 @@
     "highlighted": true,
     "price": 19,
     "priceFrom": true,
-    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a> or <a href='#' target='_blank' rel='noopener noreferrer'>Azure</a>",
+    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a> or <a href='https://azuremarketplace.microsoft.com/en-us/marketplace/apps/neon1722366567200.neon_serverless_postgres_azure_prod?tab=PlansAndPrice' target='_blank' rel='noopener noreferrer'>Azure</a>",
     "description": "The resources, features, and support you need to launch.",
     "features": [
       {
@@ -91,7 +91,7 @@
     "type": "Scale",
     "price": 69,
     "priceFrom": true,
-    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a> or <a href='#' target='_blank' rel='noopener noreferrer'>Azure</a>",
+    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a> or <a href='https://azuremarketplace.microsoft.com/en-us/marketplace/apps/neon1722366567200.neon_serverless_postgres_azure_prod?tab=PlansAndPrice' target='_blank' rel='noopener noreferrer'>Azure</a>",
     "description": "More capacity and functionality for scaling production workloads.",
     "features": [
       {

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -52,7 +52,7 @@ const Hero = () => (
                 highlighted = false,
                 price,
                 priceFrom = false,
-                headerLink,
+                headerLinks,
                 description,
                 features,
                 otherFeatures,
@@ -76,18 +76,15 @@ const Hero = () => (
                   >
                     {type}
                   </h3>
-                  {headerLink && (
-                    <a
+                  {headerLinks && (
+                    <p
                       className={clsx(
-                        'border-b border-[#85888E]/50 pb-0.5 text-sm font-light leading-none tracking-tighter text-gray-new-50',
-                        'transition-colors duration-200 hover:border-transparent hover:text-gray-new-80'
+                        'text-sm font-light leading-none text-gray-new-50',
+                        '[&_a]:border-b [&_a]:border-[#85888E]/50 [&_a]:pb-0.5 [&_a]:tracking-tighter',
+                        '[&_a]:transition-colors [&_a]:duration-200 hover:[&_a]:border-transparent hover:[&_a]:text-gray-new-80'
                       )}
-                      href={headerLink.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {headerLink.text}
-                    </a>
+                      dangerouslySetInnerHTML={{ __html: headerLinks }}
+                    />
                   )}
                 </div>
                 <p className="relative mt-16 ">


### PR DESCRIPTION
This PR brings adds Azure to pricing plans payment methods

![image](https://github.com/user-attachments/assets/9fed8db7-4442-4244-b84f-29ff364181fa)

TODO:
- [x] update Azure links before release

[Preview](https://neon-next-git-pay-via-azure-pricing-page-neondatabase.vercel.app/pricing)