### PR TITLE
Switch PostgreSQL Joins tutorial to teams/players

### DIFF
--- a/content/postgresql/postgresql-tutorial/postgresql-joins.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-joins.md
@@ -110,7 +110,7 @@ FROM
 INNER JOIN players
     ON teams.id = players.team_id;
 ```
-
+**Note:** It is common practice to use `JOIN` as shorthand for `INNER JOIN`.
 Output:
 
 ```text


### PR DESCRIPTION
Hi, thanks for hosting this PostgreSQL Tutorial content, that's great!

And thanks for creating the new diagrams - after some consideration, I think they are better than the Venn-style diagrams that were there before.

In my teaching at [UpLeveled](https://upleveled.io), I have found that teaching joins with 2 real tables with multiple columns is easier to grasp than 2 tables which are named `_1` and `_2` or `_a` and `_b` (which is not common in most database schemas).

In this PR, I:

- [x] Update the tables `basket_a` and `basket_b` to become `teams` and `players`
- [x] Switch from joining on the fruit name to joining on `team.id = players.team_id`, to show a more realistic scenario using a primary key
- [x] Add additional fields, to drive the point home better
- [x] Use short column names to keep the examples compact

AI disclosure: I guided ChatGPT 5.2 Extended Thinking to carefully make this update

cc @ruf-io 