### PR TITLE
fix: docs sidebar fixes

### DIFF
--- a/src/components/pages/doc/menu/item/item.jsx
+++ b/src/components/pages/doc/menu/item/item.jsx
@@ -41,7 +41,7 @@ const Item = ({
     <li className="group/item flex flex-col">
       <LinkTag
         className={clsx(
-          'group flex w-full items-center gap-2 py-1.5 text-left text-sm leading-tight tracking-extra-tight transition-colors duration-200 md:py-[7px]',
+          'group flex w-full gap-2 py-1.5 text-left text-sm leading-tight tracking-extra-tight transition-colors duration-200 md:py-[7px]',
           currentSlug === slug
             ? 'font-medium text-black-new dark:text-white'
             : 'font-normal text-gray-new-40 hover:text-black-new dark:text-gray-new-80 dark:hover:text-white'
@@ -53,13 +53,11 @@ const Item = ({
         onClick={handleClick}
       >
         {ariaLabel && <span className="sr-only">{ariaLabel}</span>}
-        {icon && <Icon title={icon} className="size-4.5" />}
-        <span
-          className="[&_code]:rounded-sm [&_code]:bg-gray-new-94 [&_code]:px-1.5 [&_code]:py-px [&_code]:font-mono [&_code]:font-normal [&_code]:leading-none dark:[&_code]:bg-gray-new-15"
-          aria-hidden={!!ariaLabel}
-          dangerouslySetInnerHTML={{ __html: title }}
-        />
-        {tag && <Tag className="ml-2 mt-0.5" label={tag} size="sm" />}
+        {icon && <Icon title={icon} className="size-4.5 shrink-0" />}
+        <span className="text-pretty" aria-hidden={!!ariaLabel}>
+          {title}&nbsp;
+          {tag && <Tag className="relative -top-px ml-1 inline-block" label={tag} size="sm" />}
+        </span>
       </LinkTag>
       {children}
     </li>

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -107,7 +107,7 @@ const Sidebar = ({ className = null, sidebar, slug, basePath, customType, docPag
               className="no-scrollbars z-10 h-[calc(100vh-166px)] overflow-y-scroll py-8"
               ref={menuWrapperRef}
             >
-              <div className="relative w-full" style={{ height: menuHeight }}>
+              <div className="relative w-full overflow-hidden" style={{ height: menuHeight }}>
                 <Menu
                   depth={0}
                   basePath={basePath}


### PR DESCRIPTION
This PR brings fixes for Docs sidebar

- extra scroll for small menus
- align for icons and tags in case of the long menu item

Before/After
![image](https://github.com/user-attachments/assets/6b9bbe8b-dc93-444a-a6ad-9846b4e5090a)
![image](https://github.com/user-attachments/assets/a9b303a2-c56e-4cf3-a213-28825aabe778)

[Preview](https://neon-next-git-docs-sidebar-fix-neondatabase.vercel.app/docs/introduction)