### PR TITLE
Fix: URL Markdown formatting on AI Concepts page

### DIFF
--- a/content/docs/ai/ai-concepts.md
+++ b/content/docs/ai/ai-concepts.md
@@ -50,7 +50,7 @@ Vector similarity search computes similarities (the distance) between data point
 - Manhattan (L1): Also known as "taxicab" or "city block" distance.
 - Cosine: This calculates the cosine of the angle between two vectors.
 
-Other distance metrics supported by the `pgvector` extension include [Hamming distance](https://en.wikipedia.org/wiki/Hamming_distance) and [Jaccard distance]https://en.wikipedia.org/wiki/Jaccard_index).
+Other distance metrics supported by the `pgvector` extension include [Hamming distance](https://en.wikipedia.org/wiki/Hamming_distance) and [Jaccard distance](https://en.wikipedia.org/wiki/Jaccard_index).
 
 Different distance metrics can be more appropriate for different tasks, depending on the nature of the data and the specific relationships you're interested in. For instance, cosine similarity is often used in text analysis.
 


### PR DESCRIPTION
Fixed URL Markdown formatting pointing to the "Jaccard distance" Wikipedia reference page, as the Markdown syntax was not being applied correctly.