### PR TITLE
docs: fix discord link on auth roadmap page

### DIFF
--- a/content/docs/auth/roadmap.md
+++ b/content/docs/auth/roadmap.md
@@ -101,6 +101,6 @@ For launch readiness, see the [production checklist](/docs/auth/production-check
 
 ## Let us know
 
-We prioritize based on demand. If you need a specific framework or plugin, let us know through our [Discord](https://discord.com/invite/neon) or [GitHub Discussions](https://github.com/orgs/neondatabase/discussions).
+We prioritize based on demand. If you need a specific framework or plugin, let us know through our [Discord](https://discord.com/invite/92vNTzKDGp) or [GitHub Discussions](https://github.com/orgs/neondatabase/discussions).
 
 <NeedHelp/>


### PR DESCRIPTION
the discord link was wrong, fixed it to point to https://discord.com/invite/92vNTzKDGp as in other places around the repo