### PR TITLE
fix: docs content overflow

### DIFF
--- a/src/components/shared/link/link.jsx
+++ b/src/components/shared/link/link.jsx
@@ -80,7 +80,7 @@ const Link = forwardRef(
       styles.size[size],
       styles.theme[theme],
       additionalClassName,
-      (withArrow || icon) && 'group inline-flex w-fit items-center gap-1'
+      (withArrow || icon) && 'group inline-flex w-fit items-center gap-1 sm:wrap-anywhere'
     );
 
     const Icon = icons[icon];

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -198,7 +198,7 @@
         @apply px-0;
 
         > code {
-          @apply inline-block w-full px-6 py-1.5 !leading-relaxed;
+          @apply inline-block w-full px-6 py-1.5 !leading-relaxed wrap-anywhere;
         }
       }
 
@@ -210,7 +210,7 @@
     }
 
     :not(pre) > code {
-      @apply !rounded-sm bg-gray-new-94 !px-1.5 !py-0.5 !font-mono !font-normal !text-black-new dark:bg-gray-new-15 dark:!text-white;
+      @apply break-words !rounded-sm bg-gray-new-94 !px-1.5 !py-0.5 !font-mono !font-normal !text-black-new dark:bg-gray-new-15 dark:!text-white;
 
       &::before,
       &::after {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -402,6 +402,9 @@ module.exports = {
         '.gradient-stop-opacity-100': {
           'stop-opacity': '1',
         },
+        '.wrap-anywhere': {
+          'overflow-wrap': 'anywhere',
+        },
       });
     }),
   ],


### PR DESCRIPTION
[Preview](https://neon-next-git-docs-content-overflow-fix-pixelpoint.vercel.app/)

- fixed content overflow on **Docs** pages on mobile
- added `wrap-anywhere` util according to the `Taiwind v4+` - the only solution for links

https://neon.com/docs/guides/logical-replication-alloydb
<img width="510" height="263" alt="image" src="https://github.com/user-attachments/assets/31ae9161-d544-4e08-a39a-c3c4a8807e71" />

https://neon.com/docs/import/import-sample-data
<img width="496" height="293" alt="image" src="https://github.com/user-attachments/assets/6d0c4974-330e-42a4-9bf9-cafe63beeeaa" />
