### PR TITLE
fix: pricing page table check icons update

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -85,9 +85,9 @@
       "feature": {
         "title": "Autoscaling"
       },
-      "free": "✓",
-      "launch": "✓",
-      "scale": "✓"
+      "free": true,
+      "launch": true,
+      "scale": true
     },
     {
       "rows": "2",

--- a/src/components/pages/pricing/plans/table/table.jsx
+++ b/src/components/pages/pricing/plans/table/table.jsx
@@ -211,7 +211,7 @@ const Table = () => {
                   let cell;
                   if (typeof item[key] === 'boolean') {
                     cell = item[key] ? (
-                      <span className="pricing-shield-icon flex size-6 bg-green-45" />
+                      <span className="pricing-check-icon flex size-6 bg-green-45" />
                     ) : (
                       <span className="pricing-cross-icon flex size-[14px] bg-gray-new-30" />
                     );

--- a/src/styles/mask-icons.css
+++ b/src/styles/mask-icons.css
@@ -43,9 +43,9 @@
   }
 
   /* Used in a /src/components/pages/pricing/table/table.jsx */
-  .pricing-shield-icon {
-    -webkit-mask-image: url('/images/pricing/shield.svg');
-    -webkit-mask-size: 24px 24px;
+  .pricing-check-icon {
+    -webkit-mask-image: url('/images/check.svg');
+    -webkit-mask-size: 16px 16px;
   }
 
   .pricing-cross-icon {


### PR DESCRIPTION
This PR brings fix for Pricing page table check icons

<img width="1342" height="989" alt="image" src="https://github.com/user-attachments/assets/7f5c1f44-f2f1-4fdc-a188-33e3e6298938" />

[Preview](https://neon-next-git-fix-pricing-page-check-icons-neondatabase.vercel.app/pricing)