### PR TITLE
feat: add docs link to docs-list

### DIFF
--- a/src/components/pages/doc/docs-link/docs-link.jsx
+++ b/src/components/pages/doc/docs-link/docs-link.jsx
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import LinkPreview from 'components/pages/doc/link-preview';
+import Link from 'components/shared/link';
+import getGlossaryItem from 'utils/get-glossary-item';
+
+const DocsLink = ({ href, children, ...otherProps }) => {
+  const baseUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
+  const isExternal = href?.startsWith('http') && !href?.startsWith(baseUrl);
+  const isGlossary =
+    href?.startsWith('/docs/reference/glossary') ||
+    href?.startsWith(`${baseUrl}/docs/reference/glossary`);
+  const icon = (isExternal && 'external') || (isGlossary && 'glossary') || null;
+
+  if (children === '#id') {
+    const id = href?.startsWith('#') ? href.replace('#', '') : undefined;
+    return <span id={id} />;
+  }
+
+  // Automatically generate previews for glossary links
+  if (isGlossary) {
+    const glossaryItem = getGlossaryItem(href);
+    if (glossaryItem) {
+      const { title, preview } = glossaryItem;
+      return (
+        <LinkPreview href={href} title={title} preview={preview} {...otherProps}>
+          {children}
+        </LinkPreview>
+      );
+    }
+  }
+
+  return (
+    <Link
+      to={href}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
+      icon={icon}
+      {...otherProps}
+    >
+      {children}
+    </Link>
+  );
+};
+
+DocsLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default DocsLink;

--- a/src/components/pages/doc/docs-link/docs-link.jsx
+++ b/src/components/pages/doc/docs-link/docs-link.jsx
@@ -33,6 +33,7 @@ const DocsLink = ({ href, children, ...otherProps }) => {
 
   return (
     <Link
+      className="!block text-pretty [&_svg]:ml-2 [&_svg]:inline-flex"
       to={href}
       target={isExternal ? '_blank' : undefined}
       rel={isExternal ? 'noopener noreferrer' : undefined}

--- a/src/components/pages/doc/docs-link/index.js
+++ b/src/components/pages/doc/docs-link/index.js
@@ -1,0 +1,3 @@
+import DocsLink from './docs-link';
+
+export default DocsLink;

--- a/src/components/pages/doc/docs-list/docs-list.jsx
+++ b/src/components/pages/doc/docs-list/docs-list.jsx
@@ -2,6 +2,8 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import DocsLink from 'components/pages/doc/docs-link';
+
 import CheckIcon from './images/check.inline.svg';
 import GithubIcon from './images/github.inline.svg';
 import PageIcon from './images/page.inline.svg';
@@ -17,6 +19,14 @@ Icon.propTypes = {
   className: PropTypes.string,
 };
 
+const parsedChildren = (children) =>
+  React.Children.map(children, (child) => {
+    if (React.isValidElement(child) && child.type === 'a') {
+      return <DocsLink {...child.props} />;
+    }
+    return child;
+  });
+
 const DocsList = ({ title, theme = 'default', children }) => (
   <>
     {title && (
@@ -25,7 +35,7 @@ const DocsList = ({ title, theme = 'default', children }) => (
       </h3>
     )}
     <ul className="!m-0 !p-0">
-      {React.Children.map(children, (child) => (
+      {parsedChildren(children).map((child) => (
         <li
           className={clsx(
             '!mb-0 !mt-2 flex w-fit items-start gap-1.5 text-gray-new-20 before:hidden dark:text-gray-new-70',

--- a/src/components/shared/content/content.jsx
+++ b/src/components/shared/content/content.jsx
@@ -11,6 +11,7 @@ import CodeTabs from 'components/pages/doc/code-tabs';
 import CommunityBanner from 'components/pages/doc/community-banner';
 import DefinitionList from 'components/pages/doc/definition-list';
 import DetailIconCards from 'components/pages/doc/detail-icon-cards';
+import DocsLink from 'components/pages/doc/docs-link';
 import DocsList from 'components/pages/doc/docs-list';
 // eslint-disable-next-line import/no-cycle
 import IncludeBlock from 'components/pages/doc/include-block';
@@ -38,10 +39,8 @@ import DocCta from 'components/shared/doc-cta';
 import ImageZoom from 'components/shared/image-zoom';
 import InkeepEmbedded from 'components/shared/inkeep-embedded';
 import LatencyCalculator from 'components/shared/latency-calculator';
-import Link from 'components/shared/link';
 import RequestForm from 'components/shared/request-form';
 import getCodeProps from 'lib/rehype-code-props';
-import getGlossaryItem from 'utils/get-glossary-item';
 
 import sharedMdxComponents from '../../../../content/docs/shared-content';
 
@@ -69,45 +68,7 @@ const getComponents = (withoutAnchorHeading, isReleaseNote, isPostgres, isUseCas
   // eslint-disable-next-line react/jsx-no-useless-fragment
   undefined: (props) => <Fragment {...props} />,
   pre: (props) => <CodeBlock {...props} />,
-  a: (props) => {
-    const { href, children, ...otherProps } = props;
-    const baseUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
-    const isExternal = href?.startsWith('http') && !href?.startsWith(baseUrl);
-    const isGlossary =
-      href?.startsWith('/docs/reference/glossary') ||
-      href?.startsWith(`${baseUrl}/docs/reference/glossary`);
-    const icon = (isExternal && 'external') || (isGlossary && 'glossary') || null;
-
-    if (children === '#id') {
-      const id = href?.startsWith('#') ? href.replace('#', '') : undefined;
-      return <span id={id} />;
-    }
-
-    // Automatically generate previews for glossary links
-    if (isGlossary) {
-      const glossaryItem = getGlossaryItem(href);
-      if (glossaryItem) {
-        const { title, preview } = glossaryItem;
-        return (
-          <LinkPreview href={href} title={title} preview={preview} {...otherProps}>
-            {children}
-          </LinkPreview>
-        );
-      }
-    }
-
-    return (
-      <Link
-        to={href}
-        target={isExternal ? '_blank' : undefined}
-        rel={isExternal ? 'noopener noreferrer' : undefined}
-        icon={icon}
-        {...otherProps}
-      >
-        {children}
-      </Link>
-    );
-  },
+  a: (props) => <DocsLink {...props} />,
   img: (props) => {
     const { className, title, src, ...rest } = props;
 


### PR DESCRIPTION
This PR brings a custom DocsLink to the DocsList components to handle external and glossary links

![image](https://github.com/user-attachments/assets/99b76bec-cda4-48ae-b63c-6ca881463308)

[Preview](https://neon-next-git-docslist-external-links-pixelpoint.vercel.app/docs/guides/drizzle)