### PR TITLE
chore: add tracking for doc actions

### DIFF
--- a/src/components/pages/doc/actions/actions.jsx
+++ b/src/components/pages/doc/actions/actions.jsx
@@ -10,6 +10,7 @@ import ArrowBackToTopIcon from 'icons/arrow-back-to-top.inline.svg';
 import ChatGptIcon from 'icons/docs/chat-gpt.inline.svg';
 import MarkdownIcon from 'icons/docs/markdown.inline.svg';
 import GitHubIcon from 'icons/github.inline.svg';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const ActionItem = ({ icon: Icon, text, url, onClick, iconClassName }) => {
   const Tag = url ? Link : 'button';
@@ -98,21 +99,32 @@ const Actions = ({ gitHubPath, withBorder = false, isTemplate = false }) => {
   const chatGptLink = `https://chatgpt.com/?hints=search&q=Read+${rawFileLink}`;
   const backToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
 
-  const buttonsDocs = (
+  const docsActions = (
     <>
       <CopyMarkdownButton rawFileLink={rawFileLink} />
-      <ActionItem icon={GitHubIcon} text="Edit this page on GitHub" url={gitHubLink} />
-      <ActionItem icon={ChatGptIcon} text="Open in ChatGPT" url={chatGptLink} />
+      <ActionItem
+        icon={GitHubIcon}
+        text="Edit this page on GitHub"
+        url={gitHubLink}
+        onClick={() => sendGtagEvent('Action Clicked', { text: 'Edit this page on GitHub' })}
+      />
+      <ActionItem
+        icon={ChatGptIcon}
+        text="Open in ChatGPT"
+        url={chatGptLink}
+        onClick={() => sendGtagEvent('Action Clicked', { text: 'Open in ChatGPT' })}
+      />
     </>
   );
 
-  const buttonsTemplate = (
+  const templateActions = (
     <>
       <ActionItem
         icon={GitHubIcon}
         text="Suggest edits"
         url={gitHubLink}
         iconClassName="size-[18px] text-white"
+        onClick={() => sendGtagEvent('Action Clicked', { text: 'Suggest edits' })}
       />
       <ActionItem
         icon={ArrowBackToTopIcon}
@@ -130,7 +142,7 @@ const Actions = ({ gitHubPath, withBorder = false, isTemplate = false }) => {
         withBorder ? 'mt-4 border-t border-gray-new-90 pt-4 dark:border-gray-new-15/70' : 'mt-12'
       )}
     >
-      {isTemplate ? buttonsTemplate : buttonsDocs}
+      {isTemplate ? templateActions : docsActions}
     </div>
   );
 };

--- a/src/components/shared/content/content.jsx
+++ b/src/components/shared/content/content.jsx
@@ -35,7 +35,7 @@ import AnchorHeading from 'components/shared/anchor-heading';
 import Button from 'components/shared/button';
 import CodeBlock from 'components/shared/code-block';
 import ComputeCalculator from 'components/shared/compute-calculator';
-import CopyPrompt from 'components/shared/copy-prompt/CopyPrompt';
+import CopyPrompt from 'components/shared/copy-prompt/copy-prompt';
 import CtaBlock from 'components/shared/cta-block';
 import DeployPostgresButton from 'components/shared/deploy-postgres-button';
 import DocCta from 'components/shared/doc-cta';

--- a/src/components/shared/copy-prompt/copy-prompt.jsx
+++ b/src/components/shared/copy-prompt/copy-prompt.jsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 
 import Button from 'components/shared/button';
 import CopyIcon from 'components/shared/code-block-wrapper/images/copy.inline.svg';
+import sendGtagEvent from 'utils/send-gtag-event';
 
 const DEFAULT_DISPLAY_TEXT = 'Use this pre-built prompt to get started faster.';
 const DEFAULT_BUTTON_TEXT = 'Copy prompt';
@@ -25,12 +26,13 @@ const CopyPrompt = (props) => {
     await navigator.clipboard.writeText(markdown);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
+    sendGtagEvent('Button Clicked', { text: 'Copy prompt' });
   };
 
   return (
     <figure
       className={clsx(
-        'not-prose my-5 flex items-center gap-x-6 rounded-[10px] px-7 py-4',
+        'not-prose my-5 flex items-center gap-x-6 rounded-[10px] px-7 py-4 sm:flex-col sm:items-start sm:gap-y-4 sm:px-5',
         'border border-gray-new-90 bg-[linear-gradient(to_right,#FAFAFA_0%,rgba(250,250,250,0)100%)]',
         'dark:border-gray-new-20 dark:bg-[linear-gradient(to_right,#18191B_28.86%,#131415_74.18%)]'
       )}
@@ -39,7 +41,7 @@ const CopyPrompt = (props) => {
         {description}
       </div>
       <Button
-        className="inline-flex items-center gap-2 rounded-md px-4 py-1.5 text-sm font-semibold"
+        className="inline-flex w-[140px] items-center gap-2 rounded-md px-4 py-1.5 text-sm font-medium xs:w-full"
         theme="primary"
         aria-label={copied ? 'Copied!' : buttonText}
         onClick={handleCopy}


### PR DESCRIPTION
This PR brings tracking for Docs actions

<img width="1277" height="452" alt="image" src="https://github.com/user-attachments/assets/1f3c7d23-63a4-496b-875a-59511f96bcbf" />

[Preview](https://neon-next-git-docs-tracking-neondatabase.vercel.app/docs/guides/astro)