### PR TITLE
chore: update about-us page numbers

### DIFF
--- a/src/app/about-us/page.jsx
+++ b/src/app/about-us/page.jsx
@@ -30,7 +30,8 @@ const AboutUsPage = async () => {
       label: 'Contributors',
     },
     {
-      number: '18k',
+      number: '18',
+      isThousands: true,
       hasPlus: true,
       label: 'Databases created daily',
     },

--- a/src/app/about-us/page.jsx
+++ b/src/app/about-us/page.jsx
@@ -30,7 +30,7 @@ const AboutUsPage = async () => {
       label: 'Contributors',
     },
     {
-      number: '3000',
+      number: '18k',
       hasPlus: true,
       label: 'Databases created daily',
     },

--- a/src/app/about-us/page.jsx
+++ b/src/app/about-us/page.jsx
@@ -21,12 +21,12 @@ const AboutUsPage = async () => {
 
   const statistics = [
     {
-      number: !gitHubStars ? 13 : Math.floor(gitHubStars / 1000),
+      number: !gitHubStars ? 16 : Math.floor(gitHubStars / 1000),
       isThousands: true,
       label: 'Stars on GitHub',
     },
     {
-      number: !gitHubContributors ? 111 : gitHubContributors,
+      number: !gitHubContributors ? 130 : gitHubContributors,
       label: 'Contributors',
     },
     {

--- a/src/components/pages/about/open-source/open-source.jsx
+++ b/src/components/pages/about/open-source/open-source.jsx
@@ -43,7 +43,7 @@ const OpenSource = ({ items }) => (
         {items.map(({ label, number, isThousands, hasPlus }, index) => (
           <li className="flex flex-col" key={index}>
             <p>
-              <span className={clsx('flex', hasPlus ? 'items-center' : 'items-end')}>
+              <span className="flex items-center">
                 <span className="bg-[linear-gradient(73deg,#7F95EB_1%,#89E0EA_33%,#EFEFEF_81%)] bg-clip-text pr-3 font-title text-[192px] font-medium leading-[.8] tracking-[-0.06em] text-transparent xl:text-[160px] lg:pr-2 lg:text-[112px]">
                   {number}
                 </span>
@@ -51,10 +51,11 @@ const OpenSource = ({ items }) => (
                   <span
                     className={clsx(
                       'bg-[linear-gradient(164deg,#FFF_53%,rgba(255,255,255,.4)_72.79%,transparent_89.16%)] bg-clip-text pr-1.5 font-title text-[100px] font-medium leading-[.96] tracking-[-0.06em] text-transparent xl:text-[88px] lg:text-6xl',
-                      isThousands && '-mb-0.5'
+                      isThousands && '-mb-0.5 self-end'
                     )}
                   >
-                    {hasPlus ? '+' : 'k'}
+                    {isThousands && 'k'}
+                    {hasPlus && '+'}
                   </span>
                 )}
               </span>

--- a/src/utils/get-github-data.js
+++ b/src/utils/get-github-data.js
@@ -9,7 +9,7 @@ const getGithubStars = async () => {
     }
     return json.stargazers_count;
   }
-  return 9000;
+  return 16000;
 };
 
 const getGithubContributors = async () => {


### PR DESCRIPTION
This PR updates numbers on About Us page:
- db created daily to `18k+`
- github stars and contributors fallback numbers

[Preview](https://neon-next-git-about-us-daily-db-increase-neondatabase.vercel.app/about-us)