### PR TITLE
docs: fix nextjs quick start docs

### DIFF
--- a/content/docs/auth/quick-start/nextjs.md
+++ b/content/docs/auth/quick-start/nextjs.md
@@ -146,15 +146,9 @@ export const authClient = createAuthClient();
 Copy and paste following code in `lib/auth/server.ts` file:
 
 ```tsx
-'use server';
-
 import { createAuthServer } from '@neondatabase/auth/next/server';
 
-const authServer = createAuthServer();
-
-export async function getSession() {
-  return authServer.getSession();
-}
+export const authServer = createAuthServer();
 ```
 
 </TabItem>
@@ -441,10 +435,10 @@ export default function ClientRenderedPage() {
 Create a new API route at `app/api/secure-api-route/route.ts` and add the following code:
 
 ```tsx
-import { getSession } from "@/lib/auth/server";
+import { authServer } from "@/lib/auth/server";
 
 export async function GET() {
-  const { data } = await getSession();
+  const { data } = await authServer.getSession();
   if (data?.session) {
     return new Response(
       JSON.stringify({ "session": data.session, "user": data.user }),


### PR DESCRIPTION
Following the Next.js quick start guide for Neon Auth with Better Auth (https://neon.com/docs/auth/quick-start/nextjs) causes an issue with the API route. Quick fix to export async.

```bash
GET /api/secure-api-route 500 in 1958ms (compile: 1804ms, render: 154ms)
⨯ Error: A "use server" file can only export async functions, found object.
Read more: https://nextjs.org/docs/messages/invalid-use-server-value
    at module evaluation (.next/dev/server/chunks/[root-of-the-server]__e32e1aa6._.js:58:368)
    at module evaluation (src/app/api/secure-api-route/route.ts:1:1)
    at Object.<anonymous> (.next/dev/server/app/api/secure-api-route/route.js:8:3)
> 1 | import { authServer } from "@/lib/auth/server";
    | ^
  2 |
  3 | export async function GET() {
  4 |   const { data } = await authServer.getSession(); {
  page: '/api/secure-api-route'
}
```

Next.js 16.1.1
React 19.2.3
Node 24.11.1