### PR TITLE
 docs: fix broken link in PostgreSQL tutorial

### DIFF
--- a/content/postgresql/postgresql-getting-started/install-postgresql-linux.md
+++ b/content/postgresql/postgresql-getting-started/install-postgresql-linux.md
@@ -134,7 +134,7 @@ Third, quit the psql:
 First, download the sample database using the `curl` tool:
 
 ```shell
-curl -O https://neon.tech/postgresql//postgresqltutorial/dvdrental.zip
+curl -O https://neon.tech/postgresqltutorial/dvdrental.zip
 ```
 
 Second, unzip the dvdrental.zip file to get the dvdrental.tar file:


### PR DESCRIPTION
This PR fixes https://github.com/neondatabase/website/issues/3274