### PR TITLE
fix: reduce next revalidate for topbar to 10 minutes

### DIFF
--- a/src/components/shared/topbar/topbar.jsx
+++ b/src/components/shared/topbar/topbar.jsx
@@ -8,7 +8,7 @@ const Topbar = async ({ isDarkTheme }) => {
   try {
     const response = await fetch(TOPBAR_API_URL, {
       next: {
-        revalidate: 3600,
+        revalidate: 600, // 10 minutes
       },
     });
     const topbar = await response.json();


### PR DESCRIPTION
This PR reduces next revalidate for fetching topbar from WP to 10 minutes

Preview