### PR TITLE
docs: add console log example

### DIFF
--- a/content/docs/security/hipaa.md
+++ b/content/docs/security/hipaa.md
@@ -97,25 +97,25 @@ fb7c2e2f-cb09-4405-b543-dbe1b88614b6 2025-05-25 10:18:45.340 +0000 { "changes": 
 
 **Field descriptions:**
 
-| **Field position** | **Example value**                            | **Description**                                             |
-|--------------------|----------------------------------------------|-------------------------------------------------------------|
-| 1                  | fb7c2e2f-cb09-4405-b543-dbe1b88614b6         | Unique ID for the raw log event                             |
-| 2                  | 2025-05-25 10:18:45.340 +0000                | Timestamp when Airbyte extracted the record                 |
-| 3                  | { "changes": [], "sync_id": 57949 }          | Metadata from the ingestion tool                            |
-| 4                  | e640c32c-0387-4fc2-8ca5-f823f7ebc4b6         | Unique identifier for the API event                         |
-| 5                  | GET                                          | HTTP method used in the request                             |
-| 6                  | {}                                           | Request body payload (if present)                           |
-| 7                  |                                              | Reserved for future metadata fields (empty in this case)    |
-| 8                  | /projects/misty-breeze-49601234/branches     | URL path of the API call                                    |
-| 9                  | a92b3088-7f92-4871-bf91-0aac64edc4b6         | Internal ID for the response object                         |
-| 10                 | b8c58a4b-0a33-4d54-987e-4155e95a64b6         | Internal ID representing the auth/session context           |
-| 11                 | 2025-05-24 15:42:39.088 +0000                | Actual time when the API call was made                      |
-| 12                 | misty-breeze-49601234                        | Project identifier targeted by the API call                 |
-| 13                 | keycloak                                     | Authentication mechanism used                               |
-| 14                 | 200                                          | HTTP status code of the response                            |
-| 15                 | {}                                           | Resource identifiers returned (if any)                      |
-| 16                 | ListProjectBranches                          | Operation name associated with the endpoint                 |
-| 17                 | 0                                            | Internal sync batch identifier                              |
+| **Field position** | **Example value**                        | **Description**                                          |
+| ------------------ | ---------------------------------------- | -------------------------------------------------------- |
+| 1                  | fb7c2e2f-cb09-4405-b543-dbe1b88614b6     | Unique ID for the raw log event                          |
+| 2                  | 2025-05-25 10:18:45.340 +0000            | Timestamp when Airbyte extracted the record              |
+| 3                  | { "changes": [], "sync_id": 57949 }      | Metadata from the ingestion tool                         |
+| 4                  | e640c32c-0387-4fc2-8ca5-f823f7ebc4b6     | Unique identifier for the API event                      |
+| 5                  | GET                                      | HTTP method used in the request                          |
+| 6                  | {}                                       | Request body payload (if present)                        |
+| 7                  |                                          | Reserved for future metadata fields (empty in this case) |
+| 8                  | /projects/misty-breeze-49601234/branches | URL path of the API call                                 |
+| 9                  | a92b3088-7f92-4871-bf91-0aac64edc4b6     | Internal ID for the response object                      |
+| 10                 | b8c58a4b-0a33-4d54-987e-4155e95a64b6     | Internal ID representing the auth/session context        |
+| 11                 | 2025-05-24 15:42:39.088 +0000            | Actual time when the API call was made                   |
+| 12                 | misty-breeze-49601234                    | Project identifier targeted by the API call              |
+| 13                 | keycloak                                 | Authentication mechanism used                            |
+| 14                 | 200                                      | HTTP status code of the response                         |
+| 15                 | {}                                       | Resource identifiers returned (if any)                   |
+| 16                 | ListProjectBranches                      | Operation name associated with the endpoint              |
+| 17                 | 0                                        | Internal sync batch identifier                           |
 
 ### Postgres audit logs (pgAudit)
 

--- a/content/docs/security/hipaa.md
+++ b/content/docs/security/hipaa.md
@@ -65,7 +65,7 @@ Audit events may not be logged if database endpoints experience exceptionally he
 
 Neon maintains a comprehensive audit trail to support HIPAA compliance. This includes the following categories of logged events:
 
-1. [Neon Console and API audit logs](#neon-console-api-audit-logs): Captures user actions in the Neon Console and via the Neon API.
+1. [Neon Console and API audit logs](#neon-console-and-api-audit-logs): Captures user actions in the Neon Console and via the Neon API.
 2. [Postgres audit logs](#postgres-audit-logs-pgaudit): Logged using the [pgAudit](https://www.pgaudit.org/) extension (`pgaudit`) for Postgres.
 
 > Self-serve access to HIPAA audit logs is currently not supported. Access to audit logs can be requested by contacting `hipaa@neon.tech`.

--- a/content/docs/security/hipaa.md
+++ b/content/docs/security/hipaa.md
@@ -92,7 +92,7 @@ The following example shows how a `List project branches` operation is captured 
 **Audit log record:**
 
 ```ini
-fb7c2e2f-cb09-4405-b543-dbe1b88614b6 2025-05-25 10:18:45.340 +0000 { "changes": [], "sync_id": 57949 } e640c32c-0387-4fc2-8ca5-f823f7ebc4b6 GET {} /projects/misty-breeze-49601234/branches a92b3088-7f92-4871-bf91-0aac64edc4b6 b8c58a4b-0a33-4d54-987e-4155e95a64b6 2025-05-24 15:42:39.088 +0000 misty-breeze-49601234 keycloak 200 {} ListProjectBranches 0
+fb7c2e2f-cb09-4405-b543-dbe1b88614b6 2025-05-25 10:18:45.340 +0000 `{ "changes": [], "sync_id": 57949 }` e640c32c-0387-4fc2-8ca5-f823f7ebc4b6 GET `{}` /projects/misty-breeze-49601234/branches a92b3088-7f92-4871-bf91-0aac64edc4b6 b8c58a4b-0a33-4d54-987e-4155e95a64b6 2025-05-24 15:42:39.088 +0000 misty-breeze-49601234 keycloak 200 `{}` ListProjectBranches 0
 ```
 
 **Field descriptions:**
@@ -101,10 +101,10 @@ fb7c2e2f-cb09-4405-b543-dbe1b88614b6 2025-05-25 10:18:45.340 +0000 { "changes": 
 | ------------------ | ---------------------------------------- | -------------------------------------------------------- |
 | 1                  | fb7c2e2f-cb09-4405-b543-dbe1b88614b6     | Unique ID for the raw log event                          |
 | 2                  | 2025-05-25 10:18:45.340 +0000            | Timestamp when Airbyte extracted the record              |
-| 3                  | { "changes": [], "sync_id": 57949 }      | Metadata from the ingestion tool                         |
+| 3                  | `{ "changes": [], "sync_id": 57949 }`    | Metadata from the ingestion tool                         |
 | 4                  | e640c32c-0387-4fc2-8ca5-f823f7ebc4b6     | Unique identifier for the API event                      |
 | 5                  | GET                                      | HTTP method used in the request                          |
-| 6                  | {}                                       | Request body payload (if present)                        |
+| 6                  | `{}`                                     | Request body payload (if present)                        |
 | 7                  |                                          | Reserved for future metadata fields (empty in this case) |
 | 8                  | /projects/misty-breeze-49601234/branches | URL path of the API call                                 |
 | 9                  | a92b3088-7f92-4871-bf91-0aac64edc4b6     | Internal ID for the response object                      |
@@ -113,7 +113,7 @@ fb7c2e2f-cb09-4405-b543-dbe1b88614b6 2025-05-25 10:18:45.340 +0000 { "changes": 
 | 12                 | misty-breeze-49601234                    | Project identifier targeted by the API call              |
 | 13                 | keycloak                                 | Authentication mechanism used                            |
 | 14                 | 200                                      | HTTP status code of the response                         |
-| 15                 | {}                                       | Resource identifiers returned (if any)                   |
+| 15                 | `{}`                                     | Resource identifiers returned (if any)                   |
 | 16                 | ListProjectBranches                      | Operation name associated with the endpoint              |
 | 17                 | 0                                        | Internal sync batch identifier                           |
 

--- a/content/docs/security/hipaa.md
+++ b/content/docs/security/hipaa.md
@@ -91,7 +91,7 @@ The following example shows how a `List project branches` operation is captured 
 
 **Audit log record:**
 
-```ini
+```ini shouldWrap
 fb7c2e2f-cb09-4405-b543-dbe1b88614b6 2025-05-25 10:18:45.340 +0000 `{ "changes": [], "sync_id": 57949 }` e640c32c-0387-4fc2-8ca5-f823f7ebc4b6 GET `{}` /projects/misty-breeze-49601234/branches a92b3088-7f92-4871-bf91-0aac64edc4b6 b8c58a4b-0a33-4d54-987e-4155e95a64b6 2025-05-24 15:42:39.088 +0000 misty-breeze-49601234 keycloak 200 `{}` ListProjectBranches 0
 ```
 


### PR DESCRIPTION

# Fix MDX parsing errors in HIPAA audit log examples

## Summary

This PR resolves Vercel build failures in the HIPAA documentation by escaping curly braces in JSON audit log examples. The issue was that unescaped `{}` characters in the documentation were being interpreted as JSX expressions by the MDX parser, causing build errors.

**Changes made:**
- Wrapped JSON objects in backticks in the audit log record example (line 95)
- Updated corresponding table entries to maintain consistency (lines 104, 107, 116)
- All changes are in `content/docs/security/hipaa.md`

The fix converts problematic text like `{ "changes": [], "sync_id": 57949 }` to `` `{ "changes": [], "sync_id": 57949 }` ``, which renders as inline code and prevents MDX parsing conflicts.

## Review & Testing Checklist for Human

- [ ] **Verify Vercel preview**: Check that the [HIPAA documentation page](https://neon-next-git-docs-hipaa-console-log-example-neondatabase.vercel.app/docs/security/hipaa) renders correctly and the JSON examples are properly formatted as inline code
- [ ] **Content accuracy**: Confirm that no audit log content meaning was accidentally changed - the JSON structures should be identical to the original, just with backtick formatting
- [ ] **Build verification**: Ensure the Vercel deployment remains stable and no other MDX parsing errors surface

---

### Diagram

```mermaid
graph TD
    A[content/docs/security/hipaa.md]:::major-edit --> B[MDX Parser]
    B --> C[Vercel Build Process]
    C --> D[Deployed Documentation]
    
    E[Unescaped Curly Braces] --> F[MDX Parsing Error]:::context
    G[Backtick-Wrapped JSON] --> H[Inline Code Rendering]:::context
    
    A --> I[Audit Log Examples<br/>Lines 95, 104, 107, 116]:::major-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- This was a straightforward content formatting fix to resolve a build blocker
- The changes are semantically appropriate since JSON objects should be rendered as code
- All CI checks are passing, including the previously failing Vercel deployment
- No functional code changes were made - only documentation formatting

---

**Link to Devin run**: https://app.devin.ai/sessions/df514d0bbb4b40d584dd7ea1e129a412  
**Requested by**: Daniel (daniel@neon.tech)
