### PR TITLE
chore: updating pricing page to show 30 free projects

### DIFF
--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -9,7 +9,7 @@
     "features": [
       {
         "icon": "projects",
-        "title": "20 projects",
+        "title": "30 projects",
         "info": "<p>A project is a top-level container<br/> for your database environment.</p>",
         "moreLink": { "text": "Read more", "href": "#what-is-a-project" }
       },


### PR DESCRIPTION
**Context**
We recently rolled out console changes that allow free plan users to create up to 30 projects

**What changes are proposed in this pull request?**
This PR updates the pricing page to specify **30** projects for the free plan (instead of 20)

**How did we test this?**
Tested locally
<img width="331" height="425" alt="Screenshot 2025-11-03 at 20 59 01" src="https://github.com/user-attachments/assets/f337d55e-8c16-40d9-b64a-26c170359249" />

#[LKB-0](https://databricks.atlassian.net/browse/LKB-0)