### PR TITLE
docs: update support page

### DIFF
--- a/content/docs/introduction/support.md
+++ b/content/docs/introduction/support.md
@@ -31,7 +31,7 @@ The support channels you can access differ according to your [Support Plan](#sup
 | [Support tickets](#support-tickets)                                           |         -         |       \*        |     &check;      |
 | [Slack channel](#slack-channel)                                               |         -         |        -        |       \*\*       |
 | [Dedicated Support Engineer](#dedicated-support-engineer)                     |         -         |        -        |       \*\*       |
-| [SLAs](#slas)                                                                 |         -         |        -        |     &check;      |
+| [SLAs](#slas)                                                                 |         -         |        -        |        -         |
 
 <div style={{margin: '-30px 0 30px 0'}}>
 <small><sup>\*</sup> [Support tickets](#support-tickets) are only supported for billing-related issues under this support plan, which means Neon Launch plan users can only create support tickets if the issue is related to billing.</small><br/>
@@ -83,7 +83,7 @@ A dedicated engineer can develop in-depth knowledge of your systems, leading to 
 
 ### SLAs
 
-If you are interested in exploring a Support Level Agreement (SLAs), [get in touch with our sales team](/contact-sales).
+Response time SLAs are available only to existing customers on our legacy Enterprise plans. If you are interested in exploring a Support Level Agreement (SLAs), [get in touch with our sales team](/contact-sales).
 
 ## General support policy
 
@@ -103,93 +103,40 @@ If you, the Customer, believe that your invoice or billing receipt is incorrect,
 
 ### Response times
 
-Neon aims to respond to all **paid subscription** requests in a timely manner and as soon as practically possible. Customers are prioritized based on their plan and [Severity](#severity-levels) of their issue. We only commit to responding to Customers with an Scale plan using the target response time guidelines below.
+Neon aims to respond to all Enterprise plan support requests in a timely manner and as soon as practically possible. Customers are prioritized based on their plan and [Severity](#severity-levels) of their issue.
 
-#### Target response times
-
-The table below outlines Neon’s guidelines for the various support tiers of our Standard support plan.
+The table below outlines Neon’s guidelines for the support tiers of our legacy Enterprise support plan.
 
 These times relate to the time it takes Neon to respond to the Customer’s initial request. This guideline only applies when submitting a support ticket through the Neon Console.
 
-|    Severity Level     | Standard                                  | Gold                                     | Platinum                                 |
-| :-------------------: | ----------------------------------------- | ---------------------------------------- | ---------------------------------------- |
-| Severity 1 (Critical) | \< 2 hours (during Normal Business Hours) | \< 1 hour                                | \< 1 hour                                |
-|   Severity 2 (High)   | \< 2 days (during Normal Business Hours)  | \< 1 day                                 | \< 4 hours                               |
-|  Severity 3 (Normal)  | \< 3 days (during Normal Business Hours)  | \< 3 days (during Normal Business Hours) | \< 3 days (during Normal Business Hours) |
-|   Severity 4 (Low)    | \< 3 days (during Normal Business Hours)  | \< 3 days (during Normal Business Hours) | \< 3 days (during Normal Business Hours) |
+|       Severity Level        | Business              | Production            |
+| :-------------------------: | --------------------- | --------------------- |
+| Standard Support Severity 1 | Within 4 hours        | Within 1 hour         |
+| Standard Support Severity 2 | Within 1 business day | Within 4 hours        |
+| Standard Support Severity 3 | Within 1 business day | Within 1 business day |
+| Standard Support Severity 4 | Within 1 business day | Within 1 business day |
 
 ### Severity levels
 
 When the Customer submits an issue (with or without specifying a starting severity), Neon will reasonably assess its severity according to the appropriate severity levels defined below. Neon reserves the right to set, upgrade and downgrade severities of support tickets, on a case-by-case basis, considering any available mitigations, workarounds, and timely cooperation from Customers. Neon will explain the reasoning to the Customer and will resolve any disagreement regarding the severity as soon as is reasonably practicable. **Critical and High-priority levels should not be used for low-impact issues or general questions\!**
 
-A detailed explanation of each severity level, including several examples, is provided below.
+A detailed explanation of each severity level is provided below.
 
-#### Severity 1 (Critical)
+#### Standard Support Severity 1
 
-- Catastrophic problems in the Customer’s production system leading to loss of service or impact on the Customer’s business
-- Unavailability of the service
-- Security breaches that compromise the confidentiality, integrity, or availability of the database or its data.
+Production system is down or severely impacted such that routine operation is impossible
 
-<Admonition type="note">
-If Critical is selected during the case creation, the customer will be asked to provide in-depth details on the business impact the issue has caused.
-</Admonition>
+#### Standard Support Severity 2
 
-Examples:
+Production issue where the system is functioning but in degraded or restricted capacity
 
-1. A complete outage of the service provided by Neon
-2. Security breaches
-3. Error impacting the project as a whole (all endpoints/db affected)
-4. Error impacting multiple projects
-5. EP/Branch/DB unreachable
-6. Data corruption/Data loss
+#### Standard Support Severity 3
 
-#### Severity 2 (High)
+Issue where minor functionality is impacted or a development issue occurs
 
-Means a high-impact problem in a customer’s production systems. Essential operations are seriously disrupted, but a workaround exists that allows for continued essential operations.
+#### Standard Support Severity 4
 
-- Non-essential modifications to configuration, like adjusting database parameters or table schema
-- Minor performance concerns that have minimal impact on database usability
-- Minor issues related to application integrations, such as minor API connectivity problems
-- Small-scale challenges with data import/export, data transformation, or data loading processes
-
-Examples:
-
-1. Partial outage of the service provided by Neon: service usable, but key feature unusable, e.g.:
-   - Cannot create a new branch
-   - Cannot execute a branch [restore](/docs/guides/branch-restore)
-   - Cannot perform point-in-time recovery (PITR)
-   - Etc.
-2. Any use case that would require a high load of manual work on the customer side to mitigate an issue on our end
-3. Any use case which massively and negatively affects the customer's business
-
-#### Severity 3 (Normal)
-
-A medium-impact problem on a production or non-production system that involves:
-
-- Partial or limited loss of non-critical functionality
-- A usage problem that involves no loss in functionality
-
-Customers can continue essential operations. Normal problems also include issues with non-production systems, such as test and development systems.
-
-Examples:
-
-1. RCA for past outages or incidents (no disruption of the service at the moment)
-2. Sporadic connection failure/timeouts/retries
-3. Cannot connect with random third-party framework or tool (but can connect generally speaking)
-4. Any use case which has a minor impact on the customer's business
-5. Poor performing queries/ingestion
-6. Billing issues
-
-#### Severity 4 (Low)
-
-- A general usage question; here is no impact on the product's quality, performance, or functionality in a production or non-production system
-- Any request for information, enhancement, or documentation clarification regarding the platform
-
-Examples:
-
-1. Feature requests/feature enablement
-2. General questions (“active time,” “how to backup a DB,” “how to ingest data”) and feedback
-3. Any use case that has no impact on the customer's business at all
+Request for information or feature request with no impact on business operations
 
 ### Etiquette
 


### PR DESCRIPTION
- Interim support page update until new paid support options (Business & Production) are available
- No SLAs for Neon's existing "standard" support plan (available to Neon Neon Scale plan customers)
- SLA response times for Enterprise Legacy standard and gold plans mapped to DBX Business and Production support plan response times.