### PR TITLE
chore: nav update

### DIFF
--- a/src/components/pages/doc/breadcrumbs/breadcrumbs.jsx
+++ b/src/components/pages/doc/breadcrumbs/breadcrumbs.jsx
@@ -4,20 +4,15 @@ import { Fragment } from 'react';
 
 import Link from 'components/shared/link';
 import { DOCS_BASE_PATH, POSTGRESQL_BASE_PATH } from 'constants/docs';
+import HomeIcon from 'icons/docs/home.inline.svg';
 
 const linkClassName = 'transition-colors duration-200 hover:text-black dark:hover:text-white';
 
 const Breadcrumbs = ({ breadcrumbs, isPostgresPost = false }) => (
-  <div className="mb-4 flex flex-wrap space-x-2 text-sm leading-normal text-gray-new-40 dark:text-gray-new-60 lg:hidden">
-    {isPostgresPost ? (
-      <Link className={linkClassName} to={POSTGRESQL_BASE_PATH}>
-        PostgreSQL Tutorial
-      </Link>
-    ) : (
-      <Link className={linkClassName} to={DOCS_BASE_PATH}>
-        Docs
-      </Link>
-    )}
+  <div className="mb-4 flex flex-wrap items-center gap-x-2 text-sm leading-normal text-gray-new-40 dark:text-gray-new-60 lg:hidden">
+    <Link className={linkClassName} to={isPostgresPost ? POSTGRESQL_BASE_PATH : DOCS_BASE_PATH}>
+      <HomeIcon />
+    </Link>
 
     <span>/</span>
 

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -85,7 +85,7 @@ export default {
               icon: RestoreIcon,
               iconGradient: RestoreGradientIcon,
               title: 'Instant restores',
-              description: 'Copy-on-write storage',
+              description: 'Recover TBs in seconds',
               to: LINKS.branchRestore,
             },
           ],
@@ -97,7 +97,7 @@ export default {
               icon: AuthIcon,
               iconGradient: AuthGradientIcon,
               title: 'Auth',
-              description: 'UI for data management',
+              description: 'Authenticate your users',
               to: LINKS.auth,
             },
             {
@@ -118,7 +118,7 @@ export default {
               icon: AiIcon,
               iconGradient: AiGradientIcon,
               title: 'AI',
-              description: 'Powered by pgvector',
+              description: 'Embeddings & agents',
               to: LINKS.ai,
             },
             {

--- a/src/icons/docs/home.inline.svg
+++ b/src/icons/docs/home.inline.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 7.6L8 2L2 7.6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.59961 8.40002V14H6.79961V10.8H9.19961V14H12.3996V8.40002" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
This PR brings nav update:

 - main navigation subtitles in Product section
    <img width="504" height="368" alt="image" src="https://github.com/user-attachments/assets/095bb5dc-9bde-45c2-bbf3-baac2b553a02" />
- Docs breadcrumbs home link changed to icon
    <img width="336" height="138" alt="image" src="https://github.com/user-attachments/assets/eb8aae14-70f1-4293-a423-fd86066a715d" />

[Preview](https://neon-next-git-nav-update-neondatabase.vercel.app/)
[Preview Docs](https://neon-next-git-nav-update-neondatabase.vercel.app/docs/get-started-with-neon/why-neon)