### PR TITLE
docs: Fix doc for ANY operator behavior with empty subquery

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-any.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-any.md
@@ -34,7 +34,7 @@ In this syntax:
 
 The `ANY` operator returns `true` if the comparison returns `true` for at least one of the values in the set, and `false` otherwise.
 
-If the subquery returns an empty set, the result of `ANY` comparison is always `true`.
+If the subquery returns an empty set, the result of `ANY` comparison is always `false`.
 
 Besides the subquery, you can use any construct that returns a set of values such as an [`ARRAY`](postgresql-array).
 


### PR DESCRIPTION
If the subquery returns an empty set, the result of an ANY comparison is always `false`, not `true`.

This behavior is based on logical reasoning:
- The ANY operator checks whether the condition is satisfied by any element in the set.
- If the set is empty, there are no elements to satisfy the condition.
- Therefore, the result of the comparison is false, since the condition cannot be true for any element.

### Example
``` sql
CREATE TABLE users (id INT, name TEXT);

INSERT INTO users (id, name) VALUES 
(1, 'Alice'),
(2, 'Bob'),
(3, 'Charlie');
```
Query: 
``` sql
SELECT 1 = ANY (SELECT id FROM users WHERE id > 100);
```
return `false`;
