### PR TITLE
fix: broken toc links that start with a number

### DIFF
--- a/src/components/shared/table-of-contents/item/item.jsx
+++ b/src/components/shared/table-of-contents/item/item.jsx
@@ -29,7 +29,7 @@ const Item = ({
       setIsUserScrolling(false);
     }
 
-    const element = document.querySelector(anchor);
+    const element = document.getElementById(anchor.replace(/^#/, ''));
     if (element) {
       // Account for scroll margin and header offset
       const elementTop = element.getBoundingClientRect().top + window.pageYOffset;


### PR DESCRIPTION
## The problem

Clicking on a link in table of contents that start with a number doesn't trigger the url change and scroll to the corresponding heading.

Example: [PostgreSQL Column Alias](https://neon.com/postgresql/postgresql-tutorial/postgresql-column-alias#postgresql-column-alias-examples)

https://github.com/user-attachments/assets/0f53733f-1fa6-4556-8b9e-6f981d6d0e55

This also triggers an error:

```
Uncaught SyntaxError: Failed to execute 'querySelector' on 'Document': '#1-assigning-a-column-alias-to-a-column-example' is not a valid selector.
```

## The solution

Either escape the first number in anchors or use `getElementById`, I chose the latter.