### PR TITLE
docs:Fix incorrect C++ notation in PostgreSQL language support list

### DIFF
--- a/content/postgresql/postgresql-getting-started/what-is-postgresql.md
+++ b/content/postgresql/postgresql-getting-started/what-is-postgresql.md
@@ -63,7 +63,7 @@ PostgreSQL supports the most popular programming languages:
 - Python
 - Java
 - C\#
-- C/C\+
+- C/C\+\+
 - Ruby
 - JavaScript (Node.js)
 - Perl


### PR DESCRIPTION
Fix incorrect C++ notation in PostgreSQL language support list