### PR TITLE
chore: update scale to zero feature description

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -156,14 +156,14 @@
       "business": "Up to 16 CU"
     },
     {
-      "rows": "2",
+      "rows": "1",
       "feature": {
         "title": "Scale to zero"
       },
-      "free": "Fixed <span>5 minutes</span>",
-      "launch": "Configurable <span>5 min+ or never</span>",
-      "scale": "Configurable <span>1 min+ or never</span>",
-      "business": "Configurable <span>1 min+ or never</span>"
+      "free": "Always enabled",
+      "launch": "Configurable",
+      "scale": "Configurable",
+      "business": "Configurable"
     },
     {
       "rows": "1",

--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -160,10 +160,10 @@
       "feature": {
         "title": "Scale to zero"
       },
-      "free": "Always enabled",
-      "launch": "Configurable",
-      "scale": "Configurable",
-      "business": "Configurable"
+      "free": true,
+      "launch": true,
+      "scale": true,
+      "business": true
     },
     {
       "rows": "1",


### PR DESCRIPTION
Relates to https://linear.app/neondb/issue/GRW-327/turn-autosuspend-into-a-single-toggle-that-says-scale-to-zero

## Before

![image](https://github.com/user-attachments/assets/2e66af8a-989e-4e10-abcd-50554459c6b3)

## After

![image](https://github.com/user-attachments/assets/228bfd7f-03df-42aa-a714-9bf21bd711bb)

UPD: Text replaced by check marks:

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/395cb2dd-e309-4918-b1bd-07b6fa7bb168" />
