### PR TITLE
chore: force disable "website_growth_compute_price_rising" exp

### DIFF
--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -34,7 +34,7 @@ const scaleCardBorderVariants = {
 const Hero = () => {
   const posthog = usePostHog();
   const isComputePriceRaised =
-    useFeatureFlagVariantKey('website_growth_compute_price_rising') === 'show_0_24';
+    useFeatureFlagVariantKey('website_growth_compute_price_rising') === 'show_0_24' && false;
 
   const plans = useMemo(() => {
     if (isComputePriceRaised) {

--- a/src/components/pages/pricing/plans/table/table.jsx
+++ b/src/components/pages/pricing/plans/table/table.jsx
@@ -99,7 +99,7 @@ const getColumnAlignment = (item) => {
 const Table = () => {
   const posthog = usePostHog();
   const isComputePriceRaised =
-    useFeatureFlagVariantKey('website_growth_compute_price_rising') === 'show_0_24';
+    useFeatureFlagVariantKey('website_growth_compute_price_rising') === 'show_0_24' && false;
 
   const tableData = useMemo(() => {
     if (isComputePriceRaised) {


### PR DESCRIPTION
Relates to [linear.app/neondb/issue/GRW-290/experiment-build](https://linear.app/neondb/issue/GRW-290/experiment-build)

I want to disable this experiment in code and run experiment again to check posthog's results in this case, where we 100% sure that there are no any actual changes.

The previous results of experiment is very suspicious for me https://us.posthog.com/project/49356/experiments/68916

Later I will remove this exp from codebase completely.