### PR TITLE
Replace ARRAY_AGG screenshot with Markdown table for improved readability

### DIFF
--- a/content/postgresql/postgresql-aggregate-functions/postgresql-array_agg.md
+++ b/content/postgresql/postgresql-aggregate-functions/postgresql-array_agg.md
@@ -56,13 +56,13 @@ ORDER BY
 
 Here is the partial output:
 
-| title            | actors                                                              |
-| ---------------- | ------------------------------------------------------------------- |
-| Academy Dinosaur | "Rock Dukakis","Mary Keitel","Johnny Cage","Penelope Guiness",...   |
-| Ace Goldfinger   | "Minnie Zellweger","Chris Depp","Bob Fawcett","Sean Guiness",..     |
-| Adaptation Holes | "Cameron Streep","Bob Fawcett","Nick Wahlberg","Ray Johansson",...  |
-| Affair Prejudice | "Jodie Degeneres","Kenneth Pesci","Fay Winslet","Oprah Kilmer",...  |
-| African Egg      | "Dustin Tautou","Matthew Leigh","Gary Phoenix","Matthew Carrey",... |
+| title            | actors                                                                 |
+| ---------------- | ---------------------------------------------------------------------- |
+| Academy Dinosaur | \{"Rock Dukakis","Mary Keitel","Johnny Cage","Penelope Guiness",...}   |
+| Ace Goldfinger   | \{"Minnie Zellweger","Chris Depp","Bob Fawcett","Sean Guiness",...}     |
+| Adaptation Holes | \{"Cameron Streep","Bob Fawcett","Nick Wahlberg","Ray Johansson",...}   |
+| Affair Prejudice | \{"Jodie Degeneres","Kenneth Pesci","Fay Winslet","Oprah Kilmer",...}   |
+| African Egg      | \{"Dustin Tautou","Matthew Leigh","Gary Phoenix","Matthew Carrey",...} |
 
 
 As you can see, the actors in each film are arbitrarily ordered. To sort the actors by last name or first name, you can use the `ORDER BY` clause in the `ARRAY_AGG()` function.


### PR DESCRIPTION
This PR replaces the screenshot-based ARRAY_AGG output example with a partial Markdown table.  

**Changes include:**  
- Improves readability and accessibility across devices  
- Ensures consistency with other documentation tables  
- Addresses the small output image issue for better clarity  

**Future enhancements:**  
- Extend similar Markdown table formatting to other aggregate function examples  
- Continue improving the overall readability and consistency of the PostgreSQL docs

Closes #4160
