### PR TITLE
fix: guides and changelog props for algolia

### DIFF
--- a/src/app/(docs)/docs/changelog/[...slug]/page.jsx
+++ b/src/app/(docs)/docs/changelog/[...slug]/page.jsx
@@ -50,6 +50,7 @@ export async function generateMetadata({ params }) {
     pathname: `${CHANGELOG_BASE_PATH}${currentSlug}`,
     imagePath: `${VERCEL_URL}/docs/og?title=${encodedLabel}`,
     type: 'article',
+    category: 'Changelog',
   });
 }
 
@@ -67,7 +68,8 @@ const ChangelogPost = async ({ currentSlug }) => {
   if (!getPostBySlug(currentSlug, CHANGELOG_DIR_PATH)) return notFound();
   const date = getFormattedDate(currentSlug);
 
-  const { content } = getPostBySlug(currentSlug, CHANGELOG_DIR_PATH);
+  const { data, content } = getPostBySlug(currentSlug, CHANGELOG_DIR_PATH);
+  const title = data.title || getExcerpt(content, 160);
 
   const isChangelogPage = CHANGELOG_SLUG_REGEX.test(currentSlug);
 
@@ -94,13 +96,15 @@ const ChangelogPost = async ({ currentSlug }) => {
       <div className="col-span-9 col-start-3 -ml-6 flex max-w-[832px] flex-col 3xl:col-span-10 3xl:col-start-2 3xl:ml-0 2xl:col-span-11 2xl:col-start-1 xl:max-w-[calc(100vw-366px)] lg:ml-0 lg:max-w-full lg:pt-0 md:mx-auto md:pb-[70px] sm:pb-8">
         <Hero className="flex justify-center lg:pt-16 md:py-10 sm:py-7" date={date} withContainer />
         <article className="relative flex w-full max-w-full flex-col items-start">
-          <h2>
+          {/* Special title for Algolia */}
+          <h2 className="post-title">
             <time
               className="mt-3 whitespace-nowrap text-gray-new-20 dark:text-gray-new-70"
               dateTime={currentSlug}
             >
               {date}
             </time>
+            <span className="sr-only">– {title}</span>
           </h2>
           <Content className="mt-8 w-full max-w-full prose-h3:text-xl" content={content} />
           <Link

--- a/src/app/guides/[slug]/page.jsx
+++ b/src/app/guides/[slug]/page.jsx
@@ -38,6 +38,7 @@ export async function generateMetadata({ params }) {
     pathname: `${LINKS.guides}/${slug}`,
     rssPathname: null,
     type: 'article',
+    category: 'Guides',
     authors: [author.name],
   });
 }

--- a/src/components/shared/content/content.jsx
+++ b/src/components/shared/content/content.jsx
@@ -198,10 +198,14 @@ const Content = ({
   isUseCase = false,
 }) => (
   <div
-    className={clsx('prose-doc prose dark:prose-invert xs:prose-code:break-words', className, {
-      'dark:prose-p:text-gray-new-70 dark:prose-strong:text-white dark:prose-li:text-gray-new-70 dark:prose-table:text-gray-new-70':
-        isUseCase,
-    })}
+    className={clsx(
+      'prose-doc post-content prose dark:prose-invert xs:prose-code:break-words',
+      className,
+      {
+        'dark:prose-p:text-gray-new-70 dark:prose-strong:text-white dark:prose-li:text-gray-new-70 dark:prose-table:text-gray-new-70':
+          isUseCase,
+      }
+    )}
   >
     {asHTML ? (
       <div dangerouslySetInnerHTML={{ __html: content }} />


### PR DESCRIPTION
This PR brings fix for Guides and Changelog posts with custom props for Algolia:
- added `meta category`
- added `.post-title`, `.post-author` and` .post-content`

![image](https://github.com/user-attachments/assets/2ba77c6a-6847-4923-98f1-e971c9e4ba22)

[Preview Guides](https://neon-next-git-blog-guides-changelog-algolia-neondatabase.vercel.app/guides)
[Preview Changelog](https://neon-next-git-blog-guides-changelog-algolia-neondatabase.vercel.app/docs/changelog)