### PR TITLE
chore: update Next.js to version 14.2.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "lodash.shuffle": "^4.2.0",
         "lottie-web": "^5.12.2",
         "markdownlint-cli": "^0.39.0",
-        "next": "^14.2.33",
+        "next": "^14.2.35",
         "next-auth": "^4.24.12",
         "next-mdx-remote": "^4.4.1",
         "next-sitemap": "^4.2.3",
@@ -4896,9 +4896,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
-      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -21448,12 +21448,12 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
-      "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.33",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lodash.shuffle": "^4.2.0",
     "lottie-web": "^5.12.2",
     "markdownlint-cli": "^0.39.0",
-    "next": "^14.2.33",
+    "next": "^14.2.35",
     "next-auth": "^4.24.12",
     "next-mdx-remote": "^4.4.1",
     "next-sitemap": "^4.2.3",


### PR DESCRIPTION
This PR fixes vulnerabilities CVE-2025-55184 and CVE-2025-55183 in React and Next.js

[Affected and patched version list](https://vercel.com/kb/bulletin/security-bulletin-cve-2025-55184-and-cve-2025-55183?inf_ver=2&inf_ctx=W7FEnCA8KFBRFPX5Xk-0yKivrnXdYM56uWE1G6mrZ59Jf3UHuZkDZuUAe-a7okILrBplxAMa3lHUnJ4kjEt3BIZPv_ESIfeN7UTxbBoJoZ3ZS4ROsEFmNSOE3X_2865Aioy41-UZE962YAFw1Z46uq4lvllROICRKwi2BhE1HGsY2T1VtbvhupkIRGzUxerkyEUuHiM1Z54-d7b3Ze91t7MIlqFE5kbeZrpCYpmSNGsVBnwXudjSOG05BwRvMGxdWYRtSwHNHD8PfZsQJDULOkxxKmT19x7t1d2ROJnpHNfeA_aTRVOpC0rvWQ-JoHaUKgGGOaKFMmEfoJpeMru9Eg%3D%3D#patched-versions)