### PR TITLE
fix: correct typo in user creation instructions for Next.js guide

### DIFF
--- a/content/docs/neon-auth/quick-start/nextjs.md
+++ b/content/docs/neon-auth/quick-start/nextjs.md
@@ -51,6 +51,6 @@ Then \`npm run dev\` to start your dev server.
 
 #### Test your integration
 
-Go to [http://localhost:3000/handler/sign-up](http://localhost:3000/handler/sign-up) in your browser. Create a user or two, and you can them [show up immediately](#see-your-users-in-the-database) in your database.
+Go to [http://localhost:3000/handler/sign-up](http://localhost:3000/handler/sign-up) in your browser. Create a user or two, and you can see them [show up immediately](#see-your-users-in-the-database) in your database.
 `}
 />

--- a/public/llms/neon-auth-quick-start-nextjs.txt
+++ b/public/llms/neon-auth-quick-start-nextjs.txt
@@ -71,7 +71,7 @@ Then `npm run dev` to start your dev server.
 
 #### Test your integration
 
-Go to [http://localhost:3000/handler/sign-up](http://localhost:3000/handler/sign-up) in your browser. Create a user or two, and you can them [show up immediately](https://neon.com/docs/neon-auth/quick-start/nextjs#see-your-users-in-the-database) in your database.
+Go to [http://localhost:3000/handler/sign-up](http://localhost:3000/handler/sign-up) in your browser. Create a user or two, and you can see them [show up immediately](https://neon.com/docs/neon-auth/quick-start/nextjs#see-your-users-in-the-database) in your database.
 
 ## Create users in the Console (optional)
 


### PR DESCRIPTION

**Summary:**  
This PR fixes minor grammatical issues in `neon-auth/quick-start/nextjs.md` for better clarity and correctness.

**Changes Made:**

-   Corrected sentence structure in the sign-up instruction.
    
-   Improved flow and readability in related lines.
    

**Before:**

> "Create a user or two, and you can them show up..."

**After:**

> "Createa user or two, and you can see them show up..."

closes #3684 