### PR TITLE
docs: add TabItem for Intel x64 and Apple Silicon with separate export paths

### DIFF
--- a/content/docs/connect/query-with-psql-editor.md
+++ b/content/docs/connect/query-with-psql-editor.md
@@ -21,7 +21,16 @@ Neon also provides a passwordless auth feature that uses `psql`. For more inform
 
 If you don't have `psql` installed already, follow these steps to get set up:
 
-<Tabs labels={["Mac", "Linux", "Windows"]}>
+<Tabs labels={["Mac (Intel x64)", "Mac (Apple Silicon)", "Linux", "Windows"]}>
+
+<TabItem>
+```bash
+brew install libpq
+echo 'export PATH="/usr/local/opt/libpq/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+</TabItem>
 
 <TabItem>
 ```bash


### PR DESCRIPTION
This commit adds an intel based export path. Originally the export path only contained the apple silicon export path