### PR TITLE
Clarify Data API and Neon RLS are not compatible

### DIFF
--- a/content/docs/data-api/demo.md
+++ b/content/docs/data-api/demo.md
@@ -69,7 +69,11 @@ Before we dive into the queries, let's first secure our tables. When making dire
 
 RLS is crucial for any real-world app. RLS policies act as a safety net at the database level, so even if your frontend code has bugs, your data stays protected.
 
-Our demo app uses [Drizzle](/docs/guides/neon-rls-drizzle) ORM to define RLS policies, which we highly recommend as a simpler, more maintainable way of writing RLS policies:
+<Admonition type="info" title="A note on Neon RLS">
+You might notice another feature in Neon called **Neon RLS**. Please be aware that it's a different method for client-side querying and **is not compatible with the Data API**.
+</Admonition>
+
+Our demo app uses [Drizzle ORM](/docs/guides/neon-rls-drizzle) to define RLS policies, which we highly recommend as a simpler, more maintainable way of writing RLS policies:
 
 ```typescript shouldWrap
 // src/db/schema.ts - RLS policies using Drizzle
@@ -126,7 +130,7 @@ pgPolicy("shared_policy", {
 <Admonition type="info" title="About auth.user_id()">
 Neon's RLS policies use the <code>auth.user_id()</code> function, which extracts the user's ID from the JWT (JSON Web Token) provided by your authentication provider. In this demo, <a href="/docs/guides/neon-auth">Neon Auth</a> issues the JWTs, and Neon's Data API passes them to Postgres, so RLS can enforce per-user access.
 
-See our [RLS docs](/docs/guides/neon-rls) and [Neon Auth](/docs/guides/neon-auth) for details.
+For more details on RLS with Data API, see our [Row-Level Security with Neon guide](/docs/guides/row-level-security).
 </Admonition>
 
 Now that our tables are secure, let's look at how to perform CRUD operations using our note-taking app as an example.

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -45,16 +45,16 @@ Once enabled, you'll see your Data API **Project URL** here — this is your end
 
 ![Data API enabled view with Project URL](/docs/data-api/data-api-enabled.png)
 
-*Always secure your data before using the Data API in production.*
+_Always secure your data before using the Data API in production._
 
 ### About activation times and schema changes
 
 - After enabling the Data API, it may take a minute for your endpoints to become available. Be aware of that.
 - If you change your database schema, you'll need to tell the Data API to refresh its cache. You can do this by reloading the schema from the SQL Editor:
 
-   ```sql
-   NOTIFY pgrst, 'reload schema'
-   ```
+  ```sql
+  NOTIFY pgrst, 'reload schema'
+  ```
 
 ## Authentication
 

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -26,7 +26,11 @@ The Neon Data API, powered by [PostgREST](https://docs.postgrest.org/en/v13/), o
 const { data } = await client.from('playing_with_neon').select('*').gte('value', 0.5);
 ```
 
-> When using the Data API, it is essential to set up RLS policies so that you can safely expose your databases to clients such as web apps. Make sure that _all_ of your tables have RLS policies, and that you have carefully reviewed each policy.
+> When using the Data API, it is essential to set up RLS policies so that you can safely expose your databases to clients such as web apps. Make sure that all of your tables have RLS policies, and that you have carefully reviewed each policy.
+
+<Admonition type="info" title="A note on Neon RLS">
+You might notice another feature in Neon called **Neon RLS**. Please be aware that it's a different method for client-side querying and **is not compatible with the Data API**.
+</Admonition>
 
 <Steps>
 ## Enabling the Data API
@@ -41,7 +45,16 @@ Once enabled, you'll see your Data API **Project URL** here — this is your end
 
 ![Data API enabled view with Project URL](/docs/data-api/data-api-enabled.png)
 
-Always secure your data before using the Data API in production.
+*Always secure your data before using the Data API in production.*
+
+### About activation times and schema changes
+
+- After enabling the Data API, it may take a minute for your endpoints to become available. Be aware of that.
+- If you change your database schema, you'll need to tell the Data API to refresh its cache. You can do this by reloading the schema from the SQL Editor:
+
+   ```sql
+   NOTIFY pgrst, 'reload schema'
+   ```
 
 ## Authentication
 
@@ -76,13 +89,19 @@ CREATE POLICY "user_can_access_own_data" ON your_table
   FOR ALL USING (auth.user_id() = user_id);
 ```
 
-We recommend using [Drizzle](/docs/guides/neon-rls-drizzle) to help simplify writing RLS policies.
+We recommend using [Drizzle ORM](/docs/guides/neon-rls-drizzle) to help simplify writing RLS policies for the Data API.
+
+<Admonition type="info" title="About auth.user_id()">
+The `auth.user_id()` function extracts the user's ID from the JSON Web Token (JWT) issued by [Neon Auth](/docs/guides/neon-auth). The Data API validates this token, making the user's ID available to your RLS policies for enforcing per-user access.
+
+For guidance on writing RLS policies, see our [PostgreSQL RLS tutorial](/postgresql/postgresql-administration/postgresql-row-level-security) for the basics, or our recommended [Drizzle RLS guide](/docs/guides/neon-rls-drizzle) for a simpler approach.
+</Admonition>
 
 ## Using the Data API
 
 By default, all tables in your database are accessible via the API with `SELECT` permissions granted to **unauthenticated requests**. This lets you directly interact with the API without requiring additional authorization headers.
 
-> **Warning:** This means your data is **publicly accessbile** until you enable Row-Level Security (RLS). Again, enable RLS on _all_ your tables before using the Data API in production.
+> **Warning:** This means your data is **publicly accessible** until you enable Row-Level Security (RLS). Again, enable RLS on _all_ your tables before using the Data API in production.
 
 ### Example of creating a table and querying it via the Data API
 

--- a/content/docs/guides/neon-rls-drizzle.md
+++ b/content/docs/guides/neon-rls-drizzle.md
@@ -206,7 +206,7 @@ export const posts = pgTable(
 
 For tables with foreign key relationships, you can create policies that check ownership through related tables:
 
-```typescript {15-19,21-25} shouldWrap
+```typescript {15-19,21-25,38-42,44-48} shouldWrap
 import { crudPolicy, authenticatedRole, pgPolicy } from 'drizzle-orm/neon';
 
 export const notes = pgTable(

--- a/content/docs/guides/neon-rls.md
+++ b/content/docs/guides/neon-rls.md
@@ -27,7 +27,7 @@ redirectFrom:
 
 > Neon also offers a **Data API** feature, which provides an instant REST interface for your database. We recommend this approach for most use cases. You can learn more in our [Data API guide](/docs/data-api/get-started).
 >
->  Note that while both features require RLS policies, the *Data API and Neon RLS are not compatible* and cannot be enabled at the same time.
+> Note that while both features require RLS policies, the _Data API and Neon RLS are not compatible_ and cannot be enabled at the same time.
 
 ## Authentication and authorization
 

--- a/content/docs/guides/neon-rls.md
+++ b/content/docs/guides/neon-rls.md
@@ -1,7 +1,6 @@
 ---
 title: About Neon RLS
-subtitle: Secure your application at the database level using Postgres's Row-Level
-  Security
+subtitle: Secure your application at the database level using Postgres's Row-Level Security
 enableTableOfContents: true
 updatedOn: '2025-06-25T02:56:37.085Z'
 redirectFrom:
@@ -18,13 +17,17 @@ redirectFrom:
 
 <DocsList title="Related docs" theme="docs">
   <a href="/docs/guides/neon-rls-tutorial">Neon RLS Tutorial</a>
-  <a href="/postgresql/postgresql-administration/postgresql-row-level-security">Postgres Row-Level Security tutorial</a>
+  <a href="/docs/guides/row-level-security">Row-Level Security with Neon</a>
   <a href="/docs/guides/neon-rls-drizzle">Simplify RLS with Drizzle</a>
 </DocsList>
 
 </InfoBlock>
 
-**Neon RLS** integrates with third-party **JWT-based authentication providers** like Auth0 and Clerk, bringing authorization closer to your data by leveraging [Row-Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) at the database level.
+**Neon RLS** integrates with third-party **JWT-based authentication providers** like Auth0 and Clerk, allowing you to query your database directly from client-side applications. It enables direct SQL queries over HTTP by leveraging [Row-Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) at the database level.
+
+> Neon also offers a **Data API** feature, which provides an instant REST interface for your database. We recommend this approach for most use cases. You can learn more in our [Data API guide](/docs/data-api/get-started).
+>
+>  Note that while both features require RLS policies, the *Data API and Neon RLS are not compatible* and cannot be enabled at the same time.
 
 ## Authentication and authorization
 

--- a/content/docs/guides/row-level-security.md
+++ b/content/docs/guides/row-level-security.md
@@ -41,7 +41,6 @@ The **Data API** turns your database tables into a REST API, and it requires RLS
 - Your RLS policies use `auth.user_id()` to control access.
 - All tables accessed via the Data API must have RLS enabled.
 
-
 <DetailIconCards>
 
 <a href="/docs/data-api/get-started" description="Learn how to enable and use the Data API with RLS policies" icon="database">Get started</a>

--- a/content/docs/guides/row-level-security.md
+++ b/content/docs/guides/row-level-security.md
@@ -34,7 +34,7 @@ Neon provides two ways to apply RLS for client-side querying:
 - [Data API](#data-api-with-rls) (recommended)
 - [Neon RLS (JWT/JWKS Integration)](#neon-rls-jwtjwks-integration)
 
->  Note, the Data API and Neon RLS **are not compatible**. If you are using the Data API on a given branch, make sure Neon RLS is disabled for your project.
+> Note, the Data API and Neon RLS **are not compatible**. If you are using the Data API on a given branch, make sure Neon RLS is disabled for your project.
 
 ## Data API with RLS
 

--- a/content/docs/guides/row-level-security.md
+++ b/content/docs/guides/row-level-security.md
@@ -31,9 +31,14 @@ CREATE POLICY "users_can_only_access_own_notes" ON notes
 
 Neon provides two ways to apply RLS for client-side querying:
 
+- [Data API](#data-api-with-rls) (recommended)
+- [Neon RLS (JWT/JWKS Integration)](#neon-rls-jwtjwks-integration)
+
+>  Note, the Data API and Neon RLS **are not compatible**. If you are using the Data API on a given branch, make sure Neon RLS is disabled for your project.
+
 ## Data API with RLS
 
-The **Data API** turns your database tables into a REST API, and it requires RLS policies on all tables to ensure your data is secure.
+The **Data API** turns your database tables on a given branch into a REST API, and it requires RLS policies on all tables to ensure your data is secure.
 
 ### How it works
 
@@ -58,10 +63,6 @@ The **Data API** turns your database tables into a REST API, and it requires RLS
 - The `pg_session_jwt` extension provides the `auth.user_id()` function.
 - Your RLS policies use `auth.user_id()` to control access.
 - It works with the Neon HTTP driver for direct database queries.
-
-<Admonition type="warning" title="Important: Data API and Neon RLS are not compatible">
-If you are using the Data API, make sure the **Neon RLS** feature is disabled for your project.
-</Admonition>
 
 <DetailIconCards>
 

--- a/content/docs/guides/row-level-security.md
+++ b/content/docs/guides/row-level-security.md
@@ -1,0 +1,93 @@
+---
+title: Row-Level Security with Neon
+subtitle: How Neon features use Postgres Row-Level Security
+enableTableOfContents: true
+---
+
+<InfoBlock>
+<DocsList title="What you will learn:">
+<p>How the Data API and Neon RLS use Row-Level Security</p>
+</DocsList>
+
+<DocsList title="Related docs" theme="docs">
+  <a href="/docs/data-api/get-started">Data API</a>
+  <a href="/docs/guides/neon-rls">Neon RLS (JWT/JWKS Integration)</a>
+  <a href="/docs/guides/neon-rls-drizzle">Simplify RLS with Drizzle</a>
+  <a href="/postgresql/postgresql-administration/postgresql-row-level-security">Postgres RLS Tutorial</a>
+</DocsList>
+
+</InfoBlock>
+
+Row-Level Security (RLS) is a Postgres feature that controls access to individual rows in a table based on the current user. Here's a simple example that limits the `notes` a user can see by matching rows where their `user_id` matches the session's `auth.user_id()`:
+
+```sql
+-- Enable RLS on a table
+ALTER TABLE notes ENABLE ROW LEVEL SECURITY;
+
+-- Create a policy that only allows users to access their own notes
+CREATE POLICY "users_can_only_access_own_notes" ON notes
+  FOR ALL USING (auth.user_id() = user_id);
+```
+
+Neon provides two ways to apply RLS for client-side querying:
+
+## Data API with RLS
+
+The **Data API** turns your database tables into a REST API, and it requires RLS policies on all tables to ensure your data is secure.
+
+### How it works
+
+- The Data API handles JWT validation and provides the `auth.user_id()` function.
+- Your RLS policies use `auth.user_id()` to control access.
+- All tables accessed via the Data API must have RLS enabled.
+
+
+<DetailIconCards>
+
+<a href="/docs/data-api/get-started" description="Learn how to enable and use the Data API with RLS policies" icon="database">Get started</a>
+
+<a href="/docs/data-api/demo" description="See a complete example of the Data API with RLS in action" icon="github">Building a note-taking app</a>
+
+</DetailIconCards>
+
+## Neon RLS (JWT/JWKS Integration)
+
+**Neon RLS** provides JWT/JWKS integration at the database level, exposing a single endpoint that accepts direct SQL queries over HTTP.
+
+### How it works
+
+- The `pg_session_jwt` extension provides the `auth.user_id()` function.
+- Your RLS policies use `auth.user_id()` to control access.
+- It works with the Neon HTTP driver for direct database queries.
+
+<Admonition type="warning" title="Important: Data API and Neon RLS are not compatible">
+If you are using the Data API, make sure the **Neon RLS** feature is disabled for your project.
+</Admonition>
+
+<DetailIconCards>
+
+<a href="/docs/guides/neon-rls" description="Learn how Neon RLS works and when to use it" icon="privacy">About Neon RLS</a>
+
+<a href="/docs/guides/neon-rls-tutorial" description="A step-by-step guide to setting up Neon RLS" icon="github">Tutorial</a>
+
+</DetailIconCards>
+
+## RLS with Drizzle ORM
+
+Drizzle makes it simple to write RLS policies that work with both the Data API and Neon RLS. We highly recommend using its `crudPolicy` helper to simplify common RLS patterns.
+
+<DetailIconCards>
+
+<a href="/docs/guides/neon-rls-drizzle" description="Learn how to use Drizzle's crudPolicy function to simplify RLS policies" icon="drizzle">Simplify RLS with Drizzle</a>
+
+</DetailIconCards>
+
+## Postgres RLS Tutorial
+
+To learn the fundamentals of Row-Level Security in Postgres, including detailed concepts and examples, see the Postgres tutorial:
+
+<DetailIconCards>
+
+<a href="/postgresql/postgresql-administration/postgresql-row-level-security" description="A complete guide to Postgres Row-Level Security concepts and implementation" icon="database">Postgres RLS Tutorial</a>
+
+</DetailIconCards>

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -886,6 +886,16 @@
               slug: guides/auth-okta
 - section: Auth & backend
   items:
+    - title: Data API
+      icon: api
+      tag: new
+      slug: data-api/get-started
+      collapsible: true
+      items:
+        - title: Get started
+          slug: data-api/get-started
+        - title: Building a note-taking app
+          slug: data-api/demo
     - title: Neon Auth
       icon: auth
       tag: beta
@@ -1065,7 +1075,18 @@
               slug: neon-auth/customization/internationalization
             - title: Custom Pages
               slug: neon-auth/customization/custom-pages
-    - title: Neon RLS
+    - title: Row-Level security
+      icon: lock
+      slug: guides/row-level-security
+      collapsible: true
+      items:
+        - title: RLS in Neon
+          slug: guides/row-level-security
+        - title: Simplify RLS with Drizzle
+          slug: guides/neon-rls-drizzle
+        - title: PostgreSQL RLS Tutorial
+          slug: https://neon.com/postgresql/postgresql-administration/postgresql-row-level-security
+    - title: Neon RLS (JWT/JWKS)
       icon: lock
       slug: guides/neon-rls
       items:
@@ -1075,8 +1096,6 @@
               slug: guides/neon-rls
             - title: Tutorial
               slug: guides/neon-rls-tutorial
-            - title: Drizzle RLS
-              slug: guides/neon-rls-drizzle
             - title: Troubleshooting
               slug: guides/neon-rls-troubleshooting
             - title: What's next
@@ -1111,15 +1130,6 @@
               slug: guides/neon-rls-workos
             - title: Custom JWT
               slug: guides/neon-rls-custom-jwt
-    - title: Data API
-      icon: api
-      tag: new
-      collapsible: true
-      items:
-        - title: Get started
-          slug: data-api/get-started
-        - title: Building a note-taking app
-          slug: data-api/demo
 - section: Workflows
   items:
     - title: Data anonymization

--- a/content/postgresql/postgresql-administration/postgresql-row-level-security.md
+++ b/content/postgresql/postgresql-administration/postgresql-row-level-security.md
@@ -16,8 +16,6 @@ nextLink:
 
 **Summary**: in this tutorial, you will learn how to use PostgreSQL row\-level security to control access to individual rows in a table.
 
-<CTA title="Looking to use Postgres RLS?" description="<a href='/docs/guides/neon-authorize'>Neon Authorize</a> uses the open-source <a href='https://github.com/neondatabase/pg_session_jwt'>pg_session_jwt</a> extension to help you write RLS policies that map to your app's or service's auth." buttonText="Learn More" buttonUrl="/docs/guides/neon-authorize" />
-
 ## Introduction to the PostgreSQL Row\-Level Security
 
 Row\-level security (RLS) is a feature that allows you to restrict rows returned by a query based on the user executing the query.


### PR DESCRIPTION
1. Separate out [vanilla RLS info](https://neon-next-git-bgrenon-clarify-rls-neondatabase.vercel.app/docs/guides/row-level-security) (including drizzle policies) from Neon RLS
2. Clarify Data API is recommended, and not compatible with Neon RLS (noted in various places). e.g.
   <img width="762" height="143" alt="image" src="https://github.com/user-attachments/assets/11029ab0-01fb-4daa-8897-62c8cda79214" />


Top level TOC view:
<img width="313" height="171" alt="image" src="https://github.com/user-attachments/assets/32a11161-fc0d-453b-b21a-4afb69379648" />


More detail about Data API to come in separate PR later (explain roles and schemas etc bootstrapped when enabled).