### PR TITLE
docs: correct PostGIS coordinate description from lat/long to long/lat

### DIFF
--- a/content/docs/extensions/postgis.md
+++ b/content/docs/extensions/postgis.md
@@ -60,7 +60,7 @@ VALUES
     ('Elm St & 5th Ave', ST_Point(-73.991070, 40.730824));
 ```
 
-The `ST_Point` function is used to create a point from the specified latitude and longitude.
+The `ST_Point` function is used to create a point from the specified longitude and latitude.
 
 **Querying spatial data**
 
@@ -88,7 +88,7 @@ The `ST_DWithin` function returns true if the distance between two points is les
 PostGIS extends Postgres data types to handle spatial data. The primary spatial types are:
 
 - **GEOMETRY**: A flexible type for spatial data, supporting various shapes. It models shapes in the cartesian coordinate plane. Each `GEOMETRY` value is also associated with a spatial reference system (SRS), which defines the coordinate system and units of measurement.
-- **GEOGRAPHY**: Specifically designed for large-scale spatial operations on the Earth's surface, factoring in the Earth's curvature. The coordinates for a `GEOGRAPHY` shape are specified in degrees of latitude and longitude.
+- **GEOGRAPHY**: Specifically designed for large-scale spatial operations on the Earth's surface, factoring in the Earth's curvature. The coordinates for a `GEOGRAPHY` shape are specified in degrees of longitude and latitude.
 
 The actual shapes are stored as a set of coordinates. For example, a point is stored as a pair of coordinates, a line as a set of points, and a polygon as a set of lines.
 


### PR DESCRIPTION
Fixed documentation that incorrectly described `ST_Point` parameters as  **"latitude and longitude"** when the actual code examples correctly use **longitude,latitude** order. Also corrected the **GEOGRAPHY** description to clarify proper coordinate order. The code examples themselves were correct - only the explanatory text needed updating.

PostGIS follows the GIS convention of storing coordinates as _(x,y)_ where **`x` is longitude** and **`y` is latitude**, contrary to the common web mapping convention of **latitude,longitude** ordering.