### PR TITLE
feat: allow preset values in contact sales form

### DIFF
--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -3,9 +3,8 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import { yupResolver } from '@hookform/resolvers/yup';
 import clsx from 'clsx';
-import { useSearchParams } from 'next/navigation';
 import PropTypes from 'prop-types';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
@@ -65,31 +64,16 @@ const schema = yup
 
 const labelClassName = 'text-sm text-gray-new-90';
 
-const azurePresetKey = 'azure-migration';
-
-const MESSAGE_PRESETS = {
-  [azurePresetKey]: "I'd like to migrate my Azure managed account.",
-};
-
-const getDefaultMessageFromSearchParams = (searchParams) => {
-  const messageParam = searchParams?.get('message');
-  if (messageParam === azurePresetKey) return MESSAGE_PRESETS[azurePresetKey];
-  return '';
-};
+const AZURE_MIGRATION_MESSAGE = "I'd like to migrate my Azure managed account.";
 
 const ContactForm = () => {
-  const searchParams = useSearchParams();
   const [formState, setFormState] = useState(FORM_STATES.DEFAULT);
   const [isBroken, setIsBroken] = useState(false);
-
-  const defaultMessage = useMemo(
-    () => getDefaultMessageFromSearchParams(searchParams),
-    [searchParams]
-  );
 
   const {
     register,
     reset,
+    setValue,
     handleSubmit,
     formState: { isValid, errors },
   } = useForm({
@@ -97,9 +81,16 @@ const ContactForm = () => {
     defaultValues: {
       companySize: 'hidden',
       reasonForContact: 'hidden',
-      message: defaultMessage,
+      message: '',
     },
   });
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('message') === 'azure-migration') {
+      setValue('message', AZURE_MIGRATION_MESSAGE);
+    }
+  }, [setValue]);
 
   useEffect(() => {
     const hasErrors = Object.keys(errors).length > 0;


### PR DESCRIPTION
**Context**
We want to allow for certain messages to be preset in the contact-sales form based on URL parameters.

**Change Made**
This PR support one preset message for Azure deprecation.

**Test Plan**
Tested locally
<img width="1556" height="1021" alt="Screenshot 2026-02-12 at 15 43 33" src="https://github.com/user-attachments/assets/aee6bc5f-8773-42a8-89c0-908ba4775dca" />

#LKB-9471