### PR TITLE
fix: small api inconsistencies with better-auth

### DIFF
--- a/content/docs/reference/javascript-sdk.md
+++ b/content/docs/reference/javascript-sdk.md
@@ -125,13 +125,13 @@ const client = createClient({
 <details>
 <summary>View parameters</summary>
 
-| Parameter            | Type                        | Required |
-| -------------------- | --------------------------- | -------- |
-| <tt>email</tt>       | string                      | ✓        |
-| <tt>name</tt>        | string                      | ✓        |
-| <tt>password</tt>    | string                      | ✓        |
-| <tt>image</tt>       | string \| undefined         |          |
-| <tt>callbackURL</tt> | string \| undefined         |          |
+| Parameter            | Type                | Required |
+| -------------------- | ------------------- | -------- |
+| <tt>email</tt>       | string              | ✓        |
+| <tt>name</tt>        | string              | ✓        |
+| <tt>password</tt>    | string              | ✓        |
+| <tt>image</tt>       | string \| undefined |          |
+| <tt>callbackURL</tt> | string \| undefined |          |
 
 </details>
 
@@ -296,10 +296,10 @@ Note: Password updates require password reset flow for security.
 <details>
 <summary>View parameters</summary>
 
-| Parameter            | Type                        | Required |
-| -------------------- | --------------------------- | -------- |
-| <tt>name</tt>        | string \| undefined         |          |
-| <tt>image</tt>       | string \| null \| undefined |          |
+| Parameter      | Type                        | Required |
+| -------------- | --------------------------- | -------- |
+| <tt>name</tt>  | string \| undefined         |          |
+| <tt>image</tt> | string \| null \| undefined |          |
 
 </details>
 
@@ -324,10 +324,10 @@ The user must then call `signIn.emailOtp()` with the received code.
 <details>
 <summary>View parameters</summary>
 
-| Parameter      | Type   | Required |
-| -------------- | ------ | -------- |
-| <tt>email</tt> | string | ✓        |
-| <tt>type</tt>  | "email-verification" | "sign-in" | "forget-password" | ✓        |
+| Parameter      | Type                 | Required  |
+| -------------- | -------------------- | --------- | ----------------- | --- |
+| <tt>email</tt> | string               | ✓         |
+| <tt>type</tt>  | "email-verification" | "sign-in" | "forget-password" | ✓   |
 
 </details>
 


### PR DESCRIPTION
## Summary
Fixes documentation inconsistencies in the JavaScript SDK reference to accurately reflect the actual Better Auth API.

### Changes
- **Removed `phoneNumber` parameter** from `signUp.email()` and `updateUser()` - this field is not part of the default Better Auth API
- **Fixed `provider` type** in `signIn.social()` - corrected from `object` to `string`
- **Fixed `type` parameter type** in `sendVerificationEmail()` and `verifyEmail()` - changed from generic `object` to the actual enum type `"email-verification" | "sign-in" | "forget-password"`
- **Fixed `updateUser()` code example** - replaced incorrect `email` field with `name` (email updates require verification flow, not direct update)

### Why
These documentation fixes ensure our SDK reference accurately matches the Better Auth implementation, preventing developer confusion and errors.