### PR TITLE
Copy prompt batch 3

### DIFF
--- a/content/docs/guides/dotnet-npgsql.md
+++ b/content/docs/guides/dotnet-npgsql.md
@@ -64,7 +64,7 @@ For your .NET project, you will create a project directory and add the required 
 
 ## Store your Neon connection string
 
-Create a file named `appsettings.json` in your project's root directory. This is the standard .NET approach for storing configuration data like connection strings.
+This application uses `appsettings.json` for configuration, which is the standard .NET approach. You do not need a `.env` file for this guide.
 
 1.  In the [Neon Console](https://console.neon.tech), select your project on the **Dashboard**.
 2.  Click **Connect** on your **Project Dashboard** to open the **Connect to your database** modal.

--- a/content/docs/guides/dotnet-npgsql.md
+++ b/content/docs/guides/dotnet-npgsql.md
@@ -420,6 +420,43 @@ ID: 4, Title: Dune, Author: Frank Herbert, Year: 1965, In Stock: True
 
 > You can see that the book '1984' has been successfully removed from the table.
 
+### Using transactions
+
+The examples above execute each operation independently. For production code where multiple operations must succeed or fail together, wrap them in a transaction using `BeginTransactionAsync`. If any operation fails, call `RollbackAsync` to undo all changes.
+
+```csharp
+await using var conn = new NpgsqlConnection(connectionString);
+await conn.OpenAsync();
+
+await using var transaction = await conn.BeginTransactionAsync();
+try
+{
+    await using (var cmd = new NpgsqlCommand("INSERT INTO books (title, author, publication_year) VALUES (@title, @author, @year)", conn, transaction))
+    {
+        cmd.Parameters.AddWithValue("title", "Brave New World");
+        cmd.Parameters.AddWithValue("author", "Aldous Huxley");
+        cmd.Parameters.AddWithValue("year", 1932);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    await using (var cmd = new NpgsqlCommand("UPDATE books SET in_stock = @in_stock WHERE title = @title", conn, transaction))
+    {
+        cmd.Parameters.AddWithValue("in_stock", false);
+        cmd.Parameters.AddWithValue("title", "Brave New World");
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    await transaction.CommitAsync();
+    Console.WriteLine("Transaction committed successfully.");
+}
+catch (Exception e)
+{
+    await transaction.RollbackAsync();
+    Console.WriteLine($"Transaction rolled back: {e.Message}");
+    throw; // Re-throw to avoid silently swallowing errors
+}
+```
+
 ## Run the application
 
 To run the entire script, execute the following command from your project directory:
@@ -453,5 +490,15 @@ You can find the source code for the application described in this guide on GitH
 - [Npgsql Documentation](https://www.npgsql.org/doc/index.html)
 - [.NET Documentation](https://learn.microsoft.com/en-us/dotnet/)
 - [Connect an Entity Framework application to Neon](/docs/guides/dotnet-entity-framework)
+
+<details>
+<summary>**Notes for AI-assisted setup**</summary>
+
+- Always use parameterized queries (`@param` placeholders) for INSERT, UPDATE, and DELETE operations. Never concatenate user input into SQL strings. This prevents SQL injection.
+- Wrap related database operations in a transaction (`BeginTransactionAsync` / `CommitAsync` / `RollbackAsync`). Always call `RollbackAsync` in the catch block and re-throw the exception with `throw;` to avoid silently swallowing errors.
+- Use `await using` for `NpgsqlConnection`, `NpgsqlCommand`, and `NpgsqlDataReader` to ensure resources are properly disposed.
+- Do not hardcode credentials in `.cs` files or `appsettings.json` that is committed to version control. In production, use environment variables or a secure secrets manager. For more information, see [Security overview](/docs/security/security-overview).
+
+</details>
 
 <NeedHelp/>

--- a/content/docs/guides/dotnet-npgsql.md
+++ b/content/docs/guides/dotnet-npgsql.md
@@ -64,7 +64,7 @@ For your .NET project, you will create a project directory and add the required 
 
 ## Store your Neon connection string
 
-This application uses `appsettings.json` for configuration, which is the standard .NET approach. You do not need a `.env` file for this guide.
+Create a file named `appsettings.json` in your project's root directory. This is the standard .NET approach for storing configuration data like connection strings.
 
 1.  In the [Neon Console](https://console.neon.tech), select your project on the **Dashboard**.
 2.  Click **Connect** on your **Project Dashboard** to open the **Connect to your database** modal.
@@ -497,7 +497,8 @@ You can find the source code for the application described in this guide on GitH
 - Always use parameterized queries (`@param` placeholders) for INSERT, UPDATE, and DELETE operations. Never concatenate user input into SQL strings. This prevents SQL injection.
 - Wrap related database operations in a transaction (`BeginTransactionAsync` / `CommitAsync` / `RollbackAsync`). Always call `RollbackAsync` in the catch block and re-throw the exception with `throw;` to avoid silently swallowing errors.
 - Use `await using` for `NpgsqlConnection`, `NpgsqlCommand`, and `NpgsqlDataReader` to ensure resources are properly disposed.
-- Do not hardcode credentials in `.cs` files or `appsettings.json` that is committed to version control. In production, use environment variables or a secure secrets manager. For more information, see [Security overview](/docs/security/security-overview).
+- This application uses `appsettings.json` for configuration, not a `.env` file. Do not create a `.env` file — it is not read by the application.
+- Do not hardcode credentials in `.cs` files or commit `appsettings.json` with real credentials to version control. In production, use environment variables or a secure secrets manager. For more information, see [Security overview](/docs/security/security-overview).
 
 </details>
 

--- a/content/docs/guides/elixir.md
+++ b/content/docs/guides/elixir.md
@@ -353,7 +353,57 @@ ID: 4, Title: Dune, Author: Frank Herbert, Year: 1965, In Stock: true
 
 > You can see that the book '1984' has been successfully deleted from the `books` table.
 
+### Using transactions
+
+The examples above execute each operation independently. For production code where multiple operations must succeed or fail together, wrap them in a transaction using `Postgrex.transaction/2`. If any operation inside the function fails, the entire transaction is rolled back automatically.
+
+```elixir title="transaction_example.exs"
+defmodule TransactionExample do
+  def run do
+    config = Application.get_all_env(:neon_elixir_quickstart)
+    {:ok, pid} = Postgrex.start_link(config)
+    IO.puts("Connection established")
+
+    try do
+      Postgrex.transaction(pid, fn conn ->
+        # Insert
+        Postgrex.query!(conn, "INSERT INTO books (title, author, publication_year) VALUES ($1, $2, $3)", ["Brave New World", "Aldous Huxley", 1932])
+        IO.puts("Inserted book.")
+
+        # Update
+        Postgrex.query!(conn, "UPDATE books SET in_stock = $1 WHERE title = $2", [false, "Brave New World"])
+        IO.puts("Updated stock status.")
+
+        IO.puts("Transaction committed successfully.")
+      end)
+    rescue
+      e in Postgrex.Error ->
+        IO.puts("Transaction failed and was rolled back.")
+        IO.inspect(e)
+    end
+  end
+end
+
+TransactionExample.run()
+```
+
+Run with:
+
+```bash
+mix run transaction_example.exs
+```
+
 </Steps>
+
+<details>
+<summary>**Notes for AI-assisted setup**</summary>
+
+- The `ssl: [cacerts: :public_key.cacerts_get()]` option in the Postgrex configuration is mandatory. The connection to Neon will fail without it.
+- Use `Postgrex.transaction/2` to wrap related database operations. If any operation inside the transaction function fails, the entire transaction is rolled back automatically.
+- Always use parameterized queries (`$1`, `$2`, etc.) for INSERT, UPDATE, and DELETE operations. Never concatenate user input into SQL strings.
+- Do not hardcode credentials in `.ex` or `.exs` files. Store connection parameters in `config/config.exs` and keep that file out of version control. For more information, see [Security overview](/docs/security/security-overview).
+
+</details>
 
 ## Next steps: Using an ORM or framework
 

--- a/content/docs/guides/rust.md
+++ b/content/docs/guides/rust.md
@@ -688,6 +688,7 @@ You can find the source code for the applications described in this guide on Git
 <details>
 <summary>**Notes for AI-assisted setup**</summary>
 
+- Ask the user which Rust Postgres driver they want to use: `postgres` (synchronous) or `tokio-postgres` (asynchronous). Only after they choose, proceed with the relevant code and instructions for that driver.
 - The TLS/SSL connector setup is mandatory. Neon requires a secure connection, and the `postgres-openssl` and `openssl` crates must be included. The connection will fail without the `SslConnector` / `MakeTlsConnector` setup shown in the examples.
 - Mutability matters for transactions. In the synchronous `postgres` crate, both the `client` and the `transaction` must be declared as `mut`. In `tokio-postgres`, the `client` must be `mut` to call `.transaction()`, but the returned transaction object is not `mut`. Getting this wrong causes compile errors.
 - Use `dotenvy` (not `dotenv`) for loading `.env` files. The `dotenv` crate is unmaintained; `dotenvy` is the actively maintained fork.

--- a/content/docs/guides/rust.md
+++ b/content/docs/guides/rust.md
@@ -685,4 +685,15 @@ You can find the source code for the applications described in this guide on Git
 - [tokio-postgres crate documentation](https://docs.rs/tokio-postgres/latest/tokio_postgres/)
 - [Tokio async runtime](https://tokio.rs/)
 
+<details>
+<summary>**Notes for AI-assisted setup**</summary>
+
+- The TLS/SSL connector setup is mandatory. Neon requires a secure connection, and the `postgres-openssl` and `openssl` crates must be included. The connection will fail without the `SslConnector` / `MakeTlsConnector` setup shown in the examples.
+- Mutability matters for transactions. In the synchronous `postgres` crate, both the `client` and the `transaction` must be declared as `mut`. In `tokio-postgres`, the `client` must be `mut` to call `.transaction()`, but the returned transaction object is not `mut`. Getting this wrong causes compile errors.
+- Use `dotenvy` (not `dotenv`) for loading `.env` files. The `dotenv` crate is unmaintained; `dotenvy` is the actively maintained fork.
+- Always use parameterized queries (`$1`, `$2`, etc.) for INSERT, UPDATE, and DELETE operations. Never concatenate user input into SQL strings.
+- Do not hardcode credentials in `.rs` files. Use environment variables via `dotenvy` and `std::env::var`. For more information, see [Security overview](/docs/security/security-overview).
+
+</details>
+
 <NeedHelp/>


### PR DESCRIPTION
Enriched Rust, Elixir, and .NET Npgsql guides with content from their corresponding copy prompts. This is batch 3 of the copy prompt enrichment project (batch 1: Express, Prisma, Django in #4692; batch 2: Go, Java in #4700).

**Changes:**

- **Rust:** "Notes for AI-assisted setup" `<details>` section (TLS/SSL mandatory, mutability gotcha for `tokio-postgres` transactions, `dotenvy` not `dotenv`, parameterized queries, security cross-reference)
- **Elixir:** Transaction example with `Postgrex.transaction/2`, "Notes for AI-assisted setup" `<details>` section (SSL mandatory, transaction pattern, parameterized queries, security cross-reference)
- **.NET Npgsql:** Transaction example with `BeginTransactionAsync`/`CommitAsync`/`RollbackAsync`, "Notes for AI-assisted setup" `<details>` section (parameterized queries, transaction pattern, `await using`, `.env` vs `appsettings.json` clarification, security cross-reference)

**Automated test harness results:**

| Guide | Raw | Infra issues | Adjusted | Harness finding |
| --- | --- | --- | --- | --- |
| Rust | 9/10 | None | ~10/10 | Mutability note in `<details>` worked silently — agent got transactions right without backtracking |
| Elixir | 7.5/10 | Package detection missing Elixir patterns | ~8/10 | All CRUD + transactions passed. Harness needs `_build`/`deps` detection (not a docs issue) |
| .NET Npgsql | 7.5/10 | .NET SDK install overhead | ~9/10 | Agent created unused `.env` alongside `appsettings.json`. Added clarification to `<details>` section |

The .NET finding is a good example of the `<details>` section earning its keep: `.env` files are the default pattern across most guides, so agents default to creating one. The .NET guide uses `appsettings.json` instead, and the agent-correctional note now catches this.