### PR TITLE
chore: update posthog-js to version 1.298.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "next-mdx-remote": "^4.4.1",
         "next-sitemap": "^4.2.3",
         "next-themes": "^0.3.0",
-        "posthog-js": "^1.194.3",
+        "posthog-js": "^1.298.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-calendly": "^4.3.0",
@@ -5558,6 +5558,15 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
       "license": "MIT"
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-Tbh8UACwbb7jFdDC7wwXHtfNzO+4wKh3VbyMHmp2UBe6w1jliJixexTJNfkqdGZm+ht3M10mcKvGGPnoZ2zLBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
     },
     "node_modules/@prisma/client": {
       "version": "5.19.1",
@@ -23046,14 +23055,16 @@
       "license": "MIT"
     },
     "node_modules/posthog-js": {
-      "version": "1.194.3",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.194.3.tgz",
-      "integrity": "sha512-/YFpBMqZzRpywa07QeoaIojdrUDijFajT4gZBSCFUBuZA5BN5xr5S1spsvtpT7E4RjkQSVgRvUngI4W19csgQw==",
+      "version": "1.298.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.298.0.tgz",
+      "integrity": "sha512-Zwzsf7TO8qJ6DFLuUlQSsT/5OIOcxSBZlKOSk3satkEnwKdmnBXUuxgVXRHrvq1kj7OB2PVAPgZiQ8iHHj9DRA==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@posthog/core": "1.6.0",
         "core-js": "^3.38.1",
         "fflate": "^0.4.8",
         "preact": "^10.19.3",
-        "web-vitals": "^4.2.0"
+        "web-vitals": "^4.2.4"
       }
     },
     "node_modules/preact": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "next-mdx-remote": "^4.4.1",
     "next-sitemap": "^4.2.3",
     "next-themes": "^0.3.0",
-    "posthog-js": "^1.194.3",
+    "posthog-js": "^1.298.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-calendly": "^4.3.0",


### PR DESCRIPTION
resolves SHA1-Hulud V2 vulnerability