### PR TITLE
docs: updated agentstack card and users_sync table name admonition

### DIFF
--- a/content/docs/ai/ai-intro.md
+++ b/content/docs/ai/ai-intro.md
@@ -22,7 +22,7 @@ Neon supports Postgres for AI agents with the following tools and interfaces:
 
 <a href="https://github.com/neondatabase/mcp-server-neon/tree/main/mcp-client" description="A Model Context Protocol (MCP) client CLI that can be used to interact with any MCP server" icon="github">Neon MCP Client CLI</a>
 
-<a href="https://github.com/AgentOps-AI/AgentStack/blob/main/agentstack/templates/crewai/tools/neon_tool.py" description="A Neon tool for AgentStack that allows agents to create ephemeral or long-lived Postgres instances for structured data storage" icon="github">Neon tool for AgentStack</a>
+<a href="https://github.com/AgentOps-AI/AgentStack/blob/main/docs/tools/tool/neon.mdx" description="A Neon tool for AgentStack that allows agents to create ephemeral or long-lived Postgres instances for structured data storage" icon="github">Neon tool for AgentStack</a>
 
 <a href="https://composio.dev/tools?search=neon" description="A full integration between LLMs and AI agents and Neon's API" icon="openai">Neon tool for Composio</a>
 

--- a/content/docs/guides/neon-identity.md
+++ b/content/docs/guides/neon-identity.md
@@ -65,6 +65,10 @@ The following columns are included in the `neon_identity.users_sync` table:
 
 Updates to user profiles in the auth provider are automatically synchronized.
 
+<Admonition type="note">
+Do not try to change the `neon_identity.users_sync` table name. It's needed for the synchronization process to work correctly.
+</Admonition>
+
 ## Before and after Neon Identity
 
 Let's take a look at how Neon Identiy can help simplify the code in a typical todos application:


### PR DESCRIPTION
- Agentstack docs site is not yet rebuilt; linking to the docs page in the repo instead
- Added admonition about not changing the name of the users_sync table