### PR TITLE
docs: schedule naming

### DIFF
--- a/content/changelog/2025-08-22.md
+++ b/content/changelog/2025-08-22.md
@@ -14,7 +14,7 @@ Learn more in our Data API [docs](/docs/data-api/get-started).
 
 You can now restore to your root branches' snapshots from any branch in your project, giving more flexibility in restoring data for your workflows — simply select the branch you want to restore in the sidebar.
 
-Additionally, each snapshot card now shows the snapshot expiration date. The soon-to-be introduced snapshot scheduler will let you specify an expiration date. For now, the expiration date is _never_, but you can manually delete a snapshot at any time.
+Additionally, each snapshot card now shows the snapshot expiration date. The soon-to-be introduced backup scheduler will let you specify an expiration date. For now, the expiration date is _never_, but you can manually delete a snapshot at any time.
 
 ![snapshots showing on other branch view](/docs/changelog/snapshot_other_branch.png)
 _The image shows a Production branch snapshot in the Development branch view, and the new "Expires on" value_

--- a/content/changelog/2025-10-31.md
+++ b/content/changelog/2025-10-31.md
@@ -10,8 +10,8 @@ The [Backup & Restore](/docs/guides/backup-restore) page in the Neon Console is 
 
 **Snapshots (Beta):**
 
-- **Scheduled snapshots** — Automate snapshots with daily, weekly, or monthly schedules (available on paid plans, excluding the Agent plan)
-  ![Snapshot schedule configuration showing daily, weekly, and monthly options](/docs/guides/snapshot_schedule_menu.png)
+- **Scheduled snapshots** — Automate snapshots with daily, weekly, or monthly backup schedules (available on paid plans, excluding the Agent plan)
+  ![Backup schedule configuration showing daily, weekly, and monthly options](/docs/guides/snapshot_schedule_menu.png)
 
 - **Flexible retention** — Configure how long to keep automated snapshots before they're automatically deleted
 

--- a/content/changelog/2025-11-07.md
+++ b/content/changelog/2025-11-07.md
@@ -67,16 +67,16 @@ This feature is currently in beta for Cursor, with VS Code and Claude Code suppo
 
 ## Backup schedule API (Beta)
 
-You can now manage automated snapshot schedules via the Neon API. Previously, backup schedules could only be configured through the Console. With the new API endpoints, you can programmatically view and update backup schedules for your branches, enabling infrastructure-as-code workflows and automated backup management.
+You can now manage automated backup schedules via the Neon API. Previously, backup schedules could only be configured through the Console. With the new API endpoints, you can programmatically view and update backup schedules for your branches, enabling infrastructure-as-code workflows and automated backup management.
 
 **Available endpoints:**
 
 - `GET /projects/{project_id}/branches/{branch_id}/backup_schedule` — View the current backup schedule for a branch
 - `PUT /projects/{project_id}/branches/{branch_id}/backup_schedule` — Update the backup schedule configuration
 
-This makes it easier to standardize backup policies across projects and integrate snapshot scheduling into your deployment pipelines.
+This makes it easier to standardize backup policies across projects and integrate backup scheduling into your deployment pipelines.
 
-For more information, see [Backup & restore](/docs/guides/backup-restore#create-snapshot-schedules).
+For more information, see [Backup & restore](/docs/guides/backup-restore#create-backup-schedules).
 
 ## Vercel integration now supports current Neon pricing plans
 
@@ -98,7 +98,7 @@ For more information, see [Neon plans](/docs/introduction/plans).
   - Fixed an issue where the source branch selector was empty on non-root branches, preventing point-in-time restore and preview data from working
   - Fixed snapshot list sorting on the Backup & Restore page: snapshots within each time group (Today, This week, This month) now show most recent first
   - Added a "Configure" link on the Backup & Restore page that takes you directly to the Storage settings page where you can adjust your PITR retention window
-  - Changed default retention period for daily snapshot schedules from 1 to 14 days
+  - Changed default retention period for daily backup schedules from 1 to 14 days
 - **Data API**
   - The `authenticated` and `anonymous` roles created by the Data API are now granted to `neondb_owner`, allowing you to test RLS policies by switching roles (e.g., `SET ROLE authenticated`)
 - **Vercel native integration**

--- a/content/changelog/2025-11-14.md
+++ b/content/changelog/2025-11-14.md
@@ -67,7 +67,7 @@ WebSocket connections are now more stable during long-running queries and in edg
 - **Neon Console:**
   - The AI assistant and support options are now separated in the Resources menu for easier navigation, with support resources tailored to your plan.
   - The usage metrics panel on the **Branch overview** page now shows more accurate network transfer data for that branch.
-  - Snapshot schedule improvements: schedule setup now provides clearer error messages to help you avoid invalid configurations, and the snapshot hour is now explicitly shown in UTC to eliminate timezone confusion. The **Edit schedule** button no longer appears for child branches since backup schedules can only be configured on root branches.
+  - Backup schedule improvements: schedule setup now provides clearer error messages to help you avoid invalid configurations, and the snapshot hour is now explicitly shown in UTC to eliminate timezone confusion. The **Edit schedule** button no longer appears for child branches since backup schedules can only be configured on root branches.
 
 - **Drizzle Studio update**
 

--- a/content/docs/guides/backup-restore.md
+++ b/content/docs/guides/backup-restore.md
@@ -7,7 +7,7 @@ updatedOn: '2025-11-07T20:24:25.880Z'
 ---
 
 <Admonition type="note" title="Snapshots in Beta">
-The **Snapshots** feature is now in Beta and available to all users. Snapshot limits: 1 on the Free plan and 10 on paid plans. Automated snapshot schedules are available on paid plans except for the Agent plan. If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
+The **Snapshots** feature is now in Beta and available to all users. Snapshot limits: 1 on the Free plan and 10 on paid plans. Automated backup schedules are available on paid plans except for the Agent plan. If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
 </Admonition>
 
 Use the **Backup & restore** page in the Neon Console to instantly restore a branch to a previous state or create and restore snapshots of your data. This feature combines **instant point-in-time restore** and **snapshots** to help you recover from accidental changes, data loss, or schema issues.
@@ -175,15 +175,15 @@ The parameters used in the example above:
 
 </Tabs>
 
-## Create snapshot schedules
+## Create backup schedules
 
-Schedule automated snapshots to run at regular intervals — daily, weekly, or monthly — to ensure consistent backups without manual intervention. Snapshot schedules are configured per branch and only apply to root branches.
+Schedule automated snapshots to run at regular intervals — daily, weekly, or monthly — to ensure consistent backups without manual intervention. Backup schedules are configured per branch and only apply to root branches.
 
 <Tabs labels={["Console", "API"]}>
 
 <TabItem>
 
-To create or modify a snapshot schedule:
+To create or modify a backup schedule:
 
 1. **Open the schedule editor**
 
@@ -205,7 +205,7 @@ To create or modify a snapshot schedule:
 
    Depending on your selected frequency, configure how often you want to create snapshots and how long to keep them.
 
-Once configured, snapshots created by the schedule will appear on the **Backup & restore** page with a label indicating they were created automatically.
+Once configured, snapshots created by the backup schedule will appear on the **Backup & restore** page with a label indicating they were created automatically.
 
 ### Snapshot retention
 
@@ -213,7 +213,7 @@ Snapshots are automatically deleted after their retention period expires. You ca
 
 - Shorter retention periods help manage snapshot limits on your plan
 - Deleted snapshots cannot be recovered
-- Manual snapshots are not affected by schedule retention settings
+- Manual snapshots are not affected by backup schedule retention settings
 
 </TabItem>
 

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -72,7 +72,7 @@ And here's an overview of what we're looking at next:
 
 ## What we've shipped recently 🚢
 
-- **Snapshot scheduling**: Automate snapshots with daily, weekly, or monthly schedules with configurable retention periods. Available on paid plans (excluding the Agent plan). [Learn more](/docs/guides/backup-restore).
+- **Backup scheduling**: Automate snapshots with daily, weekly, or monthly backup schedules with configurable retention periods. Available on paid plans (excluding the Agent plan). [Learn more](/docs/guides/backup-restore).
 - **Postgres 18 support (Preview)**: Postgres 18 is now available in preview. Create a new project and select Postgres 18 as your version. [Read the announcement](/blog/postgres-18).
 - **AI Agent Plan**: An AI agent pricing plan for platforms that need to provision thousands of databases. [Learn more](https://neon.com/use-cases/ai-agents).
 - **Usage-based pricing plans**: Our paid plans now start at just **$5/month**. Pay only for what you use. See [Neon's New Pricing, Explained: Usage-Based With a $5 Minimum](https://neon.com/blog/new-usage-based-pricing).


### PR DESCRIPTION
On the Backup & restore page, “snapshot schedules” have been changed to “backup schedules”. Update the docs to reflect this change.
https://databricks.atlassian.net/browse/LKB-6716