### PR TITLE
Remove redundant SQL SELECT statement in the PostgreSQL UPDATE tutorial

### DIFF
--- a/content/postgresql/tutorial/update.md
+++ b/content/postgresql/tutorial/update.md
@@ -175,12 +175,6 @@ UPDATE 5
 The following statement retrieves data from the `courses` table to verify the update:
 
 ```sql
-SELECT * FROM courses;
-```
-
-Output:
-
-```sql
 SELECT
   course_name,
   price


### PR DESCRIPTION
### Detail

Remove redundant SQL SELECT statement in the PostgreSQL UPDATE tutorial.