### PR TITLE
Update Outdated neon+auth0+drizzle Integration Docs

### DIFF
--- a/content/docs/guides/auth-auth0.md
+++ b/content/docs/guides/auth-auth0.md
@@ -186,9 +186,9 @@ if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL not found in enviro
 export default {
   schema: './app/db/schema.ts',
   out: './drizzle',
-  driver: 'pg',
+  dialect: 'postgresql',
   dbCredentials: {
-    connectionString: process.env.DATABASE_URL,
+    url: process.env.DATABASE_URL,
   },
   strict: true,
 } satisfies Config;
@@ -197,13 +197,13 @@ export default {
 Now, generate the migration files by running the following command:
 
 ```bash
-npx drizzle-kit generate:pg
+npx drizzle-kit generate
 ```
 
 This will create a `drizzle` folder at the project root with the migration files. To apply the migration to the database, run:
 
 ```bash
-npx drizzle-kit push:pg
+npx drizzle-kit push
 ```
 
 The `user_messages` table will now be visible in the Neon console.


### PR DESCRIPTION
Update auth0 integration docs with drizzle.

For `Config` from `drizzle-kit`...
1. `pg` is no longer assignable to `Config["driver"]` see https://orm.drizzle.team/docs/drizzle-config-file#driver

2. `connectionString` is not a key of `Config["dbCredentials"]` see https://orm.drizzle.team/docs/drizzle-config-file#dbcredentials

For `drizzle-kit` commands, the commands appear to be deprecated.

```shell
❯ npx drizzle-kit generate:pg
This command is deprecated, please use updated 'generate' command (see https://orm.drizzle.team/kit-docs/upgrade-21#how-to-migrate-to-0210)
```

Running the commands without the `:pg` appeared to run successfully and created the table in the neon DB. `pg` appears to still run under the covers.

```shell
❯ npx drizzle-kit push
No config path provided, using default 'drizzle.config.ts'
Reading config file '/Users/$NAME/PROJECT/drizzle.config.ts'
Using 'pg' driver for database querying
[✓] Pulling schema from database...
[✓] Changes applied
```