### PR TITLE
chore: add code diff to readme

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -213,7 +213,16 @@ You can use fenced code blocks with three backticks (```) on the lines before an
   export function foo() {
     // [!code word:Hello]
     const msg = 'Hello World';
-    console.log(msg); // prints Hello World
+    console.log(msg);
+  }
+  ```
+
+- use `[!code --]` and `[!code ++]` to highlight a code diff.
+
+  ```ts
+  export function foo() {
+    const msg = 'Hello Word'; // [!code --]
+    const msg = 'Hello World'; // [!code ++]
   }
   ```
 


### PR DESCRIPTION
This PR brings a guide for showing code diff to [README](https://github.com/neondatabase/website/blob/49db507f021f9c8b8bd55867892acc4ea827e658/content/docs/README.md#code-blocks)

![image](https://github.com/user-attachments/assets/13719e17-a922-46ff-9b93-22d363bc76d6)