### PR TITLE
Add Cursor plugin docs

### DIFF
--- a/content/docs/ai/ai-agents-tools.md
+++ b/content/docs/ai/ai-agents-tools.md
@@ -4,7 +4,7 @@ subtitle: AI-powered tools for development and database management
 summary: >-
   Covers the integration of AI tools with Neon for database management,
   including setup instructions, Model Context Protocol (MCP) usage, and plugins
-  for Claude Code and GitHub Copilot.
+  for Cursor, Claude Code, and GitHub Copilot.
 enableTableOfContents: true
 updatedOn: '2026-02-15T20:51:54.027Z'
 ---
@@ -36,6 +36,14 @@ If you're using Claude Code, install the Neon plugin to get Skills, MCP integrat
 
 <DetailIconCards>
 <a href="/docs/ai/ai-claude-code-plugin" description="Includes Claude Code Skills for Neon, Neon MCP integration, and context rules" icon="github">Claude Code plugin for Neon</a>
+</DetailIconCards>
+
+## Cursor plugin
+
+If you're using Cursor, install the Neon plugin to get Neon Skills and MCP integration in one package.
+
+<DetailIconCards>
+<a href="/docs/ai/ai-cursor-plugin" description="Install the Neon Cursor plugin to use Neon Skills and Neon MCP integration directly in Cursor" icon="github">Cursor plugin for Neon</a>
 </DetailIconCards>
 
 ## GitHub Copilot agents

--- a/content/docs/ai/ai-cursor-plugin.md
+++ b/content/docs/ai/ai-cursor-plugin.md
@@ -1,0 +1,67 @@
+---
+title: Cursor plugin for Neon
+summary: >-
+  Covers setup of the Neon Cursor plugin, which bundles Neon agent skills and
+  Neon MCP server access in Cursor for natural language database workflows.
+description: >-
+  Install the Neon Cursor plugin to use Neon agent skills and MCP-powered
+  database operations directly in Cursor.
+---
+
+The **Neon Cursor plugin** adds Neon-specific Skills and MCP integration to Cursor so your assistant can both reason about best practices and take database actions.
+
+It is distributed from the [Neon agent-skills repository](https://github.com/neondatabase/agent-skills) and packages:
+
+- The `neon-postgres` Skill bundle for Neon workflows
+- Neon MCP server access for project and database operations
+- Shared plugin packaging designed for both Cursor and Claude Code
+
+## Overview
+
+The plugin combines guidance and actions:
+
+- **Skills** provide workflow-level instructions for tasks like choosing a connection method, setting up ORMs, and using Neon branching patterns.
+- **MCP integration** allows tool-driven operations such as listing projects, creating branches, and running SQL through Neon APIs.
+
+Together, this gives Cursor enough context to suggest the right approach and enough capability to execute it.
+
+## What is included
+
+The Cursor plugin currently includes:
+
+- **Neon Skill bundle (`neon-postgres`)**
+- **Neon MCP server configuration** for natural language database management
+
+For plugin packaging details, see the [Cursor plugin template](https://github.com/cursor/plugin-template).
+
+## Install the plugin in Cursor
+
+1. Open Cursor chat and run:
+
+   ```text
+   /add-plugin neon-postgres
+   ```
+
+2. After installation, prompt Cursor with:
+
+   ```text
+   Get started with Neon
+   ```
+
+3. Follow the prompts to complete authentication and start using Neon Skills and MCP tools.
+
+## Use with Neon quick setup
+
+If you want Neon to configure AI tooling automatically, run:
+
+```bash
+npx neonctl@latest init
+```
+
+This configures MCP and installs Neon agent skills for supported editors.
+
+## Learn more
+
+- [Neon Agent Skills repository](https://github.com/neondatabase/agent-skills)
+- [AI Agents and Tools overview](/docs/ai/ai-agents-tools)
+- [Connect MCP clients to Neon](/docs/ai/connect-mcp-clients-to-neon)

--- a/content/docs/ai/ai-rules.md
+++ b/content/docs/ai/ai-rules.md
@@ -3,27 +3,28 @@ title: AI rules and prompts
 subtitle: Enhance your AI development experience with Neon-specific context rules
 summary: >-
   Covers the setup of AI context rules for Neon, including installation
-  instructions for the Claude Code plugin and individual context rule files for
-  other AI tools, enhancing code suggestions and reducing errors.
+  instructions for Claude Code and Cursor plugins plus individual context rule
+  files for other AI tools, enhancing code suggestions and reducing errors.
 enableTableOfContents: true
 updatedOn: '2026-02-15T20:51:54.033Z'
 ---
 
 Boost your productivity with AI context rules for Neon. These rules help AI assistants understand Neon's features, leading to more accurate code suggestions and fewer common mistakes.
 
-If you're using **Claude Code**, install the comprehensive Neon plugin that bundles Skills, MCP integration, and all context rules in one package. For other AI tools like **Cursor**, use the individual `.mdc` context rule files.
+If you're using **Claude Code** or **Cursor**, install the Neon plugin to bundle Skills and MCP integration in one package. For other AI tools, use the individual `.mdc` context rule files.
 
 <Admonition type="note" title="AI Rules are in Beta">
 AI Rules are currently in beta. We're actively improving them and would love to hear your feedback. Join us on [Discord](https://discord.gg/92vNTzKDGp) to share your experience and suggestions.
 </Admonition>
 
-## For Claude Code
+## Plugin install
 
-If you're using Claude Code, install the Neon plugin to get Skills, MCP integration, and all the context rules in one package:
+If you're using Claude Code or Cursor, install a Neon plugin to get Skills and MCP integration:
 
 <DetailIconCards>
 
 <a href="/docs/ai/ai-claude-code-plugin" description="Install the Neon Claude Code plugin to give Claude access to Neon's APIs, Postgres workflows, and built-in Skills" icon="github">Claude Code plugin for Neon</a>
+<a href="/docs/ai/ai-cursor-plugin" description="Install the Neon Cursor plugin to use Neon Skills and Neon MCP integration directly in Cursor" icon="github">Cursor plugin for Neon</a>
 
 </DetailIconCards>
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -539,6 +539,8 @@
                   slug: ai/ai-rules
                 - title: Claude Code plugin
                   slug: ai/ai-claude-code-plugin
+                - title: Cursor plugin
+                  slug: ai/ai-cursor-plugin
                 - title: GitHub Copilot agents
                   slug: ai/ai-github-copilot-agents
                 - title: Neon Auth

--- a/src/utils/llms-redirect-map.json
+++ b/src/utils/llms-redirect-map.json
@@ -2,6 +2,7 @@
   "ai-ai-agents-tools.txt": "/docs/ai/ai-agents-tools.md",
   "ai-ai-azure-notebooks.txt": "/docs/ai/ai-azure-notebooks.md",
   "ai-ai-claude-code-plugin.txt": "/docs/ai/ai-claude-code-plugin.md",
+  "ai-ai-cursor-plugin.txt": "/docs/ai/ai-cursor-plugin.md",
   "ai-ai-concepts.txt": "/docs/ai/ai-concepts.md",
   "ai-ai-database-versioning.txt": "/docs/ai/ai-database-versioning.md",
   "ai-ai-github-copilot-agents.txt": "/docs/ai/ai-github-copilot-agents.md",


### PR DESCRIPTION
## Summary
- add a new `Cursor plugin for Neon` docs page with install and usage steps based on the `neondatabase/agent-skills` plugin
- surface the new page in AI docs discovery by linking it from `AI tools for Agents` and `AI rules and prompts`
- add navigation and LLM redirect mappings for the new `ai/ai-cursor-plugin` slug

## Test plan
- [x] Review markdown/frontmatter for the new docs page
- [x] Verify links were added to both `ai-agents-tools` and `ai-rules`
- [x] Verify docs navigation includes `Cursor plugin` under AI rules & prompts
- [x] Verify `src/utils/llms-redirect-map.json` includes `ai-ai-cursor-plugin.txt`
- [x] Confirm no linter diagnostics in edited files via Cursor lints

Made with [Cursor](https://cursor.com)