### PR TITLE
fix(docs): correct typos “jonb_build_object” → “jsonb_build_object”

### DIFF
--- a/content/postgresql/postgresql-json-functions/postgresql-jsonb_build_object.md
+++ b/content/postgresql/postgresql-json-functions/postgresql-jsonb_build_object.md
@@ -57,7 +57,7 @@ Output:
 (1 row)
 ```
 
-### 2\) Using jonb_build_object() function with table data example
+### 2\) Using jsonb_build_object() function with table data example
 
 The following example uses the `jsonb_build_object()` function to create a JSON object based on the title and length of films in the `film` table from the [sample database](../postgresql-getting-started/postgresql-sample-database):
 
@@ -81,7 +81,7 @@ Output:
 ...
 ```
 
-### 3\) Using the jonb_build_object() function with an odd number of values
+### 3\) Using the jsonb_build_object() function with an odd number of values
 
 The following example attempts to use the `jsonb_build_object()` function with an odd number of values:
 


### PR DESCRIPTION
Correct misspelling of the function name in the docs. Replace “jonb_build_object” with “jsonb_build_object” in section headings and body text.