### PR TITLE
chore(content): minor site links update

### DIFF
--- a/src/components/pages/multi-tb/high-availability/high-availability.jsx
+++ b/src/components/pages/multi-tb/high-availability/high-availability.jsx
@@ -18,7 +18,7 @@ const HighAvailability = () => (
           removing the need for full-size standby instances.
         </p>
         <Link
-          to={LINKS.docsBranching}
+          to={LINKS.docsHighAvailability}
           className="mt-6 text-[15px] leading-none tracking-tight text-white lg:mt-5 md:mt-3.5"
           withArrow
         >

--- a/src/components/pages/multi-tb/peak-demand/peak-demand.jsx
+++ b/src/components/pages/multi-tb/peak-demand/peak-demand.jsx
@@ -52,7 +52,7 @@ const PeakDemand = () => (
             </li>
           </ul>
           <Link
-            to={LINKS.docsBranching}
+            to={LINKS.autoscaling}
             className="text-[15px] leading-none tracking-extra-tight"
             theme="white"
             withArrow

--- a/src/components/pages/pricing/hero/hero.jsx
+++ b/src/components/pages/pricing/hero/hero.jsx
@@ -8,6 +8,7 @@ import Button from 'components/shared/button';
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
 import Link from 'components/shared/link';
+import LINKS from 'constants/links';
 
 import plans from './data/plans.json';
 import Features from './features';
@@ -74,11 +75,19 @@ const Hero = () => {
                   <div className="flex flex-col justify-between gap-14 lg:gap-[52px] md:gap-12">
                     <h3
                       className={clsx(
-                        'text-[18px] font-medium leading-none tracking-extra-tight lg:text-base',
+                        'flex items-center text-[18px] font-medium leading-none tracking-extra-tight lg:text-base',
                         highlighted ? 'text-green-45' : 'text-gray-new-80'
                       )}
                     >
                       {type}
+                      {type === 'Scale' && (
+                        <Link
+                          className="ml-auto text-[15px] text-gray-new-60 underline decoration-gray-new-60/50 underline-offset-4 md:text-sm"
+                          to={LINKS.contactSales}
+                        >
+                          Contact us
+                        </Link>
+                      )}
                     </h3>
                     <div className={clsx('flex flex-col flex-wrap gap-x-1 md:flex-row')}>
                       <h4 className="whitespace-nowrap text-3xl font-medium leading-snug tracking-extra-tight lg:text-xl">

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -51,6 +51,7 @@ export default {
   connectionPooling: '/docs/connect/connection-pooling',
   docsBranching: '/docs/introduction/branching',
   docsMigration: '/docs/import/import-data-assistant',
+  docsHighAvailability: '/docs/introduction/high-availability',
   manageBilling: '/docs/introduction/manage-billing',
   pgSearch: '/docs/extensions/pg_search',
   docsPgvector: '/docs/extensions/pgvector',

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -11,8 +11,6 @@ import AutoscalingIcon from 'icons/header/autoscaling.inline.svg';
 import BlogIcon from 'icons/header/blog.inline.svg';
 import BranchingGradientIcon from 'icons/header/branching-gradient.inline.svg';
 import BranchingIcon from 'icons/header/branching.inline.svg';
-import BuildingGradientIcon from 'icons/header/building-gradient.inline.svg';
-import BuildingIcon from 'icons/header/building.inline.svg';
 import CareerIcon from 'icons/header/career.inline.svg';
 import ChatIcon from 'icons/header/chat.inline.svg';
 import CloudGradientIcon from 'icons/header/cloud-gradient.inline.svg';
@@ -192,13 +190,6 @@ export default {
         {
           title: 'For teams',
           items: [
-            {
-              icon: BuildingIcon,
-              iconGradient: BuildingGradientIcon,
-              title: 'Enterprise',
-              description: 'Scale & grow',
-              to: LINKS.enterprise,
-            },
             {
               icon: RocketIcon,
               iconGradient: RocketGradientIcon,


### PR DESCRIPTION
This PR brings some minor updates:

- update links at the [Multi-TB page](https://neon-next-git-misc-minor-fixes-neondatabase.vercel.app/use-cases/multi-tb)
- add a `Contact us` link to the [pricing page](https://neon-next-git-misc-minor-fixes-neondatabase.vercel.app/pricing)
- remove Enterprise page from the header `Solutions` tab