### PR TITLE
Fix Grafana Cloud Integration page

### DIFF
--- a/content/docs/guides/grafana-cloud.md
+++ b/content/docs/guides/grafana-cloud.md
@@ -56,6 +56,7 @@ Before getting started, ensure the following:
 ### 1. Get your Grafana Cloud credentials
 
 In your Grafana Cloud instance:
+
 1. Navigate to **Connections** → **Add new connection**.
 2. Search for and select **Neon**.
 3. Follow the **Neon Integration** wizard to generate a token with the required permissions.
@@ -71,6 +72,7 @@ The wizard automatically generates a token with the correct permissions (metrics
 ### 2. Configure the integration in Neon
 
 In the Neon Console:
+
 1. Go to your project's **Integrations** page and select **OpenTelemetry** → **Add**.
 2. Configure the connection:
    - **Protocol**: HTTP (recommended).


### PR DESCRIPTION
Preview:
https://neon-next-git-bgrenon-fix-grafana-auth-clean-neondatabase.vercel.app/docs/guides/grafana-cloud

Added steps to add connection in Grafana first, to get the details to enter on the Neon side.