### PR TITLE
docs: fix typo in postgres multicolumn indexes

### DIFF
--- a/content/postgresql/postgresql-indexes/postgresql-multicolumn-indexes.md
+++ b/content/postgresql/postgresql-indexes/postgresql-multicolumn-indexes.md
@@ -159,7 +159,7 @@ Output:
 
 The output indicates that the query optimizer uses the `idx_people_names` index for the `last_name = 'Adams'` query.
 
-Sixth, find the person whose first name is `Lou` (without specifying the last name):
+Sixth, find the person whose first name is `Lou` and last name is `Adams`:
 
 ```sql
 EXPLAIN SELECT


### PR DESCRIPTION
I fixed a mistake in a sentence, the example sql query and postgres planning is not coherent with the phrase above, so I fixed it