### PR TITLE
Fixed stored procedure doc reference link

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-user-defined-data-types.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-user-defined-data-types.md
@@ -19,7 +19,7 @@ nextLink:
 Besides built\-in [data types](postgresql-data-types), PostgreSQL allows you to create user\-defined data types through the following statements:
 
 - `CREATE DOMAIN` creates a user\-defined data type with constraints such as [`NOT NULL`](postgresql-not-null-constraint), [`CHECK`](postgresql-check-constraint), etc.
-- `CREATE TYPE` creates a composite type used in [stored procedures](/postgresql/postgresql-stored-procedures/) as the data types of returned values.
+- `CREATE TYPE` creates a composite type used in [stored procedures](../postgresql-plpgsql/postgresql-create-procedure) as the data types of returned values.
 
 ## PostgreSQL CREATE DOMAIN statement
 


### PR DESCRIPTION
### Description:

- Updated `stored procedure` documentation reference link in `postgresql-user-defined-data-types.md`

### Github issue

- [3588](https://github.com/neondatabase/website/issues/3588)

### Screenshots:

**Before fix:**

https://github.com/user-attachments/assets/9f5c9404-1afb-4254-900d-67567defeb50

**After fix: (from my local)**

https://github.com/user-attachments/assets/0b17dcc9-d48e-4ed1-a681-3347edcf6763
