### PR TITLE
fix: bump swiper to 12.1.2 (fix critical prototype pollution)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "remark-parse": "^11.0.0",
         "rss": "^1.2.2",
         "slugify": "^1.6.6",
-        "swiper": "^11.1.5",
+        "swiper": "^12.1.2",
         "tailwindcss-safe-area": "^0.5.1",
         "unified": "^11.0.5",
         "unique-username-generator": "^1.4.0",
@@ -28723,9 +28723,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/swiper": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.5.tgz",
-      "integrity": "sha512-JJQWFXdxiMGC2j6ZGTYat5Z7NN9JORJBgHp0/joX9uPod+cRj0wr5H5VnWSNIz9JeAamQvYKaG7aFrGHIF9OEg==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.2.tgz",
+      "integrity": "sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==",
       "funding": [
         {
           "type": "patreon",
@@ -28736,6 +28736,7 @@
           "url": "http://opencollective.com/swiper"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "remark-parse": "^11.0.0",
     "rss": "^1.2.2",
     "slugify": "^1.6.6",
-    "swiper": "^11.1.5",
+    "swiper": "^12.1.2",
     "tailwindcss-safe-area": "^0.5.1",
     "unified": "^11.0.5",
     "unique-username-generator": "^1.4.0",


### PR DESCRIPTION
Upgrade swiper from ^11.1.5 to ^12.1.2 to address critical prototype pollution (GHSA-hmx5-qpq5-p643). No code changes; existing usage (CSS imports, custom nav, no virtual) is compatible with v12.