### PR TITLE
feat: split full name in contact sales form

### DIFF
--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -43,6 +43,9 @@ const ContactForm = () => {
     formState: { isValid, errors },
   } = useForm({
     resolver: yupResolver(schema),
+    defaultValues: {
+      companySize: 'hidden',
+    },
   });
 
   useEffect(() => {
@@ -184,7 +187,6 @@ const ContactForm = () => {
           name="companySize"
           label="Company Size *"
           tag="select"
-          defaultValue="hidden"
           theme="transparent"
           labelClassName={labelClassName}
           isDisabled={isDisabled}

--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -20,6 +20,7 @@ import { doNowOrAfterSomeTime, sendHubspotFormData } from 'utils/forms';
 const schema = yup
   .object({
     name: yup.string().required('Your name is a required field'),
+    surname: yup.string().required('Your surname is a required field'),
     email: yup
       .string()
       .email('Please enter a valid email')
@@ -63,7 +64,7 @@ const ContactForm = () => {
 
   const onSubmit = async (data, e) => {
     e.preventDefault();
-    const { name, email, companyWebsite, companySize, message } = data;
+    const { name, surname, email, companyWebsite, companySize, message } = data;
     const loadingAnimationStartedTime = Date.now();
     setFormError('');
     setFormState(FORM_STATES.LOADING);
@@ -74,8 +75,12 @@ const ContactForm = () => {
         context,
         values: [
           {
-            name: 'full_name',
+            name: 'name',
             value: name,
+          },
+          {
+            name: 'surname',
+            value: surname,
           },
           {
             name: 'email',
@@ -132,14 +137,25 @@ const ContactForm = () => {
     >
       <Field
         name="name"
-        label="Your Name *"
+        label="Name *"
         autoComplete="name"
-        placeholder="Marques Hansen"
+        placeholder="Marques"
         theme="transparent"
         labelClassName={labelClassName}
         error={errors.name?.message}
         isDisabled={isDisabled}
         {...register('name')}
+      />
+      <Field
+        name="surname"
+        label="Surname *"
+        autoComplete="name"
+        placeholder="Hansen"
+        theme="transparent"
+        labelClassName={labelClassName}
+        error={errors.surname?.message}
+        isDisabled={isDisabled}
+        {...register('surname')}
       />
       <Field
         name="email"

--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -19,8 +19,8 @@ import { doNowOrAfterSomeTime, sendHubspotFormData } from 'utils/forms';
 
 const schema = yup
   .object({
-    name: yup.string().required('Your name is a required field'),
-    surname: yup.string().required('Your surname is a required field'),
+    firstname: yup.string().required('Your first name is a required field'),
+    lastname: yup.string().required('Your last name is a required field'),
     email: yup
       .string()
       .email('Please enter a valid email')
@@ -67,7 +67,7 @@ const ContactForm = () => {
 
   const onSubmit = async (data, e) => {
     e.preventDefault();
-    const { name, surname, email, companyWebsite, companySize, message } = data;
+    const { firstname, lastname, email, companyWebsite, companySize, message } = data;
     const loadingAnimationStartedTime = Date.now();
     setFormError('');
     setFormState(FORM_STATES.LOADING);
@@ -78,12 +78,12 @@ const ContactForm = () => {
         context,
         values: [
           {
-            name: 'name',
-            value: name,
+            name: 'firstname',
+            value: firstname,
           },
           {
-            name: 'surname',
-            value: surname,
+            name: 'lastname',
+            value: lastname,
           },
           {
             name: 'email',
@@ -139,26 +139,26 @@ const ContactForm = () => {
       onSubmit={handleSubmit(onSubmit)}
     >
       <Field
-        name="name"
-        label="Name *"
+        name="firstname"
+        label="First Name *"
         autoComplete="name"
         placeholder="Marques"
         theme="transparent"
         labelClassName={labelClassName}
-        error={errors.name?.message}
+        error={errors.firstname?.message}
         isDisabled={isDisabled}
-        {...register('name')}
+        {...register('firstname')}
       />
       <Field
-        name="surname"
-        label="Surname *"
+        name="lastname"
+        label="Last Name *"
         autoComplete="name"
         placeholder="Hansen"
         theme="transparent"
         labelClassName={labelClassName}
-        error={errors.surname?.message}
+        error={errors.lastname?.message}
         isDisabled={isDisabled}
-        {...register('surname')}
+        {...register('lastname')}
       />
       <Field
         name="email"

--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -233,12 +233,12 @@ const ContactForm = () => {
         <Button
           className={clsx(
             'min-w-[176px] py-[15px] font-medium 2xl:text-base xl:min-w-[138px] lg:min-w-[180px] sm:w-full sm:py-[13px]',
-            (formState === FORM_STATES.LOADING || formState === FORM_STATES.ERROR) &&
-              'pointer-events-none !bg-secondary-1/50'
+            formState === FORM_STATES.ERROR && 'pointer-events-none !bg-secondary-1/50'
           )}
           type="submit"
           theme="primary"
           size="xs"
+          disabled={formState === FORM_STATES.LOADING}
         >
           {formState === FORM_STATES.SUCCESS ? 'Sent!' : 'Submit'}
         </Button>

--- a/src/components/shared/field/field.jsx
+++ b/src/components/shared/field/field.jsx
@@ -72,7 +72,7 @@ const Field = forwardRef(
           ref={ref}
           id={theme === 'checkbox' ? value : name}
           name={name}
-          value={theme === 'checkbox' ? value : null}
+          value={theme === 'checkbox' ? value : ''}
           type={type}
           disabled={isDisabled}
           {...otherProps}

--- a/src/components/shared/field/field.jsx
+++ b/src/components/shared/field/field.jsx
@@ -72,7 +72,7 @@ const Field = forwardRef(
           ref={ref}
           id={theme === 'checkbox' ? value : name}
           name={name}
-          value={theme === 'checkbox' ? value : ''}
+          value={theme === 'checkbox' ? value : null}
           type={type}
           disabled={isDisabled}
           {...otherProps}


### PR DESCRIPTION
This PR brings a new field `Surname` for Contact Sales form

![image](https://github.com/user-attachments/assets/e6587d18-38d6-4f76-b4aa-d85f13fe416d)

[Preview](https://neon-next-git-contact-sales-form-split-name-neondatabase.vercel.app/contact-sales)