### PR TITLE
Fix: Correct case of "and" to "AND" in postgresql-and.md

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-and.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-and.md
@@ -145,7 +145,7 @@ Output:
 The following example uses the `AND` operator to combine null with null, which returns null:
 
 ```sql
-SELECT null and null AS result;
+SELECT null AND null AS result;
 ```
 
 Output:


### PR DESCRIPTION
- Updated the logical operator "and" to the uppercase "AND" for consistency and correctness in the PostgreSQL documentation.