### PR TITLE
feat: udpate hipaa legal page url to docs, add redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -297,6 +297,11 @@ const defaultConfig = {
         destination: '/docs/introduction/roadmap#join-the-neon-early-access-program',
         permanent: true,
       },
+      {
+        source: '/hipaa-compliance-guide',
+        destination: '/docs/security/hipaa',
+        permanent: true,
+      },
       ...docsRedirects,
       ...changelogRedirects,
     ];

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -59,7 +59,7 @@ export default {
   subprocessors: '/subprocessors',
   businessInformation: '/business-info',
   sensitiveDataTerms: '/sensitive-data-terms',
-  hipaaCompliance: '/hipaa-compliance-guide',
+  hipaaCompliance: '/docs/security/hipaa',
   hipaaContractors: '/hipaa-contractors',
   // Console
   console: 'https://console.neon.tech',


### PR DESCRIPTION
This PR updates hipaa legal page url to Docs and adds a redirect

[/hipaa-compliance-guide](https://neon.tech/hipaa-compliance-guide) -> [/docs/security/hipaa](https://neon.tech/docs/security/hipaa)

NOTE:
there is was only one link on the website, in footer
![image](https://github.com/user-attachments/assets/6af63a39-aa47-4b6d-8051-e17807590bf0)


TO-DO:
- [ ] unpublish [WP page](https://neondatabase.wpengine.com/wp-admin/post.php?post=8747&action=edit) after merge

[Preview](https://neon-next-git-redirect-hipaa-page-neondatabase.vercel.app/hipaa-compliance-guide)