### PR TITLE
feat: add cross-domain login state sync with console

### DIFF
--- a/src/app/api/identify/route.js
+++ b/src/app/api/identify/route.js
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server';
+
+const ALLOWED_RETURN_URL_HOST = 'console.neon.tech';
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Check if user has given consent for personalization cookies.
+ * Reads the neon_consent cookie and checks for NomZ: true.
+ */
+function hasPersonalizationConsent(request) {
+  const consentCookie = request.cookies.get('neon_consent')?.value;
+  if (!consentCookie) return false;
+  try {
+    const consent = JSON.parse(consentCookie);
+    return consent.NomZ === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate that the return URL is allowed (must be console.neon.tech).
+ */
+function isValidReturnUrl(returnUrl) {
+  if (!returnUrl) return false;
+  try {
+    const url = new URL(returnUrl);
+    return url.host === ALLOWED_RETURN_URL_HOST;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * GET /api/identify
+ *
+ * Login flow:
+ *   /api/identify?userId=xxx&returnUrl=https://console.neon.tech/...
+ *
+ * Logout flow:
+ *   /api/identify?logout=true&returnUrl=https://console.neon.tech/...
+ *
+ * Sets cookies and redirects back to the console.
+ */
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const returnUrl = searchParams.get('returnUrl');
+  const userId = searchParams.get('userId');
+  const isLogout = searchParams.get('logout') === 'true';
+
+  // Validate returnUrl
+  if (!isValidReturnUrl(returnUrl)) {
+    return NextResponse.json(
+      { error: 'Invalid or missing returnUrl. Must be a console.neon.tech URL.' },
+      { status: 400 }
+    );
+  }
+
+  const response = NextResponse.redirect(returnUrl);
+
+  if (isLogout) {
+    // Clear cookies
+    response.cookies.set('neon_login_indicator', '', {
+      maxAge: 0,
+      path: '/',
+    });
+    response.cookies.set('ajs_user_id', '', {
+      maxAge: 0,
+      path: '/',
+    });
+  } else if (userId) {
+    // Set login indicator (always, no consent needed)
+    response.cookies.set('neon_login_indicator', 'true', {
+      maxAge: ONE_YEAR_IN_SECONDS,
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    });
+
+    // Set user ID only if personalization consent is given
+    if (hasPersonalizationConsent(request)) {
+      response.cookies.set('ajs_user_id', userId, {
+        maxAge: ONE_YEAR_IN_SECONDS,
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+      });
+    }
+  } else {
+    return NextResponse.json(
+      { error: 'Missing required parameter: userId or logout' },
+      { status: 400 }
+    );
+  }
+
+  return response;
+}

--- a/src/components/pages/doc/docs-header/docs-header.jsx
+++ b/src/components/pages/doc/docs-header/docs-header.jsx
@@ -9,7 +9,7 @@ import LINKS from 'constants/links';
 
 import DocsNavigation from '../docs-navigation';
 
-const DocsHeader = ({ customType, docPageType, basePath, navigation, isClient }) => (
+const DocsHeader = ({ customType, docPageType, basePath, navigation, isClient, isLoggedIn }) => (
   <div className="flex h-28 w-full items-center bg-white backdrop-blur-xl after:absolute after:left-0 after:right-0 after:top-16 after:h-px after:bg-gray-new-90 dark:bg-black-new after:dark:bg-gray-new-20 lg:h-14 lg:after:hidden">
     <Container className="z-10 w-full" size="1920">
       <div className="flex h-16 w-full items-center justify-between lg:h-14 lg:pr-20">
@@ -25,7 +25,7 @@ const DocsHeader = ({ customType, docPageType, basePath, navigation, isClient })
         <div className="absolute left-1/2 flex -translate-x-1/2 gap-2.5 xl:relative xl:left-0 xl:translate-x-0 lg:hidden">
           <InkeepTrigger docPageType={docPageType} />
         </div>
-        <Sidebar className="lg:hidden" isClient={isClient} isDocs />
+        <Sidebar className="lg:hidden" isClient={isClient} isLoggedIn={isLoggedIn} isDocs />
       </div>
       <div className="h-12 lg:hidden">
         <DocsNavigation navigation={navigation} basePath={basePath} />
@@ -43,6 +43,7 @@ DocsHeader.propTypes = {
   basePath: PropTypes.string.isRequired,
   navigation: PropTypes.array.isRequired,
   isClient: PropTypes.bool,
+  isLoggedIn: PropTypes.bool,
 };
 
 export default DocsHeader;

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 
+import { checkCookie } from 'app/actions';
 import DocsHeader from 'components/pages/doc/docs-header';
 import Container from 'components/shared/container';
 import Logo from 'components/shared/logo';
@@ -9,7 +10,7 @@ import MobileMenu from './mobile-menu';
 import Navigation from './navigation';
 import Sidebar from './sidebar';
 
-const Header = ({
+const Header = async ({
   className = null,
   theme = null,
   isSticky = false,
@@ -20,38 +21,43 @@ const Header = ({
   docsBasePath = null,
   customType = null,
   isClient = false,
-}) => (
-  <>
-    <HeaderWrapper
-      className={className}
-      isSticky={isSticky}
-      isStickyOverlay={isStickyOverlay}
-      theme={theme}
-    >
-      {isDocPage ? (
-        <DocsHeader
-          customType={customType}
-          docPageType={docPageType}
-          isClient={isClient}
-          navigation={docsNavigation}
-          basePath={docsBasePath}
-        />
-      ) : (
-        <Container
-          className="!static z-10 flex w-full items-center justify-between md:px-8 sm:px-5"
-          size="1920"
-        >
-          <div className="flex items-center gap-x-[92px] xl:gap-x-10">
-            <Logo width={102} height={28} priority isHeader />
-            <Navigation />
-          </div>
-          <Sidebar isClient={isClient} />
-        </Container>
-      )}
-    </HeaderWrapper>
-    <MobileMenu isDocPage={isDocPage} docPageType={docPageType} />
-  </>
-);
+}) => {
+  const isLoggedIn = await checkCookie('neon_login_indicator');
+
+  return (
+    <>
+      <HeaderWrapper
+        className={className}
+        isSticky={isSticky}
+        isStickyOverlay={isStickyOverlay}
+        theme={theme}
+      >
+        {isDocPage ? (
+          <DocsHeader
+            customType={customType}
+            docPageType={docPageType}
+            isClient={isClient}
+            isLoggedIn={isLoggedIn}
+            navigation={docsNavigation}
+            basePath={docsBasePath}
+          />
+        ) : (
+          <Container
+            className="!static z-10 flex w-full items-center justify-between md:px-8 sm:px-5"
+            size="1920"
+          >
+            <div className="flex items-center gap-x-[92px] xl:gap-x-10">
+              <Logo width={102} height={28} priority isHeader />
+              <Navigation />
+            </div>
+            <Sidebar isClient={isClient} isLoggedIn={isLoggedIn} />
+          </Container>
+        )}
+      </HeaderWrapper>
+      <MobileMenu isDocPage={isDocPage} docPageType={docPageType} isLoggedIn={isLoggedIn} />
+    </>
+  );
+};
 
 Header.propTypes = {
   className: PropTypes.string,

--- a/src/components/shared/header/mobile-menu/mobile-menu.jsx
+++ b/src/components/shared/header/mobile-menu/mobile-menu.jsx
@@ -125,7 +125,7 @@ const mobileMenuItems = [
   },
 ];
 
-const MobileMenu = ({ isDocPage = false, docPageType = null }) => {
+const MobileMenu = ({ isDocPage = false, docPageType = null, isLoggedIn = false }) => {
   const { isMobileMenuOpen, toggleMobileMenu } = useMobileMenu();
   const { hasTopbar } = useContext(TopbarContext);
 
@@ -155,28 +155,43 @@ const MobileMenu = ({ isDocPage = false, docPageType = null }) => {
             </ul>
             <div
               className={clsx(
-                'absolute inset-x-0 bottom-0 grid grid-cols-2 gap-x-6 gap-y-3 border-t border-gray-new-94 bg-white p-8 dark:border-gray-new-20 dark:bg-black-pure sm:grid-cols-1 sm:p-5',
+                'absolute inset-x-0 bottom-0 grid gap-x-6 gap-y-3 border-t border-gray-new-94 bg-white p-8 dark:border-gray-new-20 dark:bg-black-pure sm:p-5',
+                isLoggedIn ? 'grid-cols-1' : 'grid-cols-2 sm:grid-cols-1',
                 { 'pb-20 sm:pb-[68px]': isDocPage }
               )}
             >
-              <Button
-                className="h-9 border border-gray-new-40 px-[18px]"
-                to={LINKS.login}
-                theme="transparent"
-                size="xxs"
-                tagName="MobileMenu"
-              >
-                Log in
-              </Button>
-              <Button
-                className="h-9 px-[18px]"
-                to={LINKS.signup}
-                theme="white-filled-multi"
-                size="xxs"
-                tagName="MobileMenu"
-              >
-                Sign up
-              </Button>
+              {isLoggedIn ? (
+                <Button
+                  className="h-9 px-[18px]"
+                  to={LINKS.console}
+                  theme="white-filled-multi"
+                  size="xxs"
+                  tagName="MobileMenu"
+                >
+                  Go to Console
+                </Button>
+              ) : (
+                <>
+                  <Button
+                    className="h-9 border border-gray-new-40 px-[18px]"
+                    to={LINKS.login}
+                    theme="transparent"
+                    size="xxs"
+                    tagName="MobileMenu"
+                  >
+                    Log in
+                  </Button>
+                  <Button
+                    className="h-9 px-[18px]"
+                    to={LINKS.signup}
+                    theme="white-filled-multi"
+                    size="xxs"
+                    tagName="MobileMenu"
+                  >
+                    Sign up
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         </nav>
@@ -188,6 +203,7 @@ const MobileMenu = ({ isDocPage = false, docPageType = null }) => {
 MobileMenu.propTypes = {
   isDocPage: PropTypes.bool,
   docPageType: PropTypes.string,
+  isLoggedIn: PropTypes.bool,
 };
 
 export default MobileMenu;

--- a/src/components/shared/header/sidebar/sidebar.jsx
+++ b/src/components/shared/header/sidebar/sidebar.jsx
@@ -44,7 +44,7 @@ const SOCIALS = [
   },
 ];
 
-const Sidebar = ({ isClient, isDocs, className }) => (
+const Sidebar = ({ isClient, isDocs, isLoggedIn, className }) => (
   <div className={clsx('flex items-center lg:hidden', isDocs ? 'gap-x-6' : 'gap-x-8', className)}>
     <div className={clsx('flex items-center', isDocs ? 'gap-x-4' : 'gap-x-6')}>
       {SOCIALS.map(({ id, to, icon: Icon, label, hasStars }) => (
@@ -79,24 +79,38 @@ const Sidebar = ({ isClient, isDocs, className }) => (
       ))}
     </div>
     <div className={clsx('flex', isDocs ? 'gap-x-2' : 'gap-x-3.5')}>
-      <Button
-        className="h-9 px-[18px]"
-        to={LINKS.login}
-        theme="outlined"
-        size="xxs"
-        tagName="Header"
-      >
-        Log in
-      </Button>
-      <Button
-        className="h-9 px-[18px]"
-        to={LINKS.signup}
-        theme="white-filled-multi"
-        size="xxs"
-        tagName="Header"
-      >
-        Sign up
-      </Button>
+      {isLoggedIn ? (
+        <Button
+          className="h-9 px-[18px]"
+          to={LINKS.console}
+          theme="white-filled-multi"
+          size="xxs"
+          tagName="Header"
+        >
+          Go to Console
+        </Button>
+      ) : (
+        <>
+          <Button
+            className="h-9 px-[18px]"
+            to={LINKS.login}
+            theme="outlined"
+            size="xxs"
+            tagName="Header"
+          >
+            Log in
+          </Button>
+          <Button
+            className="h-9 px-[18px]"
+            to={LINKS.signup}
+            theme="white-filled-multi"
+            size="xxs"
+            tagName="Header"
+          >
+            Sign up
+          </Button>
+        </>
+      )}
     </div>
   </div>
 );
@@ -104,6 +118,7 @@ const Sidebar = ({ isClient, isDocs, className }) => (
 Sidebar.propTypes = {
   isClient: PropTypes.bool,
   isDocs: PropTypes.bool,
+  isLoggedIn: PropTypes.bool,
   className: PropTypes.string,
 };
 


### PR DESCRIPTION
## Summary
  - Add `/api/identify` endpoint that receives login/logout callbacks from console.neon.tech
  - Set first-party `neon_login_indicator` and `ajs_user_id` cookies (with GDPR consent check)
  - Header shows "Go to Console" button when user is logged in

  ## How it works
  1. Console redirects to `/api/identify?userId=xxx&returnUrl=https://console.neon.tech/...` on login
  2. Endpoint validates returnUrl is console.neon.tech, checks `neon_consent` cookie for personalization consent
  3. Sets `neon_login_indicator` (always) and `ajs_user_id` (if consent given) cookies
  4. Redirects back to console

  Logout flow uses `/api/identify?logout=true&returnUrl=...` to clear cookies.

  ## Test plan
  - [ ] Test login flow sets cookies correctly
  - [ ] Test logout flow clears cookies
  - [ ] Test header shows "Go to Console" when logged in
  - [ ] Test forms recognize user (email field optional) when `ajs_user_id` cookie is set
  - [ ] Verify consent check works (only set `ajs_user_id` if `neon_consent.NomZ === true`)