### PR TITLE
feat: remove aws from pricing page

### DIFF
--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -49,7 +49,6 @@
     "highlighted": true,
     "price": 19,
     "priceFrom": true,
-    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a>",
     "description": "The resources, features, and support you need to launch.",
     "features": [
       {
@@ -98,7 +97,7 @@
     "type": "Scale",
     "price": 69,
     "priceFrom": true,
-    "headerLinks": "Pay via <a href='https://aws.amazon.com/marketplace/pp/prodview-fgeh3a7yeuzh6?sr=0-1&ref_=beagle&applicationId=AWSMPContessa' target='_blank' rel='noopener noreferrer'>AWS</a> or <a href='https://azuremarketplace.microsoft.com/en-us/marketplace/apps/neon1722366567200.neon_serverless_postgres_azure_prod?tab=PlansAndPrice' target='_blank' rel='noopener noreferrer'>Azure</a>",
+    "headerLinks": "Pay via <a href='https://azuremarketplace.microsoft.com/en-us/marketplace/apps/neon1722366567200.neon_serverless_postgres_azure_prod?tab=PlansAndPrice' target='_blank' rel='noopener noreferrer'>Azure</a>",
     "description": "More capacity and functionality for scaling production workloads.",
     "features": [
       {


### PR DESCRIPTION
This PR removes AWS pay links from Pricing page

![image](https://github.com/user-attachments/assets/d51e4974-5481-462f-b75a-6ff107d02813)

[Preview](https://neon-next-git-pricing-page-remove-aws-neondatabase.vercel.app/pricing)