### PR TITLE
fix: prose table adaptive

### DIFF
--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -21,11 +21,11 @@
   }
 
   .table-wrapper {
-    @apply md:-mx-4 md:overflow-x-auto md:px-4;
+    @apply 2xl:-mx-4 2xl:overflow-x-auto 2xl:px-4;
   }
 
   .table {
-    @apply my-10 w-full leading-normal md:min-w-[500px];
+    @apply my-10 w-full leading-normal 2xl:min-w-[500px];
 
     .func_table_entry,
     .catalog_table_entry {
@@ -154,11 +154,11 @@
     }
 
     .table-wrapper {
-      @apply md:-mx-4 md:overflow-x-auto md:px-4;
+      @apply 2xl:-mx-4 2xl:overflow-x-auto 2xl:px-4;
     }
 
     table {
-      @apply my-10 w-full leading-normal md:min-w-[500px];
+      @apply my-10 w-full leading-normal 2xl:min-w-[500px];
 
       th {
         @apply p-2.5 pt-0 text-left align-top;


### PR DESCRIPTION
This PR makes the prose table's content scrollable and adaptable at higher resolutions

<img width="1001" height="343" alt="Screenshot 2025-09-25 at 16 39 14" src="https://github.com/user-attachments/assets/01680230-5b3d-48e3-9223-5329122633d4" />


[example post](https://neon-next-git-fix-prose-table-neondatabase.vercel.app/docs/extensions/pg-extensions) with table
