### PR TITLE
fix: neon-cli.md file formatting and build issues

### DIFF
--- a/content/docs/reference/neon-cli.md
+++ b/content/docs/reference/neon-cli.md
@@ -239,11 +239,11 @@ Global options are supported with any Neon CLI command.
       
   The authentication flow for the Neon CLI follows this order:
 
-- If the `--api-key` option is provided, it takes precedence and is used for authentication.
-- If the `--api-key` option is not provided, the `NEON_API_KEY` environment variable is used if it is set.
-- If both `--api-key` option and `NEON_API_KEY` environment variable are not provided or set, the CLI falls back to the
-  `credentials.json` file created by the `neon auth` command.
-- If the credentials file is not found, the Neon CLI initiates the `neon auth` web authentication process.
+  - If the `--api-key` option is provided, it takes precedence and is used for authentication.
+  - If the `--api-key` option is not provided, the `NEON_API_KEY` environment variable is used if it is set.
+  - If both `--api-key` option and `NEON_API_KEY` environment variable are not provided or set, the CLI falls back to the
+    `credentials.json` file created by the `neon auth` command.
+  - If the credentials file is not found, the Neon CLI initiates the `neon auth` web authentication process.
 
   </Admonition>
 


### PR DESCRIPTION
This PR brings a fix for the broken [neon-cli.md](https://github.com/neondatabase/website/pull/3190/files#diff-6e807124690a433d4c9a0838b0d072718d1a339bb6fa375a41c08d6e01a8ac2e) file formatting and build issues

Reference PR: https://github.com/neondatabase/website/pull/3180

[Preview](https://neon-next-git-fix-docs-cli-files-neondatabase.vercel.app/docs/reference/neon-cli)