### PR TITLE
chore: add algolia env variable information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ npm install
 cp .env.example .env
 ```
 
+4. Check for environment variables
+
+Particularly in cases when working on `/blog` pages, both the following variables need values, or you'll see errors.
+
+```
+NEXT_PUBLIC_ALGOLIA_APP_ID=
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=
+```
+
+You can find this information on the following internal Neon Notion page: [How to build the Neon website locally](https://www.notion.so/neondatabase/How-to-build-the-Neon-website-locally-b5fc26e020d14b6eb90fdd6f41e29db4#03975baa5bdb436bbd67553da064b541).
+
 ## Usage
 
 ### Run the website


### PR DESCRIPTION
Since both these env vars are public, is there any reason not to include them in the `.env.example` file? Then we wouldn't need this step and the `cp .env.example .env` would suffice.