### PR TITLE
Fix llms.txt bare URLs and add extensions/community

### DIFF
--- a/src/scripts/generate-llms-index.js
+++ b/src/scripts/generate-llms-index.js
@@ -275,7 +275,7 @@ function generateIndexText(organized, collapsedEntries = []) {
     lines.push('## Common Queries');
     lines.push('');
     for (const q of config.commonQueries) {
-      lines.push(`- ${q.label}: ${q.url}`);
+      lines.push(`- [${q.label}](${q.url})`);
     }
     lines.push('');
   }
@@ -313,7 +313,9 @@ function generateIndexText(organized, collapsedEntries = []) {
     // Sub-indexed sections: show only highlights + link to full sub-index
     if (sectionConf && sectionConf.subIndex) {
       const allDocs = getAllDocsForSection(sectionData);
-      lines.push(`All ${allDocs.length} pages: ${sectionConf.subIndex.url} — key pages below`);
+      lines.push(
+        `- [All ${allDocs.length} ${section} pages](${sectionConf.subIndex.url}) — key pages below`
+      );
       lines.push('');
       const highlightSet = new Set(sectionConf.subIndex.highlights || []);
       const highlighted = allDocs.filter((d) => highlightSet.has(d.path));

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -171,10 +171,25 @@ module.exports = {
     },
     {
       name: 'Extensions',
-      collapse: {
-        title: 'Postgres extensions',
-        url: 'https://neon.com/docs/extensions/pg-extensions.md',
-        description: 'Supported extensions, versions, and install/update instructions',
+      description: 'Postgres extensions supported by Neon, with install and usage instructions.',
+      subIndex: {
+        outputPath: 'public/docs/extensions/llms.txt',
+        url: 'https://neon.com/docs/extensions/llms.txt',
+        highlights: [
+          'extensions/pg-extensions.md',
+          'extensions/pg_stat_statements.md',
+          'extensions/pgvector.md',
+          'extensions/pgcrypto.md',
+        ],
+      },
+    },
+    {
+      name: 'Community',
+      description: 'Contributor guides, component architecture, and documentation standards.',
+      subIndex: {
+        outputPath: 'public/docs/community/llms.txt',
+        url: 'https://neon.com/docs/community/llms.txt',
+        highlights: ['community/contribution-guide.md', 'community/llms-markdown-guide.md'],
       },
     },
   ],
@@ -183,12 +198,9 @@ module.exports = {
   // For the "docs" route, paths are relative to content/docs/.
   excludePaths: [
     'azure/',
-    'community/',
     'functions/',
-    'data-types/',
     'auth/legacy/',
     'auth/migrate/from-auth-v0.1',
-    'auth/migrate/from-legacy-auth',
     'changelog.md',
     'get-started/production-readiness.md',
     'guides/GUIDE_TEMPLATE.md',
@@ -209,7 +221,10 @@ module.exports = {
 
   // Prefix-based reclassification (first match wins). More maintainable than
   // listing individual files when an entire path subtree should move together.
-  reclassifyPrefixes: [{ pathPrefix: 'reference/cli-', section: 'Neon CLI' }],
+  reclassifyPrefixes: [
+    { pathPrefix: 'reference/cli-', section: 'Neon CLI' },
+    { pathPrefix: 'data-types/', section: 'Extensions' },
+  ],
 
   // Route keys from CONTENT_ROUTES to collapse instead of scanning.
   // Each becomes a single link in the Additional Resources section.


### PR DESCRIPTION
## Summary

- Convert bare sub-index llms.txt URLs to `[text](url)` markdown links in generated llms.txt
- Replace collapsed Extensions section with a sub-index covering 54 pages (extensions + data types)
- Add Community section with sub-index (9 pages)
- Un-exclude `auth/migrate/from-legacy-auth` for auth migration

## Why

Bare URLs break programmatic parsers that follow the `llms.txt` spec (e.g. `afdocs`), which caused afdocs' freshness check to miss 249 pages across 4 sub-indexes.