### PR TITLE
docs: add unique titles and subtitles for CLI docs

### DIFF
--- a/content/docs/reference/cli-auth.md
+++ b/content/docs/reference/cli-auth.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — auth
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: auth'
+subtitle: Authenticate to Neon via browser or API key and manage credentials
 summary: >-
   Covers the usage of the `auth` command in the Neon CLI for user
   authentication, detailing the process of authorizing access to a Neon account

--- a/content/docs/reference/cli-branches.md
+++ b/content/docs/reference/cli-branches.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — branches
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: branches'
+subtitle: List, create, rename, and delete branches; set default; run schema diff
 summary: >-
   Covers the usage of the `branches` command in the Neon CLI for managing
   branches in a Neon project, including listing, creating, renaming, and

--- a/content/docs/reference/cli-completion.md
+++ b/content/docs/reference/cli-completion.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — completion
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: completion'
+subtitle: Generate shell completion scripts for neonctl commands and options
 summary: >-
   Covers the usage of the `completion` command in the Neon CLI to generate a
   script that enhances command-line efficiency by providing auto-completion for

--- a/content/docs/reference/cli-connection-string.md
+++ b/content/docs/reference/cli-connection-string.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — connection-string
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: connection-string'
+subtitle: Get Postgres connection strings for branches and databases
 summary: >-
   Covers the usage of the Neon CLI `connection-string` command to retrieve a
   Postgres connection string for databases in Neon projects, including options

--- a/content/docs/reference/cli-databases.md
+++ b/content/docs/reference/cli-databases.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — databases
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: databases'
+subtitle: List, create, and delete databases in a Neon project
 summary: >-
   Covers the usage of the Neon CLI `databases` command for managing databases,
   including listing, creating, and deleting databases within a Neon project.

--- a/content/docs/reference/cli-init.md
+++ b/content/docs/reference/cli-init.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — init
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: init'
+subtitle: 'Initialize an app project with Neon: auth, MCP server, extensions, and agent skills'
 summary: >-
   Step-by-step guide for initializing an app project with Neon using the CLI,
   including authentication, configuring the Neon MCP Server, and installing

--- a/content/docs/reference/cli-install.md
+++ b/content/docs/reference/cli-install.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI — Install and connect
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI: Install and connect'
+subtitle: Install the Neon CLI and connect with web auth or API key
 summary: >-
   How to install the Neon CLI on macOS, Windows, and Linux, and connect using
   web authentication or API key for terminal management of Neon.

--- a/content/docs/reference/cli-ip-allow.md
+++ b/content/docs/reference/cli-ip-allow.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — ip-allow
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: ip-allow'
+subtitle: 'Manage the IP allowlist: list, add, remove, and reset allowed IPs'
 summary: >-
   Covers the usage of the `ip-allow` command in the Neon CLI to manage the IP
   allowlist for a Neon project, including actions to list, add, remove, and

--- a/content/docs/reference/cli-me.md
+++ b/content/docs/reference/cli-me.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — me
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: me'
+subtitle: View current user info, login details, and project limits
 summary: >-
   Covers the usage of the `me` command in the Neon CLI to display information
   about the current user, including login details and project limits.

--- a/content/docs/reference/cli-operations.md
+++ b/content/docs/reference/cli-operations.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — operations
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: operations'
+subtitle: List and manage long-running operations for a Neon project
 summary: >-
   Covers the usage of the Neon CLI `operations` command to list operations for a
   Neon project, including subcommands and options for effective management from

--- a/content/docs/reference/cli-orgs.md
+++ b/content/docs/reference/cli-orgs.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — orgs
-subtitle: Use the Neon CLI to manage Neon organizations directly from the terminal
+title: 'Neon CLI command: orgs'
+subtitle: List and manage Neon organizations
 summary: >-
   How to manage organizations within the Neon CLI using the `orgs` command,
   including listing all associated organizations and utilizing various output

--- a/content/docs/reference/cli-projects.md
+++ b/content/docs/reference/cli-projects.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — projects
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: projects'
+subtitle: List, create, update, delete, and get Neon projects
 summary: >-
   Covers the usage of the Neon CLI `projects` command for managing Neon
   projects, including listing, creating, updating, deleting, and retrieving

--- a/content/docs/reference/cli-quickstart.md
+++ b/content/docs/reference/cli-quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: Neon CLI Quickstart
+title: Neon CLI quickstart
 subtitle: Get set up with the Neon CLI in just a few steps
 summary: >-
   How to quickly set up and authenticate the Neon CLI, including installation

--- a/content/docs/reference/cli-roles.md
+++ b/content/docs/reference/cli-roles.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — roles
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: roles'
+subtitle: List, create, and delete database roles in a Neon project
 summary: >-
   Covers the usage of the `roles` command in the Neon CLI for managing roles
   within a Neon project, including listing, creating, and deleting roles.

--- a/content/docs/reference/cli-set-context.md
+++ b/content/docs/reference/cli-set-context.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — set-context
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: set-context'
+subtitle: Set default project context for CLI sessions to avoid repeating project ID
 summary: >-
   Covers the usage of the `set-context` command in the Neon CLI to establish a
   background context for CLI sessions, enabling project-specific actions without

--- a/content/docs/reference/cli-vpc.md
+++ b/content/docs/reference/cli-vpc.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI commands — vpc
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: 'Neon CLI command: vpc'
+subtitle: 'Manage Private Networking: VPC endpoints and project-level restrictions'
 summary: >-
   Covers the usage of the Neon CLI `vpc` command for managing Private Networking
   configurations, including VPC endpoints and project-level restrictions.

--- a/content/docs/reference/neon-cli.md
+++ b/content/docs/reference/neon-cli.md
@@ -1,6 +1,6 @@
 ---
-title: Neon CLI
-subtitle: Use the Neon CLI to manage Neon directly from the terminal
+title: Neon CLI overview
+subtitle: 'Overview of the Neon CLI: installation, commands, and options'
 summary: >-
   How to manage Neon using the command-line interface (CLI), including
   installation instructions for macOS, Windows, and Linux, along with available


### PR DESCRIPTION
Most CLI pages contained a generic "subtitle: Use the Neon CLI to manage Neon directly from the terminal"