### PR TITLE
fix: logos collapse in safari

### DIFF
--- a/src/app/enterprise/page.jsx
+++ b/src/app/enterprise/page.jsx
@@ -253,7 +253,7 @@ const faqItems = [
   },
   {
     question: 'Is Neon compliant?',
-    answer: `Yes. Neon adheres to SOC 2, ISO 27001, ISO 27701 standards and complies with GDPR, CCPA, and HIPAA. <a href="/docs/security/compliance">Read more.</a>.`,
+    answer: `Yes. Neon adheres to SOC 2, ISO 27001, ISO 27701 standards and complies with GDPR, CCPA, and HIPAA. <a href="/docs/security/compliance">Read more.</a>`,
   },
   {
     question: 'How secure is Neon’s platform?',

--- a/src/components/pages/enterprise/faq/item/item.jsx
+++ b/src/components/pages/enterprise/faq/item/item.jsx
@@ -57,7 +57,7 @@ const Item = ({ question, answer, id = null, initialState = 'closed', index }) =
               height: { duration: 0.3 },
             }}
           >
-            <p
+            <div
               className="with-link-primary with-list-style pt-4 text-base leading-normal text-gray-new-80 lg:pt-5"
               dangerouslySetInnerHTML={{ __html: answer }}
             />

--- a/src/components/shared/logos/logos.jsx
+++ b/src/components/shared/logos/logos.jsx
@@ -74,22 +74,20 @@ const allLogos = {
 };
 
 const sizes = {
-  sm: 'logos-sm h-6',
+  sm: 'h-6',
   lg: 'h-10 md:h-8',
 };
 
 const LogosWall = ({ className, logoClassName, logos, size = 'lg' }) => (
-  <div
-    className={clsx('logos logos-sides-fade flex w-full overflow-hidden', sizes[size], className)}
-  >
+  <div className={clsx('logos logos-sides-fade flex w-full overflow-hidden', className)}>
     {Array.from({ length: 2 }).map((_, index) => (
       <ul key={index} className="logos-content" aria-hidden={index > 0 && 'true'}>
         {logos.map((logo, index) => {
           const Logo = allLogos[logo];
           if (!Logo) return null;
           return (
-            <li className="h-full" key={index}>
-              <Logo className={clsx('h-full w-auto', logoClassName)} />
+            <li key={index}>
+              <Logo className={clsx('w-auto', sizes[size], logoClassName)} />
             </li>
           );
         })}


### PR DESCRIPTION
This PR brings a fix for logos slider in Safari

![image](https://github.com/user-attachments/assets/0739b166-85ee-4c30-87a5-fe41961aeedd)

also fixes hydration error in FAQ item
![image](https://github.com/user-attachments/assets/b0bfc407-ec20-4e96-9499-0c20ff8e79cb)

[Live page](https://neon.tech/enterprise)
[Preview](https://neon-next-git-fix-clients-slider-safari-neondatabase.vercel.app/enterprise)