### PR TITLE
fix: disable autobind for home page rive animations

### DIFF
--- a/src/components/pages/home/branching/branching.jsx
+++ b/src/components/pages/home/branching/branching.jsx
@@ -53,6 +53,7 @@ const Branching = () => (
             'sm:-mr-5 sm:-ml-2.5 sm:w-[calc(100%+30px)]'
           )}
           src="/animations/pages/home/branching.riv?20260114"
+          autoBind={false}
           fit={Fit.Contain}
         />
         <ul className="mt-11 grid grid-cols-3 gap-x-16 xl:mt-9 lg:mt-12 lg:gap-x-8 lg:px-8 md:mt-10 md:grid-cols-1 md:gap-y-7 md:px-0">

--- a/src/components/pages/home/speed-scale/checkpoints/checkpoints.jsx
+++ b/src/components/pages/home/speed-scale/checkpoints/checkpoints.jsx
@@ -22,6 +22,7 @@ const Checkpoints = () => (
         )}
         wrapperClassName="relative"
         src="/animations/pages/home/checkpoints.riv?20260114"
+        autoBind={false}
       />
     </div>
   </div>


### PR DESCRIPTION
## Summary
- disable `autoBind` for the home page branching Rive animation
- disable `autoBind` for the home page speed-scale checkpoints Rive animation

## Testing
- open the preview deployment, open the browser console, and scroll down the page
- confirm there are no errors like `Could not find a View Model linked to Artboard main.`