### PR TITLE
feat: add fallback for missing algolia env variables

### DIFF
--- a/src/components/shared/algolia-search/algolia-search.jsx
+++ b/src/components/shared/algolia-search/algolia-search.jsx
@@ -18,8 +18,8 @@ const AlgoliaSearch = ({ indexName, children, posts, searchInputClassName }) => 
   // Initialize searchClient only if environment variables are available
   const algoliaAppId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
   const algoliaApiKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY;
-  const areAlgoliaCredsAvailable = algoliaAppId && algoliaApiKey;
-  const searchClient = areAlgoliaCredsAvailable ? algoliasearch(algoliaAppId, algoliaApiKey) : null;
+  const algoliaCredsAvailable = algoliaAppId && algoliaApiKey;
+  const searchClient = algoliaCredsAvailable ? algoliasearch(algoliaAppId, algoliaApiKey) : null;
 
   useEffect(() => setMounted(true), []);
 
@@ -36,10 +36,10 @@ const AlgoliaSearch = ({ indexName, children, posts, searchInputClassName }) => 
   };
 
   // Preloader and fallback for missing Algolia credentials
-  if (!mounted || !areAlgoliaCredsAvailable)
+  if (!mounted || !algoliaCredsAvailable)
     return (
       <>
-        <SearchInput className={searchInputClassName} asPlaceholder />
+        {algoliaCredsAvailable && <SearchInput className={searchInputClassName} asPlaceholder />}
         {children}
       </>
     );

--- a/src/components/shared/algolia-search/algolia-search.jsx
+++ b/src/components/shared/algolia-search/algolia-search.jsx
@@ -35,11 +35,14 @@ const AlgoliaSearch = ({ indexName, children, posts, searchInputClassName }) => 
     debouncedSetUiState(uiState, setUiState);
   };
 
-  // Preloader and fallback for missing Algolia credentials
-  if (!mounted || !algoliaCredsAvailable)
+  // Fallback for missing Algolia credentials
+  if (!algoliaCredsAvailable) return children;
+
+  // Preloader
+  if (!mounted)
     return (
       <>
-        {algoliaCredsAvailable && <SearchInput className={searchInputClassName} asPlaceholder />}
+        <SearchInput className={searchInputClassName} asPlaceholder />
         {children}
       </>
     );

--- a/src/components/shared/algolia-search/algolia-search.jsx
+++ b/src/components/shared/algolia-search/algolia-search.jsx
@@ -10,15 +10,16 @@ import debounce from 'utils/debounce';
 import SearchInput from './search-input';
 import SearchResults from './search-results';
 
-const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
-  process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY
-);
-
 const debouncedSetUiState = debounce((uiState, setUiState) => setUiState(uiState), 100);
 
 const AlgoliaSearch = ({ indexName, children, posts, searchInputClassName }) => {
   const [mounted, setMounted] = useState(false);
+
+  // Initialize searchClient only if environment variables are available
+  const algoliaAppId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
+  const algoliaApiKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY;
+  const areAlgoliaCredsAvailable = algoliaAppId && algoliaApiKey;
+  const searchClient = areAlgoliaCredsAvailable ? algoliasearch(algoliaAppId, algoliaApiKey) : null;
 
   useEffect(() => setMounted(true), []);
 
@@ -34,7 +35,8 @@ const AlgoliaSearch = ({ indexName, children, posts, searchInputClassName }) => 
     debouncedSetUiState(uiState, setUiState);
   };
 
-  if (!mounted)
+  // Preloader and fallback for missing Algolia credentials
+  if (!mounted || !areAlgoliaCredsAvailable)
     return (
       <>
         <SearchInput className={searchInputClassName} asPlaceholder />


### PR DESCRIPTION
This PR brings an empty render for Algolia search component in case of missing algolia env variables

Reference PR: https://github.com/neondatabase/website/pull/3388

TO-DO:
- [x] remove empty env variables after merge
    ![image](https://github.com/user-attachments/assets/fad2bef0-5f13-44e1-b78a-959c9ff3eb48)


[Preview Blog](https://neon-next-git-mmissing-algolia-env-fallback-neondatabase.vercel.app/blog)
[Preview Guides](https://neon-next-git-mmissing-algolia-env-fallback-neondatabase.vercel.app/guides)