### PR TITLE
simplify RLS policies

### DIFF
--- a/content/docs/guides/rls-drizzle.md
+++ b/content/docs/guides/rls-drizzle.md
@@ -138,7 +138,7 @@ For example, you might want to allow only users with an `admin` role to update o
 
 To understand how `pgPolicy` works, let's rewrite the `todos` example using it. The following `pgPolicy` definition is exactly what `crudPolicy` would generate from your simpler configuration.
 
-```typescript {17-20}
+```typescript {18-22}
 import { pgTable, text, bigint, boolean, pgPolicy } from 'drizzle-orm/pg-core';
 import { authenticatedRole, authUid } from 'drizzle-orm/neon';
 import { sql } from 'drizzle-orm';


### PR DESCRIPTION
From PG docs https://www.postgresql.org/docs/current/sql-createpolicy.html

> Using ALL for a policy means that it will apply to all commands, regardless of the type of command

> if no WITH CHECK expression is defined, then the USING expression will be used both to determine which rows are visible (normal USING case) and which new rows will be allowed to be added (WITH CHECK case)