### PR TITLE
fix: add corrected link to create first trigger page

### DIFF
--- a/content/postgresql/postgresql-triggers/creating-first-trigger-postgresql.md
+++ b/content/postgresql/postgresql-triggers/creating-first-trigger-postgresql.md
@@ -21,7 +21,7 @@ To create a new trigger in PostgreSQL, you follow these steps:
 - First, create a trigger function using [`CREATE FUNCTION`](../postgresql-plpgsql/postgresql-create-function) statement.
 - Second, bind the trigger function to a table by using `CREATE TRIGGER` statement.
 
-If you are not familiar with creating a user\-defined function, you can check out the [PL/pgSQL section](/postgresql/postgresql-stored-procedures/ 'PostgreSQL Stored Procedures').
+If you are not familiar with creating a user\-defined function, you can check out the [PL/pgSQL section](../postgresql-plpgsql/introduction-to-postgresql-stored-procedures).
 
 ## Create trigger function syntax
 


### PR DESCRIPTION
Fix broken link on `content/postgresql/postgresql-triggers/creating-first-trigger-postgresql.md` page, replaced with updated link