### PR TITLE
Remove snapshot scheduling

### DIFF
--- a/content/changelog/2025-08-08.md
+++ b/content/changelog/2025-08-08.md
@@ -1,23 +1,17 @@
 ---
-title: Schedule snapshots and restore with more control, set expiration dates for branches, and more
+title: New snapshot restore options, set expiration dates for branches, and more
 ---
 
-## Snapshot updates: schedule your snapshots plus more restore options
+## New snapshot restore options (Early Access)
 
-We've added new **Early Access** snapshot capabilities to give you more control over your data.
-
-**Schedule automated snapshots** to set up daily, weekly, or monthly snapshots with custom retention rules.
-
-![Snapshot scheduling dialog](/docs/guides/snapshot_schedule.png)
-
-**New restore options** let you choose how you want to restore from your existing snapshots:
+We've added new snapshot restore workflows that let you choose how you want to restore from your existing snapshots:
 
 - **One-step restore** instantly restores a selected snapshot to the current branch
 - **Multi-step restore** creates a new branch from the selected snapshot, which you can then inspect or test before finalizing the restore
 
 ![Snapshot restore options](/docs/relnotes/snapshot_restore_options.png)
 
-Both scheduling and restore methods are also available via the Neon API for building AI agent checkpoints and other automated workflows.
+These restore methods are also available via the Neon API for building AI agent checkpoints and other automated workflows.
 
 To try out these snapshot features, sign up for the [Early Access Program](/docs/introduction/early-access). Learn more in our [backup and restore guide](/docs/guides/backup-restore).
 


### PR DESCRIPTION
Scheduling is not available in Early Access yet after all.
https://neon-next-git-bgrenon-remove-snapshot-schedule-neondatabase.vercel.app/docs/changelog