### PR TITLE
fix: Remove `t.co` short URL for Discord links

### DIFF
--- a/content/changelog/2024-12-06.md
+++ b/content/changelog/2024-12-06.md
@@ -35,7 +35,7 @@ The **Tables** page in the Neon Console, powered by Drizzle Studio, received a m
 - Creating enums
 - Refreshing the database schema
 
-We’d love to hear your thoughts on these new capabilities! Share your feedback through the [Feedback](https://console.neon.tech/app/projects?modal=feedback) form in the Neon Console or join the conversation on [Discord](https://t.co/kORvEuCUpJ).
+We’d love to hear your thoughts on these new capabilities! Share your feedback through the [Feedback](https://console.neon.tech/app/projects?modal=feedback) form in the Neon Console or join the conversation on [Discord](https://discord.gg/92vNTzKDGp).
 
 Stay updated on Drizzle Studio improvements and fixes by following the [Neon Drizzle Studio Integration Changelog](https://github.com/neondatabase/neon-drizzle-studio-changelog/blob/main/CHANGELOG.md).
 

--- a/content/changelog/2025-05-16.md
+++ b/content/changelog/2025-05-16.md
@@ -25,7 +25,7 @@ const { data, error } = await postgrest
 
 **Want to try it?**
 
-The Data API is in Early Access and requires an invite. Message us from the [Console](https://console.neon.tech/app/projects?modal=feedback) or on [Discord](https://t.co/kORvEuCUpJ) and we'll get you set up.
+The Data API is in Early Access and requires an invite. Message us from the [Console](https://console.neon.tech/app/projects?modal=feedback) or on [Discord](https://discord.gg/92vNTzKDGp) and we'll get you set up.
 
 [Learn more in our getting started guide](/docs/data-api/get-started).
 

--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -7,7 +7,7 @@ updatedOn: '2025-09-22T14:00:22.485Z'
 ---
 
 <Admonition type="note" title="Beta">
-Snapshots are available in Beta. Please give us [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://t.co/kORvEuCUpJ). There is no charge for snapshots while the feature is in Beta. There is a limit of 1 snapshot on the Free plan and 10 on paid plans. The same limits apply to the Neon [Agent plan](https://neon.com/use-cases/ai-agents). If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
+Snapshots are available in Beta. Please give us [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://discord.gg/92vNTzKDGp). There is no charge for snapshots while the feature is in Beta. There is a limit of 1 snapshot on the Free plan and 10 on paid plans. The same limits apply to the Neon [Agent plan](https://neon.com/use-cases/ai-agents). If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
 </Admonition>
 
 ## Overview

--- a/content/docs/extensions/pg_cron.md
+++ b/content/docs/extensions/pg_cron.md
@@ -61,7 +61,7 @@ You can then install the `pg_cron` extension by running the following `CREATE EX
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 ```
 
-If you have trouble with this setup, please reach out to [Neon Support](https://console.neon.tech/app/projects?modal=support) or find us on [Discord](https://t.co/kORvEuCUpJ).
+If you have trouble with this setup, please reach out to [Neon Support](https://console.neon.tech/app/projects?modal=support) or find us on [Discord](https://discord.gg/92vNTzKDGp).
 
 ## `pg_cron` version availability
 

--- a/content/docs/shared-content/feature-beta-props.md
+++ b/content/docs/shared-content/feature-beta-props.md
@@ -3,5 +3,5 @@ updatedOn: '2025-02-19T17:45:09.015Z'
 ---
 
 <Admonition type="note" title="Beta">
-**{feature_name}** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**{feature_name}** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 </Admonition>

--- a/content/docs/shared-content/feature-beta.md
+++ b/content/docs/shared-content/feature-beta.md
@@ -3,5 +3,5 @@ updatedOn: '2024-11-15T20:32:35.031Z'
 ---
 
 <Admonition type="note" title="Beta">
-This feature is in Beta. Please give us [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://t.co/kORvEuCUpJ).
+This feature is in Beta. Please give us [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://discord.gg/92vNTzKDGp).
 </Admonition>

--- a/content/docs/shared-content/lr-inbound-beta.md
+++ b/content/docs/shared-content/lr-inbound-beta.md
@@ -3,5 +3,5 @@ updatedOn: '2024-08-23T17:19:28.790Z'
 ---
 
 <Admonition type="note" title="Beta">
-Replicating data to Neon, where Neon is configured as a subscriber in a Postgres logical replication setup, is currently in Beta. We welcome your feedback to help improve this feature. You can provide feedback via the [Feedback](https://console.neon.tech/app/projects?modal=feedback) form in the Neon Console or by reaching out to us on [Discord](https://t.co/kORvEuCUpJ).
+Replicating data to Neon, where Neon is configured as a subscriber in a Postgres logical replication setup, is currently in Beta. We welcome your feedback to help improve this feature. You can provide feedback via the [Feedback](https://console.neon.tech/app/projects?modal=feedback) form in the Neon Console or by reaching out to us on [Discord](https://discord.gg/92vNTzKDGp).
 </Admonition>

--- a/content/docs/shared-content/private-preview-enquire.md
+++ b/content/docs/shared-content/private-preview-enquire.md
@@ -3,5 +3,5 @@ updatedOn: '2025-05-16T18:44:09.381Z'
 ---
 
 <Admonition type="comingSoon" title="Early Access">
-This feature is currently available in Early Access for invited users. Want to try it out? Message us from the [Console](https://console.neon.tech/app/projects?modal=feedback) or on [Discord](https://t.co/kORvEuCUpJ) and we'll send you an invite.
+This feature is currently available in Early Access for invited users. Want to try it out? Message us from the [Console](https://console.neon.tech/app/projects?modal=feedback) or on [Discord](https://discord.gg/92vNTzKDGp) and we'll send you an invite.
 </Admonition>

--- a/content/docs/shared-content/public-preview.md
+++ b/content/docs/shared-content/public-preview.md
@@ -3,5 +3,5 @@ updatedOn: '2024-12-03T14:32:02.192Z'
 ---
 
 <Admonition type="note" title="Public Preview">
-This feature is in Public Preview. Please provide [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://t.co/kORvEuCUpJ).
+This feature is in Public Preview. Please provide [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://discord.gg/92vNTzKDGp).
 </Admonition>

--- a/public/llms/data-api-demo.txt
+++ b/public/llms/data-api-demo.txt
@@ -6,7 +6,7 @@
 
 - [Neon Data API tutorial HTML](https://neon.com/docs/data-api/demo): The original HTML version of this documentation
 
-**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 In this tutorial, we'll walk through our note-taking app to show how you can use Neon's Data API and `postgrest-js` to write queries from your frontend code, with proper authentication and Row-Level Security (RLS) policies ensuring your data stays secure.
 

--- a/public/llms/data-api-get-started.txt
+++ b/public/llms/data-api-get-started.txt
@@ -6,7 +6,7 @@
 
 - [Getting started with Neon Data API HTML](https://neon.com/docs/data-api/get-started): The original HTML version of this documentation
 
-**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 Related docs:
 - [Neon Auth](https://neon.com/docs/guides/neon-auth)

--- a/public/llms/extensions-pg_cron.txt
+++ b/public/llms/extensions-pg_cron.txt
@@ -58,7 +58,7 @@ You can then install the `pg_cron` extension by running the following `CREATE EX
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 ```
 
-If you have trouble with this setup, please reach out to [Neon Support](https://console.neon.tech/app/projects?modal=support) or find us on [Discord](https://t.co/kORvEuCUpJ).
+If you have trouble with this setup, please reach out to [Neon Support](https://console.neon.tech/app/projects?modal=support) or find us on [Discord](https://discord.gg/92vNTzKDGp).
 
 ## `pg_cron` version availability
 

--- a/public/llms/guides-datadog.txt
+++ b/public/llms/guides-datadog.txt
@@ -34,7 +34,7 @@ The integration exports [a comprehensive set of metrics](https://neon.com/docs/g
 
 ### Postgres logs
 
-**Note** Beta: **Postgres logs export** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Postgres logs export** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 The Neon Datadog integration can forward Postgres logs to your Datadog account. These logs provide visibility into database activity, errors, and performance. See [Export Postgres logs to Datadog](https://neon.com/docs/guides/datadog#export-postgres-logs-to-datadog) for details.
 

--- a/public/llms/guides-grafana-cloud.txt
+++ b/public/llms/guides-grafana-cloud.txt
@@ -34,7 +34,7 @@ The integration exports [a comprehensive set of metrics](https://neon.com/docs/g
 
 ### Postgres logs
 
-**Note** Beta: **Postgres logs export** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Postgres logs export** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 With the the Grafana Cloud integration, you can forward Postgres logs to your Grafana Cloud stack. These logs provide visibility into database activity, errors, and performance. See [Export Postgres logs to Grafana Cloud](https://neon.com/docs/guides/grafana-cloud#export-postgres-logs-to-grafana-cloud) for details.
 

--- a/public/llms/guides-opentelemetry.txt
+++ b/public/llms/guides-opentelemetry.txt
@@ -6,7 +6,7 @@
 
 - [OpenTelemetry HTML](https://neon.com/docs/guides/opentelemetry): The original HTML version of this documentation
 
-**Note** Beta: **OpenTelemetry integration** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **OpenTelemetry integration** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 What you will learn:
 - How to configure OpenTelemetry exports from Neon
@@ -38,7 +38,7 @@ The integration exports a comprehensive set of metrics including:
 
 ### Postgres logs
 
-**Note** Beta: **Postgres logs export** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Postgres logs export** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 The Neon OpenTelemetry integration can forward Postgres logs to your destination platform. These logs provide visibility into database activity, errors, and performance.
 

--- a/public/llms/import-import-data-assistant.txt
+++ b/public/llms/import-import-data-assistant.txt
@@ -8,7 +8,7 @@
 
 When you're ready to move your data to Neon, our Import Data Assistant can help you automatically copy your existing database to Neon. You only need to provide a connection string to get started.
 
-**Note** Beta: **Import Data Assistant** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Import Data Assistant** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
    **Tip** Migrate between Neon projects: You can also use the **Import Data Assistant** to migrate data between Neon projects. This is useful if you want to upgrade to a newer Postgres version (for example, from Postgres 16 to 17), or move your database to a different region. Just create a new project with the desired Postgres version or region, then use the database connection string from your existing Neon project to import the data into the new one.
 

--- a/public/llms/neon-auth-api.txt
+++ b/public/llms/neon-auth-api.txt
@@ -6,7 +6,7 @@
 
 - [Manage Neon Auth using the API HTML](https://neon.com/docs/neon-auth/api): The original HTML version of this documentation
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 Related docs:
 - [Get started](https://neon.com/docs/guides/neon-auth)

--- a/public/llms/neon-auth-best-practices.txt
+++ b/public/llms/neon-auth-best-practices.txt
@@ -6,7 +6,7 @@
 
 - [Neon Auth best practices & FAQ HTML](https://neon.com/docs/neon-auth/best-practices): The original HTML version of this documentation
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 Related docs:
 - [Get started](https://neon.com/docs/guides/neon-auth)

--- a/public/llms/neon-auth-demo.txt
+++ b/public/llms/neon-auth-demo.txt
@@ -14,7 +14,7 @@ Related docs:
 
 In this tutorial, we'll walk through some user authentication flows using our [demo todos](https://github.com/neondatabase-labs/neon-auth-demo-app) application, showing how Neon Auth automatically syncs user profiles to your database, and how that can simplify your code.
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 ## Prerequisites
 

--- a/public/llms/neon-auth-email-configuration.txt
+++ b/public/llms/neon-auth-email-configuration.txt
@@ -6,7 +6,7 @@
 
 - [Email configuration HTML](https://neon.com/docs/neon-auth/email-configuration): The original HTML version of this documentation
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 Related docs:
 - [Best practices](https://neon.com/docs/neon-auth/best-practices)

--- a/public/llms/neon-auth-how-it-works.txt
+++ b/public/llms/neon-auth-how-it-works.txt
@@ -15,7 +15,7 @@ Related docs:
 
 **Neon Auth** simplifies user management by bundling auth with your database, so your user data is always available right from Postgres. No custom integration required.
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 ## How it works
 

--- a/public/llms/neon-auth-overview.txt
+++ b/public/llms/neon-auth-overview.txt
@@ -8,7 +8,7 @@
 
 Neon Auth brings authentication and user management natively to your Neon Postgres database.
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 ## Why Neon Auth?
 

--- a/public/llms/neon-auth-quick-start-javascript.txt
+++ b/public/llms/neon-auth-quick-start-javascript.txt
@@ -12,7 +12,7 @@ Other frameworks:
   Sample project:
 - [Vanilla TS Template](https://github.com/neondatabase-labs/neon-auth-ts-template)
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 Neon Auth lets you add authentication to your app in seconds — user data is synced directly to your Neon Postgres database, so you can query and join it just like any other table.
 

--- a/public/llms/neon-auth-quick-start-nextjs.txt
+++ b/public/llms/neon-auth-quick-start-nextjs.txt
@@ -12,7 +12,7 @@ Other frameworks:
   Sample project:
 - [Next.js Demo App](https://github.com/neondatabase-labs/neon-auth-demo-app)
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 Neon Auth lets you add authentication to your app in seconds — user data is synced directly to your Neon Postgres database, so you can query and join it just like any other table.
 

--- a/public/llms/neon-auth-quick-start-react.txt
+++ b/public/llms/neon-auth-quick-start-react.txt
@@ -12,7 +12,7 @@ Other frameworks:
   Sample project:
 - [React Template](https://github.com/neondatabase-labs/neon-auth-react-template)
 
-**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://t.co/kORvEuCUpJ) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
+**Note** Beta: **Neon Auth** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
 
 Neon Auth lets you add authentication to your app in seconds — user data is synced directly to your Neon Postgres database, so you can query and join it just like any other table.
 


### PR DESCRIPTION
I was reading the documentation [Getting started with Neon Data API](https://neon.com/docs/data-api/get-started) and noticed the Discord link is using `t.co` instead of the direct link that is used across the rest of the website (e.g: the header of neon.com). I guess this is unintentional as [there doesn't appear to be any benefits of using t.co outside of ~Twitter~X](https://help.x.com/en/using-x/url-shortener) and there aren't any other `t.co` uses in the documentation. In this Pull Request I have replaced the `t.co` link with the direct link to Discord.