### PR TITLE
feat: add analytics for Inkeep

### DIFF
--- a/src/components/shared/inkeep-embedded/inkeep-embedded.jsx
+++ b/src/components/shared/inkeep-embedded/inkeep-embedded.jsx
@@ -64,7 +64,7 @@ const InkeepEmbedded = ({ isDarkTheme = false }) => {
       logEventCallback: (event) => {
         const { eventName, properties } = event;
         if (eventName === 'chat_message_submitted') {
-          sendGtagEvent(eventName, { text: properties.content });
+          sendGtagEvent('AI Chat Message Submitted', { text: properties.content });
         }
       },
     },

--- a/src/components/shared/inkeep-embedded/inkeep-embedded.jsx
+++ b/src/components/shared/inkeep-embedded/inkeep-embedded.jsx
@@ -5,6 +5,7 @@ import { useTheme } from 'next-themes';
 import { PropTypes } from 'prop-types';
 
 import { aiChatSettings, baseSettings } from 'lib/inkeep-settings';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const Skeleton = () => (
   <div className="w-full flex-col justify-center overflow-hidden">
@@ -59,6 +60,12 @@ const InkeepEmbedded = ({ isDarkTheme = false }) => {
             'grayDark.900': '#000',
           },
         },
+      },
+      logEventCallback: (event) => {
+        const { eventName, properties } = event;
+        if (eventName === 'chat_message_submitted') {
+          sendGtagEvent(eventName, { text: properties.content });
+        }
       },
     },
     aiChatSettings: {

--- a/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
+++ b/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
@@ -77,7 +77,7 @@ const InkeepTrigger = ({ className = null, isNotFoundPage = false, docPageType =
       logEventCallback: (event) => {
         const { eventName, properties } = event;
         if (eventName === 'search_query_submitted') {
-          sendGtagEvent(eventName, { text: properties.query });
+          sendGtagEvent('Search Query Submitted', { text: properties.query });
         }
       },
     },

--- a/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
+++ b/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState } from 'react';
 import InkeepSearch from 'components/shared/inkeep-search';
 import LINKS from 'constants/links';
 import { baseSettings } from 'lib/inkeep-settings';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const InkeepCustomTrigger = dynamic(
   () => import('@inkeep/uikit').then((mod) => mod.InkeepCustomTrigger),
@@ -73,6 +74,12 @@ const InkeepTrigger = ({ className = null, isNotFoundPage = false, docPageType =
         stylesheetUrls: ['/inkeep/css/base.css', '/inkeep/css/modal.css'],
       },
       optOutFunctionalCookies: true,
+      logEventCallback: (event) => {
+        const { eventName, properties } = event;
+        if (eventName === 'search_query_submitted') {
+          sendGtagEvent(eventName, { text: properties.query });
+        }
+      },
     },
     modalSettings: {
       defaultView: 'SEARCH',

--- a/src/lib/inkeep-settings.js
+++ b/src/lib/inkeep-settings.js
@@ -1,4 +1,28 @@
 import closeIcon from 'icons/close.svg';
+import sendGtagEvent from 'utils/send-gtag-event';
+
+// All available events are listed here:
+// https://docs.inkeep.com/customization-guides/use-your-own-analytics#available-events
+const EVENTS_TO_TRACK = [
+  {
+    name: 'search_query_submitted',
+    prop: 'query',
+  },
+  {
+    name: 'chat_message_submitted',
+    prop: 'content',
+  },
+];
+
+const analyticsCallback = (event) => {
+  const { eventName, properties } = event;
+  const eventToTrack = EVENTS_TO_TRACK.find((e) => e.name === eventName);
+  if (eventToTrack) {
+    sendGtagEvent(eventName, {
+      [eventToTrack.prop]: properties[eventToTrack.prop],
+    });
+  }
+};
 
 const baseSettings = {
   apiKey: process.env.INKEEP_INTEGRATION_API_KEY,
@@ -50,6 +74,7 @@ const baseSettings = {
       searchTabLabel: 'Changelog',
     },
   ],
+  logEventCallback: analyticsCallback,
 };
 
 const searchSettings = {

--- a/src/lib/inkeep-settings.js
+++ b/src/lib/inkeep-settings.js
@@ -1,28 +1,4 @@
 import closeIcon from 'icons/close.svg';
-import sendGtagEvent from 'utils/send-gtag-event';
-
-// All available events are listed here:
-// https://docs.inkeep.com/customization-guides/use-your-own-analytics#available-events
-const EVENTS_TO_TRACK = [
-  {
-    name: 'search_query_submitted',
-    prop: 'query',
-  },
-  {
-    name: 'chat_message_submitted',
-    prop: 'content',
-  },
-];
-
-const analyticsCallback = (event) => {
-  const { eventName, properties } = event;
-  const eventToTrack = EVENTS_TO_TRACK.find((e) => e.name === eventName);
-  if (eventToTrack) {
-    sendGtagEvent(eventName, {
-      [eventToTrack.prop]: properties[eventToTrack.prop],
-    });
-  }
-};
 
 const baseSettings = {
   apiKey: process.env.INKEEP_INTEGRATION_API_KEY,
@@ -74,7 +50,6 @@ const baseSettings = {
       searchTabLabel: 'Changelog',
     },
   ],
-  logEventCallback: analyticsCallback,
 };
 
 const searchSettings = {


### PR DESCRIPTION
This PR adds analytics for Inkeep:

- Search: `search_query_submitted`
- Chat: `chat_message_submitted`

### Steps to test
- Use **Docs search** or **AI Chat** with `console.log`s for events:
![image](https://github.com/user-attachments/assets/d47a46ff-7d60-4906-8001-078cba906a52)
![image](https://github.com/user-attachments/assets/add91112-2ba3-4aef-bfb0-70dc711874a4)

[Preview](https://neon-next-git-inkeep-analytics-neondatabase.vercel.app/ai-chat)