### PR TITLE
docs: config-driven llms.txt with tiered sub-indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,7 @@ public/robots.txt
 
 # ignore generated markdown/llms files
 public/md
-public/docs/llms.txt
-public/llms
+public/docs/**/llms.txt
 
 # Mac files
 .DS_Store

--- a/next.config.js
+++ b/next.config.js
@@ -549,6 +549,9 @@ const defaultConfig = {
     }));
 
     return {
+      // beforeFiles: resolve sub-index llms.txt files from public/ before the
+      // docs/[...slug] catch-all intercepts them (known Next.js behavior)
+      beforeFiles: [{ source: '/docs/:path*/llms.txt', destination: '/docs/:path*/llms.txt' }],
       // afterFiles: runs after checking pages/public files but before dynamic routes
       // This ensures physical .md files are served first, with fallback to public/md/
       afterFiles: [

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -16,38 +16,64 @@
  */
 
 module.exports = {
+  tagline:
+    "Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.",
+
   intro: [
     'Neon docs are available as markdown.',
     'Append `.md` to any doc URL or set `Accept: text/markdown`.',
-    'This index lists all available pages.',
+    'This is the primary index. Sections with many pages show key pages and link to full sub-indexes.',
   ].join(' '),
 
   // Sections in display order. Unlisted sections append alphabetically at the end.
   //   name:        must match the derived section name (from directory path or route key)
   //   description: optional text below the ## heading (omit for no description)
-  //   collapse:    optional; replaces all entries with one link { title, url, description }
+  //   collapse:         optional; replaces all entries with one link { title, url, description }
+  //   subIndex:         optional; moves full listing to a separate file, shows only highlights inline
+  //                     { outputPath, url, highlights: ['path/to/file.md', ...] }
+  //   subsectionOrder:        optional; explicit ordering for subsections (unlisted ones sort alphabetically after)
+  //   subsectionDescriptions: optional; { 'Subsection Name': 'description text' }
+  //   extraEntries:           optional; static entries appended to the section [{ title, url, description }]
   sections: [
-    {
-      name: 'Get Started',
-      description: 'Sign up, connect your first app, and learn the basics.',
-    },
     {
       name: 'Introduction',
       description: 'Architecture, features, autoscaling, branching concepts, billing, and plans.',
+      subIndex: {
+        outputPath: 'public/docs/introduction/llms.txt',
+        url: 'https://neon.com/docs/introduction/llms.txt',
+        highlights: [
+          'introduction/architecture-overview.md',
+          'introduction/about-billing.md',
+          'introduction/autoscaling.md',
+          'introduction/scale-to-zero.md',
+          'introduction/branching.md',
+          'introduction/read-replicas.md',
+        ],
+      },
+    },
+    {
+      name: 'Get Started',
+      description:
+        'First-time setup: org/project creation, connection strings, driver installation, optional auth, and initial schema setup.',
     },
     {
       name: 'Connect',
-      description: 'Drivers, connection strings, pooling, latency, and troubleshooting.',
-    },
-    { name: 'AI' },
-    {
-      name: 'Auth',
-      description: 'Managed authentication built on Better Auth that branches with your database.',
+      description: 'Drivers, connection strings, pooling, local dev tooling, and troubleshooting.',
     },
     {
       name: 'Neon CLI',
       description:
-        'Install: `npm i -g neonctl`. Manage projects, branches, databases, and roles from the terminal.',
+        'Install: `npm i -g neonctl`. Use this for terminal-first workflows, scripts, and CI/CD automation with `neonctl`.',
+    },
+    {
+      name: 'AI',
+      description:
+        'AI rules, MCP integrations, vector search, and tools for building AI-powered applications with Neon.',
+    },
+    {
+      name: 'Auth',
+      description: 'Managed authentication built on Better Auth that branches with your database.',
+      subsectionOrder: ['Quick Start', 'Reference', 'Guides', 'Migrate'],
     },
     {
       name: 'Data API',
@@ -58,23 +84,83 @@ module.exports = {
       description:
         'Instant copy-on-write database environments for dev, CI, previews, and recovery.',
     },
-    { name: 'Guides' },
     {
-      name: 'Import',
-      collapse: {
-        title: 'Neon data migration guides',
-        url: 'https://neon.com/docs/import/migrate-intro.md',
-        description:
-          'Choose a migration method by size, downtime tolerance, and source (Postgres, MySQL, MSSQL, etc.). Covers pg_dump, pgcopydb, logical replication, and provider-specific guides.',
+      name: 'Manage',
+      description: 'Projects, branches, computes, roles, databases, and organization settings.',
+      subIndex: {
+        outputPath: 'public/docs/manage/llms.txt',
+        url: 'https://neon.com/docs/manage/llms.txt',
+        highlights: [
+          'manage/projects.md',
+          'manage/branches.md',
+          'manage/computes.md',
+          'manage/organizations.md',
+          'manage/backups.md',
+        ],
       },
     },
-    { name: 'Manage' },
-    { name: 'Reference' },
-    { name: 'Local' },
-    { name: 'PostgreSQL' },
-    { name: 'Security' },
-    { name: 'Serverless' },
-    { name: 'Workflows' },
+    {
+      name: 'Guides',
+      description:
+        'Step-by-step integration guides for frameworks, ORMs, auth providers, and deployment platforms.',
+      subIndex: {
+        outputPath: 'public/docs/guides/llms.txt',
+        url: 'https://neon.com/docs/guides/llms.txt',
+        highlights: [
+          'guides/nextjs.md',
+          'guides/prisma.md',
+          'guides/drizzle.md',
+          'guides/integrations.md',
+          'guides/vercel-overview.md',
+          'guides/platform-integration-overview.md',
+          'guides/row-level-security.md',
+        ],
+      },
+    },
+    {
+      name: 'Import',
+      description:
+        'Migration guides by source, size, and downtime tolerance. Covers pg_dump, pgcopydb, logical replication, and provider-specific guides.',
+      subIndex: {
+        outputPath: 'public/docs/import/llms.txt',
+        url: 'https://neon.com/docs/import/llms.txt',
+        highlights: [
+          'import/migrate-intro.md',
+          'import/migrate-from-postgres.md',
+          'import/import-sample-data.md',
+          'import/import-from-csv.md',
+          'import/import-data-assistant.md',
+          'import/migrate-from-supabase.md',
+        ],
+      },
+    },
+    {
+      name: 'Workflows',
+      description:
+        'Automate branching, data anonymization, and database provisioning in CI/CD pipelines and GitHub Actions.',
+    },
+    {
+      name: 'Reference',
+      description:
+        'API reference, SDKs, Terraform provider, Postgres compatibility, and platform-level tooling.',
+      extraEntries: [
+        {
+          title: 'Neon API OpenAPI Spec',
+          url: 'https://neon.com/api_spec/release/v2.json',
+          description: 'Machine-readable OpenAPI 3.0 specification for the Neon API',
+        },
+      ],
+    },
+    {
+      name: 'PostgreSQL',
+      description:
+        'Postgres query optimization, indexing strategies, version upgrades, and general Postgres usage with Neon.',
+    },
+    {
+      name: 'Security',
+      description:
+        'Compliance certifications, acceptable use policies, HIPAA, and security reporting.',
+    },
     {
       name: 'Extensions',
       collapse: {
@@ -82,10 +168,6 @@ module.exports = {
         url: 'https://neon.com/docs/extensions/pg-extensions.md',
         description: 'Supported extensions, versions, and install/update instructions',
       },
-    },
-    {
-      name: 'Solutions',
-      description: 'Use-case overviews and program information.',
     },
   ],
 
@@ -109,6 +191,12 @@ module.exports = {
   // Keys are relative paths (same as doc.path). Keep minimal.
   reclassify: {
     'reference/neon-cli.md': { section: 'Neon CLI' },
+    'serverless/serverless-driver.md': { section: 'Connect' },
+    'local/neon-local.md': { section: 'Connect', subsection: 'Local Development' },
+    'local/vscode-extension.md': { section: 'Connect', subsection: 'Local Development' },
+    'guides/branching-github-actions.md': { section: 'Workflows' },
+    'guides/branching-neon-cli.md': { section: 'Branching' },
+    'guides/branching-neon-api.md': { section: 'Branching' },
   },
 
   // Prefix-based reclassification (first match wins). More maintainable than
@@ -125,7 +213,7 @@ module.exports = {
     },
     postgresql: {
       title: 'PostgreSQL Tutorial',
-      url: 'https://neon.com/postgresql',
+      url: 'https://neon.com/postgresql/tutorial',
       description: 'Comprehensive PostgreSQL tutorial and reference',
     },
     guides: {
@@ -133,6 +221,8 @@ module.exports = {
       url: 'https://neon.com/guides',
       description: 'Step-by-step tutorials for frameworks and tools',
     },
+    'use-cases': null,
+    programs: null,
   },
 
   // Extra entries appended to the Additional Resources section.


### PR DESCRIPTION
Overhauls llms.txt generation so the output is shaped by a single config file (`llms-index-config.js`) instead of ad-hoc logic in the script.

- Curated sections like Guides and Manage now show key pages in the root file and link to full sub-indexes (`docs/guides/llms.txt`, etc.)
- Every section has a short description telling an LLM when/why to read it
- Some sections (Azure, Community, Functions, Data Types, Legacy Auth) are excluded; Extensions collapsed to one link
- Build warnings flag stale config (missing files, unused excludes)