### PR TITLE
fix: fix cypress e2e test for startup form

### DIFF
--- a/cypress/e2e/startups-contact-form.cy.js
+++ b/cypress/e2e/startups-contact-form.cy.js
@@ -13,8 +13,18 @@ describe('Startups Contact Form', () => {
     cy.get("input[name='investor']").type('Y Combinator');
     cy.get('form').submit();
 
-    cy.wait('@formSuccessSubmit');
     cy.get('button').should('contain', 'Applied!');
+
+    cy.get('@zarazTrackSpy').should('have.been.calledWith', 'identify', {
+      email: 'john.doe@startup.com',
+    });
+    cy.get('@zarazTrackSpy').should('have.been.calledWith', 'Startup Form Submitted', {
+      email: 'john.doe@startup.com',
+      first_name: 'John',
+      last_name: 'Doe',
+      company_website: 'startup.example.com',
+      investor: 'Y Combinator',
+    });
   });
 
   it('displays validation errors when required fields are missing', () => {
@@ -46,7 +56,10 @@ describe('Startups Contact Form', () => {
     cy.get("input[name='investor']").type('Y Combinator');
     cy.get('form').submit();
 
-    cy.wait('@formErrorSubmit');
     cy.getByData('error-message').should('exist');
+
+    cy.get('@zarazTrackSpy').should('have.been.calledWith', 'identify', {
+      email: 'john.doe@startup.com',
+    });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,33 +1,29 @@
 Cypress.Commands.add('getByData', (selector) => cy.get(`[data-test=${selector}]`));
 
 Cypress.Commands.add('formSuccessSubmit', () => {
-  cy.intercept(
-    {
-      method: 'POST',
-      url: `/api/hubspot`,
-    },
-    {
-      statusCode: 200,
-      body: {
-        status: 'success',
-      },
-    }
-  ).as('formSuccessSubmit');
+  cy.window()
+    .then((win) => {
+      // Mock zaraz for successful gtag events
+      Object.assign(win, {
+        zaraz: {
+          track: cy.stub().resolves().as('zarazTrackSpy'),
+        },
+      });
+    })
+    .as('formSuccessSubmit');
 });
 
 Cypress.Commands.add('formErrorSubmit', () => {
-  cy.intercept(
-    {
-      method: 'POST', // or whatever method the form uses
-      url: `/api/hubspot`,
-    },
-    {
-      statusCode: 500,
-      body: {
-        error: 'Internal server error',
-      },
-    }
-  ).as('formErrorSubmit');
+  cy.window()
+    .then((win) => {
+      // Mock zaraz for failed gtag events
+      Object.assign(win, {
+        zaraz: {
+          track: cy.stub().rejects(new Error('Network error')).as('zarazTrackSpy'),
+        },
+      });
+    })
+    .as('formErrorSubmit');
 });
 
 Cypress.on('uncaught:exception', (err) => {


### PR DESCRIPTION
**Context**
In https://github.com/neondatabase/website/pull/3992, we removed some logic that sent startup form data to HubSpot via the HubSpot endpoint. Our Cypress e2e test now seems to be failing as a result. **The e2e tests also have another issue that is being looked into separately, which is causing it to fail on GitHub (including within this PR).** [Slack thread for context](https://databricks.slack.com/archives/C092730799C/p1759171526733509).

**What changes are proposed in this pull request?**
This PR edits the Cypress e2e test to account for the data now only being sent to customer.io via Zaraz.

**How did we test this?**
Tested the e2e test locally
<img width="441" height="275" alt="Screenshot 2025-09-30 at 10 51 47" src="https://github.com/user-attachments/assets/b1a8491a-6d54-49cb-8ccd-a34c5285f8fb" />

#[LKB-4026](https://databricks.atlassian.net/browse/LKB-4026)