### PR TITLE
Update HIPAA compliance section with additional resources

### DIFF
--- a/content/docs/security/compliance.md
+++ b/content/docs/security/compliance.md
@@ -34,15 +34,9 @@ The California Consumer Privacy Act (CCPA) grants California residents new right
 
 ## HIPAA
 
-Neon offers HIPAA compliance as part of our Scale plan, enabling applications that handle Protected Health Information (PHI) to meet compliance requirements.
+Neon offers HIPAA compliance as part of our Scale plan, enabling applications that handle Protected Health Information (PHI) to meet compliance requirements. more information and how to get started, refer to our [Neon HIPAA Compliance Guide](/docs/security/hipaa).
 
 A copy of Neon's HIPAA compliance report can be requested through our [Trust Center](https://trust.neon.com/).
-
-To request a draft Business Associate Agreement (BAA), please [contact the Neon Sales team](/contact-sales). Once a BAA is signed, the Neon Sales team can assist you with enabling HIPAA for your Neon account.
-
-HIPAA-enabled accounts can request access to HIPAA audit logs by [opening a support request](https://console.neon.tech/app/projects?modal=support).
-
-For additional information about HIPAA compliance and Neon, please refer to the [Neon HIPAA Compliance Guide](/docs/security/hipaa).
 
 ## Questions?
 


### PR DESCRIPTION
Added link to Neon HIPAA Compliance Guide and removed redundant information about requesting a Business Associate Agreement (BAA) and HIPAA audit logs.