### PR TITLE
feat: add redirect for /yc-startups to /startups

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -141,6 +141,16 @@ const defaultConfig = {
 
     return [
       {
+        source: '/yc-startups',
+        destination: '/startups',
+        permanent: true,
+      },
+      {
+        source: '/yc-deal-terms',
+        destination: '/startups-deal-terms',
+        permanent: true,
+      },
+      {
         source: '/postgresql',
         destination: '/postgresql/tutorial',
         permanent: true,


### PR DESCRIPTION
New pages:
- https://neon.tech/yc-startups -> https://neon.tech/startups
- https://neon.tech/yc-deal-terms -> https://neon.tech/startups-deal-terms

