### PR TITLE
docs: fixed typo in FORMAT() function documentation

### DIFF
--- a/content/postgresql/postgresql-string-functions/postgresql-format.md
+++ b/content/postgresql/postgresql-string-functions/postgresql-format.md
@@ -45,7 +45,7 @@ The following shows the syntax of the format specifier:
 %[position][flags][width]type
 ```
 
-A format specifier starts with `%` character and include three optional components `position`, `flags`, `with` and a required component `type`.
+A format specifier starts with `%` character and include three optional components `position`, `flags`, `width` and a required component `type`.
 
 **position**
 
@@ -142,7 +142,7 @@ In this example, we used two format specifiers `%s %s` which are then replaced b
 
 ### 3\) Using FORMAT() function with the flags component
 
-The following statement uses the FORMAT() function with the `flags` and `with` components in the format specifier:
+The following statement uses the FORMAT() function with the `flags` and `width` components in the format specifier:
 
 ```
 SELECT FORMAT('|%10s|', 'one');


### PR DESCRIPTION
Fixed typo where the '`with`' component where referenced as '[`width`](https://github.com/neondatabase/website/blob/2c296564a08c859da9c4d7288d6500f907568828/content/postgresql/postgresql-string-functions/postgresql-format.md?plain=1#L48)' two times in the FORMAT() function documentation [page](https://neon.tech/postgresql/postgresql-string-functions/postgresql-format).