### PR TITLE
Add RPAD function to PostgreSQL navigation

### DIFF
--- a/content/postgresql/navigation.yaml
+++ b/content/postgresql/navigation.yaml
@@ -710,6 +710,8 @@
           title: REPLACE
         - slug: postgresql-string-functions/postgresql-right
           title: RIGHT
+        - slug: postgresql-string-functions/postgresql-rpad
+          title: RPAD
         - slug: postgresql-string-functions/postgresql-rtrim
           title: RTRIM
         - slug: postgresql-string-functions/postgresql-split_part


### PR DESCRIPTION
Add missing link to [`RPAD`](https://neon.com/postgresql/postgresql-string-functions/postgresql-rpad) function into navigation