### PR TITLE
docs: fix code block copy button copying truncated text

### DIFF
--- a/src/components/pages/blog-post/code-block/code-block.jsx
+++ b/src/components/pages/blog-post/code-block/code-block.jsx
@@ -14,7 +14,11 @@ const CodeBlock = async (props) => {
 
   const highlightCode = await highlight(codeContent, props.language);
 
-  return <CodeBlockWrapper>{parse(highlightCode)}</CodeBlockWrapper>;
+  return (
+    <CodeBlockWrapper copyCode={typeof codeContent === 'string' ? codeContent : undefined}>
+      {parse(highlightCode)}
+    </CodeBlockWrapper>
+  );
 };
 
 CodeBlock.propTypes = {

--- a/src/components/shared/code-block-wrapper/code-block-wrapper.jsx
+++ b/src/components/shared/code-block-wrapper/code-block-wrapper.jsx
@@ -39,13 +39,16 @@ const CodeBlockWrapper = ({
   filename = null,
   language = null,
   trackingLabel = null,
+  copyCode = null,
   children,
   as: Tag = 'figure',
   ...otherProps
 }) => {
   const { isCopied, handleCopy } = useCopyToClipboard(3000);
 
-  const code = extractTextFromNode(children).replace(/(\n)?__line_removed_in_code__(\n)?/g, '');
+  // copyCode bypasses extractTextFromNode, which can't traverse RSC lazy chunks in children
+  const code =
+    copyCode ?? extractTextFromNode(children).replace(/(\n)?__line_removed_in_code__(\n)?/g, '');
   const isSingleLineCode = code.trimEnd().split('\n').length === 1;
   let copyButtonTopClassName = 'top-4';
 
@@ -109,6 +112,7 @@ CodeBlockWrapper.propTypes = {
   filename: PropTypes.string,
   language: PropTypes.string,
   trackingLabel: PropTypes.string,
+  copyCode: PropTypes.string,
   children: PropTypes.node,
   as: PropTypes.string,
 };

--- a/src/components/shared/code-block/code-block.jsx
+++ b/src/components/shared/code-block/code-block.jsx
@@ -36,7 +36,9 @@ const CodeBlock = async ({
   const meta = children?.props?.meta || '';
   const filename = getFileNameFromMeta(meta);
   const trackingLabel = getTrackingLabelFromMeta(meta);
-  const code = children?.props?.children?.trim() || '';
+  const code = (
+    typeof children?.props?.children === 'string' ? children.props.children : ''
+  ).trim();
   const html = await highlight(code, language, meta);
 
   return (
@@ -49,6 +51,7 @@ const CodeBlock = async ({
       filename={filename}
       language={language}
       trackingLabel={trackingLabel}
+      copyCode={code}
       data-line-numbers={meta?.includes('showLineNumbers')}
       copyButtonClassName={copyButtonClassName}
       {...otherProps}

--- a/src/components/shared/external-code/external-code.jsx
+++ b/src/components/shared/external-code/external-code.jsx
@@ -48,6 +48,7 @@ const ExternalCode = async ({
           className
         )}
         data-line-numbers={showLineNumbers}
+        copyCode={text}
         copyButtonClassName={copyButtonClassName}
         {...otherProps}
       >

--- a/src/components/shared/sql-to-rest-converter/sql-to-rest-converter.jsx
+++ b/src/components/shared/sql-to-rest-converter/sql-to-rest-converter.jsx
@@ -177,13 +177,21 @@ offset
                 'HTTP',
               ]}
             >
-              <CodeBlockWrapper>{parse(highlightedJsNeonAuth || '')}</CodeBlockWrapper>
+              <CodeBlockWrapper copyCode={jsOutputNeonAuth}>
+                {parse(highlightedJsNeonAuth || '')}
+              </CodeBlockWrapper>
 
-              <CodeBlockWrapper>{parse(highlightedJsOwnAuth || '')}</CodeBlockWrapper>
+              <CodeBlockWrapper copyCode={jsOutputOwnAuth}>
+                {parse(highlightedJsOwnAuth || '')}
+              </CodeBlockWrapper>
 
-              <CodeBlockWrapper>{parse(highlightedCurl || '')}</CodeBlockWrapper>
+              <CodeBlockWrapper copyCode={curlOutput}>
+                {parse(highlightedCurl || '')}
+              </CodeBlockWrapper>
 
-              <CodeBlockWrapper>{parse(highlightedHttp || '')}</CodeBlockWrapper>
+              <CodeBlockWrapper copyCode={httpOutput}>
+                {parse(highlightedHttp || '')}
+              </CodeBlockWrapper>
             </CodeTabs>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Code block copy buttons were copying truncated text as reported by issue #4742
- Root cause: React 19 RSC serializes large element trees as lazy chunks, which `extractTextFromNode` can't traverse; site upgraded React 18->19 via PR #4670
- Fix: pass raw code string as `copyCode` prop from server to client; `extractTextFromNode` kept as fallback for client-side callers

## Test plan
- [x] Verified with Cypress: 10/23 blocks on /guides/neon-auth-nextjs were truncated before fix, 0/23 after
- [x] Manual: visit a docs page with long code blocks, click copy, paste, then full code should appear
