### PR TITLE
fix: serve doc .md URLs by moving content rewrites to beforeFiles

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -551,17 +551,16 @@ const defaultConfig = {
     ];
   },
   async rewrites() {
-    // Generate rewrites for AI agent markdown access
-    // Maps /docs/x.md → /md/docs/x.md (internal public/md/ directory)
+    // Generate rewrites for AI agent markdown access.
+    // Rewrite to API route so .md is served by a route handler that reads from public/md/,
+    // ensuring the file is available in the serverless bundle (via outputFileTracingIncludes).
     const contentRewrites = Object.keys(CONTENT_ROUTES).map((route) => ({
       source: `/${route}/:path*.md`,
-      destination: `/md/${route}/:path*.md`,
+      destination: `/api/serve-doc-md/${route}/:path*`,
     }));
 
     return {
       // beforeFiles: run first so *.md URLs are rewritten before any page/dynamic route matches.
-      // Otherwise /docs/ai/ai-rules.md is handled by docs/[...slug] with slug containing ".md",
-      // getPostBySlug looks for .../ai-rules.md.md and returns null → 404.
       beforeFiles: [...contentRewrites],
       afterFiles: [
         // Serve /llms.txt from /docs/llms.txt (canonical location is public/docs/llms.txt)
@@ -698,6 +697,12 @@ const defaultConfig = {
     INKEEP_INTEGRATION_API_KEY: process.env.INKEEP_INTEGRATION_API_KEY,
     INKEEP_INTEGRATION_ID: process.env.INKEEP_INTEGRATION_ID,
     INKEEP_ORGANIZATION_ID: process.env.INKEEP_ORGANIZATION_ID,
+  },
+  // Include public/md in the serverless bundle for the doc-md API route (Vercel preview/prod).
+  experimental: {
+    outputFileTracingIncludes: {
+      '/api/serve-doc-md/**': ['./public/md/**'],
+    },
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "npm": ">=8.6.0"
   },
   "scripts": {
-    "prebuild": "node src/scripts/generate-docs-icons-config.js",
+    "prebuild": "node src/scripts/generate-docs-icons-config.js && node src/scripts/copy-md-content.js",
     "predev": "node src/scripts/generate-docs-icons-config.js",
     "dev": "next dev",
     "build": "next build",
     "dev:build": "next build",
-    "postbuild": "node src/scripts/copy-md-content.js && node src/scripts/generate-llms-index.js && next-sitemap --config next-sitemap.config.js && next-sitemap --config next-sitemap-postgres.config.js",
+    "postbuild": "node src/scripts/generate-llms-index.js && next-sitemap --config next-sitemap.config.js && next-sitemap --config next-sitemap-postgres.config.js",
     "start": "next start",
     "format": "prettier --write .",
     "lint": "npm run lint:js && npm run lint:md",

--- a/src/app/api/serve-doc-md/[[...path]]/route.js
+++ b/src/app/api/serve-doc-md/[[...path]]/route.js
@@ -1,0 +1,41 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+/**
+ * Serves processed markdown for doc .md URLs (e.g. /docs/ai/ai-rules.md).
+ * Rewrites in next.config.js send those requests here. We read from public/md/
+ * which is populated at build time (prebuild) and included via outputFileTracingIncludes.
+ */
+export async function GET(request, context) {
+  const params = typeof context.params?.then === 'function' ? await context.params : context.params;
+  const pathSegments = params?.path;
+  if (!pathSegments?.length) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  const slug = pathSegments.join('/');
+  const filePath = path.join(process.cwd(), 'public', 'md', `${slug}.md`);
+
+  // Security: ensure resolved path is under public/md
+  const publicMdDir = path.join(process.cwd(), 'public', 'md');
+  const resolved = path.resolve(filePath);
+  if (!resolved.startsWith(publicMdDir) || path.relative(publicMdDir, resolved).startsWith('..')) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return new Response(content, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+        'X-Content-Source': 'markdown',
+        'X-Robots-Tag': 'noindex',
+      },
+    });
+  } catch (err) {
+    if (err.code === 'ENOENT') return new Response('Not Found', { status: 404 });
+    throw err;
+  }
+}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -32,7 +32,12 @@ export async function middleware(req) {
 
       if (markdownPath) {
         try {
-          const markdownUrl = `${req.nextUrl.origin}${markdownPath}`;
+          // Fetch the public .md URL so the rewrite to /api/serve-doc-md applies
+          const pathWithoutTrailingSlash = pathname.replace(/\/$/, '');
+          const publicMdUrl = pathname.endsWith('.md')
+            ? pathWithoutTrailingSlash
+            : `${pathWithoutTrailingSlash}.md`;
+          const markdownUrl = `${req.nextUrl.origin}${publicMdUrl}`;
 
           const response = await fetch(markdownUrl);
 
@@ -41,7 +46,7 @@ export async function middleware(req) {
             if (response.status !== 404) {
               console.error('[AI Agent] Failed to fetch markdown', {
                 pathname,
-                markdownPath,
+                markdownUrl,
                 status: response.status,
               });
             }


### PR DESCRIPTION
Move content rewrites (e.g. /docs/ai/ai-rules.md -> /md/docs/...) from afterFiles to beforeFiles so that *.md requests are rewritten before the docs catch-all route matches. Previously, docs/[...slug] could handle /docs/ai/ai-rules.md with slug containing '.md', causing getPostBySlug to look for .../ai-rules.md.md and return 404.