### PR TITLE
chore: update pricing page to show 50 free projects

### DIFF
--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -9,7 +9,7 @@
     "features": [
       {
         "icon": "projects",
-        "title": "30 projects",
+        "title": "50 projects",
         "info": "<p>A project is a top-level container<br/> for your database environment.</p>",
         "moreLink": { "text": "Read more", "href": "#what-is-a-project" }
       },


### PR DESCRIPTION
**Context**
We recently rolled out console changes that allow free plan users to create up to 50 projects

**What changes are proposed in this pull request?**
This PR updates the pricing page to specify **50** projects for the free plan (instead of 30)

**How did we test this?**
Tested locally
<img width="312" height="667" alt="Screenshot 2025-11-17 at 14 46 21" src="https://github.com/user-attachments/assets/a27a3c10-f1d1-48e3-a865-bc82bdc0b67a" />

#[LKB-0](https://databricks.atlassian.net/browse/LKB-0)