### PR TITLE
docs: add one click mcp server for cursor

### DIFF
--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -89,6 +89,14 @@ For more, see [Get started with Neon MCP server with Claude Desktop](/guides/neo
 <Tabs labels={["Remote MCP Server", "Local MCP Server"]}>
 <TabItem>
 
+### Quick Install (Recommended)
+
+Click the button below to install the Neon MCP server in Cursor. When prompted, click **Install** within Cursor.
+
+<a href="https://cursor.com/install-mcp?name=Neon&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGVAbGF0ZXN0IGh0dHBzOi8vbWNwLm5lb24udGVjaC9zc2UifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add Neon MCP server to Cursor" height="32" /></a>
+
+### Manual Setup
+
 1.  Open Cursor. Create a `.cursor` directory in your project root if needed.
 2.  Create or open the `mcp.json` file in the `.cursor` directory.
 3.  Add the "Neon" server entry within the `mcpServers` object:

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -57,6 +57,13 @@ The remote hosted MCP server is currently in its preview phase. As the [OAuth sp
 - An MCP Client application (e.g., Cursor, Windsurf, Claude Desktop, Cline, Zed).
 - A Neon account.
 
+<Admonition type="tip" title="Install in a single click for Cursor users">
+Click the button below to install the Neon MCP server in Cursor. When prompted, click **Install** within Cursor.
+
+<a href="https://cursor.com/install-mcp?name=Neon&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGVAbGF0ZXN0IGh0dHBzOi8vbWNwLm5lb24udGVjaC9zc2UifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add Neon MCP server to Cursor" height="32" /></a>
+
+</Admonition>
+
 #### Setup steps:
 
 1.  Go to your MCP Client's settings where you configure MCP Servers (this varies by client)

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -45,6 +45,14 @@ Before you begin, ensure you have the following:
 
 ### Option 1: Setting up the Remote Hosted Neon MCP Server
 
+#### Quick Install (Recommended)
+
+Click the button below to install the Neon MCP server in Cursor. When prompted, click **Install** within Cursor.
+
+<a href="https://cursor.com/install-mcp?name=Neon&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGVAbGF0ZXN0IGh0dHBzOi8vbWNwLm5lb24udGVjaC9zc2UifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add Neon MCP server to Cursor" height="32" /></a>
+
+#### Manual Setup
+
 This method uses Neon's managed server and OAuth authentication.
 
 1. Open Cursor.


### PR DESCRIPTION
Updated Links:
https://neon-next-git-fork-dhanushreddy291-add-docs-aed55b-neondatabase.vercel.app/docs/ai/connect-mcp-clients-to-neon
https://neon-next-git-fork-dhanushreddy291-add-docs-aed55b-neondatabase.vercel.app/guides/cursor-mcp-neon
https://neon-next-git-fork-dhanushreddy291-add-docs-aed55b-neondatabase.vercel.app/docs/ai/neon-mcp-server

Also needs to merge: https://github.com/neondatabase-labs/mcp-server-neon/pull/76

The markdown version wasn't rendering properly so added using `<a>` tags

Markdown Version
```
[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=Neon&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGVAbGF0ZXN0IGh0dHBzOi8vbWNwLm5lb24udGVjaC9zc2UifQ%3D%3D)
```

HTML Version
```
<a href="https://cursor.com/install-mcp?name=Neon&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGVAbGF0ZXN0IGh0dHBzOi8vbWNwLm5lb24udGVjaC9zc2UifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add Neon MCP server to Cursor" height="32" /></a>
```