### PR TITLE
fix: run format-markdown action only on main branch

### DIFF
--- a/.github/workflows/format-markdown.yml
+++ b/.github/workflows/format-markdown.yml
@@ -3,7 +3,7 @@ name: Format Markdown
 on:
   push:
     branches:
-      - '**'
+      - 'main'
     paths:
       - 'content/**/*.md'
       


### PR DESCRIPTION
This PR brings a fix for format-markdown action to run it only on main branch