### PR TITLE
fix: links and hover zones & minor cta offset rework

### DIFF
--- a/src/app/about-us/page.jsx
+++ b/src/app/about-us/page.jsx
@@ -19,6 +19,7 @@ const AboutUsPage = () => (
     <Developers />
     <Connections />
     <CTANew
+      className="mt-0"
       title="Become a part of our&nbsp;team"
       description="We're looking for people who care deeply about quality to build with us."
       buttonText="View Open Roles on Databricks Careers Site"

--- a/src/components/pages/about/timeline/timeline.jsx
+++ b/src/components/pages/about/timeline/timeline.jsx
@@ -59,46 +59,52 @@ const Timeline = () => (
       <div className="no-scrollbars w-full sm:-mx-5 sm:-mt-2 sm:w-screen sm:overflow-x-auto sm:pb-2">
         <div className="relative h-[284px] w-full xl:h-[264px] lg:h-64 md:h-[189px] md:min-w-[545px] sm:mx-5">
           <ol className="grid h-full w-full grid-cols-[repeat(5,minmax(0,243fr))_320fr] xl:grid-cols-[repeat(5,minmax(0,152fr))_200fr] lg:grid-cols-[repeat(5,minmax(0,112fr))_147fr] md:grid-cols-[repeat(5,minmax(0,86fr))_114fr]">
-            {ITEMS.map((item, index) => {
-              const Wrapper = item.link ? Link : 'div';
-              const wrapperProps = item.link ? { to: item.link, isExternal: item.isExternal } : {};
-
-              return (
-                <li
-                  key={index}
+            {ITEMS.map((item, index) => (
+              <li
+                key={index}
+                className={clsx(
+                  '-ml-px border-l border-gray-new-30',
+                  index % 2 === 0 ? 'self-end' : 'self-start'
+                )}
+              >
+                <div
                   className={clsx(
-                    '-ml-px border-l border-gray-new-30',
-                    index % 2 === 0 ? 'self-end' : 'self-start'
+                    'relative flex h-[170px] flex-col gap-y-2.5 pl-[18px] xl:h-40 xl:gap-y-2 xl:pl-4 lg:h-[150px] md:h-[110px] md:gap-y-1.5 md:pl-3.5',
+                    index % 2 === 0 && 'justify-end'
                   )}
                 >
-                  <Wrapper
-                    className={clsx(
-                      'flex h-[170px] flex-col gap-y-2.5 pl-[18px] xl:h-40 xl:gap-y-2 xl:pl-4 lg:h-[150px] md:h-[110px] md:gap-y-1.5 md:pl-3.5',
-                      index % 2 === 0 && 'justify-end',
-                      item.link && 'group'
-                    )}
-                    {...wrapperProps}
+                  <time
+                    dateTime={item.dateTime}
+                    className="whitespace-nowrap font-mono text-base font-normal leading-none tracking-extra-tight text-gray-new-50 xl:text-sm md:text-xs"
                   >
-                    <time
-                      dateTime={item.dateTime}
-                      className="whitespace-nowrap font-mono text-base font-normal leading-none tracking-extra-tight text-gray-new-50 no-underline xl:text-sm md:text-xs"
+                    {item.date}
+                  </time>
+                  {item.link ? (
+                    <Link
+                      className={clsx(
+                        'text-xl font-normal leading-snug tracking-extra-tight text-white xl:text-lg md:text-[15px]',
+                        'underline decoration-white/40 decoration-dashed decoration-1 underline-offset-[6px] transition-[text-decoration-color] duration-200 hover:decoration-white md:hover:decoration-white/40',
+                        'md:after:absolute md:after:inset-0',
+                        index !== ITEMS.length - 1 && 'whitespace-nowrap'
+                      )}
+                      to={item.link}
+                      isExternal={item.isExternal}
                     >
-                      {item.date}
-                    </time>
+                      {item.title}
+                    </Link>
+                  ) : (
                     <p
                       className={clsx(
                         'text-xl font-normal leading-snug tracking-extra-tight text-white xl:text-lg md:text-[15px]',
-                        item.link &&
-                          'underline decoration-white/40 decoration-dashed decoration-1 underline-offset-[6px] transition-colors duration-200 group-hover:decoration-white',
                         index !== ITEMS.length - 1 && 'whitespace-nowrap'
                       )}
                     >
                       {item.title}
                     </p>
-                  </Wrapper>
-                </li>
-              );
-            })}
+                  )}
+                </div>
+              </li>
+            ))}
           </ol>
           <Image
             className="absolute bottom-[114px] -z-10 h-14 w-full object-fill xl:bottom-[104px] lg:bottom-[106px] lg:h-11 md:bottom-[79px] md:h-8"

--- a/src/components/shared/cta-new/cta-new.jsx
+++ b/src/components/shared/cta-new/cta-new.jsx
@@ -24,7 +24,7 @@ const CONTACT_SALES_AI_SETTINGS = {
 };
 
 const CTANew = ({
-  className,
+  className = 'mt-[183px] xl:mt-[168px] lg:mt-[145px] md:mt-[90px]',
   copyWrapperClassName = null,
   title = "The world's most advanced <br /> Postgres platform.",
   description = null,
@@ -33,12 +33,7 @@ const CTANew = ({
   buttonUrl = LINKS.signup,
   buttonType = null,
 }) => (
-  <section
-    className={clsx(
-      'cta safe-paddings relative mt-[183px] bg-[#151617] xl:mt-[168px] lg:mt-[145px] md:mt-[90px]',
-      className
-    )}
-  >
+  <section className={clsx('cta safe-paddings relative bg-[#151617]', className)}>
     <div className="absolute inset-0 z-10">
       <Container className="top-1/2 -translate-y-1/2" size="1920">
         <SectionLabel className="text-gray-new-80 sm:mb-4">{label}</SectionLabel>


### PR DESCRIPTION
This PR brings:

- Fixes timeline link interaction by moving to explicit Link rendering and improving hover/tap hit area on md screens.
- Keeps timeline text behavior consistent while preserving layout.
- Adjusts spacing for the final CTA section on About Us by making CTA top margin configurable and explicitly setting it to mt-0 on this page.

Affected:

- src/components/pages/about/timeline/timeline.jsx
- src/components/shared/cta-new/cta-new.jsx
- src/app/about-us/page.jsx