### PR TITLE
remove revalidate from homepage

### DIFF
--- a/src/app/(home-page)/page.jsx
+++ b/src/app/(home-page)/page.jsx
@@ -24,7 +24,7 @@ const jsonLd = {
   url: 'https://neon.tech/',
 };
 
-export default function () {
+const Homepage = () => {
   return <>
     <script
       type="application/ld+json"
@@ -42,3 +42,5 @@ export default function () {
     <Cta />
   </>
 }
+
+export default Homepage;

--- a/src/app/(home-page)/page.jsx
+++ b/src/app/(home-page)/page.jsx
@@ -24,8 +24,8 @@ const jsonLd = {
   url: 'https://neon.tech/',
 };
 
-const HomePage = async () => (
-  <>
+export default async function () {
+  return <>
     <script
       type="application/ld+json"
       dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
@@ -41,8 +41,4 @@ const HomePage = async () => (
     <Trusted />
     <Cta />
   </>
-);
-
-export default HomePage;
-
-export const revalidate = 60;
+}

--- a/src/app/(home-page)/page.jsx
+++ b/src/app/(home-page)/page.jsx
@@ -24,7 +24,7 @@ const jsonLd = {
   url: 'https://neon.tech/',
 };
 
-export default async function () {
+export default function () {
   return <>
     <script
       type="application/ld+json"


### PR DESCRIPTION
we no more require the logic to run on homepage specifically, hence no need to revalidate.