### PR TITLE
feat: header github and hero text

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -111,8 +111,8 @@ const Hero = () => {
             Ship faster with Postgres
           </h1>
           <p className="mt-2.5 max-w-xl text-lg font-light leading-snug tracking-tighter text-gray-new-80 lg:mt-2.5 lg:text-base">
-            The database you love, on a serverless platform designed to help you build reliable and
-            scalable applications faster.
+            The database developers trust, on a serverless platform designed to help you build
+            reliable and scalable applications faster.
           </p>
           <div className="mt-8 flex items-center gap-6">
             <Button

--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -38,7 +38,6 @@
     "button": {
       "url": "https://console.neon.tech/signup",
       "text": "Start for free",
-      "theme": "white-outline",
       "event": "Hero Free Tier Panel",
       "analyticsEvent": "pricing_page_get_started_with_free_plan_clicked"
     }
@@ -136,7 +135,6 @@
     "button": {
       "url": "https://console.neon.tech/app/billing#plans",
       "text": "Get started",
-      "theme": "white-outline",
       "event": "Hero Scale Panel",
       "analyticsEvent": "pricing_page_get_started_with_scale_plan_clicked"
     }
@@ -194,7 +192,7 @@
     "button": {
       "url": "https://console.neon.tech/app/billing#plans",
       "text": "Get started",
-      "theme": "white-outline",
+
       "event": "Hero Enterprise Panel",
       "analyticsEvent": "pricing_page_get_started_with_business_plan_clicked"
     }

--- a/src/components/shared/github-star-counter/github-star-counter.jsx
+++ b/src/components/shared/github-star-counter/github-star-counter.jsx
@@ -34,7 +34,7 @@ const GithubStarCounter = ({ className = '', isDarkTheme = false, starsCount }) 
     }}
   >
     <GitHubIcon width={20} height={20} />
-    <span className="w-8 whitespace-nowrap" aria-label={`Star us on GitHub (${starsCount})`}>
+    <span className="whitespace-nowrap" aria-label={`Star us on GitHub (${starsCount})`}>
       {formatStars(starsCount)}
     </span>
   </Link>

--- a/src/components/shared/github-star-counter/github-star-counter.jsx
+++ b/src/components/shared/github-star-counter/github-star-counter.jsx
@@ -20,11 +20,11 @@ const formatStars = (starsCount) => {
 const GithubStarCounter = ({ className = '', isDarkTheme = false, starsCount }) => (
   <Link
     className={clsx(
-      'flex items-center gap-x-1.5 text-[13px] leading-none tracking-extra-tight transition-colors duration-200',
+      'flex items-center gap-x-1.5 text-sm leading-none tracking-extra-tight transition-colors duration-200',
       className,
       isDarkTheme
-        ? 'text-white hover:text-green-45'
-        : 'text-gray-new-8 hover:text-green-45 dark:text-white dark:hover:text-green-45'
+        ? 'text-gray-new-90 hover:text-green-45'
+        : 'text-gray-new-8 hover:text-green-45 dark:text-gray-new-90 dark:hover:text-green-45'
     )}
     to={LINKS.github}
     target="_blank"
@@ -33,7 +33,7 @@ const GithubStarCounter = ({ className = '', isDarkTheme = false, starsCount }) 
       sendGtagEvent('click_star_us_button');
     }}
   >
-    <GitHubIcon width={20} height={20} />
+    <GitHubIcon width={18} height={18} />
     <span className="whitespace-nowrap" aria-label={`Star us on GitHub (${starsCount})`}>
       {formatStars(starsCount)}
     </span>

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -55,13 +55,19 @@ const Header = ({
               </Link>
             </div>
             {docPageType !== 'postgres' && (
-              <div className="col-span-7 col-start-2 -ml-6 flex max-w-[832px] gap-3.5 3xl:ml-0 2xl:col-span-8 2xl:col-start-1 xl:max-w-none md:hidden">
+              <div className="col-span-7 col-start-2 -ml-6 flex max-w-[832px] gap-3.5 3xl:ml-0 2xl:col-span-7 2xl:col-start-1 xl:max-w-none md:hidden">
                 <ModeToggler isAiChatPage={docPageType === 'aiChat'} />
               </div>
             )}
-            <div className="col-span-2 col-start-10 -ml-12 h-full max-w-64 3xl:-ml-20 2xl:col-span-4 2xl:col-start-9 2xl:ml-6 xl:ml-0 lg:hidden">
+            <div className="col-span-2 col-start-10 -ml-12 h-full 3xl:-ml-20 2xl:col-span-5 2xl:col-start-8 2xl:ml-0 2xl:flex 2xl:justify-end xl:ml-auto lg:hidden">
               <Sidebar isClient={isClient} />
             </div>
+            {/* <div className="col-start-2 col-span-10 flex items-center justify-between 2xl:col-start-1 2xl:col-span-full w-full lg:w-auto">
+              {docPageType !== 'postgres' && (
+                <ModeToggler className="md:hidden" isAiChatPage={docPageType === 'aiChat'} />
+              )}
+              <Sidebar className="lg:hidden" isClient={isClient} />
+            </div> */}
           </Container>
         </div>
       ) : (

--- a/src/components/shared/header/sidebar/sidebar.jsx
+++ b/src/components/shared/header/sidebar/sidebar.jsx
@@ -24,46 +24,49 @@ const GithubStars = async ({ isDarkTheme }) => {
 
 GithubStars.propTypes = themePropTypes;
 
-const DiscordLink = ({ isDarkTheme }) => (
-  <Link
-    className={clsx(
-      'transition-colors duration-200',
-      isDarkTheme
-        ? 'text-white hover:text-green-45'
-        : 'text-gray-new-40 hover:text-green-45 dark:text-white dark:hover:text-green-45'
-    )}
-    to={LINKS.discord}
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    <DiscordIcon width={20} height={20} />
-    <span className="sr-only">Discord</span>
-  </Link>
-);
-
-DiscordLink.propTypes = themePropTypes;
-
 const Sidebar = ({ isDarkTheme, isClient }) => (
   <div className="flex items-center gap-x-6 lg:hidden">
-    {!isClient && <GithubStars isDarkTheme={isDarkTheme} />}
-    <DiscordLink isDarkTheme={isDarkTheme} />
     <Link
-      className="whitespace-nowrap text-[13px] leading-none tracking-extra-tight lg:hidden"
-      to={LINKS.login}
-      theme={isDarkTheme ? 'white' : 'black'}
+      className={clsx(
+        'flex items-center gap-1.5 transition-colors duration-200',
+        isDarkTheme
+          ? 'text-gray-new-90 hover:text-green-45'
+          : 'text-gray-new-8 hover:text-green-45 dark:text-gray-new-90 dark:hover:text-green-45'
+      )}
+      to={LINKS.discord}
+      target="_blank"
+      rel="noopener noreferrer"
     >
-      Log In
+      <DiscordIcon width={18} height={18} />
+      <span className="text-sm leading-none tracking-extra-tight">Discord</span>
     </Link>
-
-    <Button
-      className="h-8 whitespace-nowrap px-6 text-[13px] font-semibold leading-none tracking-extra-tight transition-colors duration-200 lg:hidden"
-      to={LINKS.signup}
-      theme="primary"
-      tagName="Header"
-      analyticsEvent="header_sign_up_clicked"
-    >
-      Sign Up
-    </Button>
+    {!isClient && <GithubStars isDarkTheme={isDarkTheme} />}
+    <div className="flex gap-2.5 lg:hidden">
+      <Button
+        className={clsx(
+          'px-4.5 whitespace-nowrap border font-semibold',
+          isDarkTheme
+            ? 'border-gray-new-30 hover:border-gray-new-40'
+            : 'border-gray-new-70 hover:border-gray-new-50 dark:border-gray-new-30 dark:hover:border-gray-new-40'
+        )}
+        to={LINKS.login}
+        size="xxs"
+        tagName="Header"
+        analyticsEvent="header_sign_up_clicked"
+      >
+        Log In
+      </Button>
+      <Button
+        className="px-4.5 whitespace-nowrap font-semibold"
+        to={LINKS.signup}
+        theme="primary"
+        size="xxs"
+        tagName="Header"
+        analyticsEvent="header_sign_up_clicked"
+      >
+        Sign Up
+      </Button>
+    </div>
   </div>
 );
 

--- a/src/components/shared/header/sidebar/sidebar.jsx
+++ b/src/components/shared/header/sidebar/sidebar.jsx
@@ -24,8 +24,8 @@ const GithubStars = async ({ isDarkTheme }) => {
 
 GithubStars.propTypes = themePropTypes;
 
-const Sidebar = ({ isDarkTheme, isClient }) => (
-  <div className="flex items-center gap-x-6 lg:hidden">
+const Sidebar = ({ isDarkTheme, isClient, className }) => (
+  <div className={clsx('flex items-center gap-x-6 lg:hidden', className)}>
     <Link
       className={clsx(
         'flex items-center gap-1.5 transition-colors duration-200',
@@ -73,6 +73,7 @@ const Sidebar = ({ isDarkTheme, isClient }) => (
 Sidebar.propTypes = {
   ...themePropTypes,
   isClient: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default Sidebar;

--- a/src/components/shared/header/sidebar/sidebar.jsx
+++ b/src/components/shared/header/sidebar/sidebar.jsx
@@ -1,14 +1,28 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import { Suspense } from 'react';
 
 import Button from 'components/shared/button';
+import GithubStarCounter from 'components/shared/github-star-counter';
 import Link from 'components/shared/link';
 import LINKS from 'constants/links';
 import DiscordIcon from 'icons/discord.inline.svg';
+import { getGithubStars } from 'utils/get-github-data';
 
 const themePropTypes = {
   isDarkTheme: PropTypes.bool,
 };
+
+const GithubStars = async ({ isDarkTheme }) => {
+  const starsCount = await getGithubStars();
+  return (
+    <Suspense>
+      <GithubStarCounter isDarkTheme={isDarkTheme} starsCount={starsCount} />
+    </Suspense>
+  );
+};
+
+GithubStars.propTypes = themePropTypes;
 
 const DiscordLink = ({ isDarkTheme }) => (
   <Link
@@ -29,8 +43,9 @@ const DiscordLink = ({ isDarkTheme }) => (
 
 DiscordLink.propTypes = themePropTypes;
 
-const Sidebar = ({ isDarkTheme }) => (
+const Sidebar = ({ isDarkTheme, isClient }) => (
   <div className="flex items-center gap-x-6 lg:hidden">
+    {!isClient && <GithubStars isDarkTheme={isDarkTheme} />}
     <DiscordLink isDarkTheme={isDarkTheme} />
     <Link
       className="whitespace-nowrap text-[13px] leading-none tracking-extra-tight lg:hidden"


### PR DESCRIPTION
This PR brings:
- Github stars link in header
- Homepage hero text update

![image](https://github.com/user-attachments/assets/c1c80dcc-fcc1-4659-bdde-e151a58c758d)

[Preview](https://neon-next-git-header-github-and-hero-text-neondatabase.vercel.app/)