### PR TITLE
Copy prompt batch 4

### DIFF
--- a/content/docs/guides/elixir-ecto.md
+++ b/content/docs/guides/elixir-ecto.md
@@ -56,7 +56,7 @@ The `--sup` option ensures that the application has a supervision tree, which is
 
 1. Add the Ecto and the Postgrex driver dependencies to the `mix.exs` file by updating the `deps` definition in the file to include those items. For example:
 
-   ```bash
+   ```elixir
    defp deps do
      [
        {:ecto_sql, "~> 3.0"},
@@ -152,7 +152,7 @@ defmodule Friends.Repo.Migrations.CreatePeople do
 end
 ```
 
-Add code to the migration file to create a table called `people`. For example:
+Add code to the migration file to create a table called `people`. Including `timestamps()` will automatically generate `inserted_at` and `updated_at` columns. For example:
 
 ```elixir
 defmodule Friends.Repo.Migrations.CreatePeople do
@@ -163,6 +163,8 @@ defmodule Friends.Repo.Migrations.CreatePeople do
       add :first_name, :string
       add :last_name, :string
       add :age, :integer
+
+      timestamps()
     end
   end
 end
@@ -191,6 +193,122 @@ You can use the **Tables** feature in the Neon Console to view the table that wa
 
 </Steps>
 
+## Examples
+
+This section demonstrates how to map your Elixir application to the database table and perform operations within an Ecto transaction.
+
+### Create an Ecto schema
+
+To interact with the `people` table using Elixir structs, you need an Ecto Schema. Create a new file `lib/friends/person.ex` and add the following code:
+
+```elixir
+defmodule Friends.Person do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "people" do
+    field :first_name, :string
+    field :last_name, :string
+    field :age, :integer
+
+    timestamps()
+  end
+
+  def changeset(person, attrs) do
+    person
+    |> cast(attrs, [:first_name, :last_name, :age])
+    |> validate_required([:first_name, :last_name])
+  end
+end
+```
+
+### Execute a CRUD transaction
+
+Create a new file named `main.exs` in your project's root directory. This script demonstrates a full Create, Read, Update, and Delete lifecycle wrapped within a single database transaction. Wrapping operations in a transaction ensures that they either all succeed together or fail together.
+
+```elixir
+defmodule NeonEctoExample do
+  alias Friends.Repo
+  alias Friends.Person
+
+  def run do
+    IO.puts("Starting Neon Ecto example...")
+
+    # Repo.transaction ensures all operations inside either succeed together or fail together.
+    Repo.transaction(fn ->
+      IO.puts("\n--- Transaction Started ---")
+
+      # 1. CREATE
+      IO.puts("\n[CREATE] Inserting a new person...")
+      {:ok, person} =
+        %Person{}
+        |> Person.changeset(%{first_name: "Ada", last_name: "Lovelace", age: 36})
+        |> Repo.insert()
+      IO.puts("Inserted: #{inspect(person)}")
+
+      # 2. READ
+      IO.puts("\n[READ] Fetching the new person by ID...")
+      fetched_person = Repo.get!(Person, person.id)
+      IO.puts("Fetched: #{inspect(fetched_person)}")
+
+      # 3. UPDATE
+      IO.puts("\n[UPDATE] Updating the person's age...")
+      changeset = Person.changeset(fetched_person, %{age: 37})
+      {:ok, updated_person} = Repo.update(changeset)
+      IO.puts("Updated: #{inspect(updated_person)}")
+
+      # 4. DELETE
+      IO.puts("\n[DELETE] Deleting the person...")
+      {:ok, deleted_person} = Repo.delete(updated_person)
+      IO.puts("Deleted: #{inspect(deleted_person)}")
+
+      # Verify deletion
+      IO.puts("\nVerifying deletion...")
+      is_deleted = is_nil(Repo.get(Person, deleted_person.id))
+      IO.puts("Person with ID #{deleted_person.id} exists? #{not is_deleted}")
+
+      IO.puts("\n--- Transaction Committed Successfully ---\n")
+    end)
+  end
+end
+
+# Ensure the Ecto Repo is started before running the script
+_ = Application.ensure_all_started(:friends)
+
+NeonEctoExample.run()
+```
+
+Run the script from your terminal using the following command:
+
+```bash
+mix run main.exs
+```
+
+When the code runs successfully, you will see output detailing each operation executed within the transaction:
+
+```text
+Starting Neon Ecto example...
+
+--- Transaction Started ---
+
+[CREATE] Inserting a new person...
+Inserted: %Friends.Person{id: 1, first_name: "Ada", last_name: "Lovelace", age: 36, ...}
+
+[READ] Fetching the new person by ID...
+Fetched: %Friends.Person{id: 1, first_name: "Ada", last_name: "Lovelace", age: 36, ...}
+
+[UPDATE] Updating the person's age...
+Updated: %Friends.Person{id: 1, first_name: "Ada", last_name: "Lovelace", age: 37, ...}
+
+[DELETE] Deleting the person...
+Deleted: %Friends.Person{id: 1, first_name: "Ada", last_name: "Lovelace", age: 37, ...}
+
+Verifying deletion...
+Person with ID 1 exists? false
+
+--- Transaction Committed Successfully ---
+```
+
 ## Application code
 
 You can find the application code for the example above on GitHub.
@@ -201,7 +319,7 @@ You can find the application code for the example above on GitHub.
 
 ## Next steps
 
-The [Ecto Getting Started Guide](https://hexdocs.pm/ecto/getting-started.html#content) provides additional steps that you can follow to create a schema, insert data, and run queries. See [Creating the schema](https://hexdocs.pm/ecto/getting-started.html#creating-the-schema) in the _Ecto Getting Started Guide_ to pick up where the steps in this guide leave off.
+The [Ecto Getting Started Guide](https://hexdocs.pm/ecto/getting-started.html#content) provides additional steps that you can follow to structure your database logic, create advanced schemas and run complex queries.
 
 ## Usage notes
 

--- a/content/docs/guides/phoenix.md
+++ b/content/docs/guides/phoenix.md
@@ -26,16 +26,6 @@ If you do not have one already, create a Neon project. Save your connection deta
 2. Click **New Project**.
 3. Specify your project settings and click **Create Project**.
 
-## Store your Neon credentials
-
-Add a `.env` file to your project directory and add your Neon connection string to it. You can find your connection string by clicking the **Connect** button on your **Project Dashboard** to open the **Connect to your database** modal. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
-
-```shell shouldWrap
-DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech:<port>/<dbname>?sslmode=require&channel_binding=require"
-```
-
-You will need the connection string details later in the setup.
-
 ## Create a Phoenix project
 
 [Create a Phoenix project](https://hexdocs.pm/phoenix/installation.html#phoenix) if you do not have one:
@@ -50,15 +40,15 @@ When prompted, choose to not install the dependencies yet.
 
 ## Configure database connections
 
-Update the following configuration files with your Neon database connection details from the connection string you copied earlier.
+Update the following configuration files with your Neon database connection details. You can find your connection parameters by clicking the **Connect** button on your **Project Dashboard** to open the **Connect to your database** modal. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
-1. Update `config/dev.exs`:
+1. Update `config/dev.exs` with your database credentials:
 
    ```elixir {2-5,9}
    config :hello, Hello.Repo,
-      username: "neondb_owner",
-      password: "JngqXejzvb93",
-      hostname: "ep-rough-snowflake-a5j76tr5.us-east-2.aws.neon.tech",
+      username: "<YOUR_DB_USER>",
+      password: "<YOUR_DB_PASSWORD>",
+      hostname: "ep-xxx.aws.neon.tech",
       database: "neondb",
       stacktrace: true,
       show_sensitive_data_on_connection_error: true,
@@ -70,7 +60,7 @@ Update the following configuration files with your Neon database connection deta
    The `:ssl` option is required to connect to Neon. Postgrex, since v0.18, verifies the server SSL certificate and you need to select CA trust store using `:cacerts` or `:cacertfile` options. You can use the OS-provided CA store by setting `cacerts: :public_key.cacerts_get()`. While not recommended, you can disable certificate verification by setting `ssl: [verify: :verify_none]`.
    </Admonition>
 
-2. Update `config/runtime.exs`:
+2. Update `config/runtime.exs` to read from the `DATABASE_URL` environment variable in production:
 
    ```elixir {2}
    config :hello, Hello.Repo,
@@ -80,13 +70,13 @@ Update the following configuration files with your Neon database connection deta
       socket_options: maybe_ipv6
    ```
 
-3. Update `config/test.exs`:
+3. Update `config/test.exs` with your testing credentials:
 
    ```elixir {2,3,4,8}
    config :hello, Hello.Repo,
-      username: "neondb_owner",
-      password: "JngqXejzvb93",
-      hostname: "ep-rough-snowflake-a5j76tr5.us-east-2.aws.neon.tech",
+      username: "<YOUR_DB_USER>",
+      password: "<YOUR_DB_PASSWORD>",
+      hostname: "ep-xxx.aws.neon.tech",
       database: "with_phoenix_test#{System.get_env("MIX_TEST_PARTITION")}",
       pool: Ecto.Adapters.SQL.Sandbox,
       pool_size: System.schedulers_online() * 2,
@@ -99,9 +89,10 @@ Update the following configuration files with your Neon database connection deta
 
 ## Install dependencies and create databases
 
-1. Install the dependencies:
+1. Navigate into your project directory and install the dependencies:
 
    ```bash
+   cd hello
    mix deps.get
    ```
 
@@ -112,40 +103,97 @@ Update the following configuration files with your Neon database connection deta
    MIX_ENV=test mix ecto.create
    ```
 
-   The first command creates the development database (`neondb`). The second creates the test database (`with_phoenix_test`).
+   The first command creates the development database (`neondb`). The second creates the test database (`with_phoenix_test`). This will also create the `schema_migrations` table to prepare your database for Ecto migrations.
 
-## Build and run the Phoenix application
+</Steps>
 
-To compile the app in production mode, run the following command:
+## Examples
+
+This section demonstrates how to create a simple API endpoint in your Phoenix application to verify the database connection by querying the PostgreSQL version.
+
+### Create a database version check controller
+
+Create a new file named `lib/hello_web/controllers/db_check_controller.ex` and add the following code:
+
+```elixir
+defmodule HelloWeb.DBCheckController do
+  use HelloWeb, :controller
+
+  alias Hello.Repo
+
+  def version(conn, _params) do
+    # Execute a raw SQL query to get the PostgreSQL version
+    {:ok, result} = Ecto.Adapters.SQL.query(Repo, "SELECT version();", [])
+
+    # The result is a list with one row and one column
+    [[version_string]] = result.rows
+
+    # Return the version string as a JSON response
+    json(conn, %{version: version_string})
+  end
+end
+```
+
+### Add a route
+
+Open `lib/hello_web/router.ex`. Inside the existing `scope "/api", HelloWeb do` block, add the following route:
+
+```elixir {3}
+scope "/api", HelloWeb do
+  # ...
+  get "/db_version", DBCheckController, :version
+end
+```
+
+### Run the application locally
+
+Start your Phoenix server in development mode:
+
+```bash
+mix phx.server
+```
+
+Open a new terminal window and run the following `curl` command to verify your database connection:
+
+```bash
+curl http://localhost:4000/api/db_version
+```
+
+If successful, the output will return your database version as JSON:
+
+```json
+{"version":"PostgreSQL 17.8 (a48d9ca) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14+deb12u1) 12.2.0, 64-bit"}
+```
+
+## Production deployment
+
+When you are ready to deploy your application in production, you compile your app and pass your credentials securely using environment variables rather than hardcoded configuration files.
+
+To compile the app and assets in production mode:
 
 ```bash
 MIX_ENV=prod mix compile
-```
-
-To compile assets for the production mode, run the following command:
-
-```bash
 MIX_ENV=prod mix assets.deploy
 ```
 
-For each deployment, a secret key is required for encrypting and signing data. Run the following command to generate the key:
+Generate a secret key required for encrypting and signing data:
 
 ```bash
 mix phx.gen.secret
 ```
 
-When you run the following command, you can expect to see the Phoenix application at [http://localhost:4001](http://localhost:4001):
+Run the Phoenix application using your full `DATABASE_URL` connection string:
 
 ```bash shouldWrap
 PORT=4001 \
 MIX_ENV=prod \
 PHX_HOST=localhost \
-DATABASE_URL="postgresql://...:...@...aws.neon.tech/neondb?sslmode=require&channel_binding=require" \
-SECRET_KEY_BASE=".../..." \
+DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech/<dbname>?sslmode=require&channel_binding=require" \
+SECRET_KEY_BASE="<your_generated_secret_key>" \
 mix phx.server
 ```
 
-</Steps>
+You can expect to see the Phoenix application running at [http://localhost:4001](http://localhost:4001).
 
 ## Source code
 
@@ -163,7 +211,7 @@ You can find the source code for the application described in this guide on GitH
 - The `ssl: [cacerts: :public_key.cacerts_get()]` option is mandatory in all config files (`dev.exs`, `runtime.exs`, `test.exs`). The connection to Neon will fail without it.
 - This guide uses `hello` as the app and module name. For existing projects, read the `:app` and `:mod` values from `mix.exs` and use those consistently in config and module names.
 - Do not hardcode credentials in config files committed to version control. The `config/runtime.exs` pattern shown in this guide reads from `DATABASE_URL` at runtime, which is the recommended approach for production. For more information, see [Security overview](/docs/security/security-overview).
-- The `mix phx.new` command is interactive and requires user input. It cannot be run non-interactively.
+- The `mix phx.new` command is interactive and requires user input. It cannot be run non-interactively without specific flags.
 
 </details>
 


### PR DESCRIPTION
## Summary

Enriched Elixir Ecto and Phoenix guides with content from their corresponding copy prompts. This is batch 4 of the copy prompt enrichment project (batch 1: #4692, batch 2: #4700, batch 3: #4709).

**Changes:**

- **Elixir Ecto:** Added `pool_size: 10` to config example, Elixir 1.15+ version requirement (harness finding), "Notes for AI-assisted setup" `<details>` section (`:extra_applications` anti-pattern, SSL mandatory, transaction guidance, `config.exs` vs `runtime.exs` credential handling)
- **Phoenix:** Added Elixir 1.15+ and Erlang/OTP 25+ version requirements (harness finding), "Notes for AI-assisted setup" `<details>` section (SSL mandatory, app name handling, `mix phx.new` is interactive, security cross-reference)

**Automated test harness results:**

| Guide       | Score  | Key issue |
| ----------- | ------ | --------- |
| Elixir Ecto | 6.5/10 | Container's Elixir 1.14 too old for postgrex 0.22+. Agent spent ~14 turns installing newer Elixir. Guide steps followed correctly once environment was set up. |
| Phoenix     | 5/10   | Same Elixir version wall. Agent hit 60-turn cap while still setting up runtime. Connection verified but `mix ecto.create` never completed. |

Both guides hit the same root cause: the container shipped Elixir 1.14 but current Postgrex requires 1.15+. Added version requirements to both guides based on this finding.

**Notable finding:** When the guide body shows hardcoded credentials and the `<details>` section says "don't hardcode for production," agents follow the guide body's code example. The `<details>` section is effective for corrections that don't contradict the guide's own examples, but cannot override them.