### PR TITLE
feat: replace GitHub link with Discord link in mobile menu and sidebar

### DIFF
--- a/src/components/shared/header/mobile-menu/mobile-menu.jsx
+++ b/src/components/shared/header/mobile-menu/mobile-menu.jsx
@@ -196,8 +196,8 @@ MobileMenuItem.propTypes = {
 const mobileMenuItems = [
   ...MENUS.header,
   {
-    text: 'GitHub',
-    to: LINKS.github,
+    text: 'Discord',
+    to: LINKS.discord,
   },
 ];
 

--- a/src/components/shared/header/sidebar/sidebar.jsx
+++ b/src/components/shared/header/sidebar/sidebar.jsx
@@ -1,30 +1,34 @@
 import PropTypes from 'prop-types';
-import { Suspense } from 'react';
 
 import Button from 'components/shared/button';
-import GithubStarCounter from 'components/shared/github-star-counter';
 import Link from 'components/shared/link';
 import LINKS from 'constants/links';
-import { getGithubStars } from 'utils/get-github-data';
+import DiscordIcon from 'icons/discord.inline.svg';
 
 const themePropTypes = {
   isDarkTheme: PropTypes.bool,
 };
 
-const GithubStars = async ({ isDarkTheme }) => {
-  const starsCount = await getGithubStars();
-  return (
-    <Suspense>
-      <GithubStarCounter isDarkTheme={isDarkTheme} starsCount={starsCount} />
-    </Suspense>
-  );
-};
+const DiscordLink = ({ isDarkTheme }) => (
+  <Link
+    className={`flex items-center gap-x-1.5 text-[13px] leading-none tracking-extra-tight transition-colors duration-200 ${
+      isDarkTheme
+        ? 'text-white hover:text-green-45'
+        : 'text-gray-new-8 hover:text-green-45 dark:text-white dark:hover:text-green-45'
+    }`}
+    to={LINKS.discord}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <DiscordIcon width={20} height={20} />
+  </Link>
+);
 
-GithubStars.propTypes = themePropTypes;
+DiscordLink.propTypes = themePropTypes;
 
-const Sidebar = ({ isDarkTheme, isClient }) => (
+const Sidebar = ({ isDarkTheme }) => (
   <div className="flex items-center gap-x-6 lg:hidden">
-    {!isClient && <GithubStars isDarkTheme={isDarkTheme} />}
+    <DiscordLink isDarkTheme={isDarkTheme} />
     <Link
       className="whitespace-nowrap text-[13px] leading-none tracking-extra-tight lg:hidden"
       to={LINKS.login}


### PR DESCRIPTION
# Before

![2025-03-03 @ 03 08PM](https://github.com/user-attachments/assets/706149ea-ab3b-4c57-b810-06bac779916e)


# After

![2025-03-03 @ 03 08PM](https://github.com/user-attachments/assets/8eff17ff-d89e-4808-b887-f3929370c792)
