### PR TITLE
fix: update Neon Proxy API to use `v2` in Local Development

### DIFF
--- a/content/guides/local-development-with-neon.md
+++ b/content/guides/local-development-with-neon.md
@@ -205,7 +205,7 @@ The Neon Proxy setup uses the [local-neon-http-proxy](https://github.com/TimoWil
      };
      const connectionStringUrl = new URL(connectionString);
      neonConfig.useSecureWebSocket = connectionStringUrl.hostname !== 'db.localtest.me';
-     neonConfig.wsProxy = (host) => (host === 'db.localtest.me' ? `${host}:4444/v1` : undefined);
+     neonConfig.wsProxy = (host) => (host === 'db.localtest.me' ? `${host}:4444/v2` : host + "/v2");
      neonConfig.webSocketConstructor = ws;
    }
 


### PR DESCRIPTION
Fix #2651

This PR updates the configuration for the local Neon Proxy to use the `v2` API version, resolving compatibility errors in local environments.  

#### **Changes Made**:  
- Updated `neonConfig.wsProxy` to use `v2` endpoint:  
```ts
  neonConfig.wsProxy = (host) =>
    host === "db.localtest.me" ? `${host}:4444/v2` : host + "/v2";
```  

#### **Why This Change?**  
- The `v1` API is outdated and causes errors when working with the local proxy.  
- Switching to `v2` aligns with the latest Neon serverless driver compatibility.  

#### **Testing**:  
- Verified local development flow with the updated configuration.  
- Successfully connected to the local Neon Proxy without errors.  