### PR TITLE
Revert "fix: run format-markdown action only on main branch"

### DIFF
--- a/.github/workflows/format-markdown.yml
+++ b/.github/workflows/format-markdown.yml
@@ -3,7 +3,7 @@ name: Format Markdown
 on:
   push:
     branches:
-      - 'main'
+      - '**'
     paths:
       - 'content/**/*.md'
       


### PR DESCRIPTION
Reverts neondatabase/website#3294

Because it's needed to prevent build errors like [this](https://github.com/neondatabase/website/commit/48d70d411c5a5b0cad6deea8cde8cb0dc61541ec#diff-842e744f86778aff6f9b388f0a005657c96e6ce705d905f004fe8e369b978e0dR59) before merge