### PR TITLE
docs: remove preview notices from MCP server documentation

### DIFF
--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -74,13 +74,9 @@ The Neon MCP server grants powerful database management capabilities through nat
 
 You can set up the Neon MCP Server in two ways:
 
-### Remote hosted server (preview)
+### Remote hosted server
 
 You can use Neon's managed MCP server, available at `https://mcp.neon.tech`. This is the **easiest** way to start using the Neon MCP Server. It streamlines the setup process by utilizing OAuth for authentication, eliminating the need to manage Neon API keys directly in your client configuration.
-
-<Admonition type="note">
-The remote hosted MCP server is currently in its preview phase. As the [OAuth specification for MCP](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) is still quite new, we are releasing it in this preview state. During the initial weeks, you may experience some adjustments to the setup. However, the instructions provided should be straightforward to follow at this time.
-</Admonition>
 
 #### Prerequisites:
 

--- a/content/guides/claude-code-mcp-neon.md
+++ b/content/guides/claude-code-mcp-neon.md
@@ -94,10 +94,6 @@ Replace `<YOUR_NEON_API_KEY>` with your actual Neon API key which you obtained f
 
 </Admonition>
 
-<Admonition type="note">
-The remote hosted MCP server is in preview due to the [new OAuth MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/), expect potential changes as we continue to refine the OAuth integration.
-</Admonition>
-
 ### Option 2: Setting up the Local Neon MCP Server
 
 This method runs the Neon MCP server locally on your machine, using a Neon API key for authentication.
@@ -235,7 +231,7 @@ Claude Code will use the `create_branch` MCP tool to create the branch and provi
 
 ## Conclusion
 
-Claude Code combined with the Neon MCP Server, whether using the **Remote Hosted (Preview)** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing database ideas and making schema changes during development.
+Claude Code combined with the Neon MCP Server, whether using the **Remote Hosted** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing database ideas and making schema changes during development.
 
 ## Resources
 

--- a/content/guides/cline-mcp-neon.md
+++ b/content/guides/cline-mcp-neon.md
@@ -33,7 +33,7 @@ Let's break down the key components in this setup:
 
 You have two options for connecting Cline to the Neon MCP Server:
 
-1. **Remote MCP Server (Preview):** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Cline. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
+1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Cline. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
 
 2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
 
@@ -77,10 +77,6 @@ By default, the Remote MCP Server connects to your personal Neon account. To con
 7. A browser window will open asking you to sign in to your Neon account and authorize Cline to access your Neon projects.
    ![Neon OAuth window](/docs/guides/neon-oauth-window.png)
 8. Once authentication is complete, Cline will display a confirmation message, and **Neon** will appear under your list of available MCP servers.
-
-<Admonition type="note">
-  The remote hosted MCP server is in preview due to the [new OAuth MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/), expect potential changes as we continue to refine the OAuth integration.
-</Admonition>
 
 ### Option 2: Setting up the Local Neon MCP Server
 

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -33,7 +33,7 @@ Let's break down the key components in this setup:
 
 You have two options for connecting Cursor to the Neon MCP Server:
 
-1. **Remote MCP Server (Preview):** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Cursor. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
+1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Cursor. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
 
 2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
 
@@ -106,10 +106,6 @@ This method uses Neon's managed server and OAuth authentication.
    ![Cursor with Neon MCP Tools](/docs/guides/cursor-with-neon-mcp-tools.png)
 
 7. Cursor is now connected to Neon's remote MCP server.
-
-<Admonition type="note">
-The remote hosted MCP server is in preview due to the [new OAuth MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/), expect potential changes as we continue to refine the OAuth integration.
-</Admonition>
 
 ### Option 2: Setting up the Local Neon MCP Server
 
@@ -330,7 +326,7 @@ Cursor will use the `create_branch` MCP tool to create the branch and provide yo
 
 ## Conclusion
 
-Cursor combined with the Neon MCP Server, whether using the **Remote Hosted (Preview)** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing
+Cursor combined with the Neon MCP Server, whether using the **Remote Hosted** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing
 database ideas and making schema changes during development.
 
 ## Resources

--- a/content/guides/neon-mcp-server-github-copilot-vs-code.md
+++ b/content/guides/neon-mcp-server-github-copilot-vs-code.md
@@ -61,7 +61,7 @@ This command authenticates via OAuth, creates an API key, and configures VS Code
 
 #### Manual Remote Setup (OAuth)
 
-Alternatively, you can manually configure the [Remote Hosted MCP Server option](https://github.com/neondatabase-labs/mcp-server-neon?tab=readme-ov-file#option-1-remote-hosted-mcp-server-preview). This setup requires no local installation or API key management.
+Alternatively, you can manually configure the [Remote Hosted MCP Server option](https://github.com/neondatabase-labs/mcp-server-neon?tab=readme-ov-file#option-1-remote-hosted-mcp-server). This setup requires no local installation or API key management.
 
 In your project directory, create a new file named `.vscode/mcp.json` and add the following configuration:
 

--- a/content/guides/neon-mcp-server.md
+++ b/content/guides/neon-mcp-server.md
@@ -76,7 +76,7 @@ We'll use Claude Desktop to interact with Neon MCP server. Here's how to set it 
 
 You have two options for connecting Claude to the Neon MCP Server:
 
-1. **Remote MCP Server (Preview):** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Claude. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
+1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Claude. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
 
 2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
 
@@ -131,10 +131,6 @@ Choose one of the following methods to set up the Remote Neon MCP server in Clau
 
 </TabItem>
 </Tabs>
-
-<Admonition type="note">
-The remote hosted MCP server is in preview due to the [new OAuth MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/), expect potential changes as we continue to refine the OAuth integration.
-</Admonition>
 
 ### Option 2: Setting up the Local Neon MCP Server
 

--- a/content/guides/windsurf-mcp-neon.md
+++ b/content/guides/windsurf-mcp-neon.md
@@ -33,7 +33,7 @@ Let's break down the key components in this setup:
 
 You have two options for connecting Windsurf to the Neon MCP Server:
 
-1. **Remote MCP Server (Preview):** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Windsurf. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
+1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Windsurf. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
 
 2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
 
@@ -92,10 +92,6 @@ By default, the Remote MCP Server connects to your personal Neon account. To con
    ![Windsurf MCP Toolbar](/docs/guides/windsurf-mcp-server-available.png)
 
 9. Windsurf is now connected to the Neon MCP server.
-
-<Admonition type="note">
-The remote hosted MCP server is in preview due to the [new OAuth MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/), expect potential changes as we continue to refine the OAuth integration.
-</Admonition>
 
 <Admonition type="tip" title="Troubleshooting OAuth Errors">
 If you encounter an error message like `{"code":"invalid_request","error":"invalid redirect uri"}` when starting Windsurf with the remote MCP server, this is typically due to cached OAuth credentials. To fix this issue:

--- a/content/guides/zed-mcp-neon.md
+++ b/content/guides/zed-mcp-neon.md
@@ -23,7 +23,7 @@ For more information, see [MCP security guidance →](/docs/ai/neon-mcp-server#m
 
 You have two options for connecting Zed to the Neon MCP Server:
 
-1.  **Remote MCP Server (Preview):** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Zed. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
+1.  **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Zed. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
 
 2.  **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
 
@@ -73,10 +73,6 @@ This method uses Neon's managed server and OAuth authentication.
     ![Zed with Neon MCP](/docs/guides/zed/with-neon-mcp.png)
 
 8.  Zed is now connected to Neon's remote MCP server.
-
-<Admonition type="note">
-The remote hosted MCP server is in preview due to the [new OAuth MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/), expect potential changes as we continue to refine the OAuth integration.
-</Admonition>
 
 ### Option 2: Setting up the Local Neon MCP Server
 
@@ -322,7 +318,7 @@ Zed will use the `create_branch` MCP tool to create the branch and provide you w
 
 ## Conclusion
 
-Zed combined with the Neon MCP Server, whether using the **Remote Hosted (Preview)** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing
+Zed combined with the Neon MCP Server, whether using the **Remote Hosted** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing
 database ideas and making schema changes during development.
 
 ## Resources


### PR DESCRIPTION
The remote hosted MCP server is now a mature option alongside the local server. This removes all preview notices and "(Preview)" labels from the MCP documentation across all client guides.