### PR TITLE
docs: update cursor mcp

### DIFF
--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -158,8 +158,8 @@ Click the button below to install the Neon MCP server in Cursor. When prompted, 
     {
       "mcpServers": {
         "Neon": {
-          "command": "npx",
-          "args": ["-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp"]
+          "url": "https://mcp.neon.tech/mcp",
+          "headers": {}
         }
       }
     }

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -76,8 +76,8 @@ This method uses Neon's managed server and OAuth authentication.
    {
      "mcpServers": {
        "Neon": {
-         "command": "npx",
-         "args": ["-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp"]
+         "url": "https://mcp.neon.tech/mcp",
+         "headers": {}
        }
      }
    }


### PR DESCRIPTION
Windows:
<img width="1580" height="549" alt="image" src="https://github.com/user-attachments/assets/0e5281a4-0565-43b7-ba90-4b7870d241ae" />

Mac:
<img width="1366" height="506" alt="image" src="https://github.com/user-attachments/assets/942cd6db-38b7-40bd-9672-097fc7fd204f" />


Cursor MCP works fine without using `mcp-remote` so modified it this way


https://neon-next-git-fork-dhanushreddy291-add-docs-aed55b-neondatabase.vercel.app/guides/cursor-mcp-neon
https://neon-next-git-fork-dhanushreddy291-add-docs-aed55b-neondatabase.vercel.app/docs/ai/connect-mcp-clients-to-neon
