### PR TITLE
fix: landing form validation and errors style

### DIFF
--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -3,7 +3,7 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import useCookie from 'react-use/lib/useCookie';
 import useLocation from 'react-use/lib/useLocation';
@@ -52,6 +52,12 @@ const ContactForm = () => {
     hutk: hubspotutk,
     pageUri: href,
   };
+
+  useEffect(() => {
+    if (Object.keys(errors).length > 0) {
+      setFormState(FORM_STATES.ERROR);
+    }
+  }, [errors]);
 
   const onSubmit = async (data, e) => {
     e.preventDefault();
@@ -207,7 +213,10 @@ const ContactForm = () => {
           .
         </p>
         <Button
-          className="min-w-[176px] py-[15px] font-medium 2xl:text-base xl:min-w-[138px] lg:min-w-[180px] sm:w-full sm:py-[13px]"
+          className={clsx(
+            'min-w-[176px] py-[15px] font-medium 2xl:text-base xl:min-w-[138px] lg:min-w-[180px] sm:w-full sm:py-[13px]',
+            formState === FORM_STATES.ERROR && '!bg-secondary-1/50'
+          )}
           type="submit"
           theme="primary"
           size="xs"

--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -31,7 +31,6 @@ const schema = yup
   .required();
 
 const labelClassName = 'text-sm text-gray-new-90';
-const errorClassName = '!top-0';
 
 const ContactForm = () => {
   const [formState, setFormState] = useState(FORM_STATES.DEFAULT);
@@ -130,7 +129,6 @@ const ContactForm = () => {
         placeholder="Marques Hansen"
         theme="transparent"
         labelClassName={labelClassName}
-        errorClassName={errorClassName}
         error={errors.name?.message}
         isDisabled={isDisabled}
         {...register('name')}
@@ -143,7 +141,6 @@ const ContactForm = () => {
         placeholder="info@acme.com"
         theme="transparent"
         labelClassName={labelClassName}
-        errorClassName={errorClassName}
         isDisabled={isDisabled}
         error={errors.email?.message}
         {...register('email')}
@@ -155,7 +152,6 @@ const ContactForm = () => {
           label="Company Website"
           theme="transparent"
           labelClassName={labelClassName}
-          errorClassName={errorClassName}
           isDisabled={isDisabled}
           {...register('companyWebsite')}
         />
@@ -167,7 +163,6 @@ const ContactForm = () => {
           defaultValue="hidden"
           theme="transparent"
           labelClassName={labelClassName}
-          errorClassName={errorClassName}
           isDisabled={isDisabled}
           error={errors.companySize?.message}
           {...register('companySize')}
@@ -190,7 +185,6 @@ const ContactForm = () => {
         theme="transparent"
         labelClassName={labelClassName}
         textareaClassName="min-h-[170px] xl:min-h-[148px]"
-        errorClassName={errorClassName}
         isDisabled={isDisabled}
         error={errors.message?.message}
         {...register('message')}

--- a/src/components/pages/landing/form/form-field/form-field.jsx
+++ b/src/components/pages/landing/form/form-field/form-field.jsx
@@ -61,7 +61,6 @@ const Input = ({
     placeholder={placeholder}
     isDisabled={formState === FORM_STATES.LOADING || formState === FORM_STATES.SUCCESS}
     error={errors[name]?.message}
-    errorClassName={clsx(errorClassName, 'relative right-0 ml-auto mt-2 -mb-3')}
     {...register(name)}
   />
 );

--- a/src/components/pages/landing/form/form.jsx
+++ b/src/components/pages/landing/form/form.jsx
@@ -185,7 +185,7 @@ const Form = ({
               placeholder={simpleField.placeholder}
               isDisabled={state === FORM_STATES.LOADING || state === FORM_STATES.SUCCESS}
               error={errors[simpleField.name]?.message}
-              errorClassName="ml-7"
+              errorClassName="bottom-auto top-full !text-center w-full max-w-full translate-y-2"
               {...register(simpleField.name)}
             />
             <SubmitButton formState={state} text={submitText} simpleMode />

--- a/src/components/pages/landing/form/form.jsx
+++ b/src/components/pages/landing/form/form.jsx
@@ -185,7 +185,7 @@ const Form = ({
               placeholder={simpleField.placeholder}
               isDisabled={state === FORM_STATES.LOADING || state === FORM_STATES.SUCCESS}
               error={errors[simpleField.name]?.message}
-              errorClassName="bottom-auto top-full !text-center w-full max-w-full translate-y-2"
+              errorClassName="bottom-auto top-full !text-center w-full max-w-full !translate-y-2"
               {...register(simpleField.name)}
             />
             <SubmitButton formState={state} text={submitText} simpleMode />

--- a/src/components/shared/changelog-form/changelog-form.jsx
+++ b/src/components/shared/changelog-form/changelog-form.jsx
@@ -27,7 +27,7 @@ const themeClassNames = {
     title: 'text-[15px] lg:shrink-0 lg:text-lg',
     input: 'pr-20 lg:pr-32',
     sendText: 'hidden lg:block',
-    errorMessage: 'mt-5',
+    errorMessage: 'mt-5 sm:mt-6',
   },
   default: {
     block: 'items-center gap-[72px] px-6 py-[18px]',
@@ -120,7 +120,7 @@ const ChangelogForm = ({ isSidebar = false, className }) => {
         'changelog-form safe-paddings relative flex scroll-mt-20 rounded-lg bg-gray-new-94',
         classNames.block,
         className,
-        'lg:scroll-mt-10 md:gap-10 sm:flex-col sm:items-start sm:gap-2.5 sm:p-[18px] sm:pt-3.5',
+        'lg:scroll-mt-10 md:gap-10 sm:flex-col sm:items-start sm:gap-2.5 sm:p-[18px] sm:py-5',
         'dark:bg-subscribe-form-dark dark:shadow-[0px_2px_10px_0px_rgba(0,0,0,.4),0px_2px_30px_0px_rgba(0,0,0,.5)]'
       )}
       id="changelog-form"
@@ -231,7 +231,6 @@ const ChangelogForm = ({ isSidebar = false, className }) => {
             className={clsx(
               'absolute left-1/2 top-full -translate-x-1/2 whitespace-nowrap',
               'text-xs leading-none tracking-extra-tight text-secondary-1',
-              'xl:left-4 xl:translate-x-0 sm:left-1/2 sm:-translate-x-1/2',
               classNames.errorMessage
             )}
             data-test="error-message"

--- a/src/components/shared/field/field.jsx
+++ b/src/components/shared/field/field.jsx
@@ -84,8 +84,8 @@ const Field = forwardRef(
       {error && (
         <p
           className={clsx(
-            'error-message absolute !top-auto bottom-full right-0 z-10 max-w-[350px] translate-y-4 text-end text-sm leading-none text-secondary-1',
-            'sm:static sm:ml-auto sm:mt-2 sm:translate-y-0 [&_a:hover]:no-underline [&_a]:underline [&_a]:underline-offset-2',
+            'error-message !absolute bottom-full right-0 z-10 m-0 max-w-[350px] translate-y-4 text-end text-sm leading-none text-secondary-1',
+            'sm:!static sm:ml-auto sm:mt-2 sm:translate-y-0 [&_a:hover]:no-underline [&_a]:underline [&_a]:underline-offset-2',
             errorClassName
           )}
           data-test="error-field-message"


### PR DESCRIPTION
This PR brings a refactor for the landing form validation and errors style

Reference PR where error styles became broken: https://github.com/neondatabase/website/pull/2989

[Preview Extended Form](https://neon-next-git-refactor-landing-form-neondatabase.vercel.app/msbuild-meeting)
[Preview Small Form](https://neon-next-git-refactor-landing-form-neondatabase.vercel.app/500-startups)
[Preview Contact Sales](https://neon-next-git-refactor-landing-form-neondatabase.vercel.app/contact-sales)