### PR TITLE
style: enhance code block styling in doc-content.css for better text handling

### DIFF
--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -237,7 +237,10 @@
     }
 
     :not(pre) > code {
-      @apply inline-flex items-center justify-center break-words rounded border border-gray-new-70 bg-gray-new-98 !px-1 !py-px !font-mono text-sm !font-normal leading-[1.2] tracking-extra-tight !text-black-pure dark:border-gray-new-30 dark:bg-black-new dark:!text-white;
+      @apply inline rounded border border-gray-new-70 bg-gray-new-98 !px-1 !py-px !font-mono text-sm !font-normal leading-[1.2] tracking-extra-tight !text-black-pure dark:border-gray-new-30 dark:bg-black-new dark:!text-white;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+      white-space: normal;
 
       &::before,
       &::after {


### PR DESCRIPTION
This PR brings fix for issue with docs tables

<img width="1042" height="1226" alt="image" src="https://github.com/user-attachments/assets/d7e422a2-84db-443f-8782-280119321338" />
