### PR TITLE
chore: add slack integration to pricing page

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -484,6 +484,17 @@
       "launch": true,
       "scale": true,
       "business": true
+    },
+    {
+      "rows": "2",
+      "feature": {
+        "title": "Slack Integration",
+        "subtitle": "<a href='/docs/manage/slack-app'>More info in docs</a>"
+      },
+      "free": true,
+      "launch": true,
+      "scale": true,
+      "business": true
     }
   ]
 }


### PR DESCRIPTION
This PR adds a Slack Integration to Pricing page

![image](https://github.com/user-attachments/assets/64216398-729a-4429-aa60-ef56a0455841)

[Preview](https://neon-next-git-pricing-page-slack-neondatabase.vercel.app/pricing)