### PR TITLE
Fix quotes

### DIFF
--- a/content/docs/extensions/pg_search.md
+++ b/content/docs/extensions/pg_search.md
@@ -65,7 +65,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
     curl --request PATCH \
         --url https://console.neon.tech/api/v2/projects/<your_project_id> \
         --header 'accept: application/json' \
-        --header 'authorization: Bearer $NEON_API_KEY' \
+        --header "authorization: Bearer $NEON_API_KEY" \
         --header 'content-type: application/json' \
         --data '
     {


### PR DESCRIPTION
We need double quotes in order to interpret the ENV var. Single quotes are for literals. Let me know if this is intended for more security or something, but I generally prefer to copy paste working commands. Alternative is to change variable to <placeholder> so that it's more clear