### PR TITLE
fix: allow docs/postgres

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -17,7 +17,6 @@ module.exports = {
     '/fireship',
     '/radio',
     '/thank-you',
-    '/docs/postgres*',
     '/blog-sitemap.xml',
     '/blog/*',
     '/guides/rss.xml',


### PR DESCRIPTION
We used to disallow docs/postgres because it was the postgres docs, but now it's just a few of our docs pages and they should be indexed.