### PR TITLE
Changes Neon Serverless to Neon Serverless Driver in AI Rules page

### DIFF
--- a/content/docs/ai/ai-rules.md
+++ b/content/docs/ai/ai-rules.md
@@ -12,7 +12,7 @@ Boost your productivity with AI context rules for Neon. These rules help AI tool
 
 <a href="/docs/ai/ai-rules-neon-auth" description="Stack Auth integration, database syncing, and authentication patterns" icon="lock-landscape">Neon Auth</a>
 
-<a href="/docs/ai/ai-rules-neon-serverless" description="Efficient queries, connection pooling, and serverless best practices" icon="network">Neon Serverless</a>
+<a href="/docs/ai/ai-rules-neon-serverless" description="Efficient queries, connection pooling, and serverless best practices" icon="network">Neon Serverless Driver</a>
 
 <a href="/docs/ai/ai-rules-neon-drizzle" description="ORM setup, schema management, and usage patterns with Drizzle" icon="drizzle">Neon + Drizzle</a>
 


### PR DESCRIPTION
Neon Serverless Driver is a more fitting name for what this links to.