### PR TITLE
docs: add add-mcp command for local setup

### DIFF
--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -103,6 +103,12 @@ Run the MCP server locally on your machine.
 
 **Requires:** Node.js >= v18, [Neon API key](/docs/manage/api-keys)
 
+```bash
+npx add-mcp "npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>" --name neon
+```
+
+Or add this to your MCP config file:
+
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
Explain the add-mcp one-liner before the JSON config so users can install a local server faster.