### PR TITLE
fix: homepage copies takeover

### DIFF
--- a/src/app/(home-page)/all-things-open-2023/page.jsx
+++ b/src/app/(home-page)/all-things-open-2023/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const AllThingsOpenPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/cfe/page.jsx
+++ b/src/app/(home-page)/cfe/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const CodingForEntrepreuneursPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/devs/page.jsx
+++ b/src/app/(home-page)/devs/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const CodingForEntrepreuneursPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/education/page.jsx
+++ b/src/app/(home-page)/education/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const EducationPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/fireship/page.jsx
+++ b/src/app/(home-page)/fireship/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const FireshipPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/github/page.jsx
+++ b/src/app/(home-page)/github/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const GithubPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/home/page.jsx
+++ b/src/app/(home-page)/home/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const HomePage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/last-week-in-aws/page.jsx
+++ b/src/app/(home-page)/last-week-in-aws/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const LastWeekInAWSPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/pgt/page.jsx
+++ b/src/app/(home-page)/pgt/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const PgtPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/radio/page.jsx
+++ b/src/app/(home-page)/radio/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const RadioPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/stackoverflow/page.jsx
+++ b/src/app/(home-page)/stackoverflow/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const StackOverflowPage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />

--- a/src/app/(home-page)/youtube/page.jsx
+++ b/src/app/(home-page)/youtube/page.jsx
@@ -6,6 +6,7 @@ import InstantProvisioning from 'components/pages/home/instant-provisioning';
 import Lightning from 'components/pages/home/lightning';
 import Logos from 'components/pages/home/logos';
 import Multitenancy from 'components/pages/home/multitenancy';
+import Takeover from 'components/pages/home/takeover';
 import Trusted from 'components/pages/home/trusted';
 import Cta from 'components/shared/cta';
 import SEO_DATA from 'constants/seo-data';
@@ -18,6 +19,7 @@ export const metadata = getMetadata({
 
 const YoutubePage = () => (
   <>
+    <Takeover />
     <Hero />
     <Logos />
     <InstantProvisioning />


### PR DESCRIPTION
This PR brings a takeover section for homepage copies
(/home, /cfe, /devs e.t.c.)

Original PR: https://github.com/neondatabase/website/pull/3154

![image](https://github.com/user-attachments/assets/d4be3666-e7ef-45f4-89ff-8cb9d9fb09b8) 

[Preview](https://neon-next-git-fix-homepage-copies-takeover-neondatabase.vercel.app/devs)