### PR TITLE
docs: add Azure AI agent service to sidebar

### DIFF
--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -494,6 +494,8 @@
               slug: https://neon.tech/guides/agentstack-neon
             - title: AutoGen
               slug: https://neon.tech/guides/autogen-neon
+            - title: Azure AI Agent Service
+              slug: https://neon.tech/guides/azure-ai-agent-service 
             - title: Composio + CrewAI
               slug: https://neon.tech/guides/composio-crewai-neon
             - title: LangGraph


### PR DESCRIPTION
We have a good example of using Azure AI Agent Service with Neon, I added a reference to it.