### PR TITLE
fix: trim trailing space

### DIFF
--- a/src/components/pages/case-studies/hero/hero.jsx
+++ b/src/components/pages/case-studies/hero/hero.jsx
@@ -56,10 +56,10 @@ const FeaturedCard = ({
         <figure className="w-full">
           {quote && (
             <>
-              <blockquote className="before:content-['“'] after:content-['”']">
-                <p
-                  className="inline text-pretty text-lg font-light leading-snug tracking-extra-tight text-white sm:text-base [&_p]:inline"
-                  dangerouslySetInnerHTML={{ __html: `${quote}` }}
+              <blockquote>
+                <div
+                  className="inline text-pretty text-lg font-light leading-snug tracking-extra-tight text-white before:content-['“'] after:content-['”'] sm:text-base [&_p]:inline"
+                  dangerouslySetInnerHTML={{ __html: `${quote.trim()}` }}
                 />
               </blockquote>
               {author && author.name && (


### PR DESCRIPTION
This PR brings fixes for trailing space in case studies cards

[Preview](https://neon-next-git-case-studies-fix-pixelpoint.vercel.app/case-studies)

Before
<img width="1061" height="841" alt="image" src="https://github.com/user-attachments/assets/a99f9158-641b-432b-86ad-524ff0d71fda" />

After
<img width="1055" height="795" alt="image" src="https://github.com/user-attachments/assets/22d94e5d-74dd-4070-8f8c-3e381f5e8471" />
