### PR TITLE
docs: Updates Prisma docs to align with recent changes

### DIFF
--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -163,7 +163,7 @@ Update your Prisma Client instance:
 import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
 import { PrismaNeon } from '@prisma/adapter-neon';
-import { Pool, neonConfig } from '@neondatabase/serverless';
+import { neonConfig } from '@neondatabase/serverless';
 
 import ws from 'ws';
 neonConfig.webSocketConstructor = ws;
@@ -178,8 +178,7 @@ neonConfig.webSocketConstructor = ws;
 
 const connectionString = `${process.env.DATABASE_URL}`;
 
-const pool = new Pool({ connectionString });
-const adapter = new PrismaNeon(pool);
+const adapter = new PrismaNeon({ connectionString });
 const prisma = global.prisma || new PrismaClient({ adapter });
 
 if (process.env.NODE_ENV === 'development') global.prisma = prisma;


### PR DESCRIPTION
In reference to https://github.com/prisma/prisma/pull/26633

Pool is now handled by the `PrismaNeon` class (`PrismaNeonAdapterFactory`)
```ts
export class PrismaNeonAdapterFactory implements SqlDriverAdapterFactory {
  readonly provider = 'postgres'
  readonly adapterName = packageName

  constructor(private readonly config: neon.PoolConfig, private options?: PrismaNeonOptions) {}

  async connect(): Promise<SqlDriverAdapter> {
    return new PrismaNeonAdapter(new neon.Pool(this.config), this.options)
  }
}
```
This is the new adapter meaning that you no longer need to pass in the pool 🎉

_Please let me know if there is other parts of the docs that require changes from what I can tell nothing mentions having to instantiate Pool so this change should be enough 🙏_

EDIT: In reference to this thread on Discord https://discord.com/channels/1176467419317940276/1362210836986204180