### PR TITLE
chore: add sign up events

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -131,6 +131,7 @@ const Hero = () => {
             to={LINKS.signup}
             target="_blank"
             tag_name="Hero"
+            analyticsEvent="home_hero_get_started_clicked"
           >
             Get Started
           </Button>

--- a/src/components/shared/button/button.jsx
+++ b/src/components/shared/button/button.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
+import { usePostHog } from 'posthog-js/react';
 import PropTypes from 'prop-types';
 
 import Link from 'components/shared/link';
@@ -54,9 +55,11 @@ const Button = ({
   size = null,
   theme = null,
   tag_name = null,
+  analyticsEvent = null,
   children,
   ...otherProps
 }) => {
+  const posthog = usePostHog();
   const className = clsx(styles.base, styles.size[size], styles.theme[theme], additionalClassName);
 
   const Tag = to ? Link : 'button';
@@ -71,6 +74,11 @@ const Button = ({
           text: getNodeText(children),
           tag_name,
         });
+        if (analyticsEvent) {
+          posthog.capture('ui_interaction', {
+            action: analyticsEvent,
+          });
+        }
       }}
       {...otherProps}
     >
@@ -86,6 +94,7 @@ Button.propTypes = {
   theme: PropTypes.oneOf(Object.keys(styles.theme)),
   children: PropTypes.node.isRequired,
   tag_name: PropTypes.string,
+  analyticsEvent: PropTypes.string,
 };
 
 export default Button;

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -176,6 +176,7 @@ const Sidebar = async ({ isDarkTheme }) => {
         to={LINKS.signup}
         theme="primary"
         tag_name="Header"
+        analyticsEvent="header_sign_up_clicked"
       >
         Sign Up
       </Button>


### PR DESCRIPTION
Relates to https://linear.app/neondb/issue/GRW-290/experiment-build

Add 2 required for the experiment events:

- `header_sign_up_clicked`
- `home_hero_get_started_clicked`