### PR TITLE
fix: remove broken demo

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -424,14 +424,6 @@ const defaultConfig = {
         destination: 'https://postgres-ai-playground.vercel.app/demos/playground/:path*',
       },
       {
-        source: '/demos/instant-postgres',
-        destination: 'https://instant-postgres.mahmoudw.com/demos/instant-postgres',
-      },
-      {
-        source: '/demos/instant-postgres/:path*',
-        destination: 'https://instant-postgres.mahmoudw.com/demos/instant-postgres/:path*',
-      },
-      {
         source: '/developer-days/:path*',
         destination: 'https://neon-dev-days-next.vercel.app/developer-days/:path*',
       },


### PR DESCRIPTION
Instagres demo no longer in use and broken - replaced by launchpad