### PR TITLE
fix: missing param in postgresql-full-text-search.md

### DIFF
--- a/content/postgresql/postgresql-indexes/postgresql-full-text-search.md
+++ b/content/postgresql/postgresql-indexes/postgresql-full-text-search.md
@@ -179,7 +179,7 @@ CREATE TABLE posts(
    title TEXT NOT NULL,
    body TEXT,
    body_search TSVECTOR
-      GENERATED ALWAYS AS (to_tsvector(body)) STORED
+      GENERATED ALWAYS AS (to_tsvector('english',body)) STORED
 );
 ```
 


### PR DESCRIPTION
Fixes the missing `regconfig` parameter in `to_tsvector()` function that results in throwing this error if not provided: `ERROR:  generation expression is not immutable`

Used `english` just like the correct usage when using GIN index.