### PR TITLE
Update ai-app-build.md to not refer to the CLI anymore

### DIFF
--- a/content/docs/ai/ai-app-build.md
+++ b/content/docs/ai/ai-app-build.md
@@ -18,11 +18,10 @@ updatedOn: '2025-08-20T10:09:29.575Z'
 
 ## Getting started
 
-```bash
-npx @app.build/cli
-```
+Simply go to https://www.app.build/ and authenticate, start chatting ti build!
 
-This command launches the CLI, which will ask you to sign in with GitHub (required for code storage and deployment). Each generated application gets its own repository in your account and is deployed with a real backend and database. The CLI supports both creating new apps and iterating on existing ones (adding features or making changes).
+**Note:** the CLI is now deprecated. `npx @app.build/cli` will give you an error.
+
 
 ## What it generates
 


### PR DESCRIPTION
The CLI via NPX is deprecated 

<img width="1331" height="281" alt="image" src="https://github.com/user-attachments/assets/19094713-ab98-4265-a218-1f2561c9e331" />
