### PR TITLE
docs: Fix link to serverless driver 1.0 blog post

### DIFF
--- a/content/docs/serverless/serverless-driver.md
+++ b/content/docs/serverless/serverless-driver.md
@@ -8,7 +8,7 @@ updatedOn: '2025-03-17T20:41:57.345Z'
 The [Neon serverless driver](https://github.com/neondatabase/serverless) is a low-latency Postgres driver for JavaScript and TypeScript that allows you to query data from serverless and edge environments over **HTTP** or **WebSockets** in place of TCP. The driver's low-latency capability is due to [message pipelining and other optimizations](https://neon.tech/blog/quicker-serverless-postgres).
 
 <Admonition type="important" title="The Neon serverless driver is now generally available (GA)">
-The GA version of the Neon serverless driver, v1.0.0 and higher, requires Node.js version 19 or higher. It also includes a **breaking change** but only if you're calling the HTTP query template function as a conventional function. For details, please see the [1.0.0 release notes](https://github.com/neondatabase/serverless/pull/149) or read the [blog post](https://neon.tech/blog/serverless-driver-1-0).
+The GA version of the Neon serverless driver, v1.0.0 and higher, requires Node.js version 19 or higher. It also includes a **breaking change** but only if you're calling the HTTP query template function as a conventional function. For details, please see the [1.0.0 release notes](https://github.com/neondatabase/serverless/pull/149) or read the [blog post](https://neon.tech/blog/serverless-driver-ga).
 </Admonition>
 
 When to query over HTTP vs WebSockets:


### PR DESCRIPTION
was seeking guidance on configuring the serverless ws driver in place of the http one, and in the process i discovered a broken link to the GA blog post in the serverless driver docs (`/blog/serverless-driver-1-0` -> `/blog/serverless-driver-ga`).

thanks for a fantastic blog & service!