### PR TITLE
chore: remove beta tags for data api docs

### DIFF
--- a/content/docs/data-api/custom-authentication-providers.md
+++ b/content/docs/data-api/custom-authentication-providers.md
@@ -5,10 +5,7 @@ enableTableOfContents: true
 updatedOn: '2025-12-12T17:42:01.026Z'
 redirectFrom:
   - /docs/guides/neon-authorize
-tag: beta
 ---
-
-<FeatureBetaProps feature_name="Neon Data API" />
 
 <InfoBlock>
   <DocsList title="Related docs" theme="docs">

--- a/content/docs/data-api/demo.md
+++ b/content/docs/data-api/demo.md
@@ -5,8 +5,6 @@ enableTableOfContents: true
 updatedOn: '2025-12-11T19:49:37.740Z'
 ---
 
-<FeatureBetaProps feature_name="Neon Data API" />
-
 In this tutorial, we'll walk through our note-taking app to show how Neon's Data API works with the `@neondatabase/neon-js` client library to write queries from your frontend code, with proper authentication and Row-Level Security (RLS) policies ensuring your data stays secure. The Data API is compatible with PostgREST, so you can use any PostgREST client library.
 
 ## About the sample application

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -3,10 +3,7 @@ title: Getting started with Neon Data API
 subtitle: Learn how to enable and use the Neon Data API
 enableTableOfContents: true
 updatedOn: '2025-12-11T19:49:37.741Z'
-tag: beta
 ---
-
-<FeatureBetaProps feature_name="Neon Data API" />
 
 In this guide, you'll learn how to enable the Neon Data API for your database, create a table with Row-Level Security (RLS), and run your first query.
 

--- a/content/docs/data-api/sql-to-rest.md
+++ b/content/docs/data-api/sql-to-rest.md
@@ -5,8 +5,6 @@ enableTableOfContents: false
 updatedOn: '2025-10-01T13:33:56.063Z'
 ---
 
-<FeatureBetaProps feature_name="Neon Data API" />
-
 <InfoBlock>
   <DocsList title="Related docs" theme="docs">
     <a href="/docs/data-api/get-started">Getting started with Neon Data API</a>

--- a/content/docs/data-api/troubleshooting.md
+++ b/content/docs/data-api/troubleshooting.md
@@ -5,8 +5,6 @@ enableTableOfContents: true
 updatedOn: '2025-12-11T14:24:43.415Z'
 ---
 
-<FeatureBetaProps feature_name="Neon Data API" />
-
 <InfoBlock>
   <DocsList title="Related docs" theme="docs">
     <a href="/docs/data-api/get-started">Getting started with Data API</a>

--- a/public/llms/data-api-custom-authentication-providers.txt
+++ b/public/llms/data-api-custom-authentication-providers.txt
@@ -6,8 +6,6 @@
 
 - [Custom Authentication Providers HTML](https://neon.com/docs/data-api/custom-authentication-providers): The original HTML version of this documentation
 
-**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
-
 Related docs:
 - [Getting started with Data API](https://neon.com/docs/data-api/get-started)
 

--- a/public/llms/data-api-demo.txt
+++ b/public/llms/data-api-demo.txt
@@ -6,8 +6,6 @@
 
 - [Neon Data API tutorial HTML](https://neon.com/docs/data-api/demo): The original HTML version of this documentation
 
-**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
-
 In this tutorial, we'll walk through our note-taking app to show how you can use Neon's Data API with the `postgrest-js` client library to write queries from your frontend code, with proper authentication and Row-Level Security (RLS) policies ensuring your data stays secure. The Data API is compatible with PostgREST, so you can use any PostgREST client library.
 
 ## About the sample application

--- a/public/llms/data-api-get-started.txt
+++ b/public/llms/data-api-get-started.txt
@@ -6,8 +6,6 @@
 
 - [Getting started with Neon Data API HTML](https://neon.com/docs/data-api/get-started): The original HTML version of this documentation
 
-**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
-
 Related docs:
 - [Neon Auth](https://neon.com/docs/guides/neon-auth)
 - [Building a note-taking app](https://neon.com/docs/data-api/demo)

--- a/public/llms/data-api-sql-to-rest.txt
+++ b/public/llms/data-api-sql-to-rest.txt
@@ -6,8 +6,6 @@
 
 - [SQL to PostgREST Converter HTML](https://neon.com/docs/data-api/sql-to-rest): The original HTML version of this documentation
 
-**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
-
 Related docs:
 - [Getting started with Neon Data API](https://neon.com/docs/data-api/get-started)
 - [Building a note-taking app](https://neon.com/docs/data-api/demo)

--- a/public/llms/data-api-troubleshooting.txt
+++ b/public/llms/data-api-troubleshooting.txt
@@ -6,8 +6,6 @@
 
 - [Data API troubleshooting HTML](https://neon.com/docs/data-api/troubleshooting): The original HTML version of this documentation
 
-**Note** Beta: **Neon Data API** is in beta and ready to use. We're actively improving it based on feedback from developers like you. Share your experience in our [Discord](https://discord.gg/92vNTzKDGp) or via the [Neon Console](https://console.neon.tech/app/projects?modal=feedback).
-
 ## Permission denied to create extension "pg_session_jwt"
 
 ```bash


### PR DESCRIPTION
**Context**
Neon Data API is no longer in beta yet we have beta tags and sections still in our docs.

**What changes are proposed in this pull request?**
This PR removes the beta tags and sections.

**How did we test this?**
Tested locally
- Before
<img width="830" height="336" alt="Screenshot 2025-12-12 at 14 11 00" src="https://github.com/user-attachments/assets/8a155d00-3e75-4283-9e65-2c81906eca4c" />

- After
<img width="818" height="234" alt="Screenshot 2025-12-12 at 14 23 54" src="https://github.com/user-attachments/assets/369f718a-1442-4eb4-b516-35aecb4e703d" />

#[LKB-0](https://databricks.atlassian.net/browse/LKB-0)