### PR TITLE
docs: add llms.txt discovery headers and vary accept to doc routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -94,12 +94,6 @@ const defaultConfig = {
           },
         ],
       },
-      // Vary: Accept for content routes — set here (not middleware) because
-      // Next.js's renderer overwrites middleware Vary values during rendering.
-      ...Object.keys(CONTENT_ROUTES).map((route) => ({
-        source: `/${route}/:path*`,
-        headers: [{ key: 'Vary', value: 'Accept' }],
-      })),
       {
         source: '/blog/parsing-json-from-postgres-in-js',
         headers: [

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -84,10 +84,8 @@ export async function middleware(req) {
       }
     }
 
-    // Apply doc headers to all content route responses (.md URLs and HTML pages)
-    // Note: Vary: Accept is set in next.config.js for this path because Next.js's
-    // renderer overwrites middleware Vary values. The AI agent path above uses
-    // applyDocHeaders() which includes Vary since that response bypasses rendering.
+    // Apply doc headers to all content route responses (.md URLs and HTML pages).
+    // Vary: Accept is only set on markdown-negotiated responses (applyDocHeaders above).
     if (isContentRoute(pathname)) {
       const response = NextResponse.next();
       response.headers.set('X-LLMs-Txt', '/docs/llms.txt');


### PR DESCRIPTION
- Add X-LLMs-Txt and Link rel="llms-txt" headers to all content routes so AI agents can discover /docs/llms.txt (adopt this convention from Mintlify)
- Add Vary: Accept to Markdown responses
- Moves X-Robots-Tag: noindex for .md files into middleware

