### PR TITLE
Fix: Correct case of "from" to "FROM" and "where" to "WHERE" in postgresql-subquery.md

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-subquery.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-subquery.md
@@ -33,7 +33,7 @@ WHERE
   columnA operator (
     SELECT
       columnB
-    from
+    FROM
       table2
     WHERE
       condition
@@ -45,7 +45,7 @@ In this syntax, the subquery is enclosed within parentheses and is executed firs
 ```sql
 SELECT
   columnB
-from
+FROM
   table2
 WHERE
   condition
@@ -64,9 +64,9 @@ First, retrieve the country id of the `United States` from the `country` table:
 ```sql
 SELECT
   country_id
-from
+FROM
   country
-where
+WHERE
   country = 'United States';
 ```
 


### PR DESCRIPTION
#### Updated postgresql-subquery.md for better readability and consistency by changing:
- from to FROM
- where to WHERE