### PR TITLE
feat: update Free plan project limit from 80 to 80 across documentation and JSON data

### DIFF
--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -39,7 +39,7 @@ For AI agent platforms that provision thousands of databases, Neon offers an **A
 | ----------------------------------------------------- | ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
 | [Price](#price)                                       | $0/month                     | Pay for what you use                 | Pay for what you use                                                                              |
 | [Who it's for](#who-its-for)                          | Prototypes and side projects | Startups and growing teams           | Production-grade workloads and larger companies                                                   |
-| [Projects](#projects)                                 | 80                           | 100                                  | 1,000 (can be increased on request)                                                               |
+| [Projects](#projects)                                 | 100                          | 100                                  | 1,000 (can be increased on request)                                                               |
 | [Branches](#branches)                                 | 10/project                   | 10/project                           | 25/project                                                                                        |
 | [Extra branches](#extra-branches)                     | —                            | $1.50/branch-month (prorated hourly) | $1.50/branch-month (prorated hourly)                                                              |
 | [Compute](#compute)                                   | 100 CU-hours/project         | $0.106/CU-hour                       | $0.222/CU-hour                                                                                    |
@@ -76,7 +76,7 @@ On the **Free** plan, there is no monthly cost. You get usage allowances for pro
 
 ### ☑ Who it's for
 
-- **Free** — Prototypes, side projects, and quick experiments. Includes 80 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
+- **Free** — Prototypes, side projects, and quick experiments. Includes 100 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
 - **Launch** — Startups and growing teams needing more resources, features, and flexibility. Pay only for what you use.
 - **Scale** — Production-grade workloads and large teams. Higher limits, advanced features, full support, compliance, additional security, and SLAs. Pay only for what you use.
 
@@ -88,7 +88,7 @@ A project is a container for your database environment. It includes your databas
 
 Included per plan:
 
-- **Free**: 80 projects
+- **Free**: 100 projects
 - **Launch**: 100 projects
 - **Scale**: 1,000 projects (soft limit — request more if needed via [support](/docs/introduction/support))
 

--- a/public/llms/introduction-plans.txt
+++ b/public/llms/introduction-plans.txt
@@ -25,7 +25,7 @@ Compare Neon's **Free**, **Launch**, and **Scale** plans.
 | ----------------------------------------------------- | ------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
 | [Price](https://neon.com/docs/introduction/plans#price)                                       | $0/month                       | $5/month minimum                     | $5/month minimum                                                                                  |
 | [Who it's for](https://neon.com/docs/introduction/plans#who-its-for)                          | Prototypes and side projects   | Startups and growing teams           | Production-grade workloads and larger companies                                                   |
-| [Projects](https://neon.com/docs/introduction/plans#projects)                                 | 20                             | 100                                  | 1,000 (can be increased on request)                                                               |
+| [Projects](https://neon.com/docs/introduction/plans#projects)                                 | 100                            | 100                                  | 1,000 (can be increased on request)                                                               |
 | [Branches](https://neon.com/docs/introduction/plans#branches)                                 | 10/project                     | 10/project                           | 25/project                                                                                        |
 | [Extra branches](https://neon.com/docs/introduction/plans#extra-branches)                     | —                              | $1.50/branch-month (prorated hourly) | $1.50/branch-month (prorated hourly)                                                              |
 | [Compute](https://neon.com/docs/introduction/plans#compute)                                   | 100 CU-hours/project           | $0.106/CU-hour                       | $0.222/CU-hour                                                                                    |
@@ -60,7 +60,7 @@ On the **Free** plan, there is no monthly cost. You get usage allowances for pro
 
 ### ☑ Who it's for
 
-- **Free** — Prototypes, side projects, and quick experiments. Includes 80 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
+- **Free** — Prototypes, side projects, and quick experiments. Includes 100 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
 - **Launch** — Startups and growing teams needing more resources, features, and flexibility. Usage-based pricing starts at $5/month.
 - **Scale** — Production-grade workloads and large teams. Higher limits, advanced features, full support, compliance, additional security, and SLAs. Usage-based pricing starts at $5/month.
 
@@ -72,7 +72,7 @@ A project is a container for your database environment. It includes your databas
 
 Included per plan:
 
-- **Free**: 80 projects
+- **Free**: 100 projects
 - **Launch**: 100 projects
 - **Scale**: 1,000 projects (soft limit — request more if needed via [support](https://neon.com/docs/introduction/support))
 

--- a/src/components/pages/pricing/hero/data/plans.js
+++ b/src/components/pages/pricing/hero/data/plans.js
@@ -11,7 +11,7 @@ export default [
     features: [
       {
         icon: 'projects',
-        title: '80 projects',
+        title: '100 projects',
         info: '<p>A project is a top-level container<br/> for your database environment.</p>',
         moreLink: { text: 'Read more', href: '#what-is-a-project' },
       },

--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -32,7 +32,7 @@ export default {
       feature: {
         title: 'Projects',
       },
-      free: '80',
+      free: '100',
       launch: '100',
       scale: '1,000',
     },


### PR DESCRIPTION
### Context
We recently rolled out console changes that allow free plan users to create up to 100 projects

### What changes are proposed in this pull request?
This PR updates the pricing page to specify 100 projects for the free plan (instead of 80)

### How did we test this?
Tested locally
<img width="377" height="497" alt="Screenshot 2025-12-15 at 11 34 53 PM" src="https://github.com/user-attachments/assets/1182c69b-a242-4fcc-925a-719f4084316f" />
