### PR TITLE
fix: docs mobile issues

### DIFF
--- a/content/use-cases/database-per-tenant.md
+++ b/content/use-cases/database-per-tenant.md
@@ -116,4 +116,4 @@ author={{
 }}
 />
 
-<CTA title="Next Steps" description="Sign up here to get the Free Plan plus $100 credit.<br/> Or <a href='/contact-sales'>talk to our team</a> if you have any questions." buttonText="Get the Free Plan + $100 Credit" buttonUrl="https://fyi.neon.tech/credits" />
+<CTA title="Next Steps" description="Sign up here to get the Free Plan plus $100 credit. Or&nbsp;<a href='/contact-sales'>talk to our team</a> if you have any questions." buttonText="Get the Free Plan + $100 Credit" buttonUrl="https://fyi.neon.tech/credits" />

--- a/content/use-cases/postgres-for-saas.md
+++ b/content/use-cases/postgres-for-saas.md
@@ -163,4 +163,4 @@ Pay via AWS/Azure Marketplace
 
 </DefinitionList>
 
-<CTA title="Next Steps" description="Sign up here to get the Free Plan plus $100 credit.<br/> Or <a href='/contact-sales'>talk to our team</a> if you have any questions." buttonText="Get the Free Plan + $100 Credit" buttonUrl="https://fyi.neon.tech/credits" />
+<CTA title="Next Steps" description="Sign up here to get the Free Plan plus $100 credit. Or&nbsp;<a href='/contact-sales'>talk to our team</a> if you have any questions." buttonText="Get the Free Plan + $100 Credit" buttonUrl="https://fyi.neon.tech/credits" />

--- a/src/app/(docs)/ai-chat/page.jsx
+++ b/src/app/(docs)/ai-chat/page.jsx
@@ -46,7 +46,7 @@ const AiChatPage = async () => {
         >
           <ModeToggler className="hidden shrink-0 md:flex" isAiChatPage />
           <h1 className="sr-only">Neon AI Chat</h1>
-          <div className="col-span-7 col-start-2 -ml-6 flex w-full max-w-[832px] flex-1 items-center justify-center 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 lg:max-w-none">
+          <div className="col-span-7 col-start-2 -ml-6 flex w-full max-w-[832px] flex-1 items-center justify-center 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 lg:max-w-full">
             <InkeepEmbedded />
           </div>
         </Container>

--- a/src/app/(docs)/docs/changelog/[...slug]/page.jsx
+++ b/src/app/(docs)/docs/changelog/[...slug]/page.jsx
@@ -101,7 +101,7 @@ const ChangelogPost = async ({ currentSlug }) => {
         />
       )}
 
-      <div className="col-span-9 col-start-3 -ml-6 flex max-w-[832px] flex-col 3xl:col-span-10 3xl:col-start-2 3xl:ml-0 2xl:col-span-11 2xl:col-start-1 xl:max-w-[calc(100vw-366px)] lg:ml-0 lg:max-w-none lg:pt-0 md:mx-auto md:pb-[70px] sm:pb-8">
+      <div className="col-span-9 col-start-3 -ml-6 flex max-w-[832px] flex-col 3xl:col-span-10 3xl:col-start-2 3xl:ml-0 2xl:col-span-11 2xl:col-start-1 xl:max-w-[calc(100vw-366px)] lg:ml-0 lg:max-w-full lg:pt-0 md:mx-auto md:pb-[70px] sm:pb-8">
         <Hero
           className="flex justify-center lg:pt-16 md:py-10 sm:py-7"
           date={label}

--- a/src/components/pages/doc/detail-icon-cards/detail-icon-cards.jsx
+++ b/src/components/pages/doc/detail-icon-cards/detail-icon-cards.jsx
@@ -164,7 +164,7 @@ const DetailIconCards = ({ children = null, withNumbers = false }) => {
   const ListComponent = withNumbers ? 'ol' : 'ul';
 
   return (
-    <ListComponent className="not-prose !my-10 grid auto-rows-fr grid-cols-2 gap-5 !p-0 sm:grid-cols-1">
+    <ListComponent className="not-prose !my-10 grid grid-cols-2 gap-5 !p-0 sm:grid-cols-1">
       {React.Children.map(children, (child, index) => {
         const { children, href, description, icon, target } = child.props ?? {};
         const Icon = icons[icon];

--- a/src/components/pages/doc/post/post.jsx
+++ b/src/components/pages/doc/post/post.jsx
@@ -89,7 +89,7 @@ const Post = ({
           'flex flex-col lg:ml-0 lg:pt-0 md:mx-auto md:pb-[70px] sm:pb-8',
           isUseCase
             ? 'col-span-6 col-start-4 -mx-10 2xl:col-span-7 2xl:col-start-3 2xl:mx-0 xl:col-span-10 xl:col-start-2'
-            : 'col-span-7 col-start-2 -ml-6 max-w-[832px] 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 lg:max-w-none'
+            : 'col-span-7 col-start-2 -ml-6 max-w-[832px] 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 lg:max-w-full'
         )}
       >
         {breadcrumbs.length > 0 && (

--- a/src/components/shared/cta-block/cta-block.jsx
+++ b/src/components/shared/cta-block/cta-block.jsx
@@ -54,7 +54,7 @@ const CtaBlock = ({
   >
     <div
       className={clsx(
-        'sm:gap-[18px sm:flex-col] relative z-10 flex gap-6 sm:items-center',
+        'relative z-10 flex gap-6 sm:flex-col sm:items-center sm:gap-[18px]',
         themeClassNames[theme].container
       )}
     >
@@ -63,7 +63,7 @@ const CtaBlock = ({
         {description && (
           <p
             className={clsx(
-              'mt-2.5 [&>a:hover]:underline [&>a]:text-primary-2',
+              'mt-2.5 text-pretty [&>a:hover]:underline [&>a]:text-primary-2',
               sizeClassNames[size].description,
               hasDecor ? 'text-gray-new-70' : 'text-gray-new-60'
             )}

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -177,7 +177,7 @@
       > code {
         text-shadow: unset;
 
-        @apply !font-mono text-sm !text-black-new dark:!text-white dark:![text-shadow:unset] md:min-w-[686px];
+        @apply !font-mono text-sm !text-black-new dark:!text-white dark:![text-shadow:unset];
       }
     }
 


### PR DESCRIPTION
This PR brings fixes for Docs mobile:

- Docs layout overflow - [Preview](https://neon-next-git-docs-mobile-fixes-neondatabase.vercel.app/docs/import/migration-assistant)
![image](https://github.com/user-attachments/assets/30a40b44-0942-40ba-99fd-25129e720e6a)
- detail-icons-cards auto height - [Preview](https://neon-next-git-docs-mobile-fixes-neondatabase.vercel.app/docs/introduction)
![image](https://github.com/user-attachments/assets/69a462a3-010c-4760-a200-86cb664b6871)
- use-cases CTA - [Preview](https://neon-next-git-docs-mobile-fixes-neondatabase.vercel.app/use-cases/postgres-for-saas)
![image](https://github.com/user-attachments/assets/18c06cc6-366d-4fac-95d3-68829d6fe859)

[Preview](https://neon-next-git-docs-mobile-fixes-neondatabase.vercel.app/docs/introduction)