### PR TITLE
docs: fix typo in SQL statement by removing unnecessary 'I'

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-select-into.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-select-into.md
@@ -28,7 +28,7 @@ Here’s the basic syntax of the PostgreSQL `SELECT INTO` statement:
 
 ```sql
 SELECT
-  select_list I
+  select_list
 INTO [ TEMPORARY | TEMP ] [ TABLE ] new_table_name
 FROM
   table_name


### PR DESCRIPTION
Corrected the SQL statement to remove the unnecessary 'I' from the SELECT clause.

### Original SQL statement:
```sql
SELECT
  select_list I
INTO [ TEMPORARY | TEMP ] [ TABLE ] new_table_name
FROM
  table_name
WHERE
  search_condition;
```
### Corrected SQL statement:
```sql
SELECT
  select_list
INTO [ TEMPORARY | TEMP ] [ TABLE ] new_table_name
FROM
  table_name
WHERE
  search_condition;
```
