### PR TITLE
Clarify anonymous role in Neon Authorize

### DIFF
--- a/content/docs/guides/neon-authorize.md
+++ b/content/docs/guides/neon-authorize.md
@@ -47,13 +47,13 @@ Behind the scenes, the [Neon Proxy](#the-role-of-the-neon-proxy) performs the va
 
 ## Database roles
 
-Neon Authorize works with two primary database roles:
+Neon Authorize works with two database roles, identified by connection string prefixes:
 
-- **Authenticated role**: This role is intended for users who are logged in. Your application should send the authorization token when connecting using this role.
-- **Anonymous role**: This role is intended for users who are not logged in. It should allow limited access, such as reading public content (e.g., blog posts) without authentication.
+- **Authenticated role** (`authenticated@`): For users who are logged in. Requires a valid JWT token from your authentication provider.
+- **Anonymous role** (`anonymous@`): Currently requires authentication similar to the authenticated role. This implementation is under review and may change in the future to better support unauthenticated access.
 
 <Admonition type="note">
-Some authentication providers, like Firebase, support "anonymous authentication" where a unique user ID is automatically generated for visitors who haven't explicitly logged in. This is useful for features like shopping carts, where you want to track a user's actions before they create an account. These anonymous users will still have a valid JWT and can use the anonymous role, making it possible to track their actions while maintaining security.
+For now, if you need to implement public access in your application, we recommend creating a separate database role with a password. This provides a simpler alternative to using the anonymous role while we work on improving anonymous access support.
 </Admonition>
 
 ### Using Neon Authorize with custom JWTs


### PR DESCRIPTION
Some changes to the database roles description to address customer confusion i.e, in this ticket:
https://neon.zendesk.com/agent/tickets/4724

[preview](https://neon-next-git-bgrenon-clarify-anonymous-role-neondatabase.vercel.app/docs/guides/neon-authorize#database-roles)

@davidgomes do you agree with this wording? It's revised to basically recommend against using the anonymous role
CC @KyleNeonTech 