### PR TITLE
Fix ordering of vpc endpoints in us-east-1

### DIFF
--- a/content/docs/guides/neon-private-networking.md
+++ b/content/docs/guides/neon-private-networking.md
@@ -60,8 +60,8 @@ To configure Neon Private Networking, perform the following steps:
          - `com.amazonaws.vpce.us-east-1.vpce-svc-074ac4111275eaf07`
          - `com.amazonaws.vpce.us-east-1.vpce-svc-0de57c578b0e614a9`
          - `com.amazonaws.vpce.us-east-1.vpce-svc-0f37140e9710ee3af`
-         - `com.amazonaws.vpce.us-east-1.vpce-svc-0d07f7f68c9a99f3b`
          - `com.amazonaws.vpce.us-east-1.vpce-svc-01aeec2f4b558bc22`
+         - `com.amazonaws.vpce.us-east-1.vpce-svc-0d07f7f68c9a99f3b`
        - **us-east-2**: Create entries, one for each of the following:
          - `com.amazonaws.vpce.us-east-2.vpce-svc-010736480bcef5824`
          - `com.amazonaws.vpce.us-east-2.vpce-svc-0465c21ce8ba95fb2`


### PR DESCRIPTION
Fix an order of vpc endpoints in us-east-1 according to internal naming convention