### PR TITLE
docs: fix changelog social title

### DIFF
--- a/content/changelog/2025-01-24.md
+++ b/content/changelog/2025-01-24.md
@@ -1,5 +1,5 @@
 ---
-description: Neon Chat for VS Code, scheduled updates coming soon, and more
+title: Neon Chat for VS Code, scheduled updates coming soon, and more
 ---
 
 ### Neon Chat for Visual Studio Code

--- a/content/changelog/2025-01-31.md
+++ b/content/changelog/2025-01-31.md
@@ -1,5 +1,5 @@
 ---
-description: The Neon Slack App, scheduled updates on the Free Plan starting soon, and more
+title: The Neon Slack App, scheduled updates on the Free Plan starting soon, and more
 ---
 
 ### The Neon Slack App is available for early access

--- a/content/changelog/2025-02-07.md
+++ b/content/changelog/2025-02-07.md
@@ -1,5 +1,5 @@
 ---
-description: Query monitoring, 1Password support, and more
+title: Query monitoring, 1Password support, and more
 ---
 
 ## Monitor queries in the Neon Console

--- a/content/changelog/2025-02-14.md
+++ b/content/changelog/2025-02-14.md
@@ -1,5 +1,5 @@
 ---
-description: New London AWS region, Datadog integration now GA, and more
+title: New London AWS region, Datadog integration now GA, and more
 ---
 
 ## London AWS region now generally available 🇬🇧 ❤️


### PR DESCRIPTION
We now use title in the frontmatter instead of description. PP implemented title. We still had description in an open PR, which was carried forward to later changelogs. 