### PR TITLE
docs: update free org and member limits (neon-cloud#4513)

### DIFF
--- a/content/docs/import/migrate-from-azure-native.md
+++ b/content/docs/import/migrate-from-azure-native.md
@@ -46,7 +46,7 @@ To transfer your projects to a Neon-managed organization:
 
 If you have multiple admins, coordinate to decide which Neon-managed organization will be your shared destination:
 
-- **Free plan** users can use their existing Neon-managed organization, or upgrade to a paid plan to create an additional organization (you can only have one free organization).
+- **Free plan** users can use their existing Neon-managed organization, or upgrade to a paid plan to create an additional organization. You can have multiple free organizations (up to 1,000 per account).
 - **Paid plan** users can upgrade their existing Neon-managed organization, or create a new paid organization.
 
 ## Upgrade your Neon plan (paid users only)

--- a/content/docs/manage/orgs-manage.md
+++ b/content/docs/manage/orgs-manage.md
@@ -99,12 +99,9 @@ For detailed information on pricing and plans, refer to [Neon plans](/docs/intro
 
 ### Downgrade to Free plan
 
-You can only have one Free organization per account, and Free orgs are just for personal use (no team members). If you already have a Free org, you can't downgrade another org to Free; you'll see an error if you try.
+You can have multiple free organizations (up to 1,000 per account), and each free organization can have up to 1,000 members. You can downgrade an organization to the Free plan even if it has multiple members.
 
-To downgrade, your org must:
-
-- Have only one member (just you)
-- Stay within Free plan limits (storage, projects, branches, etc.)
+To downgrade, your org must stay within [Free plan limits](/docs/introduction/plans) (storage, projects, branches, and so on). If you have already reached the maximum number of free organizations for your account, you'll see an error and cannot downgrade another org to Free until you delete or leave a free org.
 
 If you need help or think you should be able to downgrade, use the **Request support** option during the downgrade process.
 


### PR DESCRIPTION
- Allow multiple free orgs (up to 1,000 per account) and up to 1,000 members per free org
- Downgrade to Free no longer requires single member; only free org cap applies
- Update orgs-manage.md (Downgrade to Free plan) and migrate-from-azure-native.md