### PR TITLE
docs: fix navigation order for GROUPING SETS, CUBE, ROLLUP, and SubQuery

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-cube.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-cube.md
@@ -7,11 +7,11 @@ ogImage: '/postgresqltutorial/sales-table.png'
 updatedOn: '2024-07-01T01:06:31+00:00'
 enableTableOfContents: true
 previousLink:
+  title: 'PostgreSQL GROUPING SETS'
+  slug: 'postgresql-tutorial/postgresql-grouping-sets'
+nextLink:
   title: 'PostgreSQL ROLLUP'
   slug: 'postgresql-tutorial/postgresql-rollup'
-nextLink:
-  title: 'PostgreSQL Subquery'
-  slug: 'postgresql-tutorial/postgresql-subquery'
 ---
 
 **Summary**: in this tutorial, you will learn how to use the PostgreSQL `CUBE` to generate multiple grouping sets.

--- a/content/postgresql/postgresql-tutorial/postgresql-grouping-sets.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-grouping-sets.md
@@ -10,8 +10,8 @@ previousLink:
   title: 'PostgreSQL EXCEPT'
   slug: 'postgresql-tutorial/postgresql-except'
 nextLink:
-  title: 'PostgreSQL ROLLUP'
-  slug: 'postgresql-tutorial/postgresql-rollup'
+  title: 'PostgreSQL CUBE'
+  slug: 'postgresql-tutorial/postgresql-cube'
 ---
 
 **Summary**: in this tutorial, you will learn about grouping sets and how to use the PostgreSQL `GROUPING SETS` clause to generate multiple grouping sets in a query.

--- a/content/postgresql/postgresql-tutorial/postgresql-grouping-sets.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-grouping-sets.md
@@ -7,8 +7,8 @@ ogImage: '/postgresqltutorial/PostgreSQL-Grouping-Sets-GROUPING-function-1.png'
 updatedOn: '2024-07-01T01:00:43+00:00'
 enableTableOfContents: true
 previousLink:
-  title: 'PostgreSQL EXCEPT'
-  slug: 'postgresql-tutorial/postgresql-except'
+  title: 'PostgreSQL HAVING'
+  slug: 'postgresql-tutorial/postgresql-having'
 nextLink:
   title: 'PostgreSQL CUBE'
   slug: 'postgresql-tutorial/postgresql-cube'

--- a/content/postgresql/postgresql-tutorial/postgresql-rollup.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-rollup.md
@@ -7,11 +7,11 @@ ogImage: '/postgresqltutorial/PostgreSQL-ROLLUP-example.png'
 updatedOn: '2024-07-01T01:04:08+00:00'
 enableTableOfContents: true
 previousLink:
-  title: 'PostgreSQL GROUPING SETS'
-  slug: 'postgresql-tutorial/postgresql-grouping-sets'
-nextLink:
   title: 'PostgreSQL CUBE'
   slug: 'postgresql-tutorial/postgresql-cube'
+nextLink:
+  title: 'PostgreSQL Subquery'
+  slug: 'postgresql-tutorial/postgresql-subquery'
 ---
 
 **Summary**: in this tutorial, you will learn how to use the PostgreSQL `ROLLUP` to generate multiple grouping sets.

--- a/content/postgresql/postgresql-tutorial/postgresql-rollup.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-rollup.md
@@ -10,8 +10,8 @@ previousLink:
   title: 'PostgreSQL CUBE'
   slug: 'postgresql-tutorial/postgresql-cube'
 nextLink:
-  title: 'PostgreSQL Subquery'
-  slug: 'postgresql-tutorial/postgresql-subquery'
+  title: 'PostgreSQL UNION'
+  slug: 'postgresql-tutorial/postgresql-union'
 ---
 
 **Summary**: in this tutorial, you will learn how to use the PostgreSQL `ROLLUP` to generate multiple grouping sets.

--- a/content/postgresql/postgresql-tutorial/postgresql-subquery.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-subquery.md
@@ -7,8 +7,8 @@ ogImage: ''
 updatedOn: '2024-07-01T01:04:57+00:00'
 enableTableOfContents: true
 previousLink:
-  title: 'PostgreSQL CUBE'
-  slug: 'postgresql-tutorial/postgresql-cube'
+  title: 'PostgreSQL ROLLUP'
+  slug: 'postgresql-tutorial/postgresql-rollup'
 nextLink:
   title: 'PostgreSQL Correlated Subquery'
   slug: 'postgresql-tutorial/postgresql-correlated-subquery'


### PR DESCRIPTION
Fixed the navigation relationship between the GROUPING SETS, CUBE, ROLLUP, and Subquery documents to ensure the correct sequence: GROUPING SETS, followed by CUBE, then ROLLUP, and finally Subquery according to 'content/postgresql/sidebar.yaml'.