### PR TITLE
fix: wait for async calls to emit zaraz identify and track events

### DIFF
--- a/src/components/pages/startups/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/startups/hero/contact-form/contact-form.jsx
@@ -148,8 +148,8 @@ const ContactForm = () => {
         if (isFormDataSentToCustomerIo) {
           try {
             if (window.zaraz && email) {
-              sendGtagEvent('identify', { userId: email, email });
-              sendGtagEvent(eventName, eventProps);
+              await sendGtagEvent('identify', { email });
+              await sendGtagEvent(eventName, eventProps);
             }
           } catch (error) {
             console.warn('Error submitting the form');

--- a/src/utils/send-gtag-event.js
+++ b/src/utils/send-gtag-event.js
@@ -1,5 +1,7 @@
 export default function sendGtagEvent(eventName, properties) {
   if (window.zaraz) {
-    window.zaraz.track(eventName, properties);
+    const result = window.zaraz.track(eventName, properties);
+    return Promise.resolve(result);
   }
+  return Promise.resolve();
 }


### PR DESCRIPTION
**Context**
We want to start funneling startup form data into customer.io in addition to HubSpot. We have an existing pipeline to send events to Cloudflare Zaraz -> Segment -> Customer.IO. However, we've noticed that in some cases, only one of `identify` or `Startup Form Submitted` ends up reaching Segment.

**What changes are proposed in this pull request?**
This PR fixes the logic by awaiting the promise before emitting the next track event while also adding guardrails in case `window.zaraz.track` does not return a promise. Other existing uses of `sendGtagEvent` should work the same (i.e. this change should be backward compatible).

**How to revert?**
The zaraz integration with the startup form is behind the following PostHog feature flag: https://us.posthog.com/project/49356/feature_flags/176002 

**How is this tested?**
- Tested this locally by enabling zaraz in dev env and verifying that the events are received by Segment.
![working_startup_form_submit](https://github.com/user-attachments/assets/ce747845-828d-4537-8464-d84ee999a104)


#[LKB-2733](https://databricks.atlassian.net/browse/LKB-2733)