### PR TITLE
typo fix: for issue #3027

### DIFF
--- a/content/postgresql/postgresql-plpgsql/plpgsql-block-structure.md
+++ b/content/postgresql/postgresql-plpgsql/plpgsql-block-structure.md
@@ -55,7 +55,7 @@ For example, the following declares a variable called `counter` with the type `i
 counter int = 0;
 ```
 
-Sometimes, you’ll see the :\= operator instead of \= operator. They are have the same meaning:
+Sometimes, you’ll see the :\= operator instead of \= operator. They have the same meaning:
 
 ```
 counter int := 0;

--- a/content/postgresql/postgresql-plpgsql/postgresql-create-function.md
+++ b/content/postgresql/postgresql-plpgsql/postgresql-create-function.md
@@ -174,7 +174,7 @@ If the function has many parameters, you should call it using the named notation
 
 ### 2\) Using named notation
 
-The following shows how to call the `get_film_count` function using the positional notation:
+The following shows how to call the `get_film_count` function using the named notation:
 
 ```sql
 select get_film_count(


### PR DESCRIPTION
The typo containing grammar mistake where it had a sentence like "They are have the same meaning" instead of "They have the same meaning" is fixed.

Here is the issue: https://github.com/neondatabase/website/issues/3027