### PR TITLE
fix: autoscalingChart component width

### DIFF
--- a/content/pages/autoscaling-report.md
+++ b/content/pages/autoscaling-report.md
@@ -119,7 +119,7 @@ The average production database running on Neon adjusts its compute size 32,016 
 
 Here is a detailed price comparison for a real Neon customer with a production workload.
 
-<AutoscalingChart title="Production. Autoscaling vs Provisioned (RDS)" datasetKey="predictable_fluctuation" width="window" autoscalingRate={0.222} />
+<AutoscalingChart title="Production. Autoscaling vs Provisioned (RDS)" datasetKey="predictable_fluctuation" autoscalingRate={0.222} />
 
 The results: <span className="bg-secondary-1/20 text-secondary-1 p-1">Provisioned uses 3.5x more compute</span> to serve the same workload, because much of the time only a fraction of allocated resources are being used. Translating that to costs, this workload incurs <span className="bg-green-45/20 text-green-45 p-1">60% lower cost on Neon</span> thanks to autoscaling. We're using the `$0.222/CU-hour` rate from the Neon Scale plan _recommended for businesses_ and a conservative `$0.1/CU-hour` rate for provisioned instances like RDS.
 
@@ -225,7 +225,7 @@ Scale to zero changes the equation on what types of database usage patterns are 
 
 Here is an actual autoscaling history from a scale-to-zero database on Neon:
 
-<AutoscalingChart title="Fig. 3a: Scale-to-Zero workload. Neon vs Provisioned" datasetKey="scale_to_zero" width="window" autoscalingRate={0.106} overprovision={0} compact={true} fixedRate={0.065}  />
+<AutoscalingChart title="Fig. 3a: Scale-to-Zero workload. Neon vs Provisioned" datasetKey="scale_to_zero" autoscalingRate={0.106} overprovision={0} compact={true} fixedRate={0.065}  />
 
 Because of how often this database goes idle and scales to zero, this exact workload only uses 25 CU-hours/month on Neon.
 (Because it is running at 0.25 CU when it's on, that means it's active for 100 hours per month.)

--- a/src/components/shared/autoscaling-chart/autoscaling-chart.jsx
+++ b/src/components/shared/autoscaling-chart/autoscaling-chart.jsx
@@ -678,17 +678,11 @@ const AutoscalingChart = ({
   };
 
   return (
-    <div
-      ref={containerRef}
-      className={clsx(
-        'text-gray-200 not-prose',
-        width === 'window' ? 'relative left-[50%] z-10 w-[90vw] -translate-x-1/2' : 'w-full'
-      )}
-    >
+    <div ref={containerRef} className={clsx('text-gray-200 not-prose w-full')}>
       <div className="border border-gray-new-30 bg-gray-new-8">
         <div className={clsx(compact ? 'p-6' : 'p-8')}>
           {/* Header with controls */}
-          <div className="relative mb-4">
+          <div className="mb-4 flex flex-col gap-3">
             <h1
               className={clsx(
                 'text-center font-mono font-medium text-white',
@@ -699,7 +693,7 @@ const AutoscalingChart = ({
               {displayTitle}
             </h1>
             {!autoscalingOnly && showOverprovisionSelector && (
-              <div className="absolute right-0 top-0 flex items-center gap-2.5 sm:relative">
+              <div className="flex items-center justify-center gap-2.5">
                 <select
                   value={provisioningStrategy}
                   className="border-gray-700 bg-gray-800 text-gray-200 hover:border-gray-600 hover:bg-gray-700 border px-4 py-2 font-mono text-sm transition-all focus:border-[#73bf69] focus:outline-none"


### PR DESCRIPTION
This PR brings layout updates for AutoscalingChart component

Before
<img width="772" height="505" alt="image" src="https://github.com/user-attachments/assets/c4540567-0bdf-4dc3-a50c-0ef64aa406e9" />

After
<img width="769" height="606" alt="image" src="https://github.com/user-attachments/assets/0656d6c4-bded-4dbf-a6ee-ff2678b8dcb8" />
