### PR TITLE
fix: unlock contact form submit button

### DIFF
--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -3,7 +3,7 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import useCookie from 'react-use/lib/useCookie';
 import useLocation from 'react-use/lib/useLocation';
@@ -39,10 +39,18 @@ const ContactForm = () => {
     register,
     reset,
     handleSubmit,
-    formState: { errors },
+    formState: { isValid, errors },
   } = useForm({
     resolver: yupResolver(schema),
   });
+
+  useEffect(() => {
+    const hasErrors = Object.keys(errors).length > 0;
+    if (formState !== FORM_STATES.LOADING && formState !== FORM_STATES.SUCCESS) {
+      if (hasErrors) setFormState(FORM_STATES.ERROR);
+      else setFormState(FORM_STATES.DEFAULT);
+    }
+  }, [errors, isValid, formState]);
 
   const [hubspotutk] = useCookie('hubspotutk');
   const { href } = useLocation();
@@ -52,12 +60,6 @@ const ContactForm = () => {
     hutk: hubspotutk,
     pageUri: href,
   };
-
-  useEffect(() => {
-    if (Object.keys(errors).length > 0) {
-      setFormState(FORM_STATES.ERROR);
-    }
-  }, [errors]);
 
   const onSubmit = async (data, e) => {
     e.preventDefault();
@@ -215,12 +217,12 @@ const ContactForm = () => {
         <Button
           className={clsx(
             'min-w-[176px] py-[15px] font-medium 2xl:text-base xl:min-w-[138px] lg:min-w-[180px] sm:w-full sm:py-[13px]',
-            formState === FORM_STATES.ERROR && '!bg-secondary-1/50'
+            (formState === FORM_STATES.LOADING || formState === FORM_STATES.ERROR) &&
+              'pointer-events-none !bg-secondary-1/50'
           )}
           type="submit"
           theme="primary"
           size="xs"
-          disabled={formState === FORM_STATES.LOADING || formState === FORM_STATES.SUCCESS}
         >
           {formState === FORM_STATES.SUCCESS ? 'Sent!' : 'Submit'}
         </Button>


### PR DESCRIPTION
This PR brings a fix for unlocking contact form submit button

(after the first unsuccess submit attempt and errors being fixed)

![image](https://github.com/user-attachments/assets/e55f24b9-b74b-4fa0-87c1-2f46918234ab)

[Preview](https://neon-next-git-fix-contact-form-submit-button-neondatabase.vercel.app/contact-sales)