### PR TITLE
docs: schema diff api docs

### DIFF
--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -91,9 +91,7 @@ First, create a new database called `people` on the `main` branch and add some s
 
 <TabItem>
 
-1. Create the database.
-
-   Use the [Create database](https://api-docs.neon.tech/reference/createprojectbranchdatabase) API to create the `people` database.
+1. Use the [Create database](https://api-docs.neon.tech/reference/createprojectbranchdatabase) API to create the `people` database, specifying the `project_id`, `branch_id`, database `name`, and database `owner_name` in the API call.
 
       ```bash
       curl --request POST \
@@ -109,7 +107,7 @@ First, create a new database called `people` on the `main` branch and add some s
       }'
       ```
 
-2. Retrieve your database connection string using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint:
+2. Retrieve your database connection string using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint, specifying the required `project_id`, `branch_id`, `database_name`, and  `role_name` parameters.
 
    ```bash
    curl --request GET \
@@ -230,7 +228,7 @@ For the purposes of this tutorial, name the branch `dev/jordan`, following our r
 
 <TabItem>
 
-Using the [Create branch](https://api-docs.neon.tech/reference/createprojectbranch) API, create a development branch named `dev/jordan`.
+Using the [Create branch](https://api-docs.neon.tech/reference/createprojectbranch) API, create a development branch named `dev/jordan`. You'll need to specify the `project_id`, `parent_id`, branch `name`, and add a `read_write` compute endpoint — you need a compute endpoint to connection the branch.
 
    ```bash
    curl --request POST \
@@ -319,7 +317,7 @@ CREATE TABLE address (
 
 <TabItem>
 
-1. Retrieve your database connection string using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint:
+1. Retrieve the database connection string for the `dev/jordan` branch using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint:
 
    ```bash
    curl --request GET \
@@ -336,13 +334,13 @@ CREATE TABLE address (
    }
    ```
 
-1. Connect to the people database with `psql`:
+1. Connect to the `people` database on the `dev/jordan` branch with `psql`:
 
    ```bash
    psql 'postgresql://alex:JZb5eKPpg0vD@ep-hidden-sun-a5de9i5h-pooler.us-east-2.aws.neon.tech/people?sslmode=require'
    ```
 
-1. Add a new address table
+1. Add a new `address` table.
 
    ```sql
    CREATE TABLE address (
@@ -421,7 +419,7 @@ The result shows a comparison between the `dev/jordan` branch and its parent bra
 
 <TabItem>
 
-Compare the schema of `dev/jordan` to its parent branch using the `compare-schema` API.
+Compare the schema of the `dev/jordan` branch to its parent branch using the `compare-schema` API.
 
 ```bash
 curl -X GET \

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -107,7 +107,7 @@ First, create a new database called `people` on the `main` branch and add some s
    }'
    ```
 
-2. Retrieve your database connection string using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint, specifying the required `project_id`, `branch_id`, `database_name`, and  `role_name` parameters.
+2. Retrieve your database connection string using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint, specifying the required `project_id`, `branch_id`, `database_name`, and `role_name` parameters.
 
    ```bash
    curl --request GET \

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -22,7 +22,7 @@ To complete this tutorial, you'll need:
 
 First, create a new database called `people` on the `main` branch and add some sample data to it.
 
-<Tabs labels={["Console", "CLI"]}>
+<Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
 
@@ -88,6 +88,61 @@ First, create a new database called `people` on the `main` branch and add some s
    ```
 
 </TabItem>
+
+<TabItem>
+
+1. Create the database.
+
+   Use the [Create database](https://api-docs.neon.tech/reference/createprojectbranchdatabase) API to create the `people` database.
+
+      ```bash
+      curl --request POST \
+      --url https://console.neon.tech/api/v2/projects/royal-band-06902338/branches/br-bitter-bird-a56n6lh4/databases \
+      --header 'accept: application/json' \
+      --header 'authorization: Bearer $NEON_API_KEY' \
+      --header 'content-type: application/json' \
+      --data '{
+         "database": {
+            "name": "people",
+            "owner_name": "alex"
+         }
+      }'
+      ```
+
+2. Retrieve your database connection string using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint:
+
+   ```bash
+   curl --request GET \
+     --url 'https://console.neon.tech/api/v2/projects/royal-band-06902338/connection_uri?branch_id=br-bitter-bird-a56n6lh4&database_name=people&role_name=alex' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer $NEON_API_KEY'
+   ```
+
+   The API call will return an connection string similar to this one:
+
+   ```json
+   {
+     "uri": "postgresql://alex:*********@ep-green-surf-a5yaumj3-pooler.us-east-2.aws.neon.tech/people?sslmode=require"
+   }
+   ```
+
+3. Connect to the `people` database with `psql`:
+
+   ```bash
+   psql 'postgresql://alex:*********@ep-green-surf-a5yaumj3-pooler.us-east-2.aws.neon.tech/people?sslmode=require'
+   ```
+
+4. Create the schema:
+
+   ```sql
+   CREATE TABLE person (
+       id SERIAL PRIMARY KEY,
+       name TEXT NOT NULL,
+       email TEXT UNIQUE NOT NULL
+   );
+
+</TabItem>
+
 </Tabs>
 
 ## Step 2: Create a development branch
@@ -96,7 +151,7 @@ Create a new development branch off of `main`. This branch will be an exact, iso
 
 For the purposes of this tutorial, name the branch `dev/jordan`, following our recommended convention of creating a long-lived development branch for each member of your team.
 
-<Tabs labels={["Console", "CLI"]}>
+<Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
 
@@ -172,18 +227,44 @@ For the purposes of this tutorial, name the branch `dev/jordan`, following our r
       You can do the same thing for your `main` branch and get identical results.
 
 </TabItem>
+
+<TabItem>
+
+Using the [Create branch](https://api-docs.neon.tech/reference/createprojectbranch) API, create a development branch named `dev/jordan`.
+
+   ```bash
+   curl --request POST \
+   --url https://console.neon.tech/api/v2/projects/royal-band-06902338/branches \
+   --header 'accept: application/json' \
+   --header 'authorization: Bearer $NEON_API_KEY' \
+   --header 'content-type: application/json' \
+   --data '{
+      "branch": {
+         "name": "dev/jordan",
+         "parent_id": "br-bitter-bird-a56n6lh4"
+      },
+      "endpoints": [
+         {
+         "type": "read_write"
+         }
+      ]
+   }'
+   ```
+
+</TabItem>
+
 </Tabs>
 
 ## Step 3: Update schema on a dev branch
 
 Let's introduce some differences between the two branches. Add a new table to store addresses on the `dev/jordan` branch.
 
-<Tabs labels={["Console","CLI"]}>
+<Tabs labels={["Console","CLI", "API"]}>
 
 <TabItem>
 In the **SQL Editor**, make sure you select `dev/jordan` as the branch and `people` as the database.
 
-Enter this SQL statemenet to create a new `address` table.
+Enter this SQL statement to create a new `address` table.
 
 ```sql
 CREATE TABLE address (
@@ -201,7 +282,7 @@ CREATE TABLE address (
 
 <TabItem>
 
-1. Connect to dev/jordan
+1. Connect to your `dev/jordan` branch
 
    By adding `--psql` to the CLI command, you can start the `psql` connection without having to enter the connection string directly:
 
@@ -235,13 +316,54 @@ CREATE TABLE address (
    ```
 
 </TabItem>
+
+<TabItem>
+
+1. Retrieve your database connection string using [Get connection URI](https://api-docs.neon.tech/reference/getconnectionuri) endpoint:
+
+   ```bash
+   curl --request GET \
+     --url 'https://console.neon.tech/api/v2/projects/royal-band-06902338/connection_uri?branch_id=br-mute-dew-a5930esi&database_name=people&role_name=alex' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer $NEON_API_KEY'
+   ```
+
+   The API call will return an connection string similar to this one:
+
+   ```json
+   {
+     "uri": "postgresql://alex:JZb5eKPpg0vD@ep-hidden-sun-a5de9i5h-pooler.us-east-2.aws.neon.tech/people?sslmode=require"
+   }
+   ```
+
+1. Connect to the people database with `psql`:
+
+   ```bash
+   psql 'postgresql://alex:JZb5eKPpg0vD@ep-hidden-sun-a5de9i5h-pooler.us-east-2.aws.neon.tech/people?sslmode=require'
+   ```
+
+1. Add a new address table
+
+   ```sql
+   CREATE TABLE address (
+       id SERIAL PRIMARY KEY,
+       person_id INTEGER NOT NULL,
+       street TEXT NOT NULL,
+       city TEXT NOT NULL,
+       state TEXT NOT NULL,
+       zip_code TEXT NOT NULL,
+       FOREIGN KEY (person_id) REFERENCES person(id)
+   );
+
+</TabItem>
+
 </Tabs>
 
 ## Step 4: View the schema differences
 
 Now that you have some differences between your branches, you can view the schema differences.
 
-<Tabs labels={["Console", "CLI"]}>
+<Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
 
@@ -295,6 +417,128 @@ The result shows a comparison between the `dev/jordan` branch and its parent bra
 +... // [!code ++]
 ```
 
+</TabItem>
+
+<TabItem>
+
+Compare the schema of `dev/jordan` to its parent branch using the `compare-schema` API.
+
+```bash
+curl -X GET \
+  "https://console.neon.tech/api/v2/projects/royal-band-06902338/branches/br-mute-dew-a5930esi/compare_schema" \
+  -G \
+  --data-urlencode "base_branch_id=br-bitter-bird-a56n6lh4" \
+  --data-urlencode "db_name=people" \
+  -H "accept: application/json" \
+  -H "Authorization: Bearer $NEON_API_KEY" | jq -r '.diff'
+```
+
+| Parameter          | Description                                    | Required | Example                    |
+| ------------------ | ---------------------------------------------- | -------- | -------------------------- |
+| `<project_id>`     | The ID of your Neon project.                   | Yes      | `royal-band-06902338` |
+| `<branch_id>`      | The ID of the target branch to compare.        | Yes      | `br-mute-dew-a5930esi`   |
+| `<base_branch_id>` | The ID of the base branch for comparison — the parent branch in this case.      | Yes      | `br-bitter-bird-a56n6lh4`   |
+| `<db_name>`        | The name of the database in the target branch. | Yes      | `people`                   |
+| `Authorization`    | Bearer token for API access (your [Neon API key](https://neon.tech/docs/manage/api-keys))| Yes      | `$NEON_API_KEY`            |
+
+<Admonition type="note">
+The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
+</Admonition>
+
+The result shows a comparison between the `dev/jordan` branch and its parent branch for the database `people`. The output indicates that the `address` table and its related sequences and constraints have been added in the `dev/jordan` branch but are not present in its parent branch.
+
+```diff
+--- a/people
++++ b/people
+@@ -21,6 +21,44 @@
+ SET default_table_access_method = heap;
+ 
+ --
++-- Name: address; Type: TABLE; Schema: public; Owner: alex
++--
++
++CREATE TABLE public.address (
++    id integer NOT NULL,
++    person_id integer NOT NULL,
++    street text NOT NULL,
++    city text NOT NULL,
++    state text NOT NULL,
++    zip_code text NOT NULL
++);
++
++
++ALTER TABLE public.address OWNER TO alex;
++
++--
++-- Name: address_id_seq; Type: SEQUENCE; Schema: public; Owner: alex
++--
++
++CREATE SEQUENCE public.address_id_seq
++    AS integer
++    START WITH 1
++    INCREMENT BY 1
++    NO MINVALUE
++    NO MAXVALUE
++    CACHE 1;
++
++
++ALTER SEQUENCE public.address_id_seq OWNER TO alex;
++
++--
++-- Name: address_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: alex
++--
++
++ALTER SEQUENCE public.address_id_seq OWNED BY public.address.id;
++
++
++--
+ -- Name: person; Type: TABLE; Schema: public; Owner: alex
+ --
+ 
+@@ -56,6 +94,13 @@
+ 
+ 
+ --
++-- Name: address id; Type: DEFAULT; Schema: public; Owner: alex
++--
++
++ALTER TABLE ONLY public.address ALTER COLUMN id SET DEFAULT nextval('public.address_id_seq'::regclass);
++
++
++--
+ -- Name: person id; Type: DEFAULT; Schema: public; Owner: alex
+ --
+ 
+@@ -63,6 +108,14 @@
+ 
+ 
+ --
++-- Name: address address_pkey; Type: CONSTRAINT; Schema: public; Owner: alex
++--
++
++ALTER TABLE ONLY public.address
++    ADD CONSTRAINT address_pkey PRIMARY KEY (id);
++
++
++--
+ -- Name: person person_email_key; Type: CONSTRAINT; Schema: public; Owner: alex
+ --
+ 
+@@ -79,6 +132,14 @@
+ 
+ 
+ --
++-- Name: address address_person_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: alex
++--
++
++ALTER TABLE ONLY public.address
++    ADD CONSTRAINT address_person_id_fkey FOREIGN KEY (person_id) REFERENCES public.person(id);
++
++
++--
+ -- Name: DEFAULT PRIVILEGES FOR SEQUENCES; Type: DEFAULT ACL; Schema: public; Owner: cloud_admin
+ --
+```
 </TabItem>
 
 </Tabs>

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -436,19 +436,13 @@ curl --request GET \
 | `<branch_id>`      | The ID of the target branch to compare.                                                   | Yes      | `br-mute-dew-a5930esi`    |
 | `<base_branch_id>` | The ID of the base branch for comparison — the parent branch in this case.                | Yes      | `br-bitter-bird-a56n6lh4` |
 | `<db_name>`        | The name of the database in the target branch.                                            | Yes      | `people`                  |
-| `lsn`              | The LSN on the target branch for which the schema is retrieved.                           | No       | `0/1EC5378`                |
-| `timestamp`        | The point in time on the target branch for which the schema is retrieved.                 | No       | `2022-11-30T20:09:48Z`     |
-| `base_lsn`         | The LSN for the base branch schema.                                                       | No       | `0/2FC6321`                |
-| `base_timestamp`   | The point in time for the base branch schema.                                             | No       | `2022-11-30T20:09:48Z`     |
 | `Authorization`    | Bearer token for API access (your [Neon API key](https://neon.tech/docs/manage/api-keys)) | Yes      | `$NEON_API_KEY`           |
 
-<Admonition type="note" title="notes">
-- The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
-- `timestamp` or `lsn` / `base_timestamp` or `base_lsn` values can be used to compare schemas as they existed as a precise time or [LSN](/docs/reference/glossary#lsn).  
-- `timestamp` / `base_timestamp` values must be provided in <LinkPreview href="https://en.wikipedia.org/wiki/ISO_8601" title="ISO 8601" preview="An international standard covering the worldwide exchange and communication of date and time-related data.">ISO 8601 format</LinkPreview>.
+<Admonition type="note">
+The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
 </Admonition>
 
-The result shows a comparison between the `dev/jordan` branch and its parent branch for the database `people`. The output indicates that the `address` table and its related sequences and constraints have been added in the `dev/jordan` branch but are not present in its parent branch.
+The result shows a comparison between the `dev/jordan` branch and its parent branch for the database `people`. The output indicates that the `address` table and its related sequences and constraints have been added to the `dev/jordan` branch but are not present in its parent branch.
 
 ```diff
 --- a/people

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -424,13 +424,10 @@ The result shows a comparison between the `dev/jordan` branch and its parent bra
 Compare the schema of the `dev/jordan` branch to its parent branch using the `compare-schema` API.
 
 ```bash
-curl -X GET \
-  "https://console.neon.tech/api/v2/projects/royal-band-06902338/branches/br-mute-dew-a5930esi/compare_schema" \
-  -G \
-  --data-urlencode "base_branch_id=br-bitter-bird-a56n6lh4" \
-  --data-urlencode "db_name=people" \
-  -H "accept: application/json" \
-  -H "Authorization: Bearer $NEON_API_KEY" | jq -r '.diff'
+curl --request GET \
+     --url 'https://console.neon.tech/api/v2/projects/wispy-butterfly-25042691/branches/br-rough-boat-a54bs9yb/compare_schema?base_branch_id=br-royal-star-a54kykl2&db_name=neondb' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer $NEON_API_KEY' | jq -r '.diff'
 ```
 
 | Parameter          | Description                                                                               | Required | Example                   |

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -126,7 +126,7 @@ First, create a new database called `people` on the `main` branch and add some s
 
 3. Connect to the `people` database with `psql`:
 
-   ```bash
+   ```bash shouldWrap
    psql 'postgresql://alex:*********@ep-green-surf-a5yaumj3-pooler.us-east-2.aws.neon.tech/people?sslmode=require'
    ```
 
@@ -331,14 +331,14 @@ CREATE TABLE address (
 
    ```json
    {
-     "uri": "postgresql://alex:JZb5eKPpg0vD@ep-hidden-sun-a5de9i5h-pooler.us-east-2.aws.neon.tech/people?sslmode=require"
+     "uri": "postgresql://alex:*********@ep-hidden-sun-a5de9i5h-pooler.us-east-2.aws.neon.tech/people?sslmode=require"
    }
    ```
 
 1. Connect to the `people` database on the `dev/jordan` branch with `psql`:
 
-   ```bash
-   psql 'postgresql://alex:JZb5eKPpg0vD@ep-hidden-sun-a5de9i5h-pooler.us-east-2.aws.neon.tech/people?sslmode=require'
+   ```bash shouldWrap
+   psql 'postgresql://alex:*********@ep-hidden-sun-a5de9i5h-pooler.us-east-2.aws.neon.tech/people?sslmode=require'
    ```
 
 1. Add a new `address` table.

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -73,7 +73,7 @@ First, create a new database called `people` on the `main` branch and add some s
 
 1. Connect to the `people` database with psql:
 
-   ```bash
+   ```bash shouldWrap
    psql 'postgresql://neondb_owner:*********@ep-crimson-frost-a5i6p18z.us-east-2.aws.neon.tech/people?sslmode=require'
    ```
 

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -436,10 +436,16 @@ curl --request GET \
 | `<branch_id>`      | The ID of the target branch to compare.                                                   | Yes      | `br-mute-dew-a5930esi`    |
 | `<base_branch_id>` | The ID of the base branch for comparison — the parent branch in this case.                | Yes      | `br-bitter-bird-a56n6lh4` |
 | `<db_name>`        | The name of the database in the target branch.                                            | Yes      | `people`                  |
+| `lsn`              | The LSN on the target branch for which the schema is retrieved.                           | No       | `0/1EC5378`                |
+| `timestamp`        | The point in time on the target branch for which the schema is retrieved.                 | No       | `2022-11-30T20:09:48Z`     |
+| `base_lsn`         | The LSN for the base branch schema.                                                       | No       | `0/2FC6321`                |
+| `base_timestamp`   | The point in time for the base branch schema.                                             | No       | `2022-11-30T20:09:48Z`     |
 | `Authorization`    | Bearer token for API access (your [Neon API key](https://neon.tech/docs/manage/api-keys)) | Yes      | `$NEON_API_KEY`           |
 
-<Admonition type="note">
-The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
+<Admonition type="note" title="notes">
+- The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
+- `timestamp` or `lsn` / `base_timestamp` or `base_lsn` values can be used to compare schemas as they existed as a precise time or [LSN](/docs/reference/glossary#lsn).  
+- `timestamp` / `base_timestamp` values must be provided in <LinkPreview href="https://en.wikipedia.org/wiki/ISO_8601" title="ISO 8601" preview="An international standard covering the worldwide exchange and communication of date and time-related data.">ISO 8601 format</LinkPreview>.
 </Admonition>
 
 The result shows a comparison between the `dev/jordan` branch and its parent branch for the database `people`. The output indicates that the `address` table and its related sequences and constraints have been added in the `dev/jordan` branch but are not present in its parent branch.

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -425,7 +425,7 @@ Compare the schema of the `dev/jordan` branch to its parent branch using the `co
 
 ```bash
 curl --request GET \
-     --url 'https://console.neon.tech/api/v2/projects/wispy-butterfly-25042691/branches/br-rough-boat-a54bs9yb/compare_schema?base_branch_id=br-royal-star-a54kykl2&db_name=neondb' \
+     --url 'https://console.neon.tech/api/v2/projects/royal-band-06902338/branches/br-mute-dew-a5930esi/compare_schema?base_branch_id=br-bitter-bird-a56n6lh4&db_name=neondb' \
      --header 'accept: application/json' \
      --header 'authorization: Bearer $NEON_API_KEY' | jq -r '.diff'
 ```

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -92,20 +92,17 @@ To find out what other comparisons you can make, see [Neon CLI commands — bran
 
 ### Using the Neon API
 
-The `compare_schema` endpoint lets you compare schemas between Neon branches programmatically and track schema changes. The endpoint response highlights differences in a `diff` format, making it useful for automating schema migrations and integrating schema checks into CI/CD workflows.
+The [compare_schema](https://api-docs.neon.tech/reference/getprojectbranchschemacomparison) endpoint lets you compare schemas between Neon branches programmatically and track schema changes. The endpoint response highlights differences in a `diff` format, making it useful for automating schema migrations and integrating schema checks into CI/CD workflows.
 
 Another use case for schema diff via the Neon API is AI agent-driven workflows, such as environment setup and schema migrations. The `compare_schema` endpoint allows AI agents to programmatically retrieve schema differences by comparing two Neon branches.
 
 To compare schemas between two branches, use a cURL command similar to the following:
 
 ```bash
-curl -X GET \
-  "https://console.neon.tech/api/v2/projects/wispy-butterfly-25042691/branches/br-rough-boat-a54bs9yb/compare_schema" \
-  -G \
-  --data-urlencode "base_branch_id=br-royal-star-a54kykl2" \
-  --data-urlencode "db_name=neondb" \
-  -H "accept: application/json" \
-  -H "Authorization: Bearer $NEON_API_KEY" | jq -r '.diff'
+curl --request GET \
+     --url 'https://console.neon.tech/api/v2/projects/wispy-butterfly-25042691/branches/br-rough-boat-a54bs9yb/compare_schema?base_branch_id=br-royal-star-a54kykl2&db_name=neondb' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer $NEON_API_KEY' | jq -r '.diff'
 ```
 
 | Parameter          | Description                                                                               | Required | Example                    |

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -111,10 +111,17 @@ curl --request GET \
 | `<branch_id>`      | The ID of the target branch to compare — the branch with the modified schema.             | Yes      | `br-rough-boat-a54bs9yb`   |
 | `<base_branch_id>` | The ID of the base branch for comparison.                                                 | Yes      | `br-royal-star-a54kykl2`   |
 | `<db_name>`        | The name of the database in the target branch.                                            | Yes      | `neondb`                   |
+| `lsn`              | The LSN on the target branch for which the schema is retrieved.                           | No       | `0/1EC5378`                |
+| `timestamp`        | The point in time on the target branch for which the schema is retrieved.                 | No       | `2022-11-30T20:09:48Z`     |
+| `base_lsn`         | The LSN for the base branch schema.                                                       | No       | `0/2FC6321`                |
+| `base_timestamp`   | The point in time for the base branch schema.                                             | No       | `2022-11-30T20:09:48Z`     |
 | `Authorization`    | Bearer token for API access (your [Neon API key](https://neon.tech/docs/manage/api-keys)) | Yes      | `$NEON_API_KEY`            |
 
-<Admonition type="note">
-The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
+
+<Admonition type="note" title="notes">
+- The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
+- `timestamp` or `lsn` / `base_timestamp` or `base_lsn` values can be used to compare schemas as they existed as a precise time or [LSN](/docs/reference/glossary#lsn).  
+- `timestamp` / `base_timestamp` values must be provided in <LinkPreview href="https://en.wikipedia.org/wiki/ISO_8601" title="ISO 8601" preview="An international standard covering the worldwide exchange and communication of date and time-related data.">ISO 8601 format</LinkPreview>.
 </Admonition>
 
 Here’s an example of the `compare_schema` diff output for the `neondb` database after comparing target branch `br-rough-boat-a54bs9yb` with the base branch `br-royal-star-a54kykl2`.

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -89,6 +89,58 @@ neon branch sd dev/alex@0/123456 --db people
 
 To find out what other comparisons you can make, see [Neon CLI commands — branches](/docs/reference/cli-branches#schema-diff) for full documentation of the command.
 
+### Using the Neon API
+
+The `compare_schema` endpoint lets you compare schemas between Neon branches programmatically and track schema changes. The response highlights differences in a `diff` format, making it useful for automating schema migrations and integrating schema checks into CI/CD workflows.
+
+Another use case for the this API is AI agents, which automate workflows like environment setup and running schema migrations. Th`compare_schema` endpoint API enables these agents to retrieve schema differences programmatically by comparing two branches.
+
+To compare schemas between two branches, you can use a curl command similar to the following:
+
+```bash
+url -X GET \
+  "https://console.neon.tech/api/v2/projects/wispy-butterfly-25042691/branches/br-rough-boat-a54bs9yb/compare_schema" \
+  -G \
+  --data-urlencode "base_branch_id=br-royal-star-a54kykl2" \
+  --data-urlencode "db_name=neondb" \
+  -H "accept: application/json" \
+  -H "Authorization: Bearer $NEON_API_KEY" | jq -r '.diff'
+```
+
+| Parameter        | Description                                | Required | Example                    |
+|------------------|--------------------------------------------|----------|----------------------------|
+| `<project_id>`   | The ID of your Neon project.              | Yes      | `wispy-butterfly-25042691` |
+| `<branch_id>`    | The ID of the target branch to compare.   | Yes      | `br-rough-boat-a54bs9yb`   |
+| `base_branch_id` | The ID of the base branch for comparison. | Yes      | `br-royal-star-a54kykl2`   |
+| `db_name`        | The name of the database in the target branch. | Yes      | `neondb`                   |
+| `Authorization`  | Bearer token for API access.              | Yes      | `$NEON_API_KEY`            |
+
+<Admonition type="note">
+The `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read.
+</Admonition>
+
+Here’s an example diff for the `neondb` database after comparing `br-rough-boat-a54bs9yb` with the base branch `br-royal-star-a54kykl2`, where a new column was added to the target branch.
+
+```diff
+--- a/neondb
++++ b/neondb
+@@ -27,7 +27,8 @@
+ CREATE TABLE public.playing_with_neon (
+     id integer NOT NULL,
+     name text NOT NULL,
+-    value real
++    value real,
++    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+ );
+```
+
+**Response explanation:**
+
+- `-` (minus): Lines that were removed from the base branch schema.
+- `+` (plus): Lines that were added in the target branch schema.
+
+In the example above, the `created_at` column was added to the `public.playing_with_neon` table.
+
 ### Understanding the Output
 
 - **+ Green Highlight**: Indicates additions or new elements in the schema.

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -94,12 +94,12 @@ To find out what other comparisons you can make, see [Neon CLI commands — bran
 
 The `compare_schema` endpoint lets you compare schemas between Neon branches programmatically and track schema changes. The endpoint response highlights differences in a `diff` format, making it useful for automating schema migrations and integrating schema checks into CI/CD workflows.
 
-Another use case for schema diff via the Neon API is AI agent-driven workflows, such as environment setup and schema migrations. The `compare_schema` endpoint allows AI agents to programmatically retrieve schema differences by comparing two branches.
+Another use case for schema diff via the Neon API is AI agent-driven workflows, such as environment setup and schema migrations. The `compare_schema` endpoint allows AI agents to programmatically retrieve schema differences by comparing two Neon branches.
 
 To compare schemas between two branches, use a cURL command similar to the following:
 
 ```bash
-url -X GET \
+curl -X GET \
   "https://console.neon.tech/api/v2/projects/wispy-butterfly-25042691/branches/br-rough-boat-a54bs9yb/compare_schema" \
   -G \
   --data-urlencode "base_branch_id=br-royal-star-a54kykl2" \
@@ -111,7 +111,7 @@ url -X GET \
 | Parameter          | Description                                                                               | Required | Example                    |
 | ------------------ | ----------------------------------------------------------------------------------------- | -------- | -------------------------- |
 | `<project_id>`     | The ID of your Neon project.                                                              | Yes      | `wispy-butterfly-25042691` |
-| `<branch_id>`      | The ID of the target branch to compare.                                                   | Yes      | `br-rough-boat-a54bs9yb`   |
+| `<branch_id>`      | The ID of the target branch to compare — the branch with the modified schema.             | Yes      | `br-rough-boat-a54bs9yb`   |
 | `<base_branch_id>` | The ID of the base branch for comparison.                                                 | Yes      | `br-royal-star-a54kykl2`   |
 | `<db_name>`        | The name of the database in the target branch.                                            | Yes      | `neondb`                   |
 | `Authorization`    | Bearer token for API access (your [Neon API key](https://neon.tech/docs/manage/api-keys)) | Yes      | `$NEON_API_KEY`            |
@@ -120,7 +120,7 @@ url -X GET \
 The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
 </Admonition>
 
-Here’s an example of the `compare_schema` diff output for the `neondb` database after comparing `br-rough-boat-a54bs9yb` with the base branch `br-royal-star-a54kykl2`, where a new column was added to the target branch.
+Here’s an example of the `compare_schema` diff output for the `neondb` database after comparing target branch `br-rough-boat-a54bs9yb` with the base branch `br-royal-star-a54kykl2`.
 
 ```diff
 --- a/neondb

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -107,13 +107,13 @@ url -X GET \
   -H "Authorization: Bearer $NEON_API_KEY" | jq -r '.diff'
 ```
 
-| Parameter        | Description                                | Required | Example                    |
-|------------------|--------------------------------------------|----------|----------------------------|
-| `<project_id>`   | The ID of your Neon project.              | Yes      | `wispy-butterfly-25042691` |
-| `<branch_id>`    | The ID of the target branch to compare.   | Yes      | `br-rough-boat-a54bs9yb`   |
-| `base_branch_id` | The ID of the base branch for comparison. | Yes      | `br-royal-star-a54kykl2`   |
+| Parameter        | Description                                    | Required | Example                    |
+| ---------------- | ---------------------------------------------- | -------- | -------------------------- |
+| `<project_id>`   | The ID of your Neon project.                   | Yes      | `wispy-butterfly-25042691` |
+| `<branch_id>`    | The ID of the target branch to compare.        | Yes      | `br-rough-boat-a54bs9yb`   |
+| `base_branch_id` | The ID of the base branch for comparison.      | Yes      | `br-royal-star-a54kykl2`   |
 | `db_name`        | The name of the database in the target branch. | Yes      | `neondb`                   |
-| `Authorization`  | Bearer token for API access.              | Yes      | `$NEON_API_KEY`            |
+| `Authorization`  | Bearer token for API access.                   | Yes      | `$NEON_API_KEY`            |
 
 <Admonition type="note">
 The `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read.

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -92,11 +92,11 @@ To find out what other comparisons you can make, see [Neon CLI commands — bran
 
 ### Using the Neon API
 
-The [compare_schema](https://api-docs.neon.tech/reference/getprojectbranchschemacomparison) endpoint lets you compare schemas between Neon branches programmatically and track schema changes. The endpoint response highlights differences in a `diff` format, making it useful for automating schema migrations and integrating schema checks into CI/CD workflows.
+The [compare_schema](https://api-docs.neon.tech/reference/getprojectbranchschemacomparison) endpoint lets you compare schemas between Neon branches to track schema changes. The response highlights differences in a `diff` format, making it a useful tool for integrating schema checks into CI/CD workflows.
 
-Another use case for schema diff via the Neon API is AI agent-driven workflows, such as environment setup and schema migrations. The `compare_schema` endpoint allows AI agents to programmatically retrieve schema differences by comparing two Neon branches.
+Another use case for schema diff via the Neon API is AI agent-driven workflows. The `compare_schema` endpoint allows AI agents to programmatically retrieve schema differences by comparing two branches.
 
-To compare schemas between two branches, use a cURL command similar to the following:
+To compare schemas between two branches, you can cURL command similar to the one below, which compares the schema of a target branch to the schema of a base branch. For example, the target branch could be a development branch where a schema change was applied, and the base branch could be the parent of the development branch. By comparing the two, you can inspect the changes that have been made on the development branch.
 
 ```bash
 curl --request GET \
@@ -104,6 +104,8 @@ curl --request GET \
      --header 'accept: application/json' \
      --header 'authorization: Bearer $NEON_API_KEY' | jq -r '.diff'
 ```
+
+The `compare_schema` endpoint supports the following parameters:
 
 | Parameter          | Description                                                                               | Required | Example                    |
 | ------------------ | ----------------------------------------------------------------------------------------- | -------- | -------------------------- |
@@ -119,7 +121,7 @@ curl --request GET \
 
 
 <Admonition type="note" title="notes">
-- The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
+- The optional `jq -r '.diff'` command APPENDED TO THE EXAMPLE ABOVE extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command is not  necessary when using the endpoint programmatically.
 - `timestamp` or `lsn` / `base_timestamp` or `base_lsn` values can be used to compare schemas as they existed as a precise time or [LSN](/docs/reference/glossary#lsn).  
 - `timestamp` / `base_timestamp` values must be provided in <LinkPreview href="https://en.wikipedia.org/wiki/ISO_8601" title="ISO 8601" preview="An international standard covering the worldwide exchange and communication of date and time-related data.">ISO 8601 format</LinkPreview>.
 </Admonition>
@@ -141,10 +143,10 @@ Here’s an example of the `compare_schema` diff output for the `neondb` databas
 
 **Output explanation:**
 
-- `-` (minus): Lines that were removed from the base branch schema.
-- `+` (plus): Lines that were added in the target branch schema.
+- `-` (minus) identifies Lines that were removed from the base branch schema.
+- `+` (plus) identifies lines that were added in the target branch schema.
 
-In the example above, the `created_at` column was added to the `public.playing_with_neon` table.
+In the example above, the `created_at` column was added to the `public.playing_with_neon` table on the target branch.
 
 ## Schema Diff GitHub Action
 

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -14,7 +14,7 @@ Schema Diff is available in the Neon Console for use in two ways:
 - Compare a branch's schema to its parent
 - Compare selected branches during a branch restore operation
 
-You can also use the `branches schema-diff` command in the Neon CLI to effect a variety of comparisons.
+You can also use the `branches schema-diff` command in the Neon CLI or `compare-schema` endpoint in the Neon API to effect a variety of comparisons.
 
 ### Compare to parent
 
@@ -24,9 +24,9 @@ In the detailed view for any child branch, you can check the schema differences 
 
 Built into the Time Travel assist editor, you can use Schema Diff to help when restoring branches, letting you compare states of your branch against its own or another branch's history before you complete a [branch restore](/docs/guides/branch-restore) operation.
 
-### Comparisons using the CLI
+### Comparisons using the CLI or API
 
-You can use the Neon CLI to compare a branch to any point in its own or any other branch's history. The `branches schema-diff` command offers full flexibility for any type of schema comparison: between a branch and its parent, a branch and its earlier state, or a branch to the head or prior state of another branch.
+You can use the Neon CLI to compare a branch to any point in its own or any other branch's history. The `branches schema-diff` command offers full flexibility for any type of schema comparison: between a branch and its parent, a branch and its earlier state, or a branch to the head or prior state of another branch. The Neon API provides a `compare-schema` endpoint that lets you compare schemas between Neon branches programmatically, supporting CI/CD automation and AI agent use cases.
 
 ### Practical Applications
 
@@ -34,6 +34,7 @@ You can use the Neon CLI to compare a branch to any point in its own or any othe
 - **Audit Changes**: Historically compare schema changes to understand the evolution of your database structure.
 - **Consistency Checks**: Ensure environment consistency by comparing schemas across development, staging, and production branches.
 - **Automation**: Integrate schema-diff into CI/CD pipelines to automatically compare schemas during deployments.
+- **AI Agents**: Enable AI agents to retrieve schema differences programmatically to support agent-driven database migrations. 
 
 ## How to Use Schema Diff
 
@@ -91,11 +92,11 @@ To find out what other comparisons you can make, see [Neon CLI commands — bran
 
 ### Using the Neon API
 
-The `compare_schema` endpoint lets you compare schemas between Neon branches programmatically and track schema changes. The response highlights differences in a `diff` format, making it useful for automating schema migrations and integrating schema checks into CI/CD workflows.
+The `compare_schema` endpoint lets you compare schemas between Neon branches programmatically and track schema changes. The endpoint response highlights differences in a `diff` format, making it useful for automating schema migrations and integrating schema checks into CI/CD workflows.
 
-Another use case for the this API is AI agents, which automate workflows like environment setup and running schema migrations. Th`compare_schema` endpoint API enables these agents to retrieve schema differences programmatically by comparing two branches.
+Another use case for schema diff via the Neon API is AI agent-driven workflows, such as environment setup and schema migrations. The `compare_schema` endpoint allows AI agents to programmatically retrieve schema differences by comparing two branches.
 
-To compare schemas between two branches, you can use a curl command similar to the following:
+To compare schemas between two branches, use a cURL command similar to the following:
 
 ```bash
 url -X GET \
@@ -107,19 +108,19 @@ url -X GET \
   -H "Authorization: Bearer $NEON_API_KEY" | jq -r '.diff'
 ```
 
-| Parameter        | Description                                    | Required | Example                    |
-| ---------------- | ---------------------------------------------- | -------- | -------------------------- |
-| `<project_id>`   | The ID of your Neon project.                   | Yes      | `wispy-butterfly-25042691` |
-| `<branch_id>`    | The ID of the target branch to compare.        | Yes      | `br-rough-boat-a54bs9yb`   |
-| `base_branch_id` | The ID of the base branch for comparison.      | Yes      | `br-royal-star-a54kykl2`   |
-| `db_name`        | The name of the database in the target branch. | Yes      | `neondb`                   |
-| `Authorization`  | Bearer token for API access.                   | Yes      | `$NEON_API_KEY`            |
+| Parameter          | Description                                    | Required | Example                    |
+| ------------------ | ---------------------------------------------- | -------- | -------------------------- |
+| `<project_id>`     | The ID of your Neon project.                   | Yes      | `wispy-butterfly-25042691` |
+| `<branch_id>`      | The ID of the target branch to compare.        | Yes      | `br-rough-boat-a54bs9yb`   |
+| `<base_branch_id>` | The ID of the base branch for comparison.      | Yes      | `br-royal-star-a54kykl2`   |
+| `<db_name>`        | The name of the database in the target branch. | Yes      | `neondb`                   |
+| `Authorization`    | Bearer token for API access (your [Neon API key](https://neon.tech/docs/manage/api-keys))| Yes      | `$NEON_API_KEY`            |
 
 <Admonition type="note">
-The `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read.
+The optional `jq -r '.diff'` command extracts the diff field from the JSON response and outputs it as plain text to make it easier to read. This command would not be necessary when using the endpoint programmatically.
 </Admonition>
 
-Here’s an example diff for the `neondb` database after comparing `br-rough-boat-a54bs9yb` with the base branch `br-royal-star-a54kykl2`, where a new column was added to the target branch.
+Here’s an example of the `compare_schema` diff output for the `neondb` database after comparing `br-rough-boat-a54bs9yb` with the base branch `br-royal-star-a54kykl2`, where a new column was added to the target branch.
 
 ```diff
 --- a/neondb
@@ -134,17 +135,12 @@ Here’s an example diff for the `neondb` database after comparing `br-rough-boa
  );
 ```
 
-**Response explanation:**
+**Output explanation:**
 
 - `-` (minus): Lines that were removed from the base branch schema.
 - `+` (plus): Lines that were added in the target branch schema.
 
 In the example above, the `created_at` column was added to the `public.playing_with_neon` table.
-
-### Understanding the Output
-
-- **+ Green Highlight**: Indicates additions or new elements in the schema.
-- **- Red Highlight**: Marks deletions or removed elements from the schema.
 
 ## Schema Diff GitHub Action
 


### PR DESCRIPTION
Schema diff topic update:
https://neon-next-git-dprice-schema-diff-api-neondatabase.vercel.app/docs/guides/schema-diff#using-the-neon-api

Schema diff tutorial update to include API tabs:
https://neon-next-git-dprice-schema-diff-api-neondatabase.vercel.app/docs/guides/schema-diff-tutorial

Note: The compare-schema API is not public yet. I still need to add a link to the endpoint in the API Ref.
