### PR TITLE
fix: small typo in code snippet postgresql-index-types.md

### DIFF
--- a/content/postgresql/postgresql-indexes/postgresql-index-types.md
+++ b/content/postgresql/postgresql-indexes/postgresql-index-types.md
@@ -41,7 +41,7 @@ In addition, the query planner can use a B\-tree index for queries that involve 
 
 ```
 column_name LIKE 'foo%'
-column_name LKE 'bar%'
+column_name LIKE 'bar%'
 column_name  ~ '^foo'
 ```
 


### PR DESCRIPTION
just a small typo in key word LIKE