### PR TITLE
docs: add neon init references

### DIFF
--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -66,7 +66,7 @@ Run the [init](/docs/reference/cli-init) command:
 npx neonctl@latest init
 ```
 
-Authenticates via OAuth, creates an API key, and configures Cursor automatically. Then ask your AI assistant **"Get started with Neon"**.
+Authenticates via OAuth, creates an API key, and configures Cursor to connect to Neon's remote MCP server. Then ask your AI assistant **"Get started with Neon"**.
 
 </TabItem>
 <TabItem>
@@ -125,7 +125,7 @@ Run the [init](/docs/reference/cli-init) command:
 npx neonctl@latest init
 ```
 
-Authenticates via OAuth, creates an API key, and configures Claude Code automatically. Then ask your AI assistant **"Get started with Neon"**.
+Authenticates via OAuth, creates an API key, and configures Claude Code to connect to Neon's remote MCP server. Then ask your AI assistant **"Get started with Neon"**.
 
 </TabItem>
 
@@ -175,7 +175,7 @@ Run the [init](/docs/reference/cli-init) command:
 npx neonctl@latest init
 ```
 
-Authenticates via OAuth, creates an API key, and configures VS Code automatically. Then ask your AI assistant **"Get started with Neon"**.
+Authenticates via OAuth, creates an API key, and configures VS Code to connect to Neon's remote MCP server. Then ask your AI assistant **"Get started with Neon"**.
 
 </TabItem>
 

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -20,7 +20,7 @@ This command will:
 
 - Authenticate via OAuth (opens your browser)
 - Create a Neon API key for you automatically
-- Configure your editor's MCP settings automatically
+- Configure your editor to connect to Neon's remote MCP server
 
 Currently the `init` command supports: **Cursor**, **VS Code with GitHub Copilot**, and **Claude Code**
 

--- a/content/docs/reference/cli-init.md
+++ b/content/docs/reference/cli-init.md
@@ -18,7 +18,7 @@ This command will:
 
 - Authenticate via OAuth (opens your browser)
 - Create a Neon API key for you automatically
-- Configure your editor's MCP settings
+- Configure your editor to connect to Neon's remote MCP server
 
 The `init` command supports: **Cursor**, **VS Code with GitHub Copilot**, and **Claude Code**. It automatically detects which IDE you have installed and configures the MCP server accordingly.
 

--- a/content/guides/claude-code-mcp-neon.md
+++ b/content/guides/claude-code-mcp-neon.md
@@ -60,7 +60,7 @@ The fastest way to get started is with the [`neonctl init`](/docs/reference/cli-
 npx neonctl@latest init
 ```
 
-This command authenticates via OAuth, creates an API key, and configures Claude Code automatically. Once complete, ask your AI assistant **"Get started with Neon"**.
+This command authenticates via OAuth, creates an API key, and configures Claude Code to connect to Neon's remote MCP server. Once complete, ask your AI assistant **"Get started with Neon"**.
 
 ### Option 1: Setting up the Remote Hosted Neon MCP Server (OAuth)
 

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -59,7 +59,7 @@ The fastest way to get started is with the [`neonctl init`](/docs/reference/cli-
 npx neonctl@latest init
 ```
 
-This command authenticates via OAuth, creates an API key, and configures Cursor automatically. API key authentication means **fewer approval prompts** when using MCP tools. Once complete, ask your AI assistant **"Get started with Neon"**.
+This command authenticates via OAuth, creates an API key, and configures Cursor to connect to Neon's remote MCP server. API key authentication means **fewer approval prompts** when using MCP tools. Once complete, ask your AI assistant **"Get started with Neon"**.
 
 <Admonition type="tip" title="Cursor Users: One-Click Alternative">
 Cursor offers a deep link for quick OAuth setup:

--- a/content/guides/neon-mcp-server-github-copilot-vs-code.md
+++ b/content/guides/neon-mcp-server-github-copilot-vs-code.md
@@ -57,7 +57,7 @@ The fastest way to get started is with the [`neonctl init`](/docs/reference/cli-
 npx neonctl@latest init
 ```
 
-This command authenticates via OAuth, creates an API key, and configures VS Code automatically. Once complete, ask your AI assistant **"Get started with Neon"**.
+This command authenticates via OAuth, creates an API key, and configures VS Code to connect to Neon's remote MCP server. Once complete, ask your AI assistant **"Get started with Neon"**.
 
 #### Manual Remote Setup (OAuth)
 


### PR DESCRIPTION
Main pages for preview: 
- https://neon-next-git-add-init-references-neondatabase.vercel.app/docs/ai/connect-mcp-clients-to-neon
- https://neon-next-git-add-init-references-neondatabase.vercel.app/docs/ai/neon-mcp-server
- https://neon-next-git-add-init-references-neondatabase.vercel.app/docs/reference/cli-init