### PR TITLE
docs: swap pg.new and neon.new URLs

### DIFF
--- a/content/docs/data-api/demo.md
+++ b/content/docs/data-api/demo.md
@@ -32,7 +32,7 @@ Before you begin, ensure you have:
 
 ### Create a Neon project with Auth and Data API
 
-1. Go to [pg.new](https://pg.new) to create a new Neon project
+1. Go to [neon.new](https://neon.new) to create a new Neon project
 2. In the Neon Console, navigate to your project and go to the **Data API** page in the left sidebar
 3. Select **Neon Auth** as your authentication option (the default), then click **Enable**
 

--- a/content/docs/guides/aws-s3.md
+++ b/content/docs/guides/aws-s3.md
@@ -19,7 +19,7 @@ This guide demonstrates how to integrate AWS S3 with Neon by storing file metada
 
 ## Create a Neon project
 
-1.  Navigate to [pg.new](https://pg.new) to create a new Neon project.
+1.  Navigate to [neon.new](https://neon.new) to create a new Neon project.
 2.  Copy the connection string by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Create an AWS account and S3 bucket

--- a/content/docs/guides/azure-blob-storage.md
+++ b/content/docs/guides/azure-blob-storage.md
@@ -18,7 +18,7 @@ This guide demonstrates how to integrate Azure Blob Storage with Neon by storing
 
 ## Create a Neon project
 
-1.  Navigate to [pg.new](https://pg.new) to create a new Neon project.
+1.  Navigate to [neon.new](https://neon.new) to create a new Neon project.
 2.  Copy the connection string by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Create an Azure account, storage account, and container

--- a/content/docs/guides/backblaze-b2.md
+++ b/content/docs/guides/backblaze-b2.md
@@ -19,7 +19,7 @@ This guide demonstrates how to integrate Backblaze B2 with Neon by storing file 
 
 ## Create a Neon project
 
-1.  Navigate to [pg.new](https://pg.new) to create a new Neon project.
+1.  Navigate to [neon.new](https://neon.new) to create a new Neon project.
 2.  Copy the connection string by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Create a Backblaze account and B2 bucket

--- a/content/docs/guides/cloudflare-r2.md
+++ b/content/docs/guides/cloudflare-r2.md
@@ -19,7 +19,7 @@ This guide demonstrates how to integrate Cloudflare R2 with Neon by storing file
 
 ## Create a Neon project
 
-1.  Navigate to [pg.new](https://pg.new) to create a new Neon project.
+1.  Navigate to [neon.new](https://neon.new) to create a new Neon project.
 2.  Copy the connection string by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Create a Cloudflare account and R2 bucket

--- a/content/docs/guides/cloudinary.md
+++ b/content/docs/guides/cloudinary.md
@@ -19,7 +19,7 @@ This guide demonstrates how to integrate Cloudinary with Neon. You'll learn how 
 
 ## Create a Neon project
 
-1.  Navigate to [pg.new](https://pg.new) to create a new Neon project.
+1.  Navigate to [neon.new](https://neon.new) to create a new Neon project.
 2.  Copy the connection string by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Create a Cloudinary account and get credentials

--- a/content/docs/guides/imagekit.md
+++ b/content/docs/guides/imagekit.md
@@ -18,7 +18,7 @@ This guide demonstrates how to integrate ImageKit.io with Neon. You'll learn how
 
 ## Create a Neon project
 
-1.  Navigate to [pg.new](https://pg.new) to create a new Neon project.
+1.  Navigate to [neon.new](https://neon.new) to create a new Neon project.
 2.  Copy the connection string by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Create an ImageKit.io account and get credentials

--- a/content/docs/guides/platform-integration-overview.md
+++ b/content/docs/guides/platform-integration-overview.md
@@ -77,7 +77,7 @@ Use this approach when you want to create databases for your users without requi
 
 - [TanStack](https://neon.com/blog/neon-joins-tanstack-instant-postgres-integration-for-faster-javascript-development): Official database partner offering instant Postgres through their Vite plugin and create-tanstack CLI
 - [Netlify DB](https://www.netlify.com/blog/netlify-db-database-for-ai-native-development/): One-click Postgres databases for Netlify projects, built on the claimable database flow
-- [Instagres](https://neon.new/): Try instant Postgres provisioning without signup using `npx get-db` or at [neon.new](https://neon.new/)
+- [Instagres](https://pg.new/): Try instant Postgres provisioning without signup using `npx get-db` or at [pg.new](https://pg.new/)
 
 <DetailIconCards>
 

--- a/content/docs/guides/tanstack-start.md
+++ b/content/docs/guides/tanstack-start.md
@@ -59,7 +59,7 @@ Add a `.env` file to your project directory and add your Neon connection string 
 DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech:<port>/<dbname>?sslmode=require&channel_binding=require"
 ```
 
-If you haven't created a database yet, run the following command to generate a [Neon Instagres DB](https://neon.new/). It will spin up a database instance that you can use for 72 hours, or claim to keep forever.
+If you haven't created a database yet, run the following command to generate a [Neon Instagres DB](https://pg.new/). It will spin up a database instance that you can use for 72 hours, or claim to keep forever.
 
 <CodeTabs labels={["npm", "yarn", "pnpm", "bun", "deno"]}>
 

--- a/content/docs/guides/uploadcare.md
+++ b/content/docs/guides/uploadcare.md
@@ -18,7 +18,7 @@ This guide demonstrates how to integrate Uploadcare with Neon by storing file me
 
 ## Create a Neon project
 
-1. Navigate to [pg.new](https://pg.new) to create a new Neon project.
+1. Navigate to [neon.new](https://neon.new) to create a new Neon project.
 2. Copy the connection string by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 ## Create an Uploadcare account and project

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -37,7 +37,7 @@ To create a Neon project:
 After creating a project, you are directed to the **Project Dashboard**.
 
 <Admonition type="tip">
-You can also use [pg.new](https://pg.new) to create a new Neon Postgres project. Simply visit [pg.new](https://pg.new) and you'll be taken directly to the **Create project** page where you can create your new project.
+You can also use [neon.new](https://neon.new) to create a new Neon Postgres project. Simply visit [neon.new](https://neon.new) and you'll be taken directly to the **Create project** page where you can create your new project.
 </Admonition>
 
 ## View projects

--- a/content/docs/reference/instagres.md
+++ b/content/docs/reference/instagres.md
@@ -15,7 +15,7 @@ Instagres gives you an instant Postgres database with a single API call. No acco
 
 Your database expires after 72 hours unless you claim it to your Neon account. Databases are provisioned on AWS us-east-2 running Postgres 17.
 
-Access it at [instagres.com](https://instagres.com/) or [neon.new](https://neon.new/).
+Access it at [instagres.com](https://instagres.com/) or [pg.new](https://pg.new/).
 
 ## Quick start
 

--- a/content/docs/shared-content/neon-auth-sdk-shared/get-started.md
+++ b/content/docs/shared-content/neon-auth-sdk-shared/get-started.md
@@ -10,7 +10,7 @@ Neon Auth lets you add authentication to your app in seconds — user data is sy
 
 ## Add Neon Auth to a project
 
-Go to [pg.new](https://pg.new) to create a new Neon project.
+Go to [neon.new](https://neon.new) to create a new Neon project.
 
 Once your project is ready, open your project's **Auth** page and click **Enable Neon Auth** to get started.
 

--- a/content/docs/workflows/claimable-database-integration.md
+++ b/content/docs/workflows/claimable-database-integration.md
@@ -238,7 +238,7 @@ Without the `org_id` parameter, the project transfers to the user's personal acc
 - **Demo environments** - Create ready-to-use demo databases that prospects can claim
 - **Team environments** - Provision project databases for team members to claim into their organization
 
-For a working implementation of claimable databases, try [Instagres](https://neon.new/). This service demonstrates the complete flow: users receive a Postgres connection string immediately without creating an account, and databases remain active for 72 hours. To retain the database beyond this period, users claim it by creating a Neon account using the provided transfer URL. See the [Instagres documentation](/docs/reference/instagres) for implementation details. This same pattern enables SaaS providers to offer instant database provisioning while allowing users to take ownership when ready.
+For a working implementation of claimable databases, try [Instagres](https://pg.new/). This service demonstrates the complete flow: users receive a Postgres connection string immediately without creating an account, and databases remain active for 72 hours. To retain the database beyond this period, users claim it by creating a Neon account using the provided transfer URL. See the [Instagres documentation](/docs/reference/instagres) for implementation details. This same pattern enables SaaS providers to offer instant database provisioning while allowing users to take ownership when ready.
 
 ## Troubleshooting
 

--- a/content/guides/admin-dashboard-neon-auth.md
+++ b/content/guides/admin-dashboard-neon-auth.md
@@ -28,7 +28,7 @@ Before you begin, ensure you have the following:
 
 You'll need to create a Neon project and enable Neon Auth.
 
-1.  **Create a Neon project:** Navigate to [pg.new](https://pg.new) to create a new Neon project. Give your project a name, such as `admin-dashboard-demo`.
+1.  **Create a Neon project:** Navigate to [neon.new](https://neon.new) to create a new Neon project. Give your project a name, such as `admin-dashboard-demo`.
 2.  **Enable Neon Auth:**
     - In your project's dashboard, go to the **Neon Auth** tab.
     - Click on the **Enable Neon Auth** button to set up authentication for your project.

--- a/content/guides/cline-mcp-neon.md
+++ b/content/guides/cline-mcp-neon.md
@@ -44,7 +44,7 @@ Before you begin, ensure you have the following:
 1.  **Cline extension and Setup:**
     - Download and install the Cline VS Code extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev).
     - Set up Cline by following the [Getting Started guide](https://docs.cline.bot/getting-started/getting-started-new-coders#setting-up-openrouter-api-key) which involves obtaining an [OpenRouter API key](https://openrouter.ai) to work with Cline.
-2.  **A Neon Account and Project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [pg.new](https://pg.new)
+2.  **A Neon Account and Project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [neon.new](https://neon.new)
 3.  **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/profile). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
     <Admonition type="warning" title="Neon API Key Security">
     Keep your Neon API key secure, and never share it publicly. It provides access to your Neon projects.

--- a/content/guides/convex-neon.md
+++ b/content/guides/convex-neon.md
@@ -38,7 +38,7 @@ Before you begin, ensure you have the following prerequisites installed and conf
 
 ## Setting up Neon Database
 
-To get started with your Postgres database, create a new Neon project using [pg.new](https://pg.new). This project will provide the Postgres instance that Convex will use to store your application data. Within this Neon project, you'll need to create a database named `convex_self_hosted` – this is the specific database Convex is configured to use for storing chat messages. Follow these steps to set up your Neon Postgres database:
+To get started with your Postgres database, create a new Neon project using [neon.new](https://neon.new). This project will provide the Postgres instance that Convex will use to store your application data. Within this Neon project, you'll need to create a database named `convex_self_hosted` – this is the specific database Convex is configured to use for storing chat messages. Follow these steps to set up your Neon Postgres database:
 
 - Navigate to the [SQL Editor](/docs/get-started/query-with-neon-sql-editor) in your Neon project console to create the `convex_self_hosted` database.
 - Execute the following SQL command to create the database:

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -42,7 +42,7 @@ You have two options for connecting Cursor to the Neon MCP Server:
 Before you begin, ensure you have the following:
 
 1. **Cursor Editor:** Download and install Cursor from [cursor.com](https://cursor.com).
-2. **A Neon Account and Project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [pg.new](https://pg.new)
+2. **A Neon Account and Project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [neon.new](https://neon.new)
 3. **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
 
    <Admonition type="important" title="Neon API Key Security">

--- a/content/guides/dbeaver-hosted-postgres.md
+++ b/content/guides/dbeaver-hosted-postgres.md
@@ -23,7 +23,7 @@ DBeaver is a versatile database management tool that allows you to interact with
 
 ## Provisioning a Serverless Postgres
 
-1. To get started, go to the the [Neon Console](https://console.neon.tech/) or [pg.new](https://pg.new/) and create a new project by entering a project name of your choice.
+1. To get started, go to the the [Neon Console](https://console.neon.tech/) or [neon.new](https://neon.new/) and create a new project by entering a project name of your choice.
 
 2. Retrieve connection details for your Neon Postgres database:
    - Navigate to the **Dashboard** of your Neon project.

--- a/content/guides/dbvisualizer-neon-postgres.md
+++ b/content/guides/dbvisualizer-neon-postgres.md
@@ -23,7 +23,7 @@ DbVisualizer is a universal SQL client and database‑management tool that provi
 
 ## Create a Neon Postgres Database
 
-1. If you haven't already, create a new Neon project. You can use the [Neon Console](https://console.neon.tech/) or [pg.new](https://pg.new/).
+1. If you haven't already, create a new Neon project. You can use the [Neon Console](https://console.neon.tech/) or [neon.new](https://neon.new/).
 
 2. Retrieve connection details for your Neon Postgres database:
    - Navigate to the **Dashboard** of your Neon project.

--- a/content/guides/electric-sql.md
+++ b/content/guides/electric-sql.md
@@ -30,7 +30,7 @@ Before you begin, ensure you have the following prerequisites installed and conf
 
 ElectricSQL requires a Postgres database with logical replication enabled. You'll configure your Neon project accordingly.
 
-1.  **Create a Neon Project:** If you haven't already, create a new Neon project. You can use the Neon Console or [pg.new](https://pg.new).
+1.  **Create a Neon Project:** If you haven't already, create a new Neon project. You can use the Neon Console or [neon.new](https://neon.new).
 2.  **Enable Logical Replication:** ElectricSQL uses Postgres logical replication (`wal_level = logical`) to receive changes from your database.
     - Navigate to your Neon Project in the [Neon Console](https://console.neon.tech/).
     - Open the **Settings** menu.

--- a/content/guides/hasura-dynamic-routing-with-neon.md
+++ b/content/guides/hasura-dynamic-routing-with-neon.md
@@ -16,7 +16,7 @@ This guide demonstrates how to combine the power of [Neon's database branching](
 Before you start, ensure you have the following:
 
 - **A Neon Account:** Sign up for a free Neon account at [neon.tech](https://console.neon.tech/signup).
-- **A Neon Project:** You need to have a Neon project. If you do not have one, create it via [pg.new](https://pg.new)
+- **A Neon Project:** You need to have a Neon project. If you do not have one, create it via [neon.new](https://neon.new)
 - **A Hasura Instance:** A running Hasura instance (v2.x or later). This can be Hasura Cloud Professional or Enterprise tiers, or a self-hosted Enterprise instance. Dynamic routing is not available in the free tier.
 
 ## Understanding the core concepts

--- a/content/guides/metabase-neon.md
+++ b/content/guides/metabase-neon.md
@@ -23,7 +23,7 @@ By the end of this guide, you'll have a fully functional Metabase setup connecte
 
 To follow along with this guide, you'll need the following:
 
-- **Neon account and project:** A Neon account with a project containing a running Postgres database. You can create one at [pg.new](https://pg.new).
+- **Neon account and project:** A Neon account with a project containing a running Postgres database. You can create one at [neon.new](https://neon.new).
 - **Metabase instance:** You can use [Metabase Cloud](https://www.metabase.com/cloud/), run Metabase locally via [Docker](/docs/guides/metabase-neon#option-2-run-metabase-locally), or deploy to your preferred hosting platform. This guide covers both Metabase Cloud and local Docker setups.
 
 <Admonition type="important" title="Latency Considerations">

--- a/content/guides/n8n-neon.md
+++ b/content/guides/n8n-neon.md
@@ -17,7 +17,7 @@ Before you begin, ensure you have the following:
 
 - **n8n Instance:** A running n8n instance. This can be a [self-hosted](https://docs.n8n.io/hosting/) version or an [n8n cloud account](https://app.n8n.cloud).
 - **Google Account:** A Google account with access to Google Drive.
-- **Neon Account and Project:** A Neon account and a project are needed to create a Postgres database. You can sign up for a free account at [pg.new](https://pg.new).
+- **Neon Account and Project:** A Neon account and a project are needed to create a Postgres database. You can sign up for a free account at [neon.new](https://neon.new).
 - **Google Cloud Platform (GCP) Account:** A [GCP account](https://cloud.google.com/free) is needed to enable the Google Drive API and to manage OAuth credentials. Free tier accounts are sufficient for this guide.
 - **Google Gemini API key:** You'll need an API key for Google Gemini to generate embeddings and power the chat model. You can obtain this from [Google AI Studio](https://aistudio.google.com/apikey).
   ![Google Gemini API Key](/docs/guides/gemini-api-key.png)

--- a/content/guides/neon-auth-nextjs.md
+++ b/content/guides/neon-auth-nextjs.md
@@ -26,7 +26,7 @@ Before you begin, ensure you have the following:
 
 You'll need to create a Neon project and enable Neon Auth.
 
-1.  **Create a Neon project:** Navigate to [pg.new](https://pg.new) to create a new Neon project. Give your project a name, such as `next-neon-todo`.
+1.  **Create a Neon project:** Navigate to [neon.new](https://neon.new) to create a new Neon project. Give your project a name, such as `next-neon-todo`.
 2.  **Enable Neon Auth:**
     - In your project's dashboard, go to the **Neon Auth** tab.
     - Click on the **Enable Neon Auth** button to set up authentication for your project.

--- a/content/guides/pgroll.md
+++ b/content/guides/pgroll.md
@@ -119,7 +119,7 @@ Now that you understand the basics, let's dive into using `pgroll` for schema mi
 ### Prerequisites
 
 - **`pgroll` CLI installed**: Follow the [installation instructions](#step-1-installation) below.
-- **Neon Account and Project**: A Neon account and a project with a running Postgres database. You can create a free Neon account and project at [pg.new](https://pg.new).
+- **Neon Account and Project**: A Neon account and a project with a running Postgres database. You can create a free Neon account and project at [neon.new](https://neon.new).
 
 ### Step 1: Installation
 

--- a/content/guides/react-neon-auth-hono.md
+++ b/content/guides/react-neon-auth-hono.md
@@ -32,7 +32,7 @@ Before you begin, ensure you have the following:
 
 You'll need to create a Neon project and enable Neon Auth.
 
-1.  **Create a Neon project:** Navigate to [pg.new](https://pg.new) to create a new Neon project. Give your project a name, such as `journal-app`.
+1.  **Create a Neon project:** Navigate to [neon.new](https://neon.new) to create a new Neon project. Give your project a name, such as `journal-app`.
 2.  **Enable Neon Auth:**
     - In your project's dashboard, go to the **Neon Auth** tab.
     - Click on the **Enable Neon Auth** button to set up authentication for your project.

--- a/content/guides/windsurf-mcp-neon.md
+++ b/content/guides/windsurf-mcp-neon.md
@@ -42,7 +42,7 @@ You have two options for connecting Windsurf to the Neon MCP Server:
 Before you begin, ensure you have the following:
 
 1.  **Codeium Windsurf Editor:** Download and install Windsurf from [codeium.com/windsurf](https://codeium.com/windsurf).
-2.  **A Neon Account and Project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [pg.new](https://pg.new)
+2.  **A Neon Account and Project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [neon.new](https://neon.new)
 3.  **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
 
     <Admonition type="important" title="Neon API Key Security">

--- a/content/guides/zapier-neon.md
+++ b/content/guides/zapier-neon.md
@@ -22,7 +22,7 @@ Before you begin, ensure you have the following:
 
 - **Zapier Account:** A Zapier account is required to create and manage Zaps. Please note that the PostgreSQL integration is a Pro feature on Zapier and requires a [paid plan](https://zapier.com/pricing).
 
-* **Neon Account and Project:** A Neon account and a project with a running Postgres database. You can create a free Neon account and project at [pg.new](https://pg.new).
+* **Neon Account and Project:** A Neon account and a project with a running Postgres database. You can create a free Neon account and project at [neon.new](https://neon.new).
 * **Database tables (for examples):** For the examples in this guide, we'll be using the following tables to demonstrate the functionality. Create these tables in your Neon database if you intend to follow along:
   - A table named `users` to demonstrate triggering actions from new rows.
   - A table named `form_submissions` to demonstrate adding data from an external source.

--- a/content/guides/zed-mcp-neon.md
+++ b/content/guides/zed-mcp-neon.md
@@ -32,7 +32,7 @@ You have two options for connecting Zed to the Neon MCP Server:
 Before you begin, ensure you have the following:
 
 1.  **Zed editor:** Download and install Zed from [zed.dev](https://zed.dev/download).
-2.  **A Neon account and project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [pg.new](https://pg.new)
+2.  **A Neon account and project:** You'll need a Neon account and a project. You can quickly create a new Neon project here [neon.new](https://neon.new)
 3.  **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
 
     <Admonition type="warning" title="Neon API Key Security">

--- a/content/guides/zero.md
+++ b/content/guides/zero.md
@@ -28,7 +28,7 @@ Before you begin, ensure you have the following prerequisites installed and conf
 
 Zero requires a Postgres database (version 15+) with logical replication enabled. You'll configure your Neon project accordingly.
 
-1.  **Create a Neon Project:** If you haven't already, create a new Neon project using [pg.new](https://pg.new).
+1.  **Create a Neon Project:** If you haven't already, create a new Neon project using [neon.new](https://neon.new).
 2.  **Enable Logical Replication:** Zero uses Postgres logical replication (`wal_level = logical`) to receive changes from your database.
     - Navigate to your Neon Project using the [Neon Console](https://console.neon.tech/).
     - Open the **Settings** menu.

--- a/content/pages/use-cases/ai-agents.md
+++ b/content/pages/use-cases/ai-agents.md
@@ -104,4 +104,4 @@ For instructions on using the Neon API to provision and manage backends on behal
 
 To learn more about the Agent Plan, [see the details on this page](https://neon.com/programs/agents#agent-plan-pricing) or [fill out the application form directly, at the top of this page](#agent-form).
 
-<CTA title="Prefer a claimable flow?" description="You can also allow your end-users to deploy a Neon database in seconds, use it immediately via connection string, claim it later." theme="column" buttonText="Explore this route" buttonUrl="https://neon.new/" linkText="See a case study" linkUrl="https://neon.com/blog/netlify-db-powered-by-neon" />
+<CTA title="Prefer a claimable flow?" description="You can also allow your end-users to deploy a Neon database in seconds, use it immediately via connection string, claim it later." theme="column" buttonText="Explore this route" buttonUrl="https://pg.new/" linkText="See a case study" linkUrl="https://neon.com/blog/netlify-db-powered-by-neon" />

--- a/next.config.js
+++ b/next.config.js
@@ -402,12 +402,12 @@ const defaultConfig = {
       },
       {
         source: '/launchpad',
-        destination: 'https://neon.new',
+        destination: 'https://pg.new',
         permanent: false,
       },
       {
         source: '/instagres',
-        destination: 'https://neon.new',
+        destination: 'https://pg.new',
         permanent: false,
       },
       {

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -112,5 +112,5 @@ export default {
   apiReference: 'https://api-docs.neon.tech/reference/getting-started-with-neon-api',
   bugBounty: 'https://hackerone.com/neon_bbp',
   bookMeeting: 'https://calendly.com/d/cm8j-8yw-fq8',
-  instagres: 'https://neon.new/',
+  instagres: 'https://pg.new/',
 };


### PR DESCRIPTION
They switched roles. Skipped old release notes for now. Updating instagres.com references also comes later, but it continues to function.