### PR TITLE
chore: update site URL references from neon.tech to neon.com

### DIFF
--- a/.github/workflows/linkinator.yml
+++ b/.github/workflows/linkinator.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * 1'
 
 env:
-  GATSBY_DEFAULT_SITE_URL: https://neon.tech
+  GATSBY_DEFAULT_SITE_URL: https://neon.com
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ npm run start
 ### Checks broken links
 
 ```bash
-npm run check:broken-links -- https://neon.tech
+npm run check:broken-links -- https://neon.com
 ```
 
-_The command may take time, be patient. You can also specify which part of the website you want to check by passing a specific URL, for example `https://neon.tech/docs` for checking the Docs_
+_The command may take time, be patient. You can also specify which part of the website you want to check by passing a specific URL, for example `https://neon.com/docs` for checking the Docs_
 
 > N.B. The automatic check is done every Monday at midnight by GitHub CI. You can find the reports on the "Actions" tab
 

--- a/next-sitemap-postgres.config.js
+++ b/next-sitemap-postgres.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.tech',
+  siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.com',
   exclude: ['/docs/*', '!/postgresql/*', '/*'],
   sitemapBaseFileName: 'sitemap-postgres',
 };

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.tech',
+  siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.com',
   exclude: [
     '/blog/wp-draft-post-preview-page',
     '/blog/rss.xml',

--- a/next.config.js
+++ b/next.config.js
@@ -190,7 +190,7 @@ const defaultConfig = {
         destination: '/docs/changelog/:path*',
         permanent: true,
       },
-      // Proxy has an error message, that suggests to read `https://neon.tech/sni` for more details.
+      // Proxy has an error message, that suggests to read `https://neon.com/sni` for more details.
       {
         source: '/sni',
         destination: '/docs/connect/connection-errors',

--- a/src/app/(home-page)/page.jsx
+++ b/src/app/(home-page)/page.jsx
@@ -21,7 +21,7 @@ const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
   name: 'Neon Postgres',
-  url: 'https://neon.tech/',
+  url: 'https://neon.com/',
 };
 
 const Homepage = () => (

--- a/src/app/guides/og/route.jsx
+++ b/src/app/guides/og/route.jsx
@@ -85,7 +85,7 @@ export async function GET(request) {
                 whiteSpace: 'pre-wrap',
               }}
             >
-              neon.tech
+              neon.com
             </div>
           </div>
         </div>

--- a/src/lib/inkeep-settings.js
+++ b/src/lib/inkeep-settings.js
@@ -16,14 +16,14 @@ const baseSettings = {
           {
             UrlMatch: {
               ruleType: 'PartialUrl',
-              partialUrl: 'https://neon.tech/docs',
+              partialUrl: 'https://neon.com/docs',
             },
           },
           {
             NOT: {
               UrlMatch: {
                 ruleType: 'PartialUrl',
-                partialUrl: 'https://neon.tech/docs/changelog',
+                partialUrl: 'https://neon.com/docs/changelog',
               },
             },
           },
@@ -35,7 +35,7 @@ const baseSettings = {
       filters: {
         UrlMatch: {
           ruleType: 'PartialUrl',
-          partialUrl: 'https://neon.tech/postgresql',
+          partialUrl: 'https://neon.com/postgresql',
         },
       },
       searchTabLabel: 'PostgreSQL Tutorial',
@@ -44,7 +44,7 @@ const baseSettings = {
       filters: {
         UrlMatch: {
           ruleType: 'PartialUrl',
-          partialUrl: 'https://neon.tech/docs/changelog',
+          partialUrl: 'https://neon.com/docs/changelog',
         },
       },
       searchTabLabel: 'Changelog',
@@ -71,7 +71,7 @@ const aiChatSettings = {
   userAvatarSrcUrl: '/inkeep/images/user.svg',
   userAvatarDarkSrcUrl: '/inkeep/images/user-dark.svg',
   isChatSharingEnabled: true,
-  shareChatUrlBasePath: 'https://neon.tech/ai-chat',
+  shareChatUrlBasePath: 'https://neon.com/ai-chat',
   getHelpCallToActions: [
     {
       type: 'OPEN_LINK',
@@ -83,7 +83,7 @@ const aiChatSettings = {
       type: 'OPEN_LINK',
       icon: { builtIn: 'IoChatbubblesOutline' },
       name: 'Neon Support',
-      url: 'https://console.neon.tech/app/projects?modal=support',
+      url: 'https://console.neon.com/app/projects?modal=support',
     },
   ],
 };


### PR DESCRIPTION
In this pull request, the main domain of the website was changed from `neon.tech` to `neon.com` in critical areas







