### PR TITLE
fix: reset cache control for docs tech logos

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -84,6 +84,15 @@ const defaultConfig = {
         ],
       },
       {
+        source: '/images/technology-logos/:all*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, must-revalidate',
+          },
+        ],
+      },
+      {
         source: '/blog/parsing-json-from-postgres-in-js',
         headers: [
           {


### PR DESCRIPTION
This PR reset cache control for docs tech logos that need to be revalidated frequently to ensure they are up-to-date

We already disabled cache for docs images in `public/docs/` folder in this PR: https://github.com/neondatabase/website/pull/1216

But it turned out that we have tech logos in the separate folder `public/images/technology-logos/`, so this PR is updating the cache control reset for this folder too.

[Preview](https://neon-next-git-tech-logos-cache-fix-neondatabase.vercel.app/docs)