### PR TITLE
fix: fix /docs/undefined link from sidebar

### DIFF
--- a/src/components/pages/doc/docs-navigation/item/item.jsx
+++ b/src/components/pages/doc/docs-navigation/item/item.jsx
@@ -71,7 +71,7 @@ const Item = ({ nav: title, slug, subnav, items, basePath, activeItems, setActiv
     }
   }, [slug, items, currentSlug, subnav, setActiveItems]);
 
-  const href = slug?.startsWith('/') ? slug : `${basePath}${slug}`;
+  const href = slug ? (slug.startsWith('/') ? slug : `${basePath}${slug}`) : undefined;
 
   // Highlight only the last found active item
   const isLastActive = isActive && activeItems.at(-1) === slug;

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -59,9 +59,9 @@ const Sidebar = ({ className = null, navigation, basePath, customType, sdkNaviga
       url={`${basePath}${currentSlug}`}
       sections={sdkTOC.sections}
     />
-  ) : (
+  ) : menu ? (
     <Menu basePath={basePath} {...menu} customType={customType} />
-  );
+  ) : null;
 
   return (
     <aside className={clsx('relative -mt-10', className)}>


### PR DESCRIPTION
Testing a fix for the `/docs/undefined` 404 errors in our logs.

When the current page isn't in navigation.yaml (e.g., community guide pages), getActiveMenu() returns undefined. The Menu component then renders a <Link to="/docs/undefined"> that Next.js prefetches in production. These add 404 errors to the logs.