### PR TITLE
Add redirect for Launchpad

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -337,6 +337,11 @@ const defaultConfig = {
         destination: '/use-cases/dev-test',
         permanent: true,
       },
+      {
+        source: '/launchpad',
+        destination: 'https://neon.new',
+        permanent: false,
+      },
       ...docsRedirects,
       ...changelogRedirects,
     ];


### PR DESCRIPTION
We're about to Launch and this may make reason to share at some places.
`302` redirect because it preserves some SEO power to `neon.com`