### PR TITLE
docs(startups): refresh Startup Program eligibility copy

### DIFF
--- a/src/components/pages/startups/info/info.jsx
+++ b/src/components/pages/startups/info/info.jsx
@@ -7,11 +7,11 @@ import GradientBorder from 'components/shared/gradient-border/index';
 const CARDS = [
   {
     title: 'Who can apply?',
-    description:
-      'Venture-backed startups with at least $1M in funding that have launched in the past 12 months.',
+    description: 'Early-stage, venture-backed startups with at least $1M in funding.',
     features: [
-      'You’ve raised less than $5M in total funding.',
+      'You’ve raised at least $1M in total funding.',
       'You’re building an early-stage product or MVP.',
+      'You’re backed by venture capital, and your funding is verifiable.',
     ],
     className: 'bg-startups-info-card-1',
   },


### PR DESCRIPTION
## Summary
Updates the **Who can apply?** section on [`/startups`](https://neon.com/startups).

## Changes
- Subheading: **Early-stage, venture-backed startups** with at least **$1M** in funding (removed the 12-month launch requirement).
- Bullets: require **at least $1M** raised (replacing the prior under-$5M cap), keep early-stage product/MVP, add **verifiable venture capital** backing.

## File
- `src/components/pages/startups/info/info.jsx`