### PR TITLE
feat: sends sales form submissions to customer io

### DIFF
--- a/cypress/e2e/contact-sales.cy.js
+++ b/cypress/e2e/contact-sales.cy.js
@@ -4,7 +4,14 @@ describe('Contact Form', () => {
   });
 
   it('allows users to contact sales', () => {
-    cy.formSuccessSubmit();
+    // Mock zaraz for successful gtag events
+    cy.window().then((win) => {
+      Object.assign(win, {
+        zaraz: {
+          track: cy.stub().resolves().as('zarazTrackSpy'),
+        },
+      });
+    });
 
     cy.get("input[name='firstname']").type('John');
     cy.get("input[name='lastname']").type('Doe');
@@ -38,7 +45,14 @@ describe('Contact Form', () => {
   });
 
   it('displays an error message when there is server error', () => {
-    cy.formErrorSubmit();
+    // Mock zaraz for failed gtag events
+    cy.window().then((win) => {
+      Object.assign(win, {
+        zaraz: {
+          track: cy.stub().rejects(new Error('Network error')).as('zarazTrackSpy'),
+        },
+      });
+    });
 
     cy.get("input[name='firstname']").type('John');
     cy.get("input[name='lastname']").type('Doe');
@@ -48,7 +62,6 @@ describe('Contact Form', () => {
     cy.get("textarea[name='message']").type('This is a test message');
     cy.get('form').submit();
 
-    cy.wait('@formErrorSubmit');
     cy.getByData('error-message').should('exist').contains('technical problem');
   });
 });


### PR DESCRIPTION
**Context**
We want to start funneling sales form data into customer.io. We have an existing pipeline to send events to Cloudflare Zaraz -> Segment -> Customer.IO.

**What changes are proposed in this pull request?**
This PR implements the following changes
- Sends track event via Cloudflare Zaraz using the sendGtagEvent util (one to identify the user and another to submit the form data)
- Edits the Cypress test to test for the sales form

**How is this tested?**
- Cypress e2e test
<img width="717" height="418" alt="Screenshot 2025-11-04 at 17 34 54" src="https://github.com/user-attachments/assets/8906c419-1151-4abe-b09d-07816b494d4b" />
- Also tested this locally by enabling zaraz in dev env ([Link to Slack Message](https://databricks.slack.com/archives/C0942GZMZ2P/p1762271251501189))
<img width="981" height="457" alt="Screenshot 2025-11-04 at 16 54 43" src="https://github.com/user-attachments/assets/20921d15-cf10-4b1f-8151-bb87ca2a5ce9" />


#[LKB-5292](https://databricks.atlassian.net/browse/LKB-5292)