### PR TITLE
feat: docs checklist update

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -456,7 +456,7 @@ Create a new development branch off of `main`. This branch will be an exact, iso
 To display a checklist, use the `CheckList` component with `CheckItem` items inside.
 
 ```md
-<CheckList id="checklist-id">
+<CheckList title="Checklist title">
 
 <CheckItem title="Check item 1" href="#check-item-1">
   Check item 1 description
@@ -471,10 +471,9 @@ To display a checklist, use the `CheckList` component with `CheckItem` items ins
 
 ### Notes
 
-- You can use `id` prop to set the id of the checklist.
 - Checklist options saved in the browser local storage.
-- Checklists with the same `id` will use the same local storage between pages.
-- If you don't pass `id`, the id will be generated from the page `slug`.
+- Checklists with the same `title` will use the same local storage between pages.
+- If you don't pass `title`, the id will be generated from the page `slug`.
 - The best practice is to use `CheckList` with the `Steps` component on the page.
 
 <details>

--- a/content/docs/get-started-with-neon/production-checklist.md
+++ b/content/docs/get-started-with-neon/production-checklist.md
@@ -6,9 +6,7 @@ enableTableOfContents: true
 updatedOn: '2025-04-18T19:08:17.175Z'
 ---
 
-<CheckList id="production-checklist">
-
-## Production checklist
+<CheckList title="Production checklist">
 
 <CheckItem title="1. Set minimum compute to at least 1 vCPU" href="#set-minimum-compute-to-at-least-1-cu">
   Make sure your default branch can handle production traffic. A higher minimum compute helps you avoid performance bottlenecks.

--- a/public/images/checklist.svg
+++ b/public/images/checklist.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.00098 4.49902L4.00098 7.49902L11.001 0.499023" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/pages/doc/check-item/check-item.jsx
+++ b/src/components/pages/doc/check-item/check-item.jsx
@@ -18,31 +18,32 @@ const CheckItem = ({ title, href, children, checklist = [], onToggle, ...otherPr
   const Tag = href ? Link : 'div';
 
   return (
-    <div className="mt-3">
-      <label className="relative flex cursor-pointer items-start gap-x-2.5 pl-6" htmlFor={id}>
+    <li className="!m-0 before:hidden">
+      <label className="relative block cursor-pointer pl-[30px]" htmlFor={id}>
         <input
           className={clsx(
             'remove-autocomplete-styles pointer-events-none appearance-none',
-            'absolute left-0 top-0.5 z-10 h-4 w-4 rounded border border-black/10 bg-black/5 transition-colors duration-200 hover:bg-black/10',
-            'dark:border-gray-new-20 dark:bg-white/5 dark:hover:bg-white/10',
-            'before:absolute before:inset-0 before:z-10 before:bg-[url(/images/checklist.svg)] before:bg-center before:bg-no-repeat before:invert',
-            'before:opacity-0 before:transition-opacity before:duration-200',
-            'checked:border-secondary-8/50 checked:!bg-secondary-8/70 checked:before:opacity-100',
-            'dark:checked:border-gray-new-20 dark:checked:!bg-white/5'
+            'absolute left-0 top-0.5 z-10 size-4 rounded-sm border border-gray-new-80 transition-colors duration-200 hover:bg-gray-new-95',
+            'dark:border-gray-new-20 dark:hover:bg-white/5',
+            'before:absolute before:inset-0 before:z-10 before:bg-[url(/images/checklist.svg)] before:bg-center before:bg-no-repeat',
+            'before:opacity-0 before:transition-opacity before:duration-200 checked:before:opacity-100',
+            'dark:before:invert dark:checked:border-gray-new-20 dark:checked:!bg-white/5'
           )}
           type="checkbox"
           id={id}
           checked={isChecked}
           onChange={() => onToggle(id)}
         />
-        <h3 className="m-0 text-lg font-medium leading-tight tracking-extra-tight">
+        <h3 className="m-0 text-lg font-medium leading-tight tracking-normal">
           <Tag className="" href={href || null} {...otherProps}>
             {title}
           </Tag>
         </h3>
       </label>
-      <div className="mt-3 pl-6 [&_p]:mb-0">{children}</div>
-    </div>
+      <div className="mt-2 pl-[30px] leading-snug tracking-tight text-gray-new-20 dark:text-gray-new-80 md:mt-1.5 [&_p]:m-0">
+        {children}
+      </div>
+    </li>
   );
 };
 

--- a/src/components/pages/doc/check-item/check-item.jsx
+++ b/src/components/pages/doc/check-item/check-item.jsx
@@ -40,7 +40,7 @@ const CheckItem = ({ title, href, children, checklist = [], onToggle, ...otherPr
           </Tag>
         </h3>
       </label>
-      <div className="mt-2 pl-[30px] leading-snug tracking-tight text-gray-new-20 dark:text-gray-new-80 md:mt-1.5 [&_p]:m-0">
+      <div className="mt-2 pl-[30px] text-gray-new-20 dark:text-gray-new-80 md:mt-1.5 [&_p]:m-0 [&_p]:leading-snug [&_p]:tracking-tight">
         {children}
       </div>
     </li>

--- a/src/components/pages/doc/check-item/check-item.jsx
+++ b/src/components/pages/doc/check-item/check-item.jsx
@@ -27,7 +27,7 @@ const CheckItem = ({ title, href, children, checklist = [], onToggle, ...otherPr
             'dark:border-gray-new-20 dark:hover:bg-white/5',
             'before:absolute before:inset-0 before:z-10 before:bg-[url(/images/checklist.svg)] before:bg-center before:bg-no-repeat',
             'before:opacity-0 before:transition-opacity before:duration-200 checked:before:opacity-100',
-            'dark:before:invert dark:checked:border-gray-new-20 dark:checked:!bg-white/5'
+            'dark:before:invert dark:checked:border-gray-new-20'
           )}
           type="checkbox"
           id={id}

--- a/src/components/pages/doc/check-item/check-item.jsx
+++ b/src/components/pages/doc/check-item/check-item.jsx
@@ -24,11 +24,11 @@ const CheckItem = ({ title, href, children, checklist = [], onToggle, ...otherPr
           className={clsx(
             'remove-autocomplete-styles pointer-events-none appearance-none',
             'absolute left-0 top-0.5 z-10 h-4 w-4 rounded border border-black/10 bg-black/5 transition-colors duration-200 hover:bg-black/10',
-            'dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10',
-            'before:absolute before:inset-0 before:z-10 before:bg-[url(/images/check.svg)] before:bg-[length:12px_12px] before:bg-center before:bg-no-repeat before:invert',
+            'dark:border-gray-new-20 dark:bg-white/5 dark:hover:bg-white/10',
+            'before:absolute before:inset-0 before:z-10 before:bg-[url(/images/checklist.svg)] before:bg-center before:bg-no-repeat before:invert',
             'before:opacity-0 before:transition-opacity before:duration-200',
             'checked:border-secondary-8/50 checked:!bg-secondary-8/70 checked:before:opacity-100',
-            'dark:checked:border-white/30 dark:checked:!bg-white/10'
+            'dark:checked:border-gray-new-20 dark:checked:!bg-white/5'
           )}
           type="checkbox"
           id={id}

--- a/src/components/pages/doc/check-list/check-list.jsx
+++ b/src/components/pages/doc/check-list/check-list.jsx
@@ -55,21 +55,25 @@ const CheckList = ({ title, children }) => {
   });
 
   return (
-    <div className="checklist doc-cta prose-doc my-5 flex flex-col rounded-[10px] border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA,transparent)] px-7 py-6 dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_30%,#131415_75%)] md:p-5 md:px-4 md:py-5">
-      <div className="mb-2 flex items-center gap-3">
-        {title && <h2 className="!m-0">{title}</h2>}
+    <div className="checklist doc-cta my-5 flex flex-col rounded-[10px] border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA,transparent)] px-8 py-6 dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_30%,#131415_75%)] md:p-5 md:px-4 md:py-5">
+      <div className="flex items-start gap-3.5">
+        {title && (
+          <h2 className="!m-0 font-medium leading-snug tracking-tighter lg:text-xl">{title}</h2>
+        )}
         <span
           className={clsx(
-            'rounded-full border px-2 py-1.5 text-[15px] font-medium leading-none tracking-extra-tight',
+            'mt-[3px] rounded-full border px-2 py-[5px] text-[15px] font-medium leading-none tracking-extra-tight lg:mt-px',
             progress === 100
               ? 'border-secondary-8/20 bg-secondary-8/10 text-secondary-8 dark:border-green-45/20 dark:bg-green-45/10 dark:text-green-45'
               : 'border-gray-new-80 bg-gray-new-94 text-gray-new-20 dark:border-white/20 dark:bg-white/10 dark:text-gray-new-90'
           )}
         >
-          {progress === 100 ? 'Completed' : `${progress} %`}
+          {progress === 100 ? 'Complete' : `${progress}%`}
         </span>
       </div>
-      {childrenWithProps}
+      <ul className="!mb-0 !mt-5 flex flex-col gap-4 !p-0 lg:mt-[18px] md:mt-4">
+        {childrenWithProps}
+      </ul>
     </div>
   );
 };

--- a/src/components/pages/doc/check-list/check-list.jsx
+++ b/src/components/pages/doc/check-list/check-list.jsx
@@ -55,14 +55,21 @@ const CheckList = ({ title, children }) => {
   });
 
   return (
-    <div className="checklist doc-cta my-5 flex flex-col rounded-[10px] border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA,transparent)] px-8 py-6 dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_30%,#131415_75%)] md:p-5 md:px-4 md:py-5">
+    <div
+      className={clsx(
+        'checklist doc-cta !mt-10 flex flex-col rounded-lg px-8 py-6',
+        'border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA,transparent)] ',
+        'dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_30%,#131415_75%)]',
+        'xl:!mt-8 lg:px-6 lg:py-5 md:p-5 md:px-5 md:py-[18px]'
+      )}
+    >
       <div className="flex items-start gap-3.5">
         {title && (
           <h2 className="!m-0 font-medium leading-snug tracking-tighter lg:text-xl">{title}</h2>
         )}
         <span
           className={clsx(
-            'mt-[3px] rounded-full border px-2 py-[5px] text-[15px] font-medium leading-none tracking-extra-tight lg:mt-px',
+            'mt-[3px] rounded-full border px-2 py-[5px] text-[15px] font-medium leading-none tracking-extra-tight lg:mt-0',
             progress === 100
               ? 'border-secondary-8/20 bg-secondary-8/10 text-secondary-8 dark:border-green-45/20 dark:bg-green-45/10 dark:text-green-45'
               : 'border-gray-new-80 bg-gray-new-94 text-gray-new-20 dark:border-white/20 dark:bg-white/10 dark:text-gray-new-90'
@@ -71,7 +78,7 @@ const CheckList = ({ title, children }) => {
           {progress === 100 ? 'Complete' : `${progress}%`}
         </span>
       </div>
-      <ul className="!mb-0 !mt-5 flex flex-col gap-4 !p-0 lg:mt-[18px] md:mt-4">
+      <ul className="!mb-0 !mt-5 flex flex-col gap-[18px] !p-0 lg:!mt-[18px] lg:gap-4 md:!mt-4">
         {childrenWithProps}
       </ul>
     </div>

--- a/src/components/pages/doc/check-list/check-list.jsx
+++ b/src/components/pages/doc/check-list/check-list.jsx
@@ -1,21 +1,36 @@
 'use client';
 
+import clsx from 'clsx';
 import { usePathname } from 'next/navigation';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
+import slugify from 'slugify';
 
 import useLocalStorage from 'hooks/use-local-storage';
 
-const CheckList = ({ id, children }) => {
+const CheckList = ({ title, children }) => {
+  const id =
+    title &&
+    slugify(title, {
+      lower: true,
+      strict: true,
+      remove: /[*+~.()'"!:@]/g,
+    }).replace(/_/g, '');
+
   const pathname = usePathname();
   const slug = pathname.split('/').pop();
   const checkListId = id || slug;
   const [mounted, setMounted] = useState(false);
+  const [progress, setProgress] = useState(0);
   const [checklist, setChecklist] = useLocalStorage(`checklist-${checkListId}`, []);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    setProgress(Math.round((checklist.length / children.length) * 100));
+  }, [checklist, children]);
 
   const handleToggle = useCallback(
     (id) => {
@@ -41,13 +56,26 @@ const CheckList = ({ id, children }) => {
 
   return (
     <div className="checklist doc-cta prose-doc my-5 flex flex-col rounded-[10px] border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA,transparent)] px-7 py-6 dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_30%,#131415_75%)] md:p-5 md:px-4 md:py-5">
+      <div className="mb-2 flex items-center gap-3">
+        {title && <h2 className="!m-0">{title}</h2>}
+        <span
+          className={clsx(
+            'rounded-full border px-2 py-1.5 text-[15px] font-medium leading-none tracking-extra-tight',
+            progress === 100
+              ? 'border-secondary-8/20 bg-secondary-8/10 text-secondary-8 dark:border-green-45/20 dark:bg-green-45/10 dark:text-green-45'
+              : 'border-gray-new-80 bg-gray-new-94 text-gray-new-20 dark:border-white/20 dark:bg-white/10 dark:text-gray-new-90'
+          )}
+        >
+          {progress === 100 ? 'Completed' : `${progress} %`}
+        </span>
+      </div>
       {childrenWithProps}
     </div>
   );
 };
 
 CheckList.propTypes = {
-  id: PropTypes.string,
+  title: PropTypes.string,
   children: PropTypes.node.isRequired,
 };
 


### PR DESCRIPTION
This PR brings an update for the docs `CheckList`, implemented at https://github.com/neondatabase/website/pull/3300

![image](https://github.com/user-attachments/assets/f10ab528-f1f3-4224-a124-9609b5f5632c)

- progressbar
- updated styles and check icon
- refactors checklist `id` to `title`

[Preview](https://neon-next-git-checklist-progress-neondatabase.vercel.app/docs/get-started-with-neon/production-checklist)