### PR TITLE
feat: add contact sales link to homepage hero

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -117,7 +117,7 @@ const Hero = () => {
           </p>
           <div className="mt-8 flex items-center gap-6">
             <Button
-              className="px-8 font-semibold md:px-7"
+              className="!px-8 font-semibold md:!px-7"
               theme="primary"
               size="md-new"
               to={LINKS.signup}

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -7,6 +7,7 @@ import useWindowSize from 'react-use/lib/useWindowSize';
 
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';
+import Link from 'components/shared/link';
 import LINKS from 'constants/links';
 import useIsSafari from 'hooks/use-is-safari';
 import branchingIcon from 'icons/home/hero/branching.svg';
@@ -114,17 +115,27 @@ const Hero = () => {
             The database you love, on a serverless platform designed to help you build reliable and
             scalable applications faster.
           </p>
-          <Button
-            className="pointer-events-auto relative mt-7 px-9 font-semibold xl:mt-6 md:px-7"
-            theme="primary"
-            size="md-new"
-            to={LINKS.signup}
-            target="_blank"
-            tagName="Hero"
-            analyticsEvent="home_hero_get_started_clicked"
-          >
-            Get Started
-          </Button>
+          <div className="mt-8 flex items-center gap-6">
+            <Button
+              className="px-8 font-semibold md:px-7"
+              theme="primary"
+              size="md-new"
+              to={LINKS.signup}
+              target="_blank"
+              tagName="Hero"
+              analyticsEvent="home_hero_get_started_clicked"
+            >
+              Start for Free
+            </Button>
+            <Link
+              className="text-[15px] font-medium"
+              theme="white"
+              to={LINKS.contactSales}
+              withArrow
+            >
+              Talk to Us
+            </Link>
+          </div>
         </div>
 
         <div className="mt-[74px] flex gap-x-2.5 xl:mt-16 lg:mt-14 sm:mt-9 sm:flex-col sm:gap-y-9">


### PR DESCRIPTION
This PR brings a link to Contact Sales page on Homepage hero section

![image](https://github.com/user-attachments/assets/45a4932d-03cb-4f78-a959-2918d211c666)

[Preview](https://neon-next-git-home-hero-buttons-neondatabase.vercel.app/)