### PR TITLE
fix: docs icons dark theme

### DIFF
--- a/src/components/pages/doc/tech-cards/tech-cards.jsx
+++ b/src/components/pages/doc/tech-cards/tech-cards.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable @next/next/no-img-element */
 
-import fs from 'fs';
-
 import clsx from 'clsx';
 import NextLink from 'next/link';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import { DOCS_BASE_PATH } from 'constants/docs';
+import fileExists from 'utils/file-exists';
 
 import TechCardsWrapper from './tech-cards-wrapper';
 
@@ -22,7 +21,7 @@ const TechCards = ({ children = null, withToggler = false }) => (
 
       const iconPath = `${ICONS_PATH}/${icon}.svg`;
       const iconPathDark = `${ICONS_PATH}/${icon}-dark.svg`;
-      const hasDarkIcon = fs.existsSync(`public${iconPathDark}`);
+      const hasDarkIcon = fileExists(`public${iconPathDark}`);
 
       const isExternal = href.startsWith('http') || !href.includes(DOCS_BASE_PATH);
 

--- a/src/utils/file-exists.js
+++ b/src/utils/file-exists.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+
+/**
+ * Safely check if a file exists, only on server side
+ * @param {string} filePath - The path to check
+ * @returns {boolean} - True if file exists (server only), false otherwise
+ */
+const fileExists = (filePath) => {
+  // Only run on server side
+  if (typeof window !== 'undefined') {
+    return false;
+  }
+
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
+};
+
+export default fileExists;


### PR DESCRIPTION
This PR brings a fix for Docs icons dark theme by checking their existence on server

<img width="1952" height="940" alt="image" src="https://github.com/user-attachments/assets/7cd50cff-5da8-4081-a786-c621a004a118" />

NOTE: [file-exists](https://github.com/neondatabase/website/blob/4e88577be621610040d7acc20b029383639cd3d7/src/utils/file-exists.js) moved to the separate util

[Preview](https://neon-next-git-docs-icons-fix-neondatabase.vercel.app/docs/introduction)