### PR TITLE
fix: postgresql tutorial spelling mistakes

### DIFF
--- a/content/postgresql/postgresql-tutorial/export-postgresql-table-to-csv-file.md
+++ b/content/postgresql/postgresql-tutorial/export-postgresql-table-to-csv-file.md
@@ -18,7 +18,7 @@ nextLink:
 
 In the previous tutorial, we showed you how to [import data from a CSV file into a table](import-csv-file-into-posgresql-table). We will use the same `persons` table for importing data from a CSV file.
 
-![posgresql export csv](/postgresqltutorial/posgresql-import-csv.jpg)
+![postgresql export csv](/postgresqltutorial/posgresql-import-csv.jpg)
 The following statement retrieves the data from the `persons` table.
 
 ```sql

--- a/content/postgresql/postgresql-tutorial/import-csv-file-into-posgresql-table.md
+++ b/content/postgresql/postgresql-tutorial/import-csv-file-into-posgresql-table.md
@@ -1,7 +1,7 @@
 ---
 title: 'Import CSV File Into PostgreSQL Table'
-page_title: 'Import CSV File Into PosgreSQL Table'
-page_description: 'In this tutorial, you will learn how to to import a CSV file into a PosgreSQL table using the COPY command or pgAdmin client tool.'
+page_title: 'Import CSV File Into PostgreSQL Table'
+page_description: 'In this tutorial, you will learn how to import a CSV file into a PostgreSQL table using the COPY command or pgAdmin client tool.'
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/import-csv-file-into-posgresql-table/'
 ogImage: '/postgresqltutorial/posgresql-import-csv.jpg'
 updatedOn: '2024-02-01T14:45:15+00:00'

--- a/content/postgresql/postgresql-tutorial/postgresql-boolean.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-boolean.md
@@ -1,6 +1,6 @@
 ---
 title: 'PostgreSQL Boolean Data Type with Practical Examples'
-page_title: 'PostgresQL BOOLEAN Data Type with Practical Examples'
+page_title: 'PostgreSQL BOOLEAN Data Type with Practical Examples'
 page_description: 'In this tutorial, you will learn about the PostgreSQL Boolean data type and how to use it in designing the database tables.'
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-boolean/'
 ogImage: '/postgresqltutorial/PostgreSQL-Boolean-300x146.png'

--- a/content/postgresql/postgresql-tutorial/postgresql-char-varchar-text.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-char-varchar-text.md
@@ -50,7 +50,7 @@ Unlike `VARCHAR`, The `CHARACTER` or `CHAR` without the length, specifier (`n`) 
 
 Different from other database systems, in PostgreSQL, there is no performance difference among the three character types.
 
-In most cases, you should use `TEXT`or `VARCHAR` and use the `VARCHAR(n)` only when you want PostgreSQL to check the length.
+In most cases, you should use `TEXT` or `VARCHAR` and use the `VARCHAR(n)` only when you want PostgreSQL to check the length.
 
 ## PostgreSQL character type examples
 

--- a/content/postgresql/postgresql-tutorial/postgresql-coalesce.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-coalesce.md
@@ -68,7 +68,7 @@ Because the first argument is NULL and the second argument is non\-null, the fun
 (1 row)
 ```
 
-In practice, you often use the `COLAESCE()` function to substitute a default value for null when querying data from nullable columns.
+In practice, you often use the `COALESCE()` function to substitute a default value for null when querying data from nullable columns.
 
 For example, if you want to display the excerpt from a blog post and the excerpt is not provided, you can use the first 150 characters of the content of the post.
 

--- a/content/postgresql/postgresql-tutorial/postgresql-correlated-subquery.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-correlated-subquery.md
@@ -24,7 +24,7 @@ Unlike a regular subquery, PostgreSQL evaluates the correlated subquery once for
 
 Since PostgreSQL reevaluates the correlated subquery for every row in the outer query, this may lead to performance issues, especially when dealing with large datasets.
 
-A correlated subquery can be useful when you need to perform a query that depends on the values of the current being processed.
+A correlated subquery can be useful when you need to perform a query that depends on the values of the current row being processed.
 
 ## PostgreSQL correlated subquery example
 

--- a/content/postgresql/postgresql-tutorial/postgresql-default-value.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-default-value.md
@@ -58,14 +58,14 @@ CREATE TABLE table_name(
 When inserting a new row into a table, you can ignore the column that has a default value. In this case, PostgreSQL will use the default value for the insertion:
 
 ```sql
-INSERT INTO table_name(column1, colum3)
+INSERT INTO table_name(column1, column3)
 VALUES(value1, value2);
 ```
 
 If you specify the column with a default constraint in the `INSERT` statement and want to use the default value for the insertion, you can use the `DEFAULT` keyword as follows:
 
 ```sql
-INSERT INTO table_name(column1, column2, colum3)
+INSERT INTO table_name(column1, column2, column3)
 VALUES(value1,DEFAULT,value2);
 ```
 

--- a/content/postgresql/postgresql-tutorial/postgresql-double-precision-type.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-double-precision-type.md
@@ -35,7 +35,7 @@ column_name double precision
 Alternatively, you can use the `float8` or `float` data type which is the same as `DOUBLE PRECISION`:
 
 ```sql
-colum_name float
+column_name float
 ```
 
 A column of `DOUBLE PRECISION` type can store values that have a range around `1E-307` to `1E+308` with a precision of at least 15 digits.

--- a/content/postgresql/postgresql-tutorial/postgresql-full-outer-join.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-full-outer-join.md
@@ -146,7 +146,7 @@ Output:
 
 Let’s take some examples of using the `FULL OUTER JOIN` clause.
 
-### 1\) Basic FULL OUTER JOIN examaple
+### 1\) Basic FULL OUTER JOIN example
 
 The following query uses the `FULL OUTER JOIN` to query data from both `employees` and `departments` tables:
 
@@ -207,7 +207,7 @@ Output:
 
 The result shows that the `Production` department does not have any employees.
 
-The following example use the `FULL OUTER JOIN` cluase with a `WHERE` clause to find employees who do not belong to any department:
+The following example use the `FULL OUTER JOIN` clause with a `WHERE` clause to find employees who do not belong to any department:
 
 ```sql
 SELECT
@@ -230,7 +230,7 @@ Output:
 (1 row)
 ```
 
-The output shows that `Juila Mcqueen` does not belong to any department.
+The output shows that `Julia Mcqueen` does not belong to any department.
 
 ## Summary
 

--- a/content/postgresql/postgresql-tutorial/postgresql-insert.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-insert.md
@@ -29,7 +29,7 @@ VALUES (value1, value2, …);
 
 In this syntax:
 
-- First, specify the name of the table (`table1`) that you want to insert data after the `INSERT INTO` keywords and a list of comma\-separated columns (`colum1, column2, ....`).
+- First, specify the name of the table (`table1`) that you want to insert data after the `INSERT INTO` keywords and a list of comma\-separated columns (`column1, column2, ....`).
 - Second, supply a list of comma\-separated values in parentheses `(value1, value2, ...)` after the `VALUES` keyword. The column and value lists must be in the same order.
 
 The `INSERT` statement returns a command tag with the following form:

--- a/content/postgresql/postgresql-tutorial/postgresql-json.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-json.md
@@ -248,7 +248,7 @@ CREATE TABLE contacts(
 );
 ```
 
-The `phones` column has the JSONB data type. We’ll store both work phone and personal number numbers in a JSON array in the `phones` column.
+The `phones` column has the JSONB data type. We’ll store both work phone and personal phone numbers in a JSON array in the `phones` column.
 
 Second, insert new rows into the `contacts` table:
 

--- a/content/postgresql/postgresql-tutorial/postgresql-like.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-like.md
@@ -14,7 +14,7 @@ nextLink:
   slug: 'postgresql-tutorial/postgresql-is-null'
 ---
 
-**Summary**: in this tutorial, you will learn how to use the PostgreSQL `LIKE` operators to query data based on patterns.
+**Summary**: in this tutorial, you will learn how to use the PostgreSQL `LIKE` operator to query data based on patterns.
 
 ## Introduction to PostgreSQL LIKE operator
 
@@ -149,7 +149,7 @@ first_name  |  last_name
 ...
 ```
 
-### 3\) Using the LIKE operator a pattern that contains both wildcards
+### 3\) Using the LIKE operator with a pattern that contains both wildcards
 
 The following example uses the `LIKE` operator with a pattern that contains both the percent (`%`) and underscore (`_`) wildcards:
 

--- a/content/postgresql/postgresql-tutorial/postgresql-limit.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-limit.md
@@ -133,7 +133,7 @@ How it works.
 
 - First, sort films by film id in ascending order.
 - Second, skip the first three rows using the `OFFSET 3` clause.
-- Second, take the next four rows using the `LIMIT 4` clause.
+- Third, take the next four rows using the `LIMIT 4` clause.
 
 ### 3\) Using LIMIT to get top/bottom N rows
 

--- a/content/postgresql/postgresql-tutorial/postgresql-nullif.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-nullif.md
@@ -188,7 +188,7 @@ CREATE TABLE members (
   id serial PRIMARY KEY,
   first_name VARCHAR (50) NOT NULL,
   last_name VARCHAR (50) NOT NULL,
-  gender SMALLINT NOT NULL -- 1: male, 2 female
+  gender SMALLINT NOT NULL -- 1: male, 2: female
 );
 ```
 

--- a/content/postgresql/postgresql-tutorial/postgresql-numeric.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-numeric.md
@@ -39,7 +39,7 @@ The scale of the `NUMERIC` type can be zero, positive, or negative.
 
 PostgreSQL 15 or later allows you to declare a numeric column with a negative scale.
 
-The following declares the price column with the numeric type that can store total numbers with 7 digits, 5 before the decimal points and 2 digits after the decimal point:
+The following declares the price column with the numeric type that can store total numbers with 7 digits, 5 before the decimal point and 2 digits after the decimal point:
 
 ```sql
 price NUMERIC(7,2)
@@ -206,7 +206,7 @@ Output:
 (2 rows)
 ```
 
-The output indicates that the `NaN` is greater than `500.21`
+The output indicates that the `NaN` is greater than `500.21`.
 
 ## Summary
 

--- a/content/postgresql/postgresql-tutorial/postgresql-or.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-or.md
@@ -162,7 +162,7 @@ Output:
 
 We’ll use the `film` table from the [sample database](../postgresql-getting-started/postgresql-sample-database) for the demonstration:
 
-![](/postgresqltutorial/film.png)The following example uses the `OR` operator in the `WHERE` clause to find the films that have a rental rate is `0.99` or `2.99`:
+![](/postgresqltutorial/film.png)The following example uses the `OR` operator in the `WHERE` clause to find the films that have a rental rate of `0.99` or `2.99`:
 
 ```
 SELECT

--- a/content/postgresql/postgresql-tutorial/postgresql-order-by.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-order-by.md
@@ -142,7 +142,7 @@ In the database world, `NULL` is a marker that indicates the missing data or the
 When you sort rows that contain `NULL`, you can specify the order of `NULL` with other non\-null values by using the `NULLS FIRST` or `NULLS LAST` option of the `ORDER BY` clause:
 
 ```sql
-ORDER BY sort_expresssion [ASC | DESC] [NULLS FIRST | NULLS LAST]
+ORDER BY sort_expression [ASC | DESC] [NULLS FIRST | NULLS LAST]
 ```
 
 The `NULLS FIRST` option places `NULL` before other non\-null values and the `NULLS LAST` option places `NULL` after other non\-null values.

--- a/content/postgresql/postgresql-tutorial/postgresql-primary-key.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-primary-key.md
@@ -1,7 +1,7 @@
 ---
 title: 'PostgreSQL Primary Key'
 page_title: 'PostgreSQL Primary Key'
-page_description: 'In this tutorial, we will show you what is the primary key is and how to manage PostgreSQL primary key constraints through SQL statements.'
+page_description: 'In this tutorial, we will show you what a primary key is and how to manage PostgreSQL primary key constraints through SQL statements.'
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-primary-key/'
 ogImage: ''
 updatedOn: '2024-01-25T07:25:38+00:00'
@@ -26,7 +26,7 @@ It is a good practice to add a primary key to every table. When you add a prima
 
 Technically, a primary key constraint is the combination of a [not\-null constraint](postgresql-not-null-constraint) and [a UNIQUE constraint](postgresql-unique-constraint).
 
-Typically, you define primary for a table when creating it:
+Typically, you define a primary key for a table when creating it:
 
 ```phpsql
 CREATE TABLE table_name (
@@ -50,7 +50,7 @@ CREATE TABLE table_name (
 );
 ```
 
-To add a primary key to an existing table, you the `ALTER TABLE ... ADD PRIMARY KEY` statement:
+To add a primary key to an existing table, you use the `ALTER TABLE ... ADD PRIMARY KEY` statement:
 
 ```
 ALTER TABLE table_name

--- a/content/postgresql/postgresql-tutorial/postgresql-recursive-query.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-recursive-query.md
@@ -168,7 +168,7 @@ The recursive member returns the direct subordinate(s) of the employee id 2\. Th
            9 |          2 | Benjamin Glover
 ```
 
-PostgreSQL executes the recursive member repeatedly. The second iteration of the recursive member uses the result set above step as the input value, and returns this result set:
+PostgreSQL executes the recursive member repeatedly. The second iteration of the recursive member uses the result set from the above step as the input value, and returns this result set:
 
 ```text
  employee_id | manager_id |    full_name

--- a/content/postgresql/postgresql-tutorial/postgresql-rename-table.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-rename-table.md
@@ -14,7 +14,7 @@ nextLink:
   slug: 'postgresql-tutorial/postgresql-add-column'
 ---
 
-**Summary**: in this tutorial, you will show how to rename a table using the PostgreSQL `ALTER TABLE RENAME TO` statement.
+**Summary**: in this tutorial, you will learn how to rename a table using the PostgreSQL `ALTER TABLE RENAME TO` statement.
 
 ## Introduction to PostgreSQL RENAME TABLE statement
 

--- a/content/postgresql/postgresql-tutorial/postgresql-right-join.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-right-join.md
@@ -1,7 +1,7 @@
 ---
 title: 'PostgreSQL RIGHT JOIN'
 page_title: 'PostgreSQL RIGHT JOIN'
-page_description: 'You will how to use PostgreSQL RIGHT JOIN to join two tables and return rows from the right table that may or may not have matching rows in the left table.'
+page_description: 'You will learn how to use PostgreSQL RIGHT JOIN to join two tables and return rows from the right table that may or may not have matching rows in the left table.'
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-right-join/'
 ogImage: '/postgresqltutorial/PostgreSQL-Join-Right-Join.png'
 updatedOn: '2024-01-18T03:45:01+00:00'

--- a/content/postgresql/postgresql-tutorial/postgresql-select-distinct.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-select-distinct.md
@@ -177,7 +177,7 @@ In this example, the query uses the values from both `bcolor` and `fcolor` colum
 
 In practice, you often use the `SELECT DISTINCT` clause to analyze the uniqueness of values in a column.
 
-For example, you may want to know how many rental rates for films from the `film` table:
+For example, you may want to know the rental rates for films from the `film` table:
 
 ![PostgreSQL SELECT DISTINCT - sample table](/postgresqltutorial/film.png)To achieve this, you can specify the `rental_rate` column in the `SELECT DISTINCT` clause as follows:
 

--- a/content/postgresql/postgresql-tutorial/postgresql-select.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-select.md
@@ -35,7 +35,7 @@ The `SELECT` statement has the following clauses:
 - Join with other tables using [joins](postgresql-joins) such as [`INNER JOIN`](postgresql-inner-join), [`LEFT JOIN`](postgresql-left-join), [`FULL OUTER JOIN`](postgresql-full-outer-join), [`CROSS JOIN`](postgresql-cross-join) clauses.
 - Perform set operations using [`UNION`](postgresql-union), [`INTERSECT`](postgresql-intersect), and [`EXCEPT`](/postgresql/postgresql-tutorial/postgresql-except/).
 
-In this tutorial, you are going to focus on the `SELECT`and `FROM` clauses.
+In this tutorial, you are going to focus on the `SELECT` and `FROM` clauses.
 
 ## PostgreSQL SELECT statement syntax
 

--- a/content/postgresql/postgresql-tutorial/postgresql-self-join.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-self-join.md
@@ -94,7 +94,7 @@ In this `employee` table, the `manager_id` column references the `employee_id` c
 
 The `manager_id` column indicates the direct relationship, showing the manager to whom the employee reports.
 
-If the `manager_id` column contains NULL, which signifies that the respective employee does not report to anyone, essentially holding the top managerial position.
+If the `manager_id` column contains NULL, it signifies that the respective employee does not report to anyone, essentially holding the top managerial position.
 
 The following query uses the self\-join to find who reports to whom:
 

--- a/content/postgresql/postgresql-tutorial/postgresql-sequences.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-sequences.md
@@ -50,7 +50,7 @@ The sequence name must be distinct from any other sequences, tables, [indexes](.
 
 Specify the [data type](postgresql-data-types) of the sequence. The valid data type is [`SMALLINT`](postgresql-integer), [`INT`](postgresql-interval), and [`BIGINT`](postgresql-integer). The default data type is `BIGINT` if you skip it.
 
-The data type of the sequence which determines the sequence’s minimum and maximum values.
+The data type of the sequence determines the sequence’s minimum and maximum values.
 
 ### \[ INCREMENT \[ BY ] increment ]
 
@@ -226,7 +226,7 @@ In this syntax:
 
 ### PostgreSQL DROP SEQUENCE statement examples
 
-This statement drops the table `order_details`. Since the sequence `order_item_id` associates with the `item_id` of the `order_details`, it is also dropped automatically:
+This statement drops the table `order_details`. Since the sequence `order_item_id` is associated with the `item_id` of the `order_details`, it is also dropped automatically:
 
 ```sql
 DROP TABLE order_details;

--- a/content/postgresql/postgresql-tutorial/postgresql-server-and-database-objects.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-server-and-database-objects.md
@@ -75,7 +75,7 @@ Operators are symbolic functions. PostgreSQL allows you to define custom operato
 
 ## Casts
 
-Casts enable you to convert one data type into another data type. Casts backed by functions to perform the conversion. You can also create your casts to override the default casting provided by PostgreSQL.
+Casts enable you to convert one data type into another data type. Casts are backed by functions to perform the conversion. You can also create your casts to override the default casting provided by PostgreSQL.
 
 ## Sequence
 

--- a/content/postgresql/postgresql-tutorial/postgresql-temporary-table.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-temporary-table.md
@@ -27,7 +27,7 @@ To create a temporary table, you use the `CREATE TEMPORARY TABLE` statement:
 ```sqlsqlsql
 CREATE TEMPORARY TABLE table_name(
    column1 datatype(size) constraint,
-   column1 datatype(size) constraint,
+   column2 datatype(size) constraint,
    ...,
    table_constraints
 );

--- a/content/postgresql/postgresql-tutorial/postgresql-timestamp.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-timestamp.md
@@ -60,7 +60,7 @@ It’s important to note that PostgreSQL stores `timestamptz` values in the data
 
 Let’s take a look at an example of using the `timestamp` and `timestamptz`to have a better understanding of how PostgreSQL handles them.
 
-First, [create a table](postgresql-create-table) that consists of both `timestamp` the `timestamptz` columns.
+First, [create a table](postgresql-create-table) that consists of both `timestamp` and `timestamptz` columns.
 
 ```sql
 CREATE TABLE timestamp_demo (
@@ -88,7 +88,7 @@ SHOW TIMEZONE;
 (1 row)
 ```
 
-Then, [insert a new row](postgresql-insert) into the `timstamp_demo`table:
+Then, [insert a new row](postgresql-insert) into the `timestamp_demo` table:
 
 ```sql
 INSERT INTO timestamp_demo (ts, tstz)

--- a/content/postgresql/postgresql-tutorial/postgresql-transaction.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-transaction.md
@@ -177,7 +177,7 @@ Or:
 ROLLBACK WORK;
 ```
 
-The `ROLLBACK` statement undos the changes that you made within the transaction.
+The `ROLLBACK` statement undoes the changes that you made within the transaction.
 
 For example, the following example uses the `ROLLBACK` statement to roll back the changes made to the account 1:
 

--- a/content/postgresql/postgresql-tutorial/postgresql-update-join.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-update-join.md
@@ -1,7 +1,7 @@
 ---
 title: 'PostgreSQL UPDATE Join'
 page_title: 'PostgreSQL UPDATE Join with Practical Examples'
-page_description: 'this tutorial shows you how to use the PostgreSQL UPDATE join syntax to update data in a table based on values in another table.'
+page_description: 'This tutorial shows you how to use the PostgreSQL UPDATE join syntax to update data in a table based on values in another table.'
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-update-join/'
 ogImage: '/postgresqltutorial/PostgreSQL-UPDATE-JOIN-Sample-Database.png'
 updatedOn: '2024-02-01T08:42:46+00:00'
@@ -33,7 +33,7 @@ To join a table (table1\) with another table (table2\) in the `UPDATE` statemen
 
 For each row of the table `table1`, the `UPDATE` statement examines every row of the table `table2`.
 
-If the values in the `c2` column of table `table1` equals the values in the `c2` column of table `table2`, the `UPDATE` statement updates the value in the `c1` column of the table `table1` the new value (`new_value`).
+If the values in the `c2` column of table `table1` equals the values in the `c2` column of table `table2`, the `UPDATE` statement updates the value in the `c1` column of the table `table1` with the new value (`new_value`).
 
 ## PostgreSQL UPDATE JOIN example
 

--- a/content/postgresql/postgresql-tutorial/postgresql-update.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-update.md
@@ -80,7 +80,7 @@ CREATE TABLE courses(
 INSERT INTO courses( course_name, price, description, published_date)
 VALUES
 ('PostgreSQL for Developers', 299.99, 'A complete PostgreSQL for Developers', '2020-07-13'),
-('PostgreSQL Admininstration', 349.99, 'A PostgreSQL Guide for DBA', NULL),
+('PostgreSQL Administration', 349.99, 'A PostgreSQL Guide for DBA', NULL),
 ('PostgreSQL High Performance', 549.99, NULL, NULL),
 ('PostgreSQL Bootcamp', 777.99, 'Learn PostgreSQL via Bootcamp', '2013-07-11'),
 ('Mastering PostgreSQL', 999.98, 'Mastering PostgreSQL in 21 Days', '2012-06-30');
@@ -95,7 +95,7 @@ Output:
  course_id |         course_name         | price  |             description              | published_date
 -----------+-----------------------------+--------+--------------------------------------+----------------
          1 | PostgreSQL for Developers   | 299.99 | A complete PostgreSQL for Developers | 2020-07-13
-         2 | PostgreSQL Admininstration  | 349.99 | A PostgreSQL Guide for DBA           | null
+         2 | PostgreSQL Administration  | 349.99 | A PostgreSQL Guide for DBA           | null
          3 | PostgreSQL High Performance | 549.99 | null                                 | null
          4 | PostgreSQL Bootcamp         | 777.99 | Learn PostgreSQL via Bootcamp        | 2013-07-11
          5 | Mastering PostgreSQL        | 999.98 | Mastering PostgreSQL in 21 Days      | 2012-06-30

--- a/content/postgresql/postgresql-tutorial/postgresql-xml-data-type.md
+++ b/content/postgresql/postgresql-tutorial/postgresql-xml-data-type.md
@@ -65,7 +65,7 @@ In this statement:
 
 - `DOCUMENT` indicates that the input string is a complete XML document starting with the XML declaration `<?xml version="1.0" encoding="UTF-8"?>` and having the root element `<person>`
 - `XMLPARSE` function converts the string into an XML document.
-- The `INSERT` statement inserts the new XML document into the info column of the `persons` table.
+- The `INSERT` statement inserts the new XML document into the info column of the `person` table.
 
 Third, [insert multiple rows](postgresql-insert-multiple-rows) into the `person` table:
 


### PR DESCRIPTION
This PR fixes some spelling mistakes in PostgreSQL Tutorial, done with AI + manual review