### PR TITLE
fix: filter posts without cover

### DIFF
--- a/src/app/blog/[slug]/page.jsx
+++ b/src/app/blog/[slug]/page.jsx
@@ -86,10 +86,12 @@ const BlogPage = async ({ params }) => {
             title={title}
             slug={shareUrl}
           />
-          <MoreArticles
-            className="col-span-10 col-start-2 mt-16 xl:col-span-full xl:mt-14 lg:mt-12 md:mt-11"
-            posts={relatedPosts}
-          />
+          {relatedPosts.length > 0 && (
+            <MoreArticles
+              className="col-span-10 col-start-2 mt-16 xl:col-span-full xl:mt-14 lg:mt-12 md:mt-11"
+              posts={relatedPosts}
+            />
+          )}
         </article>
       </div>
     </>

--- a/src/components/pages/blog-post/aside/aside.jsx
+++ b/src/components/pages/blog-post/aside/aside.jsx
@@ -57,46 +57,50 @@ const Aside = ({ className, title, slug, authors, posts }) => (
           </div>
         </>
       )}
-      <h3
-        className={clsx(
-          'text-[12px] font-semibold uppercase leading-none -tracking-extra-tight text-blue-80 lg:hidden',
-          {
-            'mt-16': Array.isArray(authors) && authors.length > 0,
-          }
-        )}
-      >
-        More articles
-      </h3>
-      <ul className="mt-5 flex flex-col space-y-6 lg:hidden">
-        {posts.map(({ title, slug, pageBlogPost: { authors, largeCover } }) => (
-          <li key={slug}>
-            <Link className="group block rounded-sm" to={`${LINKS.blog}/${slug}`}>
-              <article className="flex items-center space-x-3">
-                <div className="flex-grow">
-                  <h1 className="line-clamp-2 font-title font-medium leading-tight tracking-extra-tight transition-colors duration-200 group-hover:text-green-45">
-                    {title}
-                  </h1>
-                  <span className="mt-1.5 text-sm leading-none tracking-extra-tight text-gray-new-80">
-                    {authors[0]?.author?.title}
-                  </span>
-                </div>
-                {largeCover?.mediaItemUrl ? (
-                  <Image
-                    className="h-[59px] w-[104px] shrink-0 rounded-md"
-                    src={largeCover?.mediaItemUrl}
-                    width={104}
-                    height={59}
-                    quality={85}
-                    alt={largeCover?.altText || title}
-                  />
-                ) : (
-                  <span className="h-16 w-[104px] shrink-0 rounded-md bg-gray-new-30" />
-                )}
-              </article>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      {posts.length > 0 && (
+        <>
+          <h3
+            className={clsx(
+              'text-[12px] font-semibold uppercase leading-none -tracking-extra-tight text-blue-80 lg:hidden',
+              {
+                'mt-16': Array.isArray(authors) && authors.length > 0,
+              }
+            )}
+          >
+            More articles
+          </h3>
+          <ul className="mt-5 flex flex-col space-y-6 lg:hidden">
+            {posts.map(({ title, slug, pageBlogPost: { authors, largeCover } }) => (
+              <li key={slug}>
+                <Link className="group block rounded-sm" to={`${LINKS.blog}/${slug}`}>
+                  <article className="flex items-center space-x-3">
+                    <div className="flex-grow">
+                      <h1 className="line-clamp-2 font-title font-medium leading-tight tracking-extra-tight transition-colors duration-200 group-hover:text-green-45">
+                        {title}
+                      </h1>
+                      <span className="mt-1.5 text-sm leading-none tracking-extra-tight text-gray-new-80">
+                        {authors[0]?.author?.title}
+                      </span>
+                    </div>
+                    {largeCover?.mediaItemUrl ? (
+                      <Image
+                        className="h-[59px] w-[104px] shrink-0 rounded-md"
+                        src={largeCover?.mediaItemUrl}
+                        width={104}
+                        height={59}
+                        quality={85}
+                        alt={largeCover?.altText || title}
+                      />
+                    ) : (
+                      <span className="h-16 w-[104px] shrink-0 rounded-md bg-gray-new-30" />
+                    )}
+                  </article>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
       <SocialShare className="mt-16 lg:hidden" title={title} slug={slug} withTopBorder />
       <ChangelogForm className="mt-10" isSidebar />
     </div>

--- a/src/utils/api-wp.js
+++ b/src/utils/api-wp.js
@@ -1,3 +1,4 @@
+import isEmpty from 'lodash.isempty';
 import { cache } from 'react';
 
 import { BLOG_POSTS_PER_PAGE, BLOG_POSTS_FOR_PREVIEW, EXTRA_CATEGORIES } from 'constants/blog';
@@ -299,7 +300,7 @@ const getWpPostBySlug = cache(async (slug) => {
         }
         ...wpPostSeo
       }
-      posts(first: 4, where: { orderby: { field: DATE, order: DESC } }) {
+      posts(first: 6, where: { orderby: { field: DATE, order: DESC } }) {
         nodes {
           categories {
             nodes {
@@ -341,7 +342,9 @@ const getWpPostBySlug = cache(async (slug) => {
 
   const data = await fetchGraphQL(graphQLClient).request(postBySlugQuery, { id: slug });
 
-  const sortedPosts = data?.posts?.nodes.filter((post) => post.slug !== slug).slice(0, 3);
+  const sortedPosts = data?.posts?.nodes
+    .filter((post) => post.slug !== slug || isEmpty(post.pageBlogPost?.largeCover))
+    .slice(0, 3);
 
   return {
     post: data?.post,


### PR DESCRIPTION
[Preview](https://neon-next-git-filter-blog-suggestions-pixelpoint.vercel.app/)

- added filtering related posts without cover

<img width="1289" height="509" alt="image" src="https://github.com/user-attachments/assets/6aa8e497-092d-4e2e-aaf4-cd7ce2129fda" />

<img width="414" height="649" alt="image" src="https://github.com/user-attachments/assets/df8122f5-a2dd-4502-9033-6b43d3cc583f" />

