### PR TITLE
chore: remove posthog production key from env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ NEXT_PUBLIC_FLOW_GITHUB_PATH=https://github.com/neondatabase/website/tree/main/c
 NEXT_PUBLIC_USE_CASES_GITHUB_PATH=https://github.com/neondatabase/website/tree/main/content/use-cases/
 NEXT_PUBLIC_RELEASE_NOTES_GITHUB_PATH=https://github.com/neondatabase/website/tree/main/content/changelog/
 NEXT_PUBLIC_RELEASE_NOTES_API_URL=https://neon.tech/api/release-notes
-NEXT_PUBLIC_POSTHOG_KEY=phc_yv8ksk9v2FajpXIxVHYj4g59LVeLyo8yN5SaTG1JJty
+NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 NEXT_PUBLIC_SEGMENT_WRITE_KEY=


### PR DESCRIPTION
#0

It was a bad idea to put production Posthog key into `.env.example` :)

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/3794fd8c-a17d-4e00-ba47-53dbc56c9462">
