### PR TITLE
feat: theme color updater for theme provider

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -9,8 +9,8 @@ import { TabsProvider } from 'contexts/tabs-context';
 import { inter, esbuild } from './fonts';
 import { HomepageVisitProvider } from './homepage-visit-context';
 import PostHogProvider from './posthog-provider';
-import ThemeProvider from './provider';
 import SessionProvider from './session-provider';
+import ThemeProvider from './theme-provider';
 
 const PostHogPageView = dynamic(() => import('./posthog-pageview'), {
   ssr: false,
@@ -22,7 +22,6 @@ export const viewport = {
   width: 'device-width',
   initialScale: 1,
   viewportFit: 'cover',
-  themeColor: '#000000',
 };
 
 // eslint-disable-next-line react/prop-types

--- a/src/app/theme-provider.jsx
+++ b/src/app/theme-provider.jsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { ThemeProvider as PreferredProvider } from 'next-themes';
+import { ThemeProvider as PreferredProvider, useTheme } from 'next-themes';
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
 
 // eslint-disable-next-line react/prop-types
 const whiteThemePages = [
@@ -19,6 +20,27 @@ const whiteThemePages = [
 
 const themesSupportPages = ['/docs', '/guides', '/templates', '/postgresql', '/ai-chat'];
 
+const ThemeColorUpdater = () => {
+  const { theme, resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    const currentTheme = resolvedTheme || theme;
+    const themeColor = currentTheme === 'light' ? '#FFFFFF' : '#000000';
+
+    let metaThemeColor = document.querySelector('meta[name="theme-color"]');
+
+    if (!metaThemeColor) {
+      metaThemeColor = document.createElement('meta');
+      metaThemeColor.name = 'theme-color';
+      document.head.appendChild(metaThemeColor);
+    }
+
+    metaThemeColor.content = themeColor;
+  }, [theme, resolvedTheme]);
+
+  return null;
+};
+
 const ThemeProvider = ({ children }) => {
   const pathname = usePathname();
   const isWhiteThemePage = whiteThemePages.some((page) => pathname.startsWith(page));
@@ -32,6 +54,7 @@ const ThemeProvider = ({ children }) => {
       storageKey="neon-theme"
       disableTransitionOnChange
     >
+      <ThemeColorUpdater />
       {children}
     </PreferredProvider>
   );


### PR DESCRIPTION
This PR brins ThemeColorUpdater to update next theme-color according to the theme toggler

<img width="630" height="253" alt="image" src="https://github.com/user-attachments/assets/d37bdcae-7d96-4186-9c2b-77970d09e14c" />

<img width="648" height="254" alt="image" src="https://github.com/user-attachments/assets/1145704a-47e6-44a7-a784-0749031d9197" />

fixes IPhone Safari notch and page background

[Preview](https://neon-next-git-theme-color-updater-neondatabase.vercel.app/docs)