### PR TITLE
fix: OG image rendering issue

### DIFF
--- a/src/app/(docs)/docs/og/route.jsx
+++ b/src/app/(docs)/docs/og/route.jsx
@@ -55,13 +55,13 @@ export async function GET(request) {
         }}
       >
         <img
-          width="1200"
-          height="630"
+          width={1200}
+          height={630}
           src={backgroundData}
           style={{ position: 'absolute', top: 0, left: 0 }}
           alt=""
         />
-        {hasLogo && <img width="199" height="56" src={logoData} alt="" />}
+        {hasLogo && <img width={199} height={56} src={logoData} alt="" />}
         <div
           style={{
             display: 'flex',

--- a/src/app/api/og/route.jsx
+++ b/src/app/api/og/route.jsx
@@ -45,13 +45,13 @@ export async function GET(request) {
         }}
       >
         <img
-          width="1200"
-          height="630"
+          width={1200}
+          height={630}
           src={backgroundData}
           style={{ position: 'absolute', top: 0, left: 0 }}
           alt=""
         />
-        <img width="235" height="64" src={logoData} alt="" />
+        <img width={235} height={64} src={logoData} alt="" />
         <div
           style={{
             display: 'flex',


### PR DESCRIPTION
This PR fixes the issue where OG images were displaying a plain black background instead of the intended pattern template.

Satori (the next/OG renderer) requires numeric values for the width and height attributes of img elements. If string values are passed (e.g. '1200'), images are silently skipped, resulting in a plain black background.

This issue arose after upgrading to `Next.js 16.2.1`, which included a stricter version of Satori.

This affects both the `docs` and `api` OG image routes.