### PR TITLE
Update postgresql-row_number.md

### DIFF
--- a/content/postgresql/postgresql-window-function/postgresql-row_number.md
+++ b/content/postgresql/postgresql-window-function/postgresql-row_number.md
@@ -180,12 +180,12 @@ FROM
       ROW_NUMBER () OVER (
         ORDER BY
           product_name
-      )
+      ) as rn
     FROM
       products
   ) x
 WHERE
-  ROW_NUMBER BETWEEN 6 AND 10;
+  rn BETWEEN 6 AND 10;
 ```
 
 ![PostgreSQL ROW_NUMBER with pagination](/postgresqltutorial/PostgreSQL-ROW_NUMBER-with-pagination.png)


### PR DESCRIPTION
ROW_NUMBER is not defined as an alias and will cause an error. Defined an alias for the column for future reference outside of the subquery.