### PR TITLE
fix: small desktop style fixes

### DIFF
--- a/src/app/(docs)/ai-chat/page.jsx
+++ b/src/app/(docs)/ai-chat/page.jsx
@@ -46,7 +46,7 @@ const AiChatPage = async () => {
         >
           <ModeToggler className="hidden shrink-0 md:flex" isAiChatPage />
           <h1 className="sr-only">Neon AI Chat</h1>
-          <div className="col-span-7 col-start-2 -ml-6 flex w-full max-w-[832px] flex-1 items-center justify-center 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 lg:max-w-full">
+          <div className="col-span-7 col-start-2 -ml-6 flex w-full max-w-[832px] flex-1 items-center justify-center 3xl:ml-0 2xl:col-span-9 2xl:col-start-1 lg:max-w-full">
             <InkeepEmbedded />
           </div>
         </Container>

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -170,7 +170,7 @@ const Sidebar = ({ isDarkTheme, isClient }) => (
   <div className="flex items-center gap-x-6 lg:hidden">
     {!isClient && <GithubStars isDarkTheme={isDarkTheme} />}
     <Link
-      className="text-[13px] leading-none tracking-extra-tight lg:hidden"
+      className="whitespace-nowrap text-[13px] leading-none tracking-extra-tight lg:hidden"
       to={LINKS.login}
       theme={isDarkTheme ? 'white' : 'black'}
     >
@@ -178,7 +178,7 @@ const Sidebar = ({ isDarkTheme, isClient }) => (
     </Link>
 
     <Button
-      className="h-8 px-6 text-[13px] font-semibold leading-none tracking-extra-tight transition-colors duration-200 lg:hidden"
+      className="h-8 whitespace-nowrap px-6 text-[13px] font-semibold leading-none tracking-extra-tight transition-colors duration-200 lg:hidden"
       to={LINKS.signup}
       theme="primary"
       tag_name="Header"


### PR DESCRIPTION
This PR brings small style fixes for 1280px screens:
- header Log in button
- Docs AI chat

![image](https://github.com/user-attachments/assets/e99bc364-c3e7-4018-ad51-9baadc54fd86)

[Preview](https://neon-next-git-small-desktop-style-fixes-neondatabase.vercel.app//ai-chat)