### PR TITLE
docs(fix): Fix salaries schema example and INSTEAD OF trigger DELETE behavior

### DIFF
--- a/content/postgresql/postgresql-triggers/postgresql-instead-of-triggers.md
+++ b/content/postgresql/postgresql-triggers/postgresql-instead-of-triggers.md
@@ -66,7 +66,7 @@ CREATE TABLE salaries (
     effective_date DATE NOT NULL,
     salary DECIMAL(10, 2) NOT NULL DEFAULT 0,
     PRIMARY KEY (employee_id, effective_date),
-    FOREIGN KEY (employee_id) REFERENCES employees(employee_id)
+    FOREIGN KEY (employee_id) REFERENCES employees(employee_id) ON DELETE CASCADE
 );
 ```
 
@@ -120,7 +120,7 @@ BEGIN
 	WHERE employee_id = NEW.employee_id;
 
     ELSIF TG_OP = 'DELETE' THEN
-        DELETE FROM salaries
+        DELETE FROM employees
 	WHERE employee_id = OLD.employee_id;
     END IF;
     RETURN NULL;


### PR DESCRIPTION
### Problem

Affected page: https://neon.com/postgresql/postgresql-triggers/postgresql-instead-of-triggers

The PostgreSQL INSTEAD OF trigger example did not reflect the documented behavior:

- The `employee_id` foreign key in the salaries table was missing `ON DELETE CASCADE`
- The trigger incorrectly deleted salary records instead of employee records

The following fix ensure the example behaves as intended and avoids confusion for readers.

### Changes
- Added missing `ON DELETE CASCADE` to the salaries table foreign key to match the described behavior
- Fixed the `update_employee_salaries` trigger function:
  - Corrected DELETE handling (TG_OP = 'DELETE')
  - Now deletes from the employees table instead of the salaries table