### PR TITLE
Normalize File Path Separators and Update Project Dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@react-hook/window-scroll": "^1.3.0",
         "@rive-app/react-canvas": "^4.9.5",
         "@segment/analytics-next": "^1.67.0",
-        "@splinetool/react-spline": "^2.2.6",
         "@tailwindcss/typography": "github:tailwindcss/typography",
         "@upstash/ratelimit": "^2.0.5",
         "algoliasearch": "^5.20.0",
@@ -6828,28 +6827,6 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "license": "MIT"
-    },
-    "node_modules/@splinetool/react-spline": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@splinetool/react-spline/-/react-spline-2.2.6.tgz",
-      "integrity": "sha512-y9L2VEbnC6FNZZu8XMmWM9YTTTWal6kJVfP05Amf0QqDNzCSumKsJxZyGUODvuCmiAvy0PfIfEsiVKnSxvhsDw==",
-      "dependencies": {
-        "lodash.debounce": "^4.0.8",
-        "react-merge-refs": "^2.0.1"
-      },
-      "peerDependencies": {
-        "@splinetool/runtime": "*",
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/@splinetool/runtime": {
-      "version": "1.4.0",
-      "peer": true,
-      "dependencies": {
-        "on-change": "^4.0.0",
-        "semver-compare": "^1.0.0"
-      }
     },
     "node_modules/@stdlib/array-float32": {
       "version": "0.0.6",
@@ -18520,6 +18497,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.get": {
@@ -20865,17 +20843,6 @@
         "node": "^10.13.0 || >=12.0.0"
       }
     },
-    "node_modules/on-change": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/on-change?sponsor=1"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -22358,16 +22325,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-merge-refs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.1.1.tgz",
-      "integrity": "sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
     "node_modules/react-modal": {
       "version": "3.16.1",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
@@ -23286,11 +23243,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@react-hook/window-scroll": "^1.3.0",
     "@rive-app/react-canvas": "^4.9.5",
     "@segment/analytics-next": "^1.67.0",
-    "@splinetool/react-spline": "^2.2.6",
     "@tailwindcss/typography": "github:tailwindcss/typography",
     "@upstash/ratelimit": "^2.0.5",
     "algoliasearch": "^5.20.0",

--- a/src/components/shared/header/header-wrapper/header-wrapper.jsx
+++ b/src/components/shared/header/header-wrapper/header-wrapper.jsx
@@ -36,7 +36,7 @@ const HeaderWrapper = ({
   return (
     <header
       className={clsx(
-        'left-0 right-0 top-0 z-40 flex h-16 w-full items-center lg:relative',
+        'left-0 right-0 top-0 z-[60] flex h-16 w-full items-center lg:relative',
         isSticky ? 'sticky transition-[padding,background-color] duration-200' : 'absolute',
         isStickyOverlay ? '-mb-16' : bg,
         isSticky && isStickied && `${bg}`,

--- a/src/utils/api-docs.js
+++ b/src/utils/api-docs.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 const { glob } = require('glob');
 const matter = require('gray-matter');
@@ -18,14 +19,10 @@ const getPostSlugs = async (pathname) => {
       '**/GUIDE_TEMPLATE.md',
     ],
   });
-  const isWindows = process.platform === 'win32';
-  const winSeparator = '\\';
-  const unixSeparator = '/';
   return files.map((file) => {
-    const newPathName = isWindows
-      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
-      : file.replace(pathname, '');
-    return newPathName.replace('.md', '');
+    const relativePath = path.relative(pathname, file);
+    const normalizedPath = path.posix.normalize(relativePath);
+    return normalizedPath.replace('.md', '');
   });
 };
 

--- a/src/utils/api-docs.js
+++ b/src/utils/api-docs.js
@@ -18,7 +18,15 @@ const getPostSlugs = async (pathname) => {
       '**/GUIDE_TEMPLATE.md',
     ],
   });
-  return files.map((file) => file.replace(pathname, '').replace('.md', ''));
+  const isWindows = process.platform === 'win32';
+  const winSeparator = '\\';
+  const unixSeparator = '/';
+  return files.map((file) => {
+    const newPathName = isWindows
+      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
+      : file.replace(pathname, '');
+    return newPathName.replace('.md', '');
+  });
 };
 
 const getPostBySlug = (slug, pathname) => {

--- a/src/utils/api-guides.js
+++ b/src/utils/api-guides.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import { glob } from 'glob';
 import matter from 'gray-matter';
@@ -14,14 +15,10 @@ const getPostSlugs = async (pathname) => {
       '**/GUIDE_TEMPLATE.md',
     ],
   });
-  const isWindows = process.platform === 'win32';
-  const winSeparator = '\\';
-  const unixSeparator = '/';
   return files.map((file) => {
-    const newPathName = isWindows
-      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
-      : file.replace(pathname, '');
-    return newPathName.replace('.md', '');
+    const relativePath = path.relative(pathname, file);
+    const normalizedPath = path.posix.normalize(relativePath);
+    return normalizedPath.replace('.md', '');
   });
 };
 

--- a/src/utils/api-guides.js
+++ b/src/utils/api-guides.js
@@ -14,7 +14,15 @@ const getPostSlugs = async (pathname) => {
       '**/GUIDE_TEMPLATE.md',
     ],
   });
-  return files.map((file) => file.replace(pathname, '').replace('.md', ''));
+  const isWindows = process.platform === 'win32';
+  const winSeparator = '\\';
+  const unixSeparator = '/';
+  return files.map((file) => {
+    const newPathName = isWindows
+      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
+      : file.replace(pathname, '');
+    return newPathName.replace('.md', '');
+  });
 };
 
 export const getAuthors = () => {

--- a/src/utils/api-postgresql.js
+++ b/src/utils/api-postgresql.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 const { glob } = require('glob');
 const matter = require('gray-matter');
@@ -18,14 +19,10 @@ const getPostSlugs = async (pathname) => {
       '**/GUIDE_TEMPLATE.md',
     ],
   });
-  const isWindows = process.platform === 'win32';
-  const winSeparator = '\\';
-  const unixSeparator = '/';
   return files.map((file) => {
-    const newPathName = isWindows
-      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
-      : file.replace(pathname, '');
-    return newPathName.replace('.md', '');
+    const relativePath = path.relative(pathname, file);
+    const normalizedPath = path.posix.normalize(relativePath);
+    return normalizedPath.replace('.md', '');
   });
 };
 

--- a/src/utils/api-postgresql.js
+++ b/src/utils/api-postgresql.js
@@ -18,7 +18,15 @@ const getPostSlugs = async (pathname) => {
       '**/GUIDE_TEMPLATE.md',
     ],
   });
-  return files.map((file) => file.replace(pathname, '').replace('.md', ''));
+  const isWindows = process.platform === 'win32';
+  const winSeparator = '\\';
+  const unixSeparator = '/';
+  return files.map((file) => {
+    const newPathName = isWindows
+      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
+      : file.replace(pathname, '');
+    return newPathName.replace('.md', '');
+  });
 };
 
 const getPostBySlug = (slug, pathname) => {

--- a/src/utils/postgresql-pages.js
+++ b/src/utils/postgresql-pages.js
@@ -17,7 +17,16 @@ const getPostSlugs = async (pathname) => {
       '**/GUIDE_TEMPLATE.md',
     ],
   });
-  return files.map((file) => file.replace(pathname, '').replace('.md', ''));
+
+  const isWindows = process.platform === 'win32';
+  const winSeparator = '\\';
+  const unixSeparator = '/';
+  return files.map((file) => {
+    const newPathName = isWindows
+      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
+      : file.replace(pathname, '');
+    return newPathName.replace('.md', '');
+  });
 };
 
 const getPostBySlug = (slug, pathname) => {

--- a/src/utils/postgresql-pages.js
+++ b/src/utils/postgresql-pages.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 const { glob } = require('glob');
 const matter = require('gray-matter');
@@ -18,14 +19,10 @@ const getPostSlugs = async (pathname) => {
     ],
   });
 
-  const isWindows = process.platform === 'win32';
-  const winSeparator = '\\';
-  const unixSeparator = '/';
   return files.map((file) => {
-    const newPathName = isWindows
-      ? file.split(winSeparator).join(unixSeparator).replace(pathname, '')
-      : file.replace(pathname, '');
-    return newPathName.replace('.md', '');
+    const relativePath = path.relative(pathname, file);
+    const normalizedPath = path.posix.normalize(relativePath);
+    return normalizedPath.replace('.md', '');
   });
 };
 


### PR DESCRIPTION
**Fix**: Improved the getPostSlugs function to normalize file path separators for cross-platform compatibility, ensuring consistent behavior on Windows and Unix-based systems.
**Fix**: Adjusted the z-index value for the header component to resolve overlapping issues.
**Chore**: Removed the unused dependency @splinetool/react-spline from [package.json] to clean up the project.

![451b0803-1eb1-41b2-ae2f-89e8d78d309a](https://github.com/user-attachments/assets/e0cc2954-c7ed-4b71-888a-be1b3377204d)
![8cbb8a86-82a0-4540-a1b2-6bba5654bd50](https://github.com/user-attachments/assets/53dde00d-c97c-4286-ac3b-9825ec1640bd)

[Preview](https://neon-next-git-fork-hussain5618-main-neondatabase.vercel.app/)