### PR TITLE
feat: enhance GitHub markdown fetch with authorization and caching

### DIFF
--- a/src/lib/graphQLClient.js
+++ b/src/lib/graphQLClient.js
@@ -25,12 +25,12 @@ export const graphQLClientAdmin = (authToken) =>
   });
 
 // Add caching to the fetch function
-export const fetchGraphQL = (client, retries = 1) => {
+export const fetchGraphQL = (client, retries = 3) => {
   const request = async (query, variables = {}) =>
     retry(async () => await client.request(query, variables), {
       retries,
       factor: 2,
-      minTimeout: 2000,
+      minTimeout: 1000,
       onRetry: (error, attempt) => {
         console.log(`Attempt ${attempt} failed. Retrying...`);
       },


### PR DESCRIPTION
This PR brings enhance for GitHub markdown fetching for AI agents with authorization and caching

- added GitHub Token for request to increase the Rate Limit from `60` to `5000` requests/hour
- added caching for GitHub response on Vercel Edge
- added fallback to the regular HTML

Original PR: https://github.com/neondatabase/website/pull/4057

[Preview](https://neon-next-git-fix-markdown-urls-for-ai-agents-neondatabase.vercel.app/docs/introduction)