### PR TITLE
fix: video subtitles

### DIFF
--- a/src/utils/get-react-content-with-lazy-blocks.jsx
+++ b/src/utils/get-react-content-with-lazy-blocks.jsx
@@ -209,6 +209,16 @@ export default function getReactContentWithLazyBlocks(content, pageComponents, i
           });
         }
 
+        if (domNode.name === 'video') {
+          const props = transformProps(attributesToProps(domNode.attribs));
+          const children = domToReact(domNode.children);
+          return (
+            <video {...props} crossOrigin="anonymous">
+              {children}
+            </video>
+          );
+        }
+
         if (!includeBaseTags) return <></>;
       }
     },


### PR DESCRIPTION
This PR brings a fix for blog post video subtitles by adding `crossOrigin="anonymous"` for them

![image](https://github.com/user-attachments/assets/7237478f-87a5-43f6-8a3b-806bf79f94f1)

[Preview](https://neon-next-git-fix-video-subtitles-neondatabase.vercel.app/blog/announcing-neons-remote-mcp-server)