### PR TITLE
chore: remove /demos/playground route

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -592,14 +592,6 @@ const defaultConfig = {
           destination: 'https://ping-thing.vercel.app/demos/ping-thing/:path*',
         },
         {
-          source: '/demos/playground',
-          destination: 'https://postgres-ai-playground.vercel.app/demos/playground',
-        },
-        {
-          source: '/demos/playground/:path*',
-          destination: 'https://postgres-ai-playground.vercel.app/demos/playground/:path*',
-        },
-        {
           source: '/developer-days/:path*',
           destination: 'https://neon-dev-days-next.vercel.app/developer-days/:path*',
         },


### PR DESCRIPTION
## Summary
- remove fallback rewrites for `/demos/playground` and `/demos/playground/:path*`
- fully stop routing website traffic to the external postgres AI playground app
- verify no remaining references to `/demos/playground` remain in the website codebase

## Test plan
- [x] Search repo for `/demos/playground` references
- [x] Confirm `next.config.js` no longer contains playground rewrite entries

Made with [Cursor](https://cursor.com)