### PR TITLE
feat: serve /pricing.md as alias to docs/introduction/plans

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -672,6 +672,7 @@ const defaultConfig = {
         { source: '/llms.txt', destination: '/docs/llms.txt' },
         { source: '/llms-full.txt', destination: '/docs/llms-full.txt' },
         { source: '/docs/changelog/:path*.md', destination: '/md/changelog/:path*.md' },
+        { source: '/pricing.md', destination: '/md/docs/introduction/plans.md' },
         ...contentRewrites,
       ],
       // fallback: existing rewrites for external services

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -224,6 +224,7 @@ export const config = {
     '/', // Check if the user is logged in
     '/home', // Check if the user is logged in
     '/llms/:path*', // Legacy .txt redirect
+    '/pricing', // Alias to /docs/introduction/plans markdown
     '/(docs|postgresql|guides|branching|programs|use-cases)/:path*', // All markdown routes
   ],
 };

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -3,6 +3,10 @@
 
 import { CONTENT_ROUTES, EXCLUDED_ROUTES, EXCLUDED_FILES } from 'constants/content';
 
+const ROUTE_ALIASES = {
+  pricing: '/md/docs/introduction/plans.md',
+};
+
 export function isAIAgentRequest(request) {
   const userAgent = request.headers.get('user-agent') || '';
   const accept = request.headers.get('accept') || '';
@@ -44,6 +48,8 @@ export function isAIAgentRequest(request) {
 // Example: /docs/introduction -> /md/docs/introduction.md (maps to public/md/)
 export function getMarkdownPath(pathname) {
   const path = pathname.slice(1).replace(/\/$/, ''); // Remove leading and trailing slashes
+
+  if (ROUTE_ALIASES[path]) return ROUTE_ALIASES[path];
 
   // Early return for excluded routes and files
   const isExcluded =

--- a/src/utils/ai-agent-detection.test.js
+++ b/src/utils/ai-agent-detection.test.js
@@ -231,9 +231,21 @@ describe('getMarkdownPath', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null for /pricing', () => {
-      const result = getMarkdownPath('/pricing');
+    it('should return null for /blog', () => {
+      const result = getMarkdownPath('/blog');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('Route aliases', () => {
+    it('should resolve /pricing to the plans doc', () => {
+      const result = getMarkdownPath('/pricing');
+      expect(result).toBe('/md/docs/introduction/plans.md');
+    });
+
+    it('should resolve /pricing/ with trailing slash', () => {
+      const result = getMarkdownPath('/pricing/');
+      expect(result).toBe('/md/docs/introduction/plans.md');
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `/pricing.md` URL support by rewriting it to the existing `/md/docs/introduction/plans.md` static markdown file
- Adds `/pricing` to the proxy matcher so AI agents (detected via `Accept: text/markdown` or AI user-agent patterns) get the plans markdown via content negotiation
- Introduces a `ROUTE_ALIASES` map in `ai-agent-detection.js` for aliasing non-content-route URLs to existing markdown — extensible for future aliases

## How it works

| Request | Mechanism | Result |
|---------|-----------|--------|
| `GET /pricing.md` | Next.js rewrite in `next.config.js` | Serves `public/md/docs/introduction/plans.md` |
| `GET /pricing` with `Accept: text/markdown` | Proxy + `getMarkdownPath` alias | Returns plans markdown with `Content-Type: text/markdown` |
| `GET /pricing` (normal browser) | Unchanged | Renders the existing React pricing page |

## Test plan

- [x] Existing `ai-agent-detection.test.js` tests pass (71/71)
- [x] New tests added for `/pricing` and `/pricing/` alias resolution
- [ ] Verify on preview: `curl -s https://<preview>/pricing.md` returns plans markdown
- [ ] Verify on preview: `curl -H "Accept: text/markdown" https://<preview>/pricing` returns plans markdown
- [ ] Verify on preview: normal browser visit to `/pricing` still shows the React pricing page