### PR TITLE
feat: support quick link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -303,6 +303,11 @@ const defaultConfig = {
         permanent: false,
       },
       {
+        source: '/support',
+        destination: '/docs/introduction/support',
+        permanent: true,
+      },
+      {
         source: '/early-access-program',
         destination: '/docs/introduction/roadmap#join-the-neon-early-access-program',
         permanent: true,


### PR DESCRIPTION
Create new `neon.com/support` quick link. Will help our team to quickly route people to get more information about support. I also assume we get some hits on `neon.com/support` from customers looking for our support features. 