### PR TITLE
chore: add temporary redirect for changelog

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -240,6 +240,11 @@ const defaultConfig = {
         destination: '/stage',
         permanent: true,
       },
+      {
+        source: '/changelog',
+        destination: '/docs/changelog',
+        permanent: false,
+      },
       ...docsRedirects,
       ...changelogRedirects,
     ];


### PR DESCRIPTION
This PR brings **temporary** redirect for changelog page

`/changelog` -> `/docs/changelog`

[Preview](https://neon-next-git-changelog-temp-redirect-neondatabase.vercel.app/changelog)