### PR TITLE
Update next tutorial link as per the sidebar document

### DIFF
--- a/content/postgresql/postgresql-tutorial/export-postgresql-table-to-csv-file.md
+++ b/content/postgresql/postgresql-tutorial/export-postgresql-table-to-csv-file.md
@@ -10,8 +10,8 @@ previousLink:
   title: 'Import CSV File Into PostgreSQL Table'
   slug: 'postgresql-tutorial/import-csv-file-into-posgresql-table'
 nextLink:
-  title: 'PostgreSQL Data Types'
-  slug: 'postgresql-tutorial/postgresql-data-types'
+  title: 'Subquery'
+  slug: 'postgresql-tutorial/postgresql-subquery'
 ---
 
 **Summary**: in this tutorial, you will learn various techniques to export data from PostgreSQL tables to CSV files.


### PR DESCRIPTION
fix : https://neon.tech/postgresql/postgresql-tutorial/export-postgresql-table-to-csv-file this page omits the link to Subquery section and links to Data types