### PR TITLE
fix: await gtag events to emit on agent form

### DIFF
--- a/src/components/shared/program-form/program-form.jsx
+++ b/src/components/shared/program-form/program-form.jsx
@@ -59,7 +59,7 @@ const ProgramForm = ({ type, focus = false }) => {
     setIsValid(!!url && emailValid);
   }, [url, email, isRecognized, useCustomEmail]);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
 
     if (isValid) {
@@ -70,9 +70,9 @@ const ProgramForm = ({ type, focus = false }) => {
         const emailToSend = isRecognized && !useCustomEmail ? null : email;
 
         if (emailToSend) {
-          sendGtagEvent('identify', { email: emailToSend });
+          await sendGtagEvent('identify', { email: emailToSend });
         }
-        sendGtagEvent(eventName, { email: emailToSend, url });
+        await sendGtagEvent(eventName, { email: emailToSend, url });
       }
       setIsSent(true);
     }


### PR DESCRIPTION
**Context**
We want to funnel agent form data into customer.io. We have an existing pipeline to send events to Cloudflare Zaraz -> Segment -> Customer.IO, similar to startup form events.

**What changes are proposed in this pull request?**
Similar to https://github.com/neondatabase/website/pull/3864, this PR fixes the logic by awaiting the promise before emitting the next track event to make these events more reliable and ensure customer.io can link submit events to users.

**How is this tested?**
- Tested this locally by enabling zaraz in dev env and verifying that the events are received by customer.io.
<img width="1521" height="492" alt="Screenshot 2025-09-12 at 15 33 08" src="https://github.com/user-attachments/assets/35bb964a-3c23-4724-a854-a8c0eeb88e4c" />

#[LKB-4026](https://databricks.atlassian.net/browse/LKB-4026)