### PR TITLE
docs: change default branch from production to main

### DIFF
--- a/content/docs/connect/connect-from-any-app.md
+++ b/content/docs/connect/connect-from-any-app.md
@@ -29,7 +29,7 @@ You are responsible for maintaining the records and associations of any connecti
 
 ## Get a connection string from the Neon console
 
-When connecting to Neon from an application or client, you connect to a database in your Neon project. In Neon, a database belongs to a branch, which may be the default branch of your project (`production`) or a child branch.
+When connecting to Neon from an application or client, you connect to a database in your Neon project. In Neon, a database belongs to a branch, which may be the default branch of your project (`main`) or a child branch.
 
 You can find the connection details for your database by clicking the **Connect** button on your **Project Dashboard**. This opens the **Connect to your database** modal. Select a branch, a compute, a database, and a role. A connection string is constructed for you.
 

--- a/content/docs/get-started/connect-neon.md
+++ b/content/docs/get-started/connect-neon.md
@@ -204,7 +204,7 @@ func main() {
 
 ## Obtaining connection details
 
-When connecting to Neon from an application or client, you connect to a database in your Neon project. In Neon, a database belongs to a branch, which may be the default branch of your project (`production`) or a child branch.
+When connecting to Neon from an application or client, you connect to a database in your Neon project. In Neon, a database belongs to a branch, which may be the default branch of your project (`main`) or a child branch.
 
 You can obtain the database connection details you require by clicking the **Connect** button on your **Project Dashboard** to open the **Connect to your database** modal. Select a branch, a compute, a database, and a role. A connection string is constructed for you.
 

--- a/content/docs/get-started/dev-experience.md
+++ b/content/docs/get-started/dev-experience.md
@@ -17,7 +17,7 @@ Neon's branching feature lets you branch your data like you branch code. Neon br
 
 ![Branching workflows](/docs/get-started/branching_workflow.jpg)
 
-You can build your database branching workflows using the [Neon CLI](/docs/reference/neon-cli), [Neon API](https://api-docs.neon.tech/reference/getting-started-with-neon-api), or [GitHub Actions](/docs/guides/branching-github-actions). For example, this example shows how to create a development branch from `production` with a simple CLI command:
+You can build your database branching workflows using the [Neon CLI](/docs/reference/neon-cli), [Neon API](https://api-docs.neon.tech/reference/getting-started-with-neon-api), or [GitHub Actions](/docs/guides/branching-github-actions). For example, this example shows how to create a development branch from `main` with a simple CLI command:
 
 ```bash
 neon branches create --name feature/user-auth
@@ -25,7 +25,7 @@ neon branches create --name feature/user-auth
 
 Neon's copy-on-write technique makes branching instantaneous and cost-efficient. Whether your database is 1 GB or 1 TiB, [it only takes seconds to create a branch](/blog/how-to-copy-large-postgres-databases-in-seconds), and Neon's branches are full database copies by default — with schema-only as an option.
 
-Also, with Neon, you can easily keep your development branches up-to-date by resetting your schema and data to the latest from `production` with a simple command.
+Also, with Neon, you can easily keep your development branches up-to-date by resetting your schema and data to the latest from `main` with a simple command.
 
 ```bash
 neon branches reset feature/user-auth --parent

--- a/content/docs/get-started/signing-up.md
+++ b/content/docs/get-started/signing-up.md
@@ -31,12 +31,11 @@ This tutorial walks you through your first steps using Neon as your Postgres dat
 
 Each [branch](/docs/introduction/branching) is a fully-isolated copy of its parent. We suggest creating a long-term branch for each developer on your team to maintain consistent connection strings. You can reset your development branch to production whenever needed.
 
-After signing up, you'll start with two branches:
+After signing up, you'll start with a `main` branch:
 
-- A `production` branch (the default branch) intended for your production workload, configured with a larger compute size (1-4 CU)
-- A `development` branch (created as a child of production) that you can use for local development, configured with a smaller compute size (0.25-1 CU)
+- `main` is your project's root default branch and serves as your production environment (default: 0.25-2 CU, adjustable up to 56 CU)
 
-You can change these sizes at any time, but these are meant to align with typical usage, where production will need more compute than your less active development branches.
+You can create additional branches for development, staging, and other environments. For development branches, consider using a smaller compute size (0.25-1 CU) to optimize costs, while keeping production appropriately sized for your workload.
 
 <Steps>
 
@@ -74,9 +73,9 @@ The steps should be self-explanatory, but it's important to understand a few key
 
   It is the top-level container that holds your branches, databases, and roles. Typically, you should create a project for each repository in your application. This allows you to manage your database branches just like you manage your code branches: a branch for production, staging, development, new features, previews, and so forth.
 
-- **We create two branches for you**
-  - `production` is the default (primary) branch and hosts your database, role, and a compute that you can connect your application to
-  - `development` is created as a child branch of production for your development work
+- **We create a main branch for you**
+  - `main` is the root default branch and serves as your production environment. It hosts your database, role, and a compute that you can connect your application to
+  - You can create additional branches for development, staging, previews, and other workflows as needed
 
 At this point, if you want to just get started connecting Neon to your toolchain, go to [Day 2 - Connecting Neon to your tools](/docs/get-started/connect-neon). Or if you want a more detailed walkthrough of some of our key console and branching features, let's keep going.
 
@@ -84,7 +83,7 @@ At this point, if you want to just get started connecting Neon to your toolchain
 
 Let's get familiar with the **SQL Editor**, where you can run queries against your databases directly from the Neon Console, as well as access more advanced features like [Time Travel](/docs/guides/time-travel-assist) and [Explain and Analyze](/docs/get-started/query-with-neon-sql-editor#explain-and-analyze).
 
-From the Neon Console, use the sidebar navigation to open the **SQL Editor** page. Notice that your default branch `production` is already selected, along with the database created during onboarding, `neondb`.
+From the Neon Console, use the sidebar navigation to open the **SQL Editor** page. Notice that your default branch `main` is already selected, along with the database created during onboarding, `neondb`.
 
 ![Neon SQL Editor](/docs/get-started/sql_editor.png)
 
@@ -102,7 +101,7 @@ INSERT INTO playing_with_neon(name, value)
   SELECT LEFT(md5(i::TEXT), 10), random() FROM generate_series(1, 10) s(i);
 ```
 
-Your default branch `production` now has a table with some data.
+Your default branch `main` now has a table with some data.
 
 ## Try the AI Assistant
 
@@ -141,9 +140,13 @@ For a detailed guide on how to interact with your data using the **Tables** page
 
 ## Working with your development branch
 
-Your project comes with a `development` branch that's an isolated copy of your `production` branch. Let's learn how to use the Neon CLI to manage branches and make some schema changes in your development environment.
+Let's create a `development` branch and learn how to use the Neon CLI to manage branches and make schema changes in your development environment.
 
-1. **Install CLI with Brew or NPM**
+1. **Create a development branch**
+
+   From the Neon Console, navigate to the **Branches** page and click **Create branch**. Name it `development`, select `main` as the parent branch, and click **Create new branch**. This creates an isolated copy of your production data that you can safely modify.
+
+2. **Install CLI with Brew or NPM**
 
    Depending on your system, you can install the Neon CLI using either Homebrew (for macOS) or NPM (for other platforms).
    - For macOS using Homebrew:
@@ -158,7 +161,7 @@ Your project comes with a `development` branch that's an isolated copy of your `
      npm install -g neonctl
      ```
 
-2. **Authenticate with Neon**
+3. **Authenticate with Neon**
 
    The `neon auth` command launches a browser window where you can authorize the Neon CLI to access your Neon account.
 
@@ -168,7 +171,7 @@ Your project comes with a `development` branch that's an isolated copy of your `
 
    ![neon auth](/docs/get-started/neonctl_auth.png 'no-border')
 
-3. **View your branches**
+4. **View your branches**
 
    First, list your projects to get your project ID:
 
@@ -200,7 +203,7 @@ Your project comes with a `development` branch that's an isolated copy of your `
    └──────────────┴────────────────────────────┴───────────────┴──────────────────────┘
    ```
 
-   This shows your existing branches, including the `production` and `development` branches.
+   This command shows your existing branches, including the `main` branch and the `development` branch you just created.
 
    <Admonition type="tip">
    To avoid specifying `--project-id` with each command, use `neon set-context` to set your default project and organization. See [set-context](/docs/reference/cli-set-context) for details.
@@ -208,13 +211,13 @@ Your project comes with a `development` branch that's an isolated copy of your `
 
 ## Make some sample schema changes
 
-First, let's make sure our development branch is in sync with production. This ensures we're starting from the same baseline:
+First, let's make sure our development branch is in sync with main. This ensures we're starting from the same baseline:
 
 ```bash
 neon branches reset development --parent --project-id cool-forest-12345678
 ```
 
-Now that our development branch matches production, we can make some changes. The `playing_with_neon` table from production is now available in your `development` branch, and we'll modify its schema and add new data to demonstrate how branches can diverge.
+Now that our development branch matches main, we can make some changes. The `playing_with_neon` table from main is now available in your `development` branch, and we'll modify its schema and add new data to demonstrate how branches can diverge.
 
 You can use the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) for this, but let's demonstrate how to connect and modify your database from the terminal using `psql`. If you don't have `psql` installed already, follow these steps to get set up:
 

--- a/content/docs/guides/branching-schema-only.md
+++ b/content/docs/guides/branching-schema-only.md
@@ -135,7 +135,7 @@ Unlike other branches, schema-only branches do not have a parent branch, as you 
 
 ![schema-only branch](/docs/guides/schema_only_no_parent.png)
 
-Schema-only branches are independent [root branches](/docs/reference/glossary#root-branch), just like the `production` branch in your Neon project. When you create a schema-only branch, you're creating a new **root branch**.
+Schema-only branches are independent [root branches](/docs/reference/glossary#root-branch), just like the `main` branch in your Neon project. When you create a schema-only branch, you're creating a new **root branch**.
 
 ### Key points about schema-only branches
 

--- a/content/docs/guides/liquibase-workflow.md
+++ b/content/docs/guides/liquibase-workflow.md
@@ -63,7 +63,7 @@ Now, let's prepare a development database in Neon by creating a development bran
 
 To create a branch:
 
-1. In the Neon Console, select **Branches**. You will see your `production` branch, where you just created your `blog` database and tables.
+1. In the Neon Console, select **Branches**. You will see your `main` branch, where you just created your `blog` database and tables.
 2. Click **New Branch** to open the branch creation dialog.
 3. Enter a name for the branch. Let's call it `feature/blog-schema`.
 4. Leave `production` selected as the parent branch. This is where you created the `blog` database.

--- a/content/docs/guides/protected-branches.md
+++ b/content/docs/guides/protected-branches.md
@@ -32,7 +32,7 @@ To set a branch as protected:
 
    ![Branch page](/docs/guides/ip_allow_branch_page.png)
 
-3. Select a branch from the table. In this example, we'll configure our default branch `production` as a protected branch.
+3. Select a branch from the table. In this example, we'll configure our default branch `main` as a protected branch.
 4. On the branch page, click **Protect**.
 
    ![Set as protected](/docs/guides/ip_allow_set_as_protected.png)

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -158,7 +158,7 @@ For the purposes of this tutorial, name the branch `feature/address`, which coul
 1. Create the development branch
 
    On the **Branches** page, click **Create Branch**, making sure of the following:
-   - Select `production` as the default branch.
+   - Select `main` as the default branch.
    - Name the branch `feature/address`.
 
 1. Verify the schema on your new branch
@@ -374,7 +374,7 @@ Now that you have some differences between your branches, you can view the schem
 
    ![schema diff results](/docs/guides/schema_diff_result.png)
 
-You will see the schema differences between `feature/address` and its parent `production`, including the new address table that we added to the `feature/address` branch.
+You will see the schema differences between `feature/address` and its parent `main`, including the new address table that we added to the `feature/address` branch.
 
 You can also launch Schema Diff from the **Restore** page, usually as part of verifying schemas before you restore a branch to its own or another branch's history. See [Instant restore](/docs/guides/branch-restore) for more info.
 
@@ -388,7 +388,7 @@ Compare the schema of `feature/address` to its parent branch using the `schema-d
 neon branches schema-diff production feature/address --database people
 ```
 
-The result shows a comparison between the `feature/address` branch and its parent branch for the database `people`. The output indicates that the `address` table and its related sequences and constraints have been added in the `feature/address` branch but are not present in its parent branch `production`.
+The result shows a comparison between the `feature/address` branch and its parent branch for the database `people`. The output indicates that the `address` table and its related sequences and constraints have been added in the `feature/address` branch but are not present in its parent branch `main`.
 
 ```diff
 --- Database: people (Branch: br-falling-dust-a5bakdqt) // [!code --]

--- a/content/docs/guides/schema-diff.md
+++ b/content/docs/guides/schema-diff.md
@@ -69,7 +69,7 @@ Use the `schema-diff` subcommand from the `branches` command:
 neon branches schema-diff [base-branch] [compare-source[@(timestamp|lsn)]]
 ```
 
-The operation will compare a selected branch (`[compare-source]`) against the latest (head) of your base branch (`[base-branch]`). For example, if you want to compare recent changes you made to your development branch `development` against your production branch `production`, identify `production` as your base branch and `development` as your compare-source.
+The operation will compare a selected branch (`[compare-source]`) against the latest (head) of your base branch (`[base-branch]`). For example, if you want to compare recent changes you made to your development branch `development` against your production branch `main`, identify `main` as your base branch and `development` as your compare-source.
 
 ```bash
 neon branches schema-diff production development

--- a/content/docs/introduction/branch-restore.md
+++ b/content/docs/introduction/branch-restore.md
@@ -182,7 +182,7 @@ Here is an example of a command that restores a target branch to an earlier poin
 neon branches restore development production@0/12345
 ```
 
-This command will restore the target branch `development` to an earlier point in time from the source branch `production`, using the LSN `0/12345` to specify the point in time. If you left out the point-in-time identifier, the command would default to the latest data (HEAD) for the source branch `production`.
+This command will restore the target branch `development` to an earlier point in time from the source branch `main`, using the LSN `0/12345` to specify the point in time. If you left out the point-in-time identifier, the command would default to the latest data (HEAD) for the source branch `main`.
 
 For full CLI documentation for `branches restore`, see [branches restore](/docs/reference/cli-branches#restore).
 </TabItem>
@@ -301,4 +301,4 @@ There are minimal impacts to billing from the instant restore and Time Travel As
 - Deleting backup branches is only supported in certain cases. See [Deleting backup branches](#deleting-backup-branches) for details.
 - Instant restore (PITR) is currently not supported on branches created from a snapshot restore. If you restore a snapshot to create a new branch, you cannot perform point-in-time restore on that branch at this time. Attempting to do so will return an error: `restore from snapshot on target branch is still ongoing`.
 - When you restore a non-root branch to an earlier point in time, the backup branch becomes the parent of the restored branch. This means subsequent "Reset from parent" operations will reset to the backup, not to your original parent branch.
-  For example, let's say you have a `production` branch with a child development branch `development`. You restore `development` to an earlier point in time. At this point, `development`'s parent changes from `production` to the backup `development_old_timestamp`. Later, if you want to refresh `development` with the latest data from `production`, you cannot use **Reset from parent** since the backup is now the parent. Instead, use **Instant restore** and select `production` as the source.
+  For example, let's say you have a `main` branch with a child development branch `development`. You restore `development` to an earlier point in time. At this point, `development`'s parent changes from `main` to the backup `development_old_timestamp`. Later, if you want to refresh `development` with the latest data from `main`, you cannot use **Reset from parent** since the backup is now the parent. Instead, use **Instant restore** and select `main` as the source.

--- a/content/docs/manage/branches.md
+++ b/content/docs/manage/branches.md
@@ -7,7 +7,7 @@ redirectFrom:
 updatedOn: '2025-12-11T15:40:49.871Z'
 ---
 
-Data resides in a branch. Each Neon project is created with a [root branch](#root-branch) called `production`, which is also designated as your [default branch](#default-branch). You can create child branches from `production` or from previously created branches. A branch can contain multiple databases and roles. Neon's [plan allowances](/docs/introduction/plans) define the number of branches you can create.
+Data resides in a branch. Each Neon project is created with a [root branch](#root-branch) called `main`, which is also designated as your [default branch](#default-branch). You can create child branches from `main` or from previously created branches. A branch can contain multiple databases and roles. Neon's [plan allowances](/docs/introduction/plans) define the number of branches you can create.
 
 A child branch is a copy-on-write clone of the parent branch. You can modify the data in a branch without affecting the data in the parent branch.
 For more information about branches and how you can use them in your development workflows, see [Branching](/docs/introduction/branching).
@@ -106,7 +106,7 @@ Neon permits renaming a branch, including your project's default branch. To rena
 
 ## Set a branch as default
 
-Each Neon project is created with a default branch called `production`, but you can designate any branch as your project's default branch. The default branch serves two key purposes:
+Each Neon project is created with a default branch called `main`, but you can designate any branch as your project's default branch. The default branch serves two key purposes:
 
 - For users on paid plans, the compute associated with the default branch is exempt from the [concurrently active compute limit](/docs/reference/glossary#concurrently-active-compute-limit), ensuring that it is always available.
 - The [Neon-Managed Vercel integration](/docs/guides/neon-managed-vercel-integration) creates preview deployment branches from your Neon project's default branch.
@@ -227,7 +227,7 @@ Neon has different branch types with different characteristics.
 
 ### Root branch
 
-A root branch is a branch without a parent branch. Each Neon project starts with a root branch named `production`, which cannot be deleted and is set as the [default branch](#default-branch) for the project.
+A root branch is a branch without a parent branch. Each Neon project starts with a root branch named `main`, which cannot be deleted and is set as the [default branch](#default-branch) for the project.
 
 Neon also supports two other types of root branches that have no parent but _can_ be deleted:
 

--- a/content/docs/manage/overview.md
+++ b/content/docs/manage/overview.md
@@ -25,7 +25,7 @@ A project is a container for all objects except for API keys, which are global a
 
 ## Default branch
 
-Data resides in a branch. Each Neon project is created with a default branch called `production`. This initial branch is also your project's root branch, which cannot be deleted. After creating more branches, you can designate a different branch as your default branch, but your root branch cannot be deleted. You can create child branches from any branch in your project. Each branch can contain multiple databases and roles. Plan limits define the number of branches you can create in a project and the amount of data per branch. To learn more, see [Manage branches](/docs/manage/branches).
+Data resides in a branch. Each Neon project is created with a default branch called `main`. This initial branch is also your project's root branch, which cannot be deleted. After creating more branches, you can designate a different branch as your default branch, but your root branch cannot be deleted. You can create child branches from any branch in your project. Each branch can contain multiple databases and roles. Plan limits define the number of branches you can create in a project and the amount of data per branch. To learn more, see [Manage branches](/docs/manage/branches).
 
 ## R/W computes and Read Replicas
 

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -14,7 +14,7 @@ In Neon, the project is your main workspace. Within a project, you create branch
 
 When you add a new project, Neon creates the following resources by default:
 
-- Two branches are created for you by default: `production` (your main branch for production workloads) and `development` (a child branch for development work). You can create additional child branches from either of these, or from any other branch. For more information, see [Manage branches](/docs/manage/branches).
+- A branch named `main` is created as your project's root branch, which serves as your production environment. You can create child branches from `main` for development, testing, staging, and other purposes. For more information, see [Manage branches](/docs/manage/branches).
 - A single primary read-write compute. This is the compute associated with the branch. For more information, see [Manage computes](/docs/manage/computes).
 - A Postgres database that resides on the project's default branch. If you did not specify your own database name when creating the project, the database created is named `neondb`.
 - A Postgres role that is named for your database. For example, if your database is named `neondb`, the project is created with a default role named `neondb_owner`.

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -263,7 +263,7 @@ When creating a branch from a protected parent branch, role passwords on the chi
   neon branches create --name my_read_replica_branch --type read_only
   ```
 
-- Create a branch from a parent branch other than your `production` branch
+- Create a branch from a parent branch other than your `main` branch
 
   ```bash
   neon branches create --name feature/payment-api --parent development
@@ -375,10 +375,10 @@ Examples of the different kinds of restore operations you can do:
 
 #### Restoring a branch to an earlier point in its own history (with backup)
 
-This command restores the branch `production` to an earlier timestamp, saving to a backup branch called `production_restore_backup_2024-02-20`
+This command restores the branch `main` to an earlier timestamp, saving to a backup branch called `main_restore_backup_2024-05-06`
 
 ```bash shouldWrap
-neon branches restore production ^self@2024-05-06T10:00:00.000Z --preserve-under-name production_restore_backup_2024-05-06
+neon branches restore main ^self@2024-05-06T10:00:00.000Z --preserve-under-name main_restore_backup_2024-05-06
 ```
 
 Results of the operation:
@@ -395,16 +395,16 @@ Backup branch
 ┌─────────────────────────┬────────────────────────────────┐
 │ Id                      │ Name                           │
 ├─────────────────────────┼────────────────────────────────┤
-│ br-flat-forest-a5z016gm │ production_restore_backup_2024-05-06 │
+│ br-flat-forest-a5z016gm │ main_restore_backup_2024-05-06 │
 └─────────────────────────┴────────────────────────────────┘
 ```
 
 #### Restoring a branch (target) to the head of another branch (source)
 
-This command restores the target branch `feature/user-auth` to latest data (head) from the source branch `production`.
+This command restores the target branch `feature/user-auth` to latest data (head) from the source branch `main`.
 
 ```bash shouldWrap
-neon branches restore feature/user-auth production
+neon branches restore feature/user-auth main
 ```
 
 Results of the operation:
@@ -486,7 +486,7 @@ This command:
 neon branches schema-diff [base-branch] [compare-source[@(timestamp|lsn)]]
 ```
 
-`[base-branch]` specifies the branch you want to compare against. For example, if you want to compare a development branch against the production branch `production`, select `production` as your base.
+`[base-branch]` specifies the branch you want to compare against. For example, if you want to compare a development branch against the production branch `main`, select `main` as your base.
 
 This setting is **optional**. If you leave it out, the operation uses either of the following as the base:
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -65,10 +65,12 @@ A branch created by a [instant restore](#branch-restore) operation. When you res
 
 An isolated copy of data, similar to a Git branch. Data includes databases, schemas, tables, records, indexes, roles — everything that comprises data in a Postgres instance. Just as a Git branch allows developers to work on separate features or fixes without impacting their main line of code, a Neon branch enables users to modify a copy of their data in isolation from their main line of data. This approach facilitates parallel database development, testing, and other features, similar to Git's code branching system.
 
-Each Neon project is created with two branches by default:
+Each Neon project is created with a root branch called `main`, which also serves as the default branch.
 
-- **production** - The default branch. This main line of data is referred to as [root branch](#root-branch).
-- **development** - A child branch of production. A branch created from the root branch or another branch is a [copy-on-write](#copy-on-write) clone.
+You can create additional branches as needed:
+
+- **main** - The root default branch. This main line of data is the starting point for all other branches.
+- **development** - A commonly used name for a child branch dedicated to development work. Many users create a development branch from their main branch to provide an isolated environment for testing changes.
 
 You can create a branch from the current or past state of another branch. A branch created from the current state of another branch includes the data that existed on that branch at the time of branch creation. A branch created from a past state of another branch includes the data that existed in the past state.
 
@@ -425,7 +427,7 @@ A feature in Neon that allows secure connections to Neon databases through AWS P
 
 ## default branch
 
-A designation that is given to a [branch](#branch) in a Neon project. Each Neon project is initially created with a [root branch](#root-branch) called `production`, which carries the _default branch_ designation by default.
+A designation that is given to a [branch](#branch) in a Neon project. Each Neon project is initially created with a [root branch](#root-branch) called `main`, which carries the _default branch_ designation by default.
 
 The default branch serves two key purposes:
 
@@ -518,7 +520,7 @@ The period of time for which Neon retains a history of changes for your branches
 
 ## root branch
 
-Each Neon project is created with a root branch, which cannot be deleted and is set as the [default branch](#default-branch) for the project. A project created in the Neon Console has a root branch named `production`. A root branch has no parent branch.
+Each Neon project is created with a root branch, which cannot be deleted and is set as the [default branch](#default-branch) for the project. A project created in the Neon Console has a root branch named `main`. A root branch has no parent branch.
 
 Neon also supports two other types of root branches that have no parent but _can_ be deleted:
 


### PR DESCRIPTION
Console now creates a single `main` branch instead of `production + development`.