### PR TITLE
Omit unused dependency in `fastapi` guide

### DIFF
--- a/content/guides/fastapi-async.md
+++ b/content/guides/fastapi-async.md
@@ -64,7 +64,7 @@ Follow these steps to set up your project and virtual environment:
     Next, add all the necessary dependencies for your project:
 
     ```bash
-    uv add python-dotenv asyncpg loguru fastapi uvicorn requests
+    uv add python-dotenv asyncpg loguru fastapi uvicorn
     ```
 
     Where each package does the following :


### PR DESCRIPTION
## Description
Noticed the [FastAPI Async Guide](https://neon.com/guides/fastapi-async) includes a dependency (`requests`), which is not utilized or required in the guide. This PR introduces a patch to remove `requests` as one of the dependencies required.

**Note:** In this context, `requests` was probably included accidentally, given that FastAPI internals don't depend on it.

### Decisions
>This section outlines notable considerations for developers/maintainers.

This is an excellent blog from @sam-harri and the Neon team!
I'd love to hear your thoughts on the following topics. Kindly advise if they'd be a good addition to enhance the current guide:

- **Explicitly cached prepared statements to reduce SQL parsing**
- **Warm connections on startup to avoid _initial_ request latency**
The default behavior for connections is "lazy". On startup, `min_size` connections are open on the first acquire call, which can incur increased latency. Priming (warming) connections in the pool on startup ensures all `min_size` connections are open and ready:

```python
# example
conn_pool = await asyncpg.create_pool(..., init=[lambda conn: conn.execute('SELECT 1')])
```
- **Prevent indefinite waits on leasing connections**
If all (`max_size`) connections in the pool are busy, the caller is queued until a connection is released. This could lead to the coroutine waiting indefinitely. Setting `timeout` can protect against unbounded waits.

**Note:** `timeout` can be set at different levels: the DSN (default, global), query/prepared statement, or on the `Pool.acquire` API interface.

```python
# example (acquire API)
async with db_pool.acquire(timeout=2.0) as conn:  # timeout (float) of 2 seconds
   ...
```
 