### PR TITLE
chore: rename comingSoon type for the admonition block

### DIFF
--- a/content/docs/guides/neon-private-networking.md
+++ b/content/docs/guides/neon-private-networking.md
@@ -7,7 +7,7 @@ redirectFrom:
 updatedOn: '2025-02-20T17:57:40.907Z'
 ---
 
-<Admonition type="coming-soon" title="Private Networking availability">
+<Admonition type="comingSoon" title="Private Networking availability">
 Private Networking is available on Neon's [Business](/docs/introduction/plans#business) and [Enterprise](/docs/introduction/plans#enterprise) plans.
 </Admonition>
 


### PR DESCRIPTION
This PR brings fix for the Admonition comingSoon type, misused at https://github.com/neondatabase/website/pull/2885

[Preview](https://neon-next-git-fix-coming-soon-admonition-neondatabase.vercel.app/docs/guides/neon-private-networking)