### PR TITLE
Updated shared ai-rules-usage.md to include other IDE info + include props

### DIFF
--- a/content/docs/ai/ai-rules-neon-auth.md
+++ b/content/docs/ai/ai-rules-neon-auth.md
@@ -16,7 +16,7 @@ enableTableOfContents: true
 </DocsList>
 </InfoBlock>
 
-<AIRule/>
+<AIRule file="neon-auth.mdc" name="Neon Auth" />
 
 ## Rules
 

--- a/content/docs/ai/ai-rules-neon-drizzle.md
+++ b/content/docs/ai/ai-rules-neon-drizzle.md
@@ -15,7 +15,7 @@ enableTableOfContents: true
 </DocsList>
 </InfoBlock>
 
-<AIRule/>
+<AIRule file="neon-drizzle.mdc" name="Neon with Drizzle" />
 
 ## Rules
 

--- a/content/docs/ai/ai-rules-neon-serverless.md
+++ b/content/docs/ai/ai-rules-neon-serverless.md
@@ -15,7 +15,7 @@ enableTableOfContents: true
 </DocsList>
 </InfoBlock>
 
-<AIRule/>
+<AIRule file="neon-serverless.mdc" name="Neon Serverless" />
 
 ## Rules
 

--- a/content/docs/shared-content/ai-rule-usage.md
+++ b/content/docs/shared-content/ai-rule-usage.md
@@ -5,11 +5,13 @@ You can use these rules in two ways:
 <Steps>
 ## Option 1: Copy from this page
 
-Copy the rules below and save them to `.cursor/rules/neon-auth.mdc` in your project.
+With Cursor, save the [rules](https://docs.cursor.com/context/rules-for-ai#project-rules-recommended) to `.cursor/rules/{file}` and they'll be automatically applied when working with matching files (`*.ts`, `*.tsx`).
+
+For other AI tools, you can include these rules as context when chatting with your AI assistant - check your tool's documentation for the specific method (like using "Include file" or context commands).
 
 ## Option 2: Clone from repository
 
 If you prefer, you can clone or download the rules directly from our [AI Rules repository](https://github.com/neondatabase-labs/ai-rules).
 
-Once added to your project, AI tools will automatically use these rules when working with Neon Auth code. You can also reference them explicitly in prompts.
+Once added to your project, AI tools will automatically use these rules when working with {name} code. You can also reference them explicitly in prompts.
 </Steps>


### PR DESCRIPTION
The shared file uses `{name}` and  `{file}` props for each individual rule. e.g.

`<AIRule file="neon-auth.mdc" name="Neon Auth" />`

preview:
https://neon-next-git-bgrenon-ai-rules-other-ide-neondatabase.vercel.app/docs/ai/ai-rules-neon-auth
