### PR TITLE
Fix GIN index utilization in full-text search

### DIFF
--- a/content/postgresql/postgresql-indexes/postgresql-full-text-search.md
+++ b/content/postgresql/postgresql-indexes/postgresql-full-text-search.md
@@ -376,7 +376,7 @@ SELECT
 FROM
   posts
 WHERE
-  body @@ to_tsquery('basic | advanced');
+  to_tsvector('english', body) @@ to_tsquery('basic | advanced');
 ```
 
 Output:


### PR DESCRIPTION
The [Full text search using GIN indexes](https://neon.com/postgresql/postgresql-indexes/postgresql-full-text-search#full-text-search-using-gin-indexes) doesn't utilize the created index.

After creating the index:
```sql
CREATE INDEX body_fts
ON posts
USING GIN ((to_tsvector('english',body)));
```

`to_tsvector('english', body)` should be used instead of `body` in:
```sql
SELECT
  id,
  body
FROM
  posts
WHERE
  body @@ to_tsquery('basic | advanced');
```