### PR TITLE
chore: fix typo

### DIFF
--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -224,7 +224,7 @@ Postgres logs can be accessed through the [Datadog](/docs/guides/datadog) or [Op
 
 ## Unlogged tables
 
-Unlogged tables are tables that do not write to the Postgres write-ahead log (WAL). In Noen, these tables are stored on compute local storage and are not persisted across compute restarts or when a compute scales to zero. This is unlike standard Postgres, where unlogged tables are only truncated in the event of abnormal process termination. Additionally, unlogged tables are limited by compute local disk space. Computes allocate 20 GiB of local disk space or 15 GiB x the maximum compute size (whichever is highest) for temporary files used by Postgres.
+Unlogged tables are tables that do not write to the Postgres write-ahead log (WAL). In Neon, these tables are stored on compute local storage and are not persisted across compute restarts or when a compute scales to zero. This is unlike standard Postgres, where unlogged tables are only truncated in the event of abnormal process termination. Additionally, unlogged tables are limited by compute local disk space. Computes allocate 20 GiB of local disk space or 15 GiB x the maximum compute size (whichever is highest) for temporary files used by Postgres.
 
 ## Temporary tables
 


### PR DESCRIPTION
correct `Noen` with `Neon`