### PR TITLE
docs: remove neonctl init section from changelog

### DIFF
--- a/content/changelog/2025-10-24.md
+++ b/content/changelog/2025-10-24.md
@@ -25,30 +25,6 @@ Install it from our marketplace:
 
 For more information, see [Claude Code plugin for Neon](/docs/ai/ai-claude-code-plugin).
 
-## Get started with Neon + Cursor
-
-We've introduced a new init command to help you quickly connect your app and enable the Neon integration in your Cursor chat. Run the following command in your app's root directory:
-
-```bash
-npx neonctl init
-```
-
-The command walks you through an interactive setup:
-
-```
-🚀 Neon Project Initialization
-
-Step 1/3: Configuring Neon MCP Server...
-Step 2/3: Creating neon.md with detailed guidelines...
-Step 3/3: Creating AGENTS.md for Cursor...
-
-✓ Success! Neon project initialized.
-```
-
-After setup, you can ask your Cursor chat to "Get started with Neon" and it will have full context about your project and Neon best practices.
-
-This feature is currently in beta for Cursor, with VS Code and Claude Code support coming soon.
-
 ## MCP server: Schema diff and migration generation
 
 Our MCP server now supports schema diff generation and zero-downtime migration creation. Ask your AI assistant:


### PR DESCRIPTION
Remove the "Get started with Neon + Cursor" section that referenced npx neonctl init command from the October 24, 2025 changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)