### PR TITLE
chore: add a redirect for /early-access-program page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -267,6 +267,11 @@ const defaultConfig = {
         destination: '/docs/changelog',
         permanent: false,
       },
+      {
+        source: '/early-access-program',
+        destination: '/docs/introduction/roadmap#join-the-neon-early-access-program',
+        permanent: true,
+      },
       ...docsRedirects,
       ...changelogRedirects,
     ];


### PR DESCRIPTION
This PR adds a redirect

[/early-access-program](https://neon.tech/early-access-program) → [/docs/introduction/roadmap#join-the-neon-early-access-program](https://neon.tech/docs/introduction/roadmap#join-the-neon-early-access-program)

[Preview](https://neon-next-git-early-access-page-redirect-neondatabase.vercel.app/early-access-program)