### PR TITLE
docs: fix leftover SDK naming references

### DIFF
--- a/content/docs/reference/neondatabase-toolkit.md
+++ b/content/docs/reference/neondatabase-toolkit.md
@@ -234,7 +234,7 @@ As you can see, the toolkit makes it incredibly easy to manage the lifecycle of 
 
 ## Accessing the underlying API client
 
-The toolkit is a convenience wrapper. For more advanced operations not covered by the toolkit's methods (like creating a branch, managing roles, or listing all your projects), you can access the full Neon TypeScript SDK instance via the `apiClient` property.
+The toolkit is a convenience wrapper. For more advanced operations not covered by the toolkit's methods (like creating a branch, managing roles, or listing all your projects), you can access the full Neon API TypeScript SDK instance via the `apiClient` property.
 
 ```javascript
 import { NeonToolkit } from "@neondatabase/toolkit";

--- a/content/docs/reference/sdk.md
+++ b/content/docs/reference/sdk.md
@@ -29,7 +29,7 @@ Use these SDKs to programmatically manage your Neon infrastructure — projects,
 
 <a href="/docs/reference/python-sdk" description="Programmatically manage Neon projects, branches, databases, and other platform resources" icon="neon">Python SDK (Neon API)</a>
 
-<a href="/docs/reference/neondatabase-toolkit" description="An SDK for AI Agents (and humans) that includes both the Neon TypeScript SDK and the Neon Serverless Driver" icon="neon">@neondatabase/toolkit</a>
+<a href="/docs/reference/neondatabase-toolkit" description="An SDK for AI Agents (and humans) that includes both the Neon API TypeScript SDK and the Neon Serverless Driver" icon="neon">@neondatabase/toolkit</a>
 
 </DetailIconCards>
 


### PR DESCRIPTION
## Description

This PR fixes leftover references to "Neon TypeScript SDK" that should be "Neon API TypeScript SDK" for consistency with the SDK renaming changes made in #4381.

**FIXES**
- Updated SDK reference in `neondatabase-toolkit.md` documentation
- Updated SDK description in `sdk.md` index page

## Test Plan

Visual review of documentation pages to confirm correct naming.