### PR TITLE
Fix branch reset instructions in CI/CD section

### DIFF
--- a/content/docs/guides/reset-from-parent.md
+++ b/content/docs/guides/reset-from-parent.md
@@ -53,7 +53,7 @@ Using the CLI, you can reset a branch from parent using the following command:
 neon branches reset <id|name> --parent
 ```
 
-In the `id|name` field, specify the branch ID or name of the child branch whose data you want to reset. The `--parent` parameter specifies the kind of reset action that Neon will perform.
+In the `id|name` field, specify the branch ID or name of the child branch whose data you want to reset. The `--parent` parameter is a boolean specifying the kind of reset action that Neon will perform.
 
 If you have multiple projects in your account, you'll also have to include the `project-id` in the command along with the branch.
 
@@ -96,20 +96,20 @@ You can include resetting database branches as part of your CI/CD workflow. For 
 
 ### For new features
 
-Initiate feature development by resetting your development branch to align with staging or production, ensuring a fresh starting point. Use the command:
+Start feature development with a clean slate by resetting your development branch to align with staging or production (whichever is its parent). This replaces the branch's current state with the parent's latest data and schema. Use the command:
 
 ```bash
-neon branches reset --name dev-branch --parent staging
+neon branches reset dev-branch --parent
 ```
 
-This strategy preserves a stable connection string for your development environment, while still giving your team a clean slate for each new feature.
+This strategy preserves a stable connection string for your development environment, while still ensuring every new feature begins with a fully updated and consistent environment.
 
 ### Refresh staging
 
-Keep **staging** in sync with **production** to minimize discrepancies. Automate staging updates with:
+Reset **staging** to match its parent branch (i.e., **production**) for a reliable testing baseline. Automate staging updates with:
 
 ```bash
-neon branches reset --name staging --parent main
+neon branches reset staging --parent
 ```
 
 This ensures staging accurately reflects the current production state for reliable testing.


### PR DESCRIPTION
preview:
https://neon-next-git-bgrenon-fix-branch-reset-example-neondatabase.vercel.app/docs/guides/reset-from-parent#integrating-branch-resets-in-cicd-workflows