### PR TITLE
chore: change calendly link on partners page

### DIFF
--- a/src/components/pages/partners/apply/apply.jsx
+++ b/src/components/pages/partners/apply/apply.jsx
@@ -14,7 +14,7 @@ import 'styles/hubspot-form.css';
 import 'styles/calendly-widget.css';
 import CloseIcon from './images/close.inline.svg';
 
-const calendlyURL = 'https://calendly.com/arjunanr/partnership-discussion';
+const calendlyURL = 'https://calendly.com/d/ckxx-b4h-69y/neon-solutions-engineering';
 const hubspotFormID = '26f1ff16-e3ab-4adf-b09f-910f130637b0';
 
 const Testimonial = ({ className = null, ariaHidden = false }) => (


### PR DESCRIPTION
This PR updates calendly link on Partners page to match Contact Sales page link

Preview