### PR TITLE
docs: expand llms.txt coverage and use markdown links throughout

### DIFF
--- a/src/scripts/generate-llms-full.js
+++ b/src/scripts/generate-llms-full.js
@@ -189,10 +189,12 @@ async function main() {
     }
 
     const stripped = stripNavigationContext(content);
-    parts.push(`--- DOCUMENT SOURCE: ${file.url} ---\n\n${stripped.trim()}\n`);
+    parts.push(`--- [Document source](${file.url}) ---\n\n${stripped.trim()}\n`);
   }
 
-  parts.push(`---\n\nFor all past changelog entries, see https://neon.com/docs/changelog.md\n`);
+  parts.push(
+    `---\n\nFor all past changelog entries, see [changelog](https://neon.com/docs/changelog.md)\n`
+  );
 
   if (readErrors > 0) {
     console.warn(`\nWarning: ${readErrors} file(s) missing from public/md/`);

--- a/src/scripts/generate-llms-index.js
+++ b/src/scripts/generate-llms-index.js
@@ -392,7 +392,7 @@ function generateSubIndexText(sectionName, sectionConf, sectionData) {
     lines.push('');
   }
 
-  lines.push(`Parent index: ${BASE_URL}/docs/llms.txt`);
+  lines.push(`[Parent index](${BASE_URL}/docs/llms.txt)`);
   lines.push('');
 
   const directFiles = sectionData._files.sort((a, b) => a.title.localeCompare(b.title));

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -162,7 +162,17 @@ module.exports = {
     {
       name: 'PostgreSQL',
       description:
-        'Postgres query optimization, indexing strategies, version upgrades, and general Postgres usage with Neon.',
+        'Postgres functions, data types, query optimization, indexing strategies, version upgrades, and general Postgres usage with Neon.',
+      subsectionOrder: ['General', 'Functions', 'Data Types'],
+      subIndex: {
+        outputPath: 'public/docs/postgresql/llms.txt',
+        url: 'https://neon.com/docs/postgresql/llms.txt',
+        highlights: [
+          'postgresql/query-reference.md',
+          'postgresql/query-performance.md',
+          'postgresql/index-types.md',
+        ],
+      },
     },
     {
       name: 'Security',
@@ -198,11 +208,9 @@ module.exports = {
   // For the "docs" route, paths are relative to content/docs/.
   excludePaths: [
     'azure/',
-    'functions/',
     'auth/legacy/',
     'auth/migrate/from-auth-v0.1',
     'changelog.md',
-    'get-started/production-readiness.md',
     'guides/GUIDE_TEMPLATE.md',
     'introduction.md',
   ],
@@ -223,7 +231,9 @@ module.exports = {
   // listing individual files when an entire path subtree should move together.
   reclassifyPrefixes: [
     { pathPrefix: 'reference/cli-', section: 'Neon CLI' },
-    { pathPrefix: 'data-types/', section: 'Extensions' },
+    { pathPrefix: 'postgresql/', section: 'PostgreSQL', subsection: 'General' },
+    { pathPrefix: 'data-types/', section: 'PostgreSQL', subsection: 'Data Types' },
+    { pathPrefix: 'functions/', section: 'PostgreSQL', subsection: 'Functions' },
   ],
 
   // Route keys from CONTENT_ROUTES to collapse instead of scanning.


### PR DESCRIPTION
- Add functions/ and data-types/ pages to a new PostgreSQL sub-index with General, Functions, and Data Types subsections. 
- Convert bare URLs to markdown links in sub-index parent references, llms-full.txt document separators, and changelog footer.
- Remove production-readiness from excludePaths, and move data-types/ from Extensions to PostgreSQL where it belongs.
