### PR TITLE
fix: docs link inline format

### DIFF
--- a/src/components/pages/doc/docs-link/docs-link.jsx
+++ b/src/components/pages/doc/docs-link/docs-link.jsx
@@ -33,7 +33,6 @@ const DocsLink = ({ href, children, ...otherProps }) => {
 
   return (
     <Link
-      className="!block text-pretty [&_svg]:ml-2 [&_svg]:inline-flex"
       to={href}
       target={isExternal ? '_blank' : undefined}
       rel={isExternal ? 'noopener noreferrer' : undefined}


### PR DESCRIPTION
This PR brings a hotfix for docs links inline bug, caused by https://github.com/neondatabase/website/pull/3257

![image](https://github.com/user-attachments/assets/89540645-cd0b-46e5-9bcd-3dcda155285d)

[Preview](https://neon-next-git-fix-docs-links-neondatabase.vercel.app/docs/introduction/usage-metrics#archive-storage)