### PR TITLE
docs: move git pull before formatting to prevent push conflicts

### DIFF
--- a/.github/workflows/format-markdown.yml
+++ b/.github/workflows/format-markdown.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Install Prettier
       run: npm install prettier
 
+    - name: Pull latest changes
+      run: git pull --rebase
+
     - name: Run Prettier
       run: npx prettier --write "content/**/*.md" --ignore-path .prettierignore
 
@@ -54,9 +57,6 @@ jobs:
           echo "No significant changes to commit"
           exit 0
         fi
-
-    - name: Pull latest changes
-      run: git pull --rebase
 
     - name: Push changes
       run: git push


### PR DESCRIPTION
The workflow was failing with "Updates were rejected because the remote contains work that you do not have locally" because it was pulling changes after committing formatting changes.