### PR TITLE
feat: add new form linked to customer.io

### DIFF
--- a/src/components/pages/partners/apply/apply.jsx
+++ b/src/components/pages/partners/apply/apply.jsx
@@ -2,6 +2,7 @@
 
 import * as Dialog from '@radix-ui/react-dialog';
 import clsx from 'clsx';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { InlineWidget } from 'react-calendly';
@@ -10,9 +11,11 @@ import Container from 'components/shared/container';
 import GradientLabel from 'components/shared/gradient-label';
 import useHubspotForm from 'hooks/use-hubspot-form';
 
+import CloseIcon from './images/close.inline.svg';
+import PartnerForm from './partner-form';
+
 import 'styles/hubspot-form.css';
 import 'styles/calendly-widget.css';
-import CloseIcon from './images/close.inline.svg';
 
 const calendlyURL = 'https://calendly.com/d/ckxx-b4h-69y/neon-solutions-engineering';
 const hubspotFormID = '26f1ff16-e3ab-4adf-b09f-910f130637b0';
@@ -46,6 +49,8 @@ const Apply = () => {
   });
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const isCustomerIoFormEnabled = useFeatureFlagEnabled('growth_partner_form_customer_io');
+
   useHubspotForm('hubspot-form', {
     onFormSubmitted: (form, data) => {
       const { submissionValues } = data;
@@ -61,6 +66,11 @@ const Apply = () => {
 
   const handleOpenChange = () => {
     setIsModalOpen(false);
+  };
+
+  const handlePartnerFormSuccess = (userData) => {
+    setIsModalOpen(true);
+    setUserData(userData);
   };
 
   return (
@@ -81,11 +91,20 @@ const Apply = () => {
             </p>
             <Testimonial className="lg:hidden" />
           </div>
-          <div className="hubspot-form-wrapper col-span-5 xl:col-span-7 lg:col-span-full lg:mt-10 md:mt-6">
-            <div
-              className="hubspot-form not-prose with-link-primary"
-              data-form-id={hubspotFormID}
-            />
+          <div
+            className={clsx(
+              'col-span-5 xl:col-span-7 lg:col-span-full lg:mt-10 md:mt-6',
+              !isCustomerIoFormEnabled && 'hubspot-form-wrapper'
+            )}
+          >
+            {isCustomerIoFormEnabled ? (
+              <PartnerForm onSuccess={handlePartnerFormSuccess} />
+            ) : (
+              <div
+                className="hubspot-form not-prose with-link-primary"
+                data-form-id={hubspotFormID}
+              />
+            )}
           </div>
           <Testimonial className="col-span-full hidden lg:mt-10 lg:block md:mt-8" ariaHidden />
         </div>

--- a/src/components/pages/partners/apply/partner-form.jsx
+++ b/src/components/pages/partners/apply/partner-form.jsx
@@ -1,0 +1,275 @@
+'use client';
+
+import { yupResolver } from '@hookform/resolvers/yup';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import useCookie from 'react-use/lib/useCookie';
+import * as yup from 'yup';
+
+import Button from 'components/shared/button';
+import Field from 'components/shared/field';
+import Link from 'components/shared/link';
+import { FORM_STATES } from 'constants/forms';
+import LINKS from 'constants/links';
+import CloseIcon from 'icons/close.inline.svg';
+import { checkBlacklistEmails } from 'utils/check-blacklist-emails';
+import { doNowOrAfterSomeTime } from 'utils/forms';
+import sendGtagEvent from 'utils/send-gtag-event';
+
+const ErrorMessage = ({ onClose }) => (
+  <div className="absolute inset-0 flex items-center justify-center p-5" data-test="error-message">
+    <div className="relative z-10 flex max-w-sm flex-col items-center text-center">
+      <h3 className="font-title text-[32px] font-medium leading-none tracking-extra-tight sm:text-[28px]">
+        Oops, looks like there&apos;s a technical problem
+      </h3>
+      <p className="mt-3.5 max-w-[236px] leading-tight tracking-extra-tight text-gray-new-70">
+        Please reach out to us directly at{' '}
+        <Link
+          className="border-b border-green-45/40 hover:border-green-45"
+          theme="green"
+          to="mailto:partnerships@neon.tech"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          partnerships@neon.tech
+        </Link>
+      </p>
+    </div>
+    <button className="absolute right-4 top-4 z-20" type="button" onClick={onClose}>
+      <CloseIcon className="size-4 text-white opacity-50 transition-opacity duration-300 hover:opacity-100" />
+      <span className="sr-only">Close error message</span>
+    </button>
+    <span className="absolute inset-0 bg-[#0E0E11]/40 backdrop-blur-md" />
+  </div>
+);
+
+ErrorMessage.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
+
+const schema = yup
+  .object({
+    companyName: yup.string().required('Required field'),
+    firstname: yup.string().required('Required field'),
+    lastname: yup.string().required('Required field'),
+    email: yup
+      .string()
+      .email('Please enter a valid email')
+      .required('Required field')
+      .test(checkBlacklistEmails({ validation: { useDefaultBlockList: true } })),
+    jobTitle: yup.string().optional(),
+    additionalDetails: yup.string().optional(),
+    ajs_anonymous_id: yup.string().optional(),
+  })
+  .required();
+
+const labelClassName = 'text-sm text-gray-new-90';
+
+const PartnerForm = ({ onSuccess }) => {
+  const [formState, setFormState] = useState(FORM_STATES.DEFAULT);
+  const [isBroken, setIsBroken] = useState(false);
+  const [ajsAnonymousId] = useCookie('ajs_anonymous_id');
+
+  const {
+    register,
+    reset,
+    handleSubmit,
+    formState: { isValid, errors },
+  } = useForm({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      ajs_anonymous_id: ajsAnonymousId || 'none',
+    },
+  });
+
+  useEffect(() => {
+    const hasErrors = Object.keys(errors).length > 0;
+    if (formState !== FORM_STATES.LOADING && formState !== FORM_STATES.SUCCESS) {
+      if (hasErrors) setFormState(FORM_STATES.ERROR);
+      else setFormState(FORM_STATES.DEFAULT);
+    }
+  }, [errors, isValid, formState]);
+
+  const onSubmit = async (data, e) => {
+    e.preventDefault();
+    const { firstname, lastname, email, companyName, jobTitle, additionalDetails } = data;
+    const loadingAnimationStartedTime = Date.now();
+    setIsBroken(false);
+    setFormState(FORM_STATES.LOADING);
+
+    try {
+      const eventName = 'Partner Form Submitted';
+      const eventProps = {
+        email,
+        first_name: firstname,
+        last_name: lastname,
+        company_name: companyName,
+        job_title: jobTitle,
+        additional_details: additionalDetails,
+      };
+
+      if (window.zaraz && email) {
+        await sendGtagEvent('identify', { email });
+        await sendGtagEvent(eventName, eventProps);
+      }
+
+      doNowOrAfterSomeTime(() => {
+        setFormState(FORM_STATES.SUCCESS);
+        reset();
+        setIsBroken(false);
+        // Call the onSuccess callback with user data for Calendly
+        if (onSuccess) {
+          onSuccess({
+            email,
+            name: `${firstname || ''} ${lastname || ''}`.trim(),
+          });
+        }
+      }, loadingAnimationStartedTime);
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        doNowOrAfterSomeTime(() => {
+          setFormState(FORM_STATES.BROKEN);
+          setIsBroken(true);
+        }, 2000);
+      }
+    }
+  };
+
+  const isDisabled = formState === FORM_STATES.LOADING || formState === FORM_STATES.SUCCESS;
+
+  const getButtonContent = () => {
+    if (formState === FORM_STATES.LOADING) {
+      return (
+        <div className="flex items-center justify-center gap-2">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          Submitting...
+        </div>
+      );
+    }
+    if (formState === FORM_STATES.SUCCESS) {
+      return 'Submitted!';
+    }
+    return 'Submit';
+  };
+
+  return (
+    <form
+      className={clsx(
+        'relative z-10 grid w-full max-w-none gap-y-6 p-8',
+        'rounded-xl border border-gray-new-10 bg-[#020203]/70 bg-contact-form-bg shadow-contact',
+        'xl:p-6 lg:gap-y-5 md:gap-y-6'
+      )}
+      method="POST"
+      id="partner-form"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Field
+        name="companyName"
+        label="Your Company Name*"
+        theme="transparent"
+        labelClassName={labelClassName}
+        isDisabled={isDisabled}
+        error={errors.companyName?.message}
+        {...register('companyName')}
+      />
+      <div className="grid grid-cols-2 gap-6 lg:gap-5 md:contents md:flex-col md:gap-6">
+        <Field
+          name="firstname"
+          label="First Name*"
+          theme="transparent"
+          labelClassName={labelClassName}
+          error={errors.firstname?.message}
+          isDisabled={isDisabled}
+          {...register('firstname')}
+        />
+        <Field
+          name="lastname"
+          label="Last Name*"
+          theme="transparent"
+          labelClassName={labelClassName}
+          error={errors.lastname?.message}
+          isDisabled={isDisabled}
+          {...register('lastname')}
+        />
+      </div>
+      <Field
+        name="email"
+        label="Your Business Email*"
+        type="email"
+        theme="transparent"
+        labelClassName={labelClassName}
+        isDisabled={isDisabled}
+        error={errors.email?.message}
+        {...register('email')}
+      />
+      <Field
+        name="jobTitle"
+        label="Your Job Title"
+        theme="transparent"
+        labelClassName={labelClassName}
+        isDisabled={isDisabled}
+        error={errors.jobTitle?.message}
+        {...register('jobTitle')}
+      />
+      <Field
+        name="additionalDetails"
+        label="Additional Details"
+        tag="textarea"
+        rows={4}
+        theme="transparent"
+        labelClassName={labelClassName}
+        isDisabled={isDisabled}
+        error={errors.additionalDetails?.message}
+        {...register('additionalDetails')}
+      />
+
+      {/* Hidden field for ajs_anonymous_id */}
+      <input type="hidden" name="ajs_anonymous_id" {...register('ajs_anonymous_id')} />
+
+      <div className="relative">
+        <Button
+          className={clsx(
+            'mt-1 h-[46px] w-full font-semibold lg:h-10 sm:mt-0',
+            formState === FORM_STATES.ERROR && 'pointer-events-none !bg-secondary-1/50'
+          )}
+          type="submit"
+          theme="primary"
+          size="xs"
+          disabled={formState === FORM_STATES.LOADING || formState === FORM_STATES.SUCCESS}
+        >
+          {getButtonContent()}
+        </Button>
+      </div>
+
+      <p className="text-sm leading-tight text-gray-new-70">
+        By submitting, you agree to the{' '}
+        <Link
+          className="hover:text-green-50 text-green-45 transition-colors"
+          to={LINKS.terms}
+          target="_blank"
+        >
+          Terms of Service
+        </Link>{' '}
+        and acknowledge the{' '}
+        <Link
+          className="hover:text-green-50 text-green-45 transition-colors"
+          to={LINKS.privacy}
+          target="_blank"
+        >
+          Privacy Policy
+        </Link>
+        .
+      </p>
+
+      {isBroken && <ErrorMessage onClose={() => setIsBroken(false)} />}
+    </form>
+  );
+};
+
+PartnerForm.propTypes = {
+  onSuccess: PropTypes.func,
+};
+
+export default PartnerForm;


### PR DESCRIPTION
**Context**
We are sunsetting HubSpot soon, but our existing partner form (on https://neon.com/partners#partners-apply) is a HubSpot form. We want to move response data to customer.io instead.

**What changes are proposed in this pull request?**
This PR adds a new `partner-form` component 

**How did we test this?**
Tested various states locally

Broken Form
<img width="1361" height="835" alt="Broken_Partner_Form" src="https://github.com/user-attachments/assets/483e8d68-058e-4d13-9f50-1ad3da8550b6" />

Form with Missing Field
<img width="1307" height="818" alt="Error_Partner_Form" src="https://github.com/user-attachments/assets/5daf432c-f6d9-49b9-af64-aa0d7b3431af" />

Form with Invalid Email
<img width="1318" height="747" alt="Email_Error_Partner_Form" src="https://github.com/user-attachments/assets/60b4ce64-115e-44e5-9dbc-eec27c3f235f" />

Happy Path
https://github.com/user-attachments/assets/46e8d12b-9d03-4d74-8e63-f0e09b854ffc

Verified User Data on customer.io
<img width="722" height="430" alt="Screenshot 2025-10-03 at 18 30 45" src="https://github.com/user-attachments/assets/e564a902-4840-4923-8206-972078525381" />

#[LKB-4026](https://databricks.atlassian.net/browse/LKB-4026)