### PR TITLE
docs: remove version info from ext guides

### DIFF
--- a/content/docs/extensions/hstore.md
+++ b/content/docs/extensions/hstore.md
@@ -19,8 +19,6 @@ This guide covers the basics of the `hstore` extension - how to enable it, how t
 
 Please refer to the [list of all extensions](/docs/extensions/pg-extensions) available in Neon for up-to-date information.
 
-Currently, Neon uses version `1.8` of the `hstore` extension for all Postgres versions.
-
 ## Enable the `hstore` extension
 
 Enable the extension by running the following SQL statement in your Postgres client:

--- a/content/docs/extensions/pg_trgm.md
+++ b/content/docs/extensions/pg_trgm.md
@@ -21,8 +21,6 @@ In this guide, we'll explore the `pg_trgm` extension, covering how to enable it,
 
 Please refer to the [list of all extensions](/docs/extensions/pg-extensions) available in Neon for up-to-date information.
 
-Currently, Neon uses version `1.6` of the `pg_trgm` extension for all Postgres versions.
-
 ## Enable the `pg_trgm` extension
 
 Activate `pg_trgm` by running the `CREATE EXTENSION` statement in your Postgres client:


### PR DESCRIPTION
A change inspired by PR #3463