### PR TITLE
feat: contact sales page email update

### DIFF
--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -14,6 +14,7 @@ import Field from 'components/shared/field';
 import Link from 'components/shared/link';
 import { FORM_STATES, HUBSPOT_CONTACT_SALES_FORM_ID } from 'constants/forms';
 import LINKS from 'constants/links';
+import { checkBlacklistEmails } from 'utils/check-blacklist-emails';
 import { doNowOrAfterSomeTime, sendHubspotFormData } from 'utils/forms';
 
 const schema = yup
@@ -22,7 +23,8 @@ const schema = yup
     email: yup
       .string()
       .email('Please enter a valid email')
-      .required('Email address is a required field'),
+      .required('Email address is a required field')
+      .test(checkBlacklistEmails({ validation: { useDefaultBlockList: true } })),
     companySize: yup.string().notOneOf(['hidden'], 'Required field'),
     message: yup.string().required('Message is a required field'),
   })
@@ -135,7 +137,7 @@ const ContactForm = () => {
       />
       <Field
         name="email"
-        label="Email *"
+        label="Work Email *"
         type="email"
         autoComplete="email"
         placeholder="info@acme.com"

--- a/src/components/shared/field/field.jsx
+++ b/src/components/shared/field/field.jsx
@@ -84,8 +84,8 @@ const Field = forwardRef(
       {error && (
         <p
           className={clsx(
-            'error-message absolute right-0 top-[calc(100%+4px)] z-10 max-w-[350px] text-sm leading-none text-secondary-1',
-            '[&_a:hover]:no-underline [&_a]:underline [&_a]:underline-offset-2',
+            'error-message absolute !top-auto bottom-full right-0 z-10 max-w-[350px] translate-y-4 text-end text-sm leading-none text-secondary-1',
+            'xs:static xs:ml-auto xs:mt-2 xs:translate-y-0 [&_a:hover]:no-underline [&_a]:underline [&_a]:underline-offset-2',
             errorClassName
           )}
           data-test="error-field-message"

--- a/src/components/shared/field/field.jsx
+++ b/src/components/shared/field/field.jsx
@@ -85,7 +85,7 @@ const Field = forwardRef(
         <p
           className={clsx(
             'error-message absolute !top-auto bottom-full right-0 z-10 max-w-[350px] translate-y-4 text-end text-sm leading-none text-secondary-1',
-            'xs:static xs:ml-auto xs:mt-2 xs:translate-y-0 [&_a:hover]:no-underline [&_a]:underline [&_a]:underline-offset-2',
+            'sm:static sm:ml-auto sm:mt-2 sm:translate-y-0 [&_a:hover]:no-underline [&_a]:underline [&_a]:underline-offset-2',
             errorClassName
           )}
           data-test="error-field-message"


### PR DESCRIPTION
This PR brings fixed for Contact Sales page email:

- "Email" -> "Work Email"
- work email validation

![image](https://github.com/user-attachments/assets/842e3322-ded0-4c25-8759-814d88f5f628)

[Preview](https://neon-next-git-contact-saled-page-update-neondatabase.vercel.app/contact-sales)