### PR TITLE
fix: correct ai skill neon-cli command syntax

### DIFF
--- a/public/docs/ai/skills/neon-postgres/references/neon-cli.md
+++ b/public/docs/ai/skills/neon-postgres/references/neon-cli.md
@@ -72,7 +72,7 @@ neonctl branches delete <branch-id> --project-id <project-id>
 neonctl connection-string --project-id <project-id>
 
 # Get connection string for specific branch
-neonctl connection-string --project-id <project-id> --branch-id <branch-id>
+neonctl connection-string <branch-id-or-name> --project-id <project-id>
 
 # Get pooled connection string
 neonctl connection-string --project-id <project-id> --pooled
@@ -92,13 +92,13 @@ neonctl sql --file schema.sql --project-id <project-id>
 
 ```bash
 # List databases
-neonctl databases list --project-id <project-id> --branch-id <branch-id>
+neonctl databases list --project-id <project-id> --branch <branch-id-or-name>
 
 # Create database
 neonctl databases create --project-id <project-id> --name mydb
 
 # List roles
-neonctl roles list --project-id <project-id> --branch-id <branch-id>
+neonctl roles list --project-id <project-id> --branch <branch-id-or-name>
 ```
 
 ## Output Formats


### PR DESCRIPTION
The neon-cli.md skill doc uses flags that don't exist. The CLI silently ignores them then falls back to the default branch so you end up running these commands against the wrong branch without knowing.

- connection-string branch should be a positional arg, not --branch-id : [docs](https://neon.com/docs/reference/cli-connection-string#the-connection-string-command)
- databases list should use --branch, not --branch-id : [docs](https://neon.com/docs/reference/cli-databases#list)
- roles list should use --branch, not --branch-id : [docs](https://neon.com/docs/reference/cli-roles#list)

Related : [neondatabase/agent-skills#21](https://github.com/neondatabase/agent-skills/issues/21)