### PR TITLE
Update correct next link in postgresql-having.md

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-having.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-having.md
@@ -10,8 +10,8 @@ previousLink:
   title: 'PostgreSQL GROUP BY'
   slug: 'postgresql-tutorial/postgresql-group-by'
 nextLink:
-  title: 'PostgreSQL UNION'
-  slug: 'postgresql-tutorial/postgresql-union'
+  title: 'PostgreSQL GROUPING SETS'
+  slug: 'postgresql-tutorial/postgresql-grouping-sets'
 ---
 
 **Summary**: in this tutorial, you will learn how to use the **PostgreSQL HAVING** clause to specify a search condition for a group or an aggregate.


### PR DESCRIPTION
https://neon.tech/postgresql/postgresql-tutorial/postgresql-having has next link as https://neon.tech/postgresql/postgresql-tutorial/postgresql-union but sidebar indicates that next link should be postgresql-grouping-sets