### PR TITLE
feat: update Free plan project limit from 70 to 80 across documentation and JSON data

### DIFF
--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -39,7 +39,7 @@ For AI agent platforms that provision thousands of databases, Neon offers an **A
 | ----------------------------------------------------- | ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
 | [Price](#price)                                       | $0/month                     | $5/month minimum                     | $5/month minimum                                                                                  |
 | [Who it's for](#who-its-for)                          | Prototypes and side projects | Startups and growing teams           | Production-grade workloads and larger companies                                                   |
-| [Projects](#projects)                                 | 70                           | 100                                  | 1,000 (can be increased on request)                                                               |
+| [Projects](#projects)                                 | 80                           | 100                                  | 1,000 (can be increased on request)                                                               |
 | [Branches](#branches)                                 | 10/project                   | 10/project                           | 25/project                                                                                        |
 | [Extra branches](#extra-branches)                     | —                            | $1.50/branch-month (prorated hourly) | $1.50/branch-month (prorated hourly)                                                              |
 | [Compute](#compute)                                   | 100 CU-hours/project         | $0.106/CU-hour                       | $0.222/CU-hour                                                                                    |
@@ -76,7 +76,7 @@ On the **Free** plan, there is no monthly cost. You get usage allowances for pro
 
 ### ☑ Who it's for
 
-- **Free** — Prototypes, side projects, and quick experiments. Includes 70 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
+- **Free** — Prototypes, side projects, and quick experiments. Includes 80 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
 - **Launch** — Startups and growing teams needing more resources, features, and flexibility. Usage-based pricing starts at $5/month.
 - **Scale** — Production-grade workloads and large teams. Higher limits, advanced features, full support, compliance, additional security, and SLAs. Usage-based pricing starts at $5/month.
 
@@ -88,7 +88,7 @@ A project is a container for your database environment. It includes your databas
 
 Included per plan:
 
-- **Free**: 70 projects
+- **Free**: 80 projects
 - **Launch**: 100 projects
 - **Scale**: 1,000 projects (soft limit — request more if needed via [support](/docs/introduction/support))
 

--- a/public/llms/introduction-plans.txt
+++ b/public/llms/introduction-plans.txt
@@ -60,7 +60,7 @@ On the **Free** plan, there is no monthly cost. You get usage allowances for pro
 
 ### ☑ Who it's for
 
-- **Free** — Prototypes, side projects, and quick experiments. Includes 70 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
+- **Free** — Prototypes, side projects, and quick experiments. Includes 80 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
 - **Launch** — Startups and growing teams needing more resources, features, and flexibility. Usage-based pricing starts at $5/month.
 - **Scale** — Production-grade workloads and large teams. Higher limits, advanced features, full support, compliance, additional security, and SLAs. Usage-based pricing starts at $5/month.
 
@@ -72,7 +72,7 @@ A project is a container for your database environment. It includes your databas
 
 Included per plan:
 
-- **Free**: 70 projects
+- **Free**: 80 projects
 - **Launch**: 100 projects
 - **Scale**: 1,000 projects (soft limit — request more if needed via [support](https://neon.com/docs/introduction/support))
 

--- a/src/components/pages/pricing/hero/data/plans.json
+++ b/src/components/pages/pricing/hero/data/plans.json
@@ -9,7 +9,7 @@
     "features": [
       {
         "icon": "projects",
-        "title": "70 projects",
+        "title": "80 projects",
         "info": "<p>A project is a top-level container<br/> for your database environment.</p>",
         "moreLink": { "text": "Read more", "href": "#what-is-a-project" }
       },

--- a/src/components/pages/pricing/plans/data/plans.json
+++ b/src/components/pages/pricing/plans/data/plans.json
@@ -30,7 +30,7 @@
       "feature": {
         "title": "Projects"
       },
-      "free": "70",
+      "free": "80",
       "launch": "100",
       "scale": "1,000"
     },


### PR DESCRIPTION
### Context
We recently rolled out console changes that allow free plan users to create up to 80 projects

### What changes are proposed in this pull request?
This PR updates the pricing page to specify 80 projects for the free plan (instead of 70)

### How did we test this?
Tested locally
<img width="334" height="394" alt="Screenshot 2025-12-08 at 9 07 22 PM" src="https://github.com/user-attachments/assets/7f8fa8e5-9c1e-4449-abf6-783dfda3920d" />
