### PR TITLE
refactor: move redirects from homepage to middleware

### DIFF
--- a/src/app/(home-page)/home/page.jsx
+++ b/src/app/(home-page)/home/page.jsx
@@ -1,6 +1,3 @@
-import { redirect } from 'next/navigation';
-
-import { checkCookie } from 'app/actions';
 import AiIndex from 'components/pages/home/ai-index';
 import Bento from 'components/pages/home/bento';
 import Hero from 'components/pages/home/hero';
@@ -19,27 +16,20 @@ export const metadata = getMetadata({
   robotsNoindex: 'noindex',
 });
 
-const HomePage = async () => {
-  const is_logged_in = await checkCookie('neon_login_indicator');
-  if (!is_logged_in) {
-    return redirect('/');
-  }
-
-  return (
-    <>
-      <Hero />
-      <Logos />
-      <InstantProvisioning />
-      <Lightning />
-      <Bento />
-      <AiIndex />
-      <Multitenancy />
-      <Industry />
-      <Trusted />
-      <Cta />
-    </>
-  );
-};
+const HomePage = () => (
+  <>
+    <Hero />
+    <Logos />
+    <InstantProvisioning />
+    <Lightning />
+    <Bento />
+    <AiIndex />
+    <Multitenancy />
+    <Industry />
+    <Trusted />
+    <Cta />
+  </>
+);
 
 export default HomePage;
 

--- a/src/app/(home-page)/page.jsx
+++ b/src/app/(home-page)/page.jsx
@@ -1,6 +1,3 @@
-import { redirect } from 'next/navigation';
-
-import { checkCookie, getReferer } from 'app/actions';
 import AiIndex from 'components/pages/home/ai-index';
 import Bento from 'components/pages/home/bento';
 import Hero from 'components/pages/home/hero/hero';
@@ -11,7 +8,6 @@ import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
-import LINKS from 'constants/links';
 import SEO_DATA from 'constants/seo-data';
 import getMetadata from 'utils/get-metadata';
 
@@ -28,39 +24,24 @@ const jsonLd = {
   url: 'https://neon.tech/',
 };
 
-const HomePage = async () => {
-  const is_logged_in = await checkCookie('neon_login_indicator');
-  if (process.env.NODE_ENV === 'production' && is_logged_in) {
-    const referer = await getReferer();
-    if (
-      referer.includes(process.env.VERCEL_BRANCH_URL) ||
-      referer.includes(process.env.NEXT_PUBLIC_DEFAULT_SITE_URL)
-    ) {
-      return redirect('/home');
-    }
-
-    return redirect(LINKS.console);
-  }
-
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <Hero />
-      <Logos />
-      <InstantProvisioning />
-      <Lightning />
-      <Bento />
-      <AiIndex />
-      <Multitenancy />
-      <Industry />
-      <Trusted />
-      <Cta />
-    </>
-  );
-};
+const HomePage = async () => (
+  <>
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+    <Hero />
+    <Logos />
+    <InstantProvisioning />
+    <Lightning />
+    <Bento />
+    <AiIndex />
+    <Multitenancy />
+    <Industry />
+    <Trusted />
+    <Cta />
+  </>
+);
 
 export default HomePage;
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -101,3 +101,7 @@ export async function middleware(req) {
     return NextResponse.redirect(new URL(SITE_URL));
   }
 }
+
+export const config = {
+  matcher: ['/', '/home', '/generate-ticket/:path*', '/tickets/:path*'],
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -30,8 +30,8 @@ export async function middleware(req) {
     }
 
     // Check if user is logged in
-    const is_logged_in = await checkCookie('neon_login_indicator');
-    if (process.env.NODE_ENV === 'production' && is_logged_in) {
+    const isLoggedIn = await checkCookie('neon_login_indicator');
+    if (process.env.NODE_ENV === 'production' && isLoggedIn) {
       const referer = await getReferer();
       if (
         referer.includes(process.env.VERCEL_BRANCH_URL) ||

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -30,7 +30,7 @@ export async function middleware(req) {
             referer.includes(process.env.VERCEL_BRANCH_URL) ||
             referer.includes(process.env.NEXT_PUBLIC_DEFAULT_SITE_URL)
           ) {
-            return NextResponse.redirect(new URL(`${SITE_URL}/home`));
+            return NextResponse.redirect(new URL('/home', req.url));
           }
         } catch (error) {
           console.error('Error getting referer:', error);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -35,7 +35,7 @@ export async function middleware(req) {
         } catch (error) {
           console.error('Error getting referer:', error);
         }
-        return NextResponse.redirect(new URL(LINKS.console));
+        return NextResponse.redirect(LINKS.console);
       }
       if (pathname === '/home' && !isLoggedIn) return NextResponse.redirect(new URL(SITE_URL));
     } catch (error) {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,6 +2,9 @@
 import { NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 
+import { checkCookie, getReferer } from 'app/actions';
+import LINKS from 'constants/links';
+
 const SITE_URL =
   process.env.VERCEL_ENV === 'preview'
     ? `https://${process.env.VERCEL_BRANCH_URL}`
@@ -9,7 +12,7 @@ const SITE_URL =
 
 export async function middleware(req) {
   const { pathname } = req.nextUrl;
-  // Add any assets or page that you don't want to run middleware on
+
   if (
     pathname.startsWith('/_next/') ||
     pathname.startsWith('/favicon.ico') ||
@@ -19,13 +22,23 @@ export async function middleware(req) {
   }
 
   const token = await getToken({ req });
-  // if token exists, user is authorized
+  const isLoggedIn = await checkCookie('neon_login_indicator', req);
+  const referer = await getReferer(req);
+
+  if (process.env.NODE_ENV === 'production' && isLoggedIn) {
+    if (
+      referer.includes(process.env.VERCEL_BRANCH_URL) ||
+      referer.includes(process.env.NEXT_PUBLIC_DEFAULT_SITE_URL)
+    ) {
+      return NextResponse.redirect(new URL(`${SITE_URL}/home`));
+    }
+    return NextResponse.redirect(new URL(LINKS.console));
+  }
+
   if (token?.githubHandle) {
-    // authorized user should be moved to his ticket edit page from anywhere
     if (pathname === '/generate-ticket' || pathname.endsWith(`/tickets/${token.githubHandle}`)) {
       return NextResponse.redirect(new URL(`${SITE_URL}/tickets/${token.githubHandle}/edit`));
     }
-    // if user is authorized but tries to access another user's edit page, redirect to /tickets/:handle
     if (pathname.endsWith(`/edit`) && token?.githubHandle !== pathname.split('/').slice(-2)[0]) {
       return NextResponse.redirect(
         new URL(`${SITE_URL}${pathname.split('/').slice(0, -1).join('/')}`)


### PR DESCRIPTION
This PR refactors homepage redirects, moving them to middleware

reference: https://github.com/neondatabase/website/pull/2585

basic concepts:
- Root Path (`/`): In production, if the user is logged in, they are redirected to /home if the referer matches the current branch or default site URL; otherwise, they are redirected to the console.
- Home Path (`/home`): Users not logged in are redirected to the root path (/).

[Preview](https://neon-next-git-move-redirects-to-middleware-neondatabase.vercel.app/)