### PR TITLE
docs: fix unknown components + improve QuoteBlock output

### DIFF
--- a/src/scripts/LLMS_PROCESSOR_GUIDE.md
+++ b/src/scripts/LLMS_PROCESSOR_GUIDE.md
@@ -119,7 +119,7 @@ See existing handlers in the code for examples of each pattern.
 | Admonition                                                         | `**Type:** content` (handles camelCase like `comingSoon` -> `Coming Soon`)                       |
 | CodeTabs                                                           | `Tab: label` + code blocks                                                                       |
 | Tabs/TabItem                                                       | `Tab: label` + content (labels from parent Tabs)                                                 |
-| Steps, InfoBlock, DefinitionList, TestimonialsWrapper, FeatureList | Container -- extracts children                                                                   |
+| Steps, InfoBlock, DefinitionList, TestimonialsWrapper, QuoteBlocksWrapper, FeatureList | Container -- extracts children                                                                   |
 | DetailIconCards                                                    | Bullet list with links and descriptions                                                          |
 | TechCards                                                          | Bullet list using `title` attribute (self-closing `<a>` elements)                                |
 | DocsList                                                           | Title + bullet list (handles nested `<a>` and `<p>`)                                             |
@@ -128,7 +128,7 @@ See existing handlers in the code for examples of each pattern.
 | TwoColumnLayout.\*                                                 | Section headings with method signatures                                                          |
 | LinkPreview                                                        | Link with optional preview text                                                                  |
 | MegaLink                                                           | `**tag** title [Learn more](url)`                                                                |
-| QuoteBlock                                                         | Blockquote with attribution                                                                      |
+| QuoteBlock                                                         | Blockquote with attribution (object or slug author), optional case-study link                    |
 | Testimonial                                                        | Blockquote with author name/company                                                              |
 | YoutubeIframe                                                      | `Watch on YouTube: url`                                                                          |
 | CommunityBanner                                                    | Text + link                                                                                      |
@@ -137,7 +137,7 @@ See existing handlers in the code for examples of each pattern.
 | ProgramForm                                                        | Hardcoded text for form types                                                                    |
 
 **Shared content components** (load templates from `content/docs/shared-content/`):
-FeatureBeta, FeatureBetaProps (`{feature_name}`), EarlyAccess, EarlyAccessProps, AgentSkillsTip, MCPTools, LinkAPIKey, LRNotice, ComingSoon, PrivatePreview, PrivatePreviewEnquire, PublicPreview, LRBeta, MigrationAssistant, NextSteps, NewPricing
+FeatureBeta, FeatureBetaProps (`{feature_name}`), EarlyAccess, EarlyAccessProps, AgentSkillsTip, MCPTools, LinkAPIKey, LRNotice, ComingSoon, PrivatePreview, PrivatePreviewEnquire, PublicPreview, LRBeta, MigrationAssistant, NextSteps, NewPricing, AzureRegionsDeprecation, ConsumptionAccountApiDeprecation
 
 **HTML elements**: `<a>` -> markdown link (wrapped in paragraph when block-level), `<details>/<summary>` -> preserved as HTML, `<p>` -> paragraph, `<br/>` -> preserved
 

--- a/src/scripts/process-md-for-llms.js
+++ b/src/scripts/process-md-for-llms.js
@@ -66,6 +66,8 @@ const SHARED_CONTENT_COMPONENTS = {
   NextSteps: 'next-steps',
   NewPricing: 'new-pricing',
   EarlyAccess: 'early-access',
+  AzureRegionsDeprecation: 'azure-regions-deprecation',
+  ConsumptionAccountApiDeprecation: 'consumption-account-api-deprecation',
 };
 
 /**
@@ -157,6 +159,62 @@ function getAttr(node, name) {
   }
 
   return undefined;
+}
+
+/**
+ * Parse an object-style author attribute from an MDX JSX node.
+ * Handles author={{ name: '...', company: '...' }} expressions.
+ * @returns {{ name: string, company: string }} or null if not an object expression
+ */
+function parseAuthorObject(node, attrName = 'author') {
+  const attr = node.attributes?.find((a) => a.type === 'mdxJsxAttribute' && a.name === attrName);
+  if (!attr || attr.value?.type !== 'mdxJsxAttributeValueExpression') return null;
+
+  const expr = attr.value.value || '';
+  const nameMatch = expr.match(/name:\s*['"]([^'"]+)['"]/);
+  const companyMatch = expr.match(/company:\s*['"]([^'"]+)['"]/);
+
+  if (!nameMatch && !companyMatch) return null;
+  return { name: nameMatch ? nameMatch[1] : '', company: companyMatch ? companyMatch[1] : '' };
+}
+
+/**
+ * QuoteBlock slug-to-name map, loaded once from the React component source.
+ */
+let quoteBlockNameMap = null;
+
+function loadQuoteBlockNameMap() {
+  if (quoteBlockNameMap) return quoteBlockNameMap;
+  quoteBlockNameMap = new Map();
+
+  if (!projectRoot) return quoteBlockNameMap;
+
+  const filePath = path.join(projectRoot, 'src/components/shared/quote-block/quote-block.jsx');
+  try {
+    const source = fsSync.readFileSync(filePath, 'utf-8');
+    const regex = /'([^']+)':\s*\{\s*name:\s*'([^']+)'/g;
+    let match;
+    while ((match = regex.exec(source)) !== null) {
+      quoteBlockNameMap.set(match[1], match[2]);
+    }
+  } catch {
+    // File not found (e.g. tests without full repo) — title-case fallback will handle it
+  }
+
+  return quoteBlockNameMap;
+}
+
+/**
+ * Resolve a slug like "lincoln-bergeson" to a human name.
+ * Tries the quote-block map first, then falls back to title-casing.
+ */
+function resolveAuthorSlug(slug) {
+  const map = loadQuoteBlockNameMap();
+  if (map.has(slug)) return map.get(slug);
+  return slug
+    .split('-')
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(' ');
 }
 
 /**
@@ -1130,22 +1188,45 @@ const componentHandlers = {
 
   /**
    * QuoteBlock -> blockquote with attribution
-   * <QuoteBlock quote="..." author="name" role="title" />
+   * Supports author={{ name, company }} objects and author="slug" + role="..." strings.
+   * String slugs are resolved to human names via the quote-block.jsx map.
+   * Optional link prop emits a "Read case study" link.
    */
   QuoteBlock(node) {
-    const quote = getAttr(node, 'quote');
-    const author = getAttr(node, 'author') || '';
-    const role = getAttr(node, 'role') || '';
-
+    const quote = getAttr(node, 'quote') || getAttr(node, 'text') || '';
     if (!quote) return null;
 
     const children = [{ type: 'paragraph', children: [{ type: 'text', value: quote }] }];
 
-    if (author || role) {
-      const attribution = [author, role].filter(Boolean).join(', ');
+    // Try object author first (author={{ name: '...', company: '...' }})
+    const parsed = parseAuthorObject(node, 'author');
+    if (parsed && (parsed.name || parsed.company)) {
+      const attribution = [parsed.name, parsed.company].filter(Boolean).join(', ');
       children.push({
         type: 'paragraph',
         children: [{ type: 'text', value: `— ${attribution}` }],
+      });
+    } else {
+      // Fall back to string author + role
+      const authorSlug = getAttr(node, 'author') || '';
+      const role = getAttr(node, 'role') || '';
+      if (authorSlug || role) {
+        const authorName = authorSlug ? resolveAuthorSlug(authorSlug) : '';
+        const attribution = [authorName, role].filter(Boolean).join(', ');
+        children.push({
+          type: 'paragraph',
+          children: [{ type: 'text', value: `— ${attribution}` }],
+        });
+      }
+    }
+
+    // Include link prop as "Read case study" link
+    const link = getAttr(node, 'link');
+    if (link) {
+      const url = link.startsWith('/') ? `https://neon.com${link}` : link;
+      children.push({
+        type: 'paragraph',
+        children: [{ type: 'link', url, children: [{ type: 'text', value: 'Read case study' }] }],
       });
     }
 
@@ -1160,22 +1241,11 @@ const componentHandlers = {
     const text = getAttr(node, 'text');
     if (!text) return null;
 
-    // author is an object expression, try to parse it
-    let authorName = '';
-    let company = '';
-    const authorAttr = node.attributes?.find((a) => a.name === 'author');
-    if (authorAttr?.value?.type === 'mdxJsxAttributeValueExpression') {
-      const expr = authorAttr.value.value || '';
-      const nameMatch = expr.match(/name:\s*['"]([^'"]+)['"]/);
-      const companyMatch = expr.match(/company:\s*['"]([^'"]+)['"]/);
-      if (nameMatch) authorName = nameMatch[1];
-      if (companyMatch) company = companyMatch[1];
-    }
-
+    const parsed = parseAuthorObject(node, 'author');
     const children = [{ type: 'paragraph', children: [{ type: 'text', value: text }] }];
 
-    if (authorName || company) {
-      const attribution = [authorName, company].filter(Boolean).join(', ');
+    if (parsed && (parsed.name || parsed.company)) {
+      const attribution = [parsed.name, parsed.company].filter(Boolean).join(', ');
       children.push({
         type: 'paragraph',
         children: [{ type: 'text', value: `— ${attribution}` }],
@@ -1196,6 +1266,13 @@ const componentHandlers = {
    * TestimonialsWrapper -> container, extract children
    */
   TestimonialsWrapper(node) {
+    return node.children || null;
+  },
+
+  /**
+   * QuoteBlocksWrapper -> same as TestimonialsWrapper (carousel UI; emit all children for LLMs)
+   */
+  QuoteBlocksWrapper(node) {
     return node.children || null;
   },
 
@@ -1713,6 +1790,7 @@ function clearState() {
   processingErrors.length = 0;
   externalCodeCache.clear();
   sharedContentCache.clear();
+  quoteBlockNameMap = null;
   navigationMap = null;
 }
 

--- a/src/scripts/process-md-for-llms.test.js
+++ b/src/scripts/process-md-for-llms.test.js
@@ -69,6 +69,44 @@ describe('MDX to Markdown Conversion', () => {
       expect(result).not.toContain('<FeatureBeta');
     });
 
+    it('should expand AzureRegionsDeprecation shared content', async () => {
+      const inputPath = 'content/docs/introduction/regions.md';
+      const pageUrl = 'https://neon.com/docs/introduction/regions';
+      const projectRoot = process.cwd();
+
+      const result = await processFile(inputPath, pageUrl, projectRoot);
+
+      expect(result).toContain('Azure regions');
+      expect(result).toContain('April 7, 2026');
+      expect(result).not.toContain('<AzureRegionsDeprecation');
+    });
+
+    it('should expand ConsumptionAccountApiDeprecation shared content', async () => {
+      const inputPath = 'content/docs/guides/consumption-limits.md';
+      const pageUrl = 'https://neon.com/docs/guides/consumption-limits';
+      const projectRoot = process.cwd();
+
+      const result = await processFile(inputPath, pageUrl, projectRoot);
+
+      expect(result).toContain('consumption_history/account');
+      expect(result).toContain('deprecated');
+      expect(result).not.toContain('<ConsumptionAccountApiDeprecation');
+    });
+
+    it('should unwrap QuoteBlocksWrapper and preserve all quotes', async () => {
+      const inputPath = 'content/pages/use-cases/dev-test.md';
+      const pageUrl = 'https://neon.com/use-cases/dev-test';
+      const projectRoot = process.cwd();
+
+      const result = await processFile(inputPath, pageUrl, projectRoot);
+
+      expect(result).not.toContain('<QuoteBlocksWrapper');
+      expect(result).not.toContain('</QuoteBlocksWrapper>');
+      expect(result).toContain('Jonathan Reyes');
+      expect(result).toContain('Léonard Henriquez');
+      expect(result).toContain('Alex Co');
+    });
+
     it('should convert TwoColumnLayout in reference docs', async () => {
       const inputPath = 'content/docs/auth/reference/nextjs-server.md';
       const pageUrl = 'https://neon.com/docs/auth/reference/nextjs-server';
@@ -92,7 +130,7 @@ describe('MDX to Markdown Conversion', () => {
   // Test specific component conversions with inline MDX
   describe('Component conversions', () => {
     // Helper to process inline MDX content
-    async function processInlineMdx(mdxContent, pageUrl = 'https://neon.com/test') {
+    async function processInlineMdx(mdxContent, pageUrl = 'https://neon.com/test', rootDir) {
       const tempPath = '/tmp/test-mdx-conversion.md';
       const fullContent = `---
 title: Test
@@ -100,7 +138,7 @@ title: Test
 
 ${mdxContent}`;
       await fs.writeFile(tempPath, fullContent);
-      return processFile(tempPath, pageUrl);
+      return processFile(tempPath, pageUrl, rootDir);
     }
 
     it('should convert Admonition to bold label', async () => {
@@ -326,13 +364,54 @@ ${mdxContent}`;
       expect(result).not.toContain('<MegaLink');
     });
 
-    it('should convert QuoteBlock to blockquote with attribution', async () => {
+    it('should convert QuoteBlock with string slug to blockquote with title-cased name', async () => {
       const result = await processInlineMdx(`
 <QuoteBlock quote="Neon is amazing for serverless." author="jane-doe" role="CTO at Startup" />
 `);
       expect(result).toContain('> Neon is amazing for serverless.');
-      expect(result).toContain('> — jane-doe, CTO at Startup');
+      expect(result).toContain('> — Jane Doe, CTO at Startup');
+      expect(result).not.toContain('jane-doe');
       expect(result).not.toContain('<QuoteBlock');
+    });
+
+    it('should resolve QuoteBlock slug from quote-block.jsx map', async () => {
+      const result = await processInlineMdx(
+        `
+<QuoteBlock quote="Fast provisioning." author="lincoln-bergeson" role="Infrastructure Engineer at Replit" />
+`,
+        'https://neon.com/test',
+        process.cwd()
+      );
+      expect(result).toContain('> — Lincoln Bergeson, Infrastructure Engineer at Replit');
+      expect(result).not.toContain('lincoln-bergeson');
+    });
+
+    it('should convert QuoteBlock with object author', async () => {
+      const result = await processInlineMdx(`
+<QuoteBlock quote="Branching is great." author={{ name: 'Jane Doe', company: 'Acme Corp' }} />
+`);
+      expect(result).toContain('> Branching is great.');
+      expect(result).toContain('> — Jane Doe, Acme Corp');
+      expect(result).not.toContain('name:');
+      expect(result).not.toContain('<QuoteBlock');
+    });
+
+    it('should include QuoteBlock link prop as case study link', async () => {
+      const result = await processInlineMdx(`
+<QuoteBlock quote="Scales well." author="some-person" role="Engineer" link="/blog/case-study" />
+`);
+      expect(result).toContain('[Read case study](https://neon.com/blog/case-study)');
+    });
+
+    it('should handle QuoteBlock with object author and link in real file', async () => {
+      const inputPath = 'content/pages/use-cases/dev-test.md';
+      const pageUrl = 'https://neon.com/use-cases/dev-test';
+      const result = await processFile(inputPath, pageUrl, process.cwd());
+
+      expect(result).toContain('— Jonathan Reyes, Principal Engineer at Dispatch');
+      expect(result).not.toContain("name: 'Jonathan Reyes'");
+      expect(result).toContain('Read case study');
+      expect(result).toContain('https://neon.com/blog/');
     });
 
     it('should convert Testimonial to blockquote', async () => {


### PR DESCRIPTION
- Register `ConsumptionAccountApiDeprecation` and `AzureRegionsDeprecation` as shared content components (eliminates "unknown component" warnings)
- Add `QuoteBlocksWrapper` handler (unwrap carousel children)
- `QuoteBlock`: parse object authors, resolve slug authors to human names via quote-block.jsx map, emit case-study links
- Extract shared `parseAuthorObject()` helper (also used by Testimonial)
- 8 new tests