### PR TITLE
refactor: update header and sidebar colors, enhance not-found page layout

### DIFF
--- a/src/app/(docs)/not-found.jsx
+++ b/src/app/(docs)/not-found.jsx
@@ -3,7 +3,7 @@ import Layout from 'components/shared/layout';
 import SEO_DATA from 'constants/seo-data';
 
 const DocsNotFoundPage = () => (
-  <div className="fixed inset-0 z-50 bg-white">
+  <div className="fixed inset-0 z-50 overflow-auto bg-white">
     <meta httpEquiv="x-ua-compatible" content="ie=edge" />
     <meta
       name="viewport"

--- a/src/components/pages/changelog/changelog-list/changelog-list.jsx
+++ b/src/components/pages/changelog/changelog-list/changelog-list.jsx
@@ -24,7 +24,7 @@ const ChangelogPost = (post) => {
         )}
       >
         <Link
-          className="absolute top-10 right-0 -left-40 shrink-0 font-mono text-[13px] leading-none font-medium whitespace-nowrap text-gray-new-20 transition-colors duration-200 hover:text-black-pure dark:text-gray-new-80 dark:hover:text-white"
+          className="absolute top-7 right-0 -left-40 shrink-0 font-mono text-[13px] leading-none font-medium whitespace-nowrap text-gray-new-20 transition-colors duration-200 hover:text-black-pure dark:text-gray-new-80 dark:hover:text-white"
           to={changelogPath}
         >
           <div className="flex w-32 items-center gap-1.5 py-[15px]">

--- a/src/components/shared/header/header-wrapper/header-wrapper.jsx
+++ b/src/components/shared/header/header-wrapper/header-wrapper.jsx
@@ -24,7 +24,7 @@ const HeaderWrapper = ({
     <div
       className={cn(
         'navigation-overlay',
-        'pointer-events-none fixed inset-0 z-40 bg-black-pure/80 opacity-0 transition-opacity delay-150 duration-200'
+        'pointer-events-none fixed inset-0 z-40 bg-white/80 opacity-0 transition-opacity delay-150 duration-200 dark:bg-black-pure/80'
       )}
     />
   </>

--- a/src/components/shared/header/navigation/navigation.jsx
+++ b/src/components/shared/header/navigation/navigation.jsx
@@ -244,12 +244,12 @@ const Navigation = () => {
             >
               <Button
                 className={cn(
-                  'group/main-nav-trigger relative flex items-center gap-x-1 rounded-sm px-3.5 text-[15px] leading-normal! font-normal tracking-snug whitespace-pre transition-colors duration-200 group-hover/main-nav:text-gray-new-70 hover:text-white! xl:px-2.5',
+                  'group/main-nav-trigger relative flex items-center gap-x-1 rounded-sm px-3.5 text-[15px] leading-normal! font-normal tracking-snug whitespace-pre transition-colors duration-200 group-hover/main-nav:text-gray-new-30 hover:text-black-pure! dark:group-hover/main-nav:text-gray-new-70 dark:hover:text-white! xl:px-2.5',
                   {
                     '-ml-3.5 xl:-ml-2.5': index === 0,
                     '-mr-3.5 xl:-mr-2.5': index === MENUS.header.length - 1,
-                    'text-white!': isActive,
-                    'text-gray-new-70!': activeMenuIndex !== null && !isActive,
+                    'text-black-pure! dark:text-white!': isActive,
+                    'text-gray-new-30! dark:text-gray-new-70!': activeMenuIndex !== null && !isActive,
                     'before:absolute before:top-0 before:h-10 before:w-full': hasSubmenu,
                   }
                 )}
@@ -269,8 +269,8 @@ const Navigation = () => {
                 {hasSubmenu && (
                   <ChevronIcon
                     className={cn(
-                      'text-gray-new-70 opacity-60 transition-all duration-200 group-hover/main-nav-trigger:text-white',
-                      { 'text-white': isActive }
+                      'text-gray-new-30 opacity-60 transition-all duration-200 group-hover/main-nav-trigger:text-black-pure dark:text-gray-new-70 dark:group-hover/main-nav-trigger:text-white',
+                      { 'text-black-pure dark:text-white': isActive }
                     )}
                     aria-hidden="true"
                   />

--- a/src/components/shared/header/sidebar/sidebar.jsx
+++ b/src/components/shared/header/sidebar/sidebar.jsx
@@ -54,7 +54,7 @@ const Sidebar = ({ isClient, isDocs, className }) => (
             isDocs && 'size-8 justify-center border border-gray-new-60 dark:border-gray-new-40',
             isDocs
               ? 'rounded-full text-gray-new-10 hover:border-black-new hover:text-black-new dark:text-gray-new-90 dark:hover:border-gray-new-40 dark:hover:text-white'
-              : 'rounded-sm text-white hover:text-gray-new-70'
+              : 'rounded-sm text-black-pure hover:text-gray-new-30 dark:text-white dark:hover:text-gray-new-70'
           )}
           key={id}
           to={to}
@@ -66,7 +66,7 @@ const Sidebar = ({ isClient, isDocs, className }) => (
             width={18}
             height={18}
             className={cn(
-              !isDocs && 'text-gray-new-90 transition-colors group-hover:text-gray-new-80'
+              !isDocs && 'text-gray-new-20 transition-colors group-hover:text-gray-new-30 dark:text-gray-new-90 dark:group-hover:text-gray-new-80'
             )}
           />
           {!isDocs && (

--- a/src/components/shared/header/submenu/submenu.jsx
+++ b/src/components/shared/header/submenu/submenu.jsx
@@ -19,7 +19,7 @@ const Submenu = ({
   <div
     className={cn(
       'main-navigation-submenu absolute top-full left-0 z-40 -mt-px w-full overflow-hidden',
-      'border-b border-gray-new-20 bg-black-pure',
+      'border-b border-gray-new-90 bg-white dark:border-gray-new-20 dark:bg-black-pure',
       'transition-[height] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
       {
         'pointer-events-none': activeMenuIndex === null,
@@ -76,7 +76,7 @@ const Submenu = ({
                         {items?.map(({ title, description, to, isExternal }) => (
                           <li key={title} role="none">
                             <Link
-                              className={`group ${submenuLinkClassName} -mx-1 -my-3 grid min-w-[224px] gap-y-2 rounded px-1 py-3 text-[13px] leading-tight tracking-snug text-gray-new-60 transition-colors duration-200 hover:text-gray-new-80`}
+                              className={`group ${submenuLinkClassName} -mx-1 -my-3 grid min-w-[224px] gap-y-2 rounded px-1 py-3 text-[13px] leading-tight tracking-snug text-gray-new-40 dark:text-gray-new-60`}
                               to={to}
                               isExternal={isExternal}
                               tagName="Navigation"
@@ -85,7 +85,7 @@ const Submenu = ({
                               tabIndex={isActive ? 0 : -1}
                               onKeyDown={handleSubmenuNavigation(index)}
                             >
-                              <span className="text-lg leading-none font-medium text-white group-hover:text-gray-new-80">
+                              <span className="text-lg leading-none font-medium text-black-pure transition-colors duration-200 group-hover:text-gray-new-20 dark:text-white dark:group-hover:text-gray-new-80">
                                 {title}
                               </span>
                               {description}


### PR DESCRIPTION
This PR brings fixes for several issues:
1. Changelog alighnment 
https://neon.com/docs/changelog

<details>
<summary>Before</summary>
<img width="757" height="412" alt="image" src="https://github.com/user-attachments/assets/ae02f152-b065-4ffd-b9d9-b0f49471ea45" />

</details>

2. Support white and dark themes for 404 for docs route 
https://neon.com/docs/introductionsd

<details>
<summary>Before</summary>
<img width="768" height="512" alt="image" src="https://github.com/user-attachments/assets/4bca3aa2-afd4-49a6-b086-69f8dbfb8c74" />

</details>

3. Hover blinking for header

<details>
<summary>Before</summary>
<img width="758" height="379" alt="image" src="https://github.com/user-attachments/assets/e3e580a2-c25b-4d30-9ab0-75160f726f9b" />

</details>


[Preview docs not found](https://neon-next-git-not-found-docs-pixelpoint.vercel.app/docs/introduction/asas)
[Preview changelog](https://neon-next-git-not-found-docs-pixelpoint.vercel.app/docs/changelog)

