### PR TITLE
Fix typo in ORDER BY section of PostgreSQL tutorial

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-order-by.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-order-by.md
@@ -145,7 +145,7 @@ When you sort rows that contain `NULL`, you can specify the order of `NULL` with
 ORDER BY sort_expresssion [ASC | DESC] [NULLS FIRST | NULLS LAST]
 ```
 
-The `NULLS FIRST` option places `NULL` before other non\-null values and the `NULL LAST` option places `NULL` after other non\-null values.
+The `NULLS FIRST` option places `NULL` before other non\-null values and the `NULLS LAST` option places `NULL` after other non\-null values.
 
 Let’s [create a table](postgresql-create-table) for the demonstration.
 


### PR DESCRIPTION
Fix the typo in ORDER BY for NULLS LAST clause. The original one has syntax error.