### PR TITLE
Fix result value in EXTRACT() function example

### DIFF
--- a/content/postgresql/postgresql-date-functions/postgresql-extract.md
+++ b/content/postgresql/postgresql-date-functions/postgresql-extract.md
@@ -468,7 +468,7 @@ SELECT
 Result:
 
 ```sql
-60
+6
 ```
 
 The following example uses the `EXTRACT()` function to extract the millennium from an interval:


### PR DESCRIPTION
Corrected the result of the example using the EXTRACT() function.

There should be 6 decades, not 60.