### PR TITLE
docs: cross-reference launchpad and claimable db guides

### DIFF
--- a/content/docs/reference/neon-launchpad.md
+++ b/content/docs/reference/neon-launchpad.md
@@ -126,3 +126,7 @@ Neon Launchpad is designed for scenarios requiring rapid database provisioning:
 - Quick prototyping sessions
 
 Note that provisioned databases expire after 72 hours unless claimed as described in the previous section.
+
+## Technical implementation
+
+The Neon Launchpad service is built on Neon's [claimable database integration](/docs/workflows/claimable-database-integration), which provides APIs for creating projects and generating transfer requests. This allows the service to provision databases immediately while deferring account creation until users choose to claim their database. You can build similar experiences to Neon Launchpad in your own application using the APIs documented in the integration guide.

--- a/content/docs/workflows/claimable-database-integration.md
+++ b/content/docs/workflows/claimable-database-integration.md
@@ -238,6 +238,8 @@ Without the `org_id` parameter, the project transfers to the user's personal acc
 - **Demo environments** - Create ready-to-use demo databases that prospects can claim
 - **Team environments** - Provision project databases for team members to claim into their organization
 
+For a working implementation of claimable databases, try [Neon Launchpad](https://neon.new/). This service demonstrates the complete flow: users receive a Postgres connection string immediately without creating an account, and databases remain active for 72 hours. To retain the database beyond this period, users claim it by creating a Neon account using the provided transfer URL. See the [Neon Launchpad documentation](/docs/reference/neon-launchpad) for implementation details. This same pattern enables SaaS providers to offer instant database provisioning while allowing users to take ownership when ready.
+
 ## Troubleshooting
 
 | Issue                                 | Solution                                                                                                         |


### PR DESCRIPTION
This came up during review of https://github.com/neondatabase/website/pull/3493 (thanks Daniel!) 