### PR TITLE
docs: add hydration fix warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3272,7 +3272,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Description

This PR adds documentation to explain the `suppressHydrationWarning` prop in the Next.js quickstart guide.

**FEATURES**
- Added an "important" admonition explaining why `suppressHydrationWarning` is needed on the `<html>` tag (prevents React hydration errors from `next-themes` client-side theme switching)
- Highlighted the `suppressHydrationWarning` line in the code example with `[!code ++]` marker for better visibility

<img width="1291" height="904" alt="image" src="https://github.com/user-attachments/assets/bed8ab8c-8daa-43b9-b0ad-597ec3422759" />


Relates to: https://github.com/neondatabase/neon-js/issues/24
