### PR TITLE
fix: suppress topbar fetch errors during local build

### DIFF
--- a/src/components/shared/topbar/topbar.jsx
+++ b/src/components/shared/topbar/topbar.jsx
@@ -5,20 +5,32 @@ import TopbarClient from './topbar-client';
 const TOPBAR_API_URL = `${process.env.NEXT_PUBLIC_DEFAULT_SITE_URL}/api/topbar`;
 
 const Topbar = async ({ isDarkTheme }) => {
+  // Skip topbar fetch during static generation (build time)
+  // In production, Vercel will use ISR to regenerate pages with fresh data
+  const isBuildTime = !process.env.VERCEL && process.env.NODE_ENV === 'production';
+
+  if (isBuildTime) {
+    return null;
+  }
+
   try {
     const response = await fetch(TOPBAR_API_URL, {
       next: {
         revalidate: 600, // 10 minutes
       },
+      signal: AbortSignal.timeout(2000), // 2 second timeout to avoid hanging during build
     });
+
+    if (!response.ok) {
+      return null;
+    }
+
     const topbar = await response.json();
 
     if (!topbar?.text || !topbar?.link) return null;
 
     return <TopbarClient {...topbar} isDarkTheme={isDarkTheme} />;
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error);
     return null;
   }
 };


### PR DESCRIPTION
This PR brings a fix for local builds without local server started

- Skip topbar API fetch during static generation to prevent errors
- Add 2s timeout protection for topbar requests
- Silently handle fetch failures

before

<img width="900" height="476" alt="image" src="https://github.com/user-attachments/assets/795cd208-4277-459b-bdca-ddba5460bb5f" />

after

<img width="838" height="188" alt="image" src="https://github.com/user-attachments/assets/6bb057b7-afef-4fac-9339-4a84836b7147" />
