### PR TITLE
docs: add snapshot management permissions table

### DIFF
--- a/content/docs/manage/user-permissions.md
+++ b/content/docs/manage/user-permissions.md
@@ -68,15 +68,15 @@ The following table shows what each role can do regarding integrations:
 
 The following table shows what each role can do with [snapshots](/docs/guides/snapshots):
 
-| Action                          | Admin | Member | Collaborator |
-| ------------------------------- | :---: | :----: | :----------: |
-| List snapshots                  |  ✅   |   ✅   |      ✅      |
-| Create snapshots                |  ✅   |   ✅   |      ✅      |
-| Restore snapshots               |  ✅   |   ✅   |      ✅      |
-| Delete snapshots                |  ✅   |   ✅   |      ✅      |
-| Rename snapshots                |  ✅   |   ✅   |      ✅      |
-| View snapshot schedule          |  ✅   |   ✅   |      ✅      |
-| Set/update snapshot schedule    |  ✅   |   ✅   |      ✅      |
+| Action                       | Admin | Member | Collaborator |
+| ---------------------------- | :---: | :----: | :----------: |
+| List snapshots               |  ✅   |   ✅   |      ✅      |
+| Create snapshots             |  ✅   |   ✅   |      ✅      |
+| Restore snapshots            |  ✅   |   ✅   |      ✅      |
+| Delete snapshots             |  ✅   |   ✅   |      ✅      |
+| Rename snapshots             |  ✅   |   ✅   |      ✅      |
+| View snapshot schedule       |  ✅   |   ✅   |      ✅      |
+| Set/update snapshot schedule |  ✅   |   ✅   |      ✅      |
 
 </Steps>
 


### PR DESCRIPTION
Add a new "Snapshot management" section to the user-permissions page covering which roles can list, create, restore, delete, rename snapshots, and manage snapshot schedules.

Co-authored-by: Isaac