### PR TITLE
fix: correct import path for currentUser in Clerk

### DIFF
--- a/content/docs/guides/auth-clerk.md
+++ b/content/docs/guides/auth-clerk.md
@@ -244,7 +244,7 @@ Create a new file at `app/actions.ts` with the following content:
 ```typescript
 'use server';
 
-import { currentUser } from '@clerk/nextjs';
+import { currentUser } from '@clerk/nextjs/server';
 import { UserMessages } from './db/schema';
 import { db } from './db';
 import { redirect } from 'next/navigation';


### PR DESCRIPTION
Updated the import path for currentUser from @clerk/nextjs to @clerk/nextjs/server to resolve an import error. This change ensures compatibility with the latest Clerk package structure and prevents runtime issues.