### PR TITLE
Add org-to-org transfer via API to the Organization docs

### DIFF
--- a/content/docs/manage/organizations.md
+++ b/content/docs/manage/organizations.md
@@ -27,7 +27,7 @@ Here's a breakdown of what actions each role can take:
 | -------------------------------------------------------------------------------------- | :---: | :----: | :----------: |
 | [Create projects](/docs/manage/orgs-manage#create-and-delete-projects)                 |  ✅   |   ✅   |      ❌      |
 | [Delete projects](/docs/manage/orgs-manage#create-and-delete-projects)                 |  ✅   |   ❌   |      ❌      |
-| [Transfer projects](/docs/manage/orgs-project-transfer)*                               |  ✅   |   ✅   |      ❌      |
+| [Transfer projects](/docs/manage/orgs-project-transfer)\*                              |  ✅   |   ✅   |      ❌      |
 | Manage [members](/docs/manage/orgs-manage#invite-members)                              |  ✅   |   ❌   |      ❌      |
 | Manage [collaborators](/docs/manage/orgs-manage#invite-collaborators) (share projects) |  ✅   |   ✅   |      ✅      |
 | [Set permissions](/docs/manage/orgs-manage#set-permissions)                            |  ✅   |   ❌   |      ❌      |

--- a/content/docs/manage/organizations.md
+++ b/content/docs/manage/organizations.md
@@ -27,11 +27,14 @@ Here's a breakdown of what actions each role can take:
 | -------------------------------------------------------------------------------------- | :---: | :----: | :----------: |
 | [Create projects](/docs/manage/orgs-manage#create-and-delete-projects)                 |  ✅   |   ✅   |      ❌      |
 | [Delete projects](/docs/manage/orgs-manage#create-and-delete-projects)                 |  ✅   |   ❌   |      ❌      |
+| [Transfer projects](/docs/manage/orgs-project-transfer)*                               |  ✅   |   ✅   |      ❌      |
 | Manage [members](/docs/manage/orgs-manage#invite-members)                              |  ✅   |   ❌   |      ❌      |
 | Manage [collaborators](/docs/manage/orgs-manage#invite-collaborators) (share projects) |  ✅   |   ✅   |      ✅      |
 | [Set permissions](/docs/manage/orgs-manage#set-permissions)                            |  ✅   |   ❌   |      ❌      |
 | [Manage billing](/docs/manage/orgs-manage#billing)                                     |  ✅   |   ❌   |      ❌      |
 | [Delete organization](/docs/manage/orgs-manage#delete-an-organization)                 |  ✅   |   ❌   |      ❌      |
+
+\* Some restrictions apply. See the [Transfer projects to an organization](/docs/manage/orgs-project-transfer) for details.
 
 ## Create an organization
 

--- a/content/docs/manage/orgs-api.md
+++ b/content/docs/manage/orgs-api.md
@@ -49,6 +49,7 @@ Some operations require a personal API key from an organization admin and cannot
 | [Remove member from the organization](#remove-member-from-the-organization)               | ✅               | ❌                   |
 | [Get organization invitation details](#get-organization-invitation-details)               | ✅               | ✅                   |
 | [Create organization invitations](#create-organization-invitations)                       | ✅               | ❌                   |
+| [Transfer projects between organizations](#transfer-projects-between-organizations)        | ✅               | ❌                   |
 
 ## Finding your org_id
 
@@ -314,3 +315,14 @@ curl --request POST \
 ```
 
 [Try in API Reference ↗](https://api-docs.neon.tech/reference/createorganizationinvitations)
+
+## Transfer projects between organizations
+
+The API supports transferring projects between organizations. For detailed instructions and examples, see [Transfer projects to an organization](/docs/manage/orgs-project-transfer).
+
+Key requirements:
+
+- Must use a personal API key
+- Requires admin permissions in the source organization and at least member permissions in the target
+
+[Try in API Reference ↗](https://api-docs.neon.tech/reference/transferproject)

--- a/content/docs/manage/orgs-api.md
+++ b/content/docs/manage/orgs-api.md
@@ -49,7 +49,7 @@ Some operations require a personal API key from an organization admin and cannot
 | [Remove member from the organization](#remove-member-from-the-organization)               | ✅               | ❌                   |
 | [Get organization invitation details](#get-organization-invitation-details)               | ✅               | ✅                   |
 | [Create organization invitations](#create-organization-invitations)                       | ✅               | ❌                   |
-| [Transfer projects between organizations](#transfer-projects-between-organizations)        | ✅               | ❌                   |
+| [Transfer projects between organizations](#transfer-projects-between-organizations)       | ✅               | ❌                   |
 
 ## Finding your org_id
 

--- a/content/docs/manage/orgs-project-transfer.md
+++ b/content/docs/manage/orgs-project-transfer.md
@@ -4,7 +4,12 @@ enableTableOfContents: true
 updatedOn: '2025-01-20T20:22:35.268Z'
 ---
 
-When creating an organization as an Admin &#8212; or as a member of an organization that's already up and running &#8212; you may need to transfer existing projects from your personal account to your target organization.
+As an Admin or Member of an organization, you can transfer projects in the following ways:
+
+- From personal accounts to organizations
+- Between different organizations (via API)
+
+This guide explains how to transfer projects using both the UI and API methods, and covers important requirements and limitations.
 
 ## Guidelines
 

--- a/content/docs/manage/orgs-project-transfer.md
+++ b/content/docs/manage/orgs-project-transfer.md
@@ -19,8 +19,8 @@ Before transferring projects, review these important guidelines covering transfe
 
 | Transfer method                                      | Project limit                            |
 | ---------------------------------------------------- | ---------------------------------------- |
-| NeonConsole                                          | Up to 200 projects at a time             |
-| API                                                  | Up to 400 projects in a single operation |
+| [Neon Console](#transfer-from-the-neon-console)                                          | Up to 200 projects at a time             |
+| [API](#transfer-projects-via-api)                                                  | Up to 400 projects in a single operation |
 | [Python script](#transfer-large-numbers-of-projects) | Unlimited (processes in batches)         |
 
 The number of projects you can transfer is limited by the target Organization plan's allowance.
@@ -119,9 +119,9 @@ This requires:
 - Your personal API key with access to both the source and destination organizations
 - **Admin** permissions in the source organization (where projects are currently located)
 - At least **Member** permissions in the destination organization (where projects will be transferred to)
-- Compatible billing plans between organizations (e.g., projects can move some Scale to Launch but not the other way around)
+- Compatible billing plans between organizations (e.g., projects can move from Scale to Launch but not the other way around)
 
-Projects with GitHub or Vercel integrations cannot be transferred
+<Admonition type="note">Projects with GitHub or Vercel integrations cannot be transferred</Admonition>
 
 **Example request**
 

--- a/content/docs/manage/orgs-project-transfer.md
+++ b/content/docs/manage/orgs-project-transfer.md
@@ -8,16 +8,29 @@ When creating an organization as an Admin &#8212; or as a member of an organizat
 
 ## Guidelines
 
-The Neon Console allows you to transfer projects up to 200 projects at a time, while the API supports up to 400 projects in a single operation. If you need to transfer more than 200 projects, our [Python script](#transfer-large-numbers-of-projects) can help you efficiently manage this one-time​ task.
+Before transferring projects, review these important guidelines covering transfer limits, requirements, and other key considerations.
 
-A few important points to keep in mind:
+### Transfer limits
 
-- You must be at least a Member of the selected Organization to transfer projects to it.
-- The number of projects you can transfer is limited by the target Organization plan's allowance.
-- The billing plan of the organization must match or exceed the billing plan of the personal Neon account you are transferring projects from. For example, attempting to transfer projects from a Scale plan personal account to a Launch plan organization will result in an error.
-- If any organization members were already collaborators on the projects being transferred, we'll remove their collaborator access since they'll get full access as org members anyway.
-- Transferring projects between Organizations is currently not supported. You can only transfer projects from a personal Neon account to an Organization. If you need to move projects between Organizations, please contact [Neon Support](https://console.neon.tech/app/projects?modal=support).
-- Project transfers are not yet supported to or from Vercel-managed orgs.
+| Transfer method | Project limit |
+|----------------|---------------|
+| NeonConsole | Up to 200 projects at a time |
+| API | Up to 400 projects in a single operation |
+| [Python script](#transfer-large-numbers-of-projects) | Unlimited (processes in batches) |
+
+The number of projects you can transfer is limited by the target Organization plan's allowance.
+
+### Requirements
+
+- Minimum **Member** role in the target Organization. **Admin** role if tranferring from an organization.
+- Compatible billing plans (can transfer from higher to lower tier, not vice versa)
+- Projects must not have GitHub or Vercel integrations
+- Vercel-managed organizations are not supported
+
+### Additional considerations
+
+- If any organization members were already collaborators on the projects being transferred, we'll remove their collaborator access since they'll get full access as org members anyway
+- Transferring projects between Organizations is currently supported using the [API](#transfer-between-organizations-via-api) only
 
 ## Transfer from the Neon Console
 
@@ -36,6 +49,13 @@ Navigate to the Organization you want to import projects into. In the **Billing*
 ![transfer projects in bulk](/docs/manage/transfer_bulk.gif)
 
 ## Transfer projects via API
+
+You can transfer projects to a destination organization using two different API endpoints, depending on your use case:
+
+- [Transfer personal projects to an organization](#transfer-personal-projects-to-an-organization)
+- [Transfer projects between organizations](#transfer-projects-between-organizations)
+
+### Transfer personal projects to an organization
 
 Use the Project Transfer API to transfer projects from your personal Neon account to a specified organization account.
 
@@ -82,6 +102,59 @@ And here's a sample response showing incompatible subscription types:
   "error": "Transfer failed: the organization has too many projects or its plan is incompatible with the source account."
 }
 ```
+
+### Transfer projects between organizations
+
+Use the Organization Transfer API to transfer projects between two specified organization accounts.
+
+`POST /organizations/{destination_org_id}/projects/transfer`
+
+This requires:
+
+- Your personal API key with access to both the source and destination organizations
+- **Admin** permissions in the source organization (where projects are currently located)
+- At least **Member** permissions in the destination organization (where projects will be transferred to)
+- Compatible billing plans between organizations (e.g., projects can move some Scale to Launch but not the other way around)
+
+Projects with GitHub or Vercel integrations cannot be transferred
+
+**Example request**
+
+```bash
+curl --request POST \
+     --url 'https://console.neon.tech/api/v2/organizations/{destination_org_id}/projects/transfer' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer $PERSONAL_API_KEY' \
+     --header 'content-type: application/json' \
+     --data '{
+  "project_ids": [
+    "project-id-1",
+    "project-id-2"
+  ]
+}'
+```
+
+Where:
+
+- `destination_org_id` is the organization receiving the projects
+- `project_ids` is an array of up to 400 project IDs to transfer
+
+### Response behavior
+
+A successful transfer returns a 200 status code with an empty JSON object:
+
+```json
+{}
+```
+
+You can verify the transfer in the Neon Console or by listing the projects in the destination organization via API.
+
+### Error responses
+
+The API may return these errors:
+
+- **`406`** – Transfer failed - the target organization has too many projects or its plan is incompatible with the source organization. Reduce projects or upgrade the organization.
+- **`422`** – One or more of the provided project IDs have GitHub or Vercel integrations installed. Transferring integration projects is currently not supported.
 
 ## Transfer large numbers of projects
 

--- a/content/docs/manage/orgs-project-transfer.md
+++ b/content/docs/manage/orgs-project-transfer.md
@@ -62,7 +62,7 @@ You can transfer projects to a destination organization using two different API 
 
 ### Transfer personal projects to an organization
 
-Use the Project Transfer API to transfer projects from your personal Neon account to a specified organization account.
+Use the [Project Transfer API](https://api-docs.neon.tech/reference/transferprojectsfromorgtoorg) to transfer projects from your personal Neon account to a specified organization account.
 
 `POST /users/me/projects/transfer`
 

--- a/content/docs/manage/orgs-project-transfer.md
+++ b/content/docs/manage/orgs-project-transfer.md
@@ -19,8 +19,8 @@ Before transferring projects, review these important guidelines covering transfe
 
 | Transfer method                                      | Project limit                            |
 | ---------------------------------------------------- | ---------------------------------------- |
-| [Neon Console](#transfer-from-the-neon-console)                                          | Up to 200 projects at a time             |
-| [API](#transfer-projects-via-api)                                                  | Up to 400 projects in a single operation |
+| [Neon Console](#transfer-from-the-neon-console)      | Up to 200 projects at a time             |
+| [API](#transfer-projects-via-api)                    | Up to 400 projects in a single operation |
 | [Python script](#transfer-large-numbers-of-projects) | Unlimited (processes in batches)         |
 
 The number of projects you can transfer is limited by the target Organization plan's allowance.

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -2,7 +2,7 @@
 title: Neon CLI commands — projects
 subtitle: Use the Neon CLI to manage Neon directly from the terminal
 enableTableOfContents: true
-updatedOn: '2025-01-13T13:18:32.342Z'
+updatedOn: '2025-02-10T17:04:38.083Z'
 ---
 
 ## Before you begin


### PR DESCRIPTION
Main update here:
[Transfer projects between organizations](https://neon-next-git-bgrenon-transfer-org-api-neondatabase.vercel.app/docs/manage/orgs-project-transfer#transfer-projects-between-organizations)