### PR TITLE
fix: remove self-referencing redirect causing ERR_TOO_MANY_REDIRECTS

### DIFF
--- a/content/docs/get-started/signing-up.md
+++ b/content/docs/get-started/signing-up.md
@@ -7,7 +7,6 @@ redirectFrom:
   - /docs/cloud/getting-started/
   - /docs/cloud/getting_started/
   - /docs/get-started-with-neon/signing-up
-  - /docs/get-started/signing-up
 updatedOn: '2026-02-02T12:37:39.442Z'
 ---
 


### PR DESCRIPTION
The signing-up.md page had its own URL (/docs/get-started/signing-up) listed in the redirectFrom array, causing an infinite redirect loop when users clicked "Basics" in the sidebar navigation.