### PR TITLE
docs: add a neonctl argument checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "test:unit": "vitest",
     "test:unit:ui": "vitest --ui",
     "test:unit:run": "vitest run",
-    "test:unit:coverage": "vitest run --coverage"
+    "test:unit:coverage": "vitest run --coverage",
+    "check:docs": "vitest run scripts/docs-checks/**/__tests__/*.test.js",
+    "check:docs:neonctl": "vitest run scripts/docs-checks/neonctl/__tests__/neonctl-docs.test.js"
   },
   "dependencies": {
     "@emotion/memoize": "0.7.4",

--- a/scripts/docs-checks/README.md
+++ b/scripts/docs-checks/README.md
@@ -1,0 +1,49 @@
+# docs-checks
+
+Validate `content/**/*.md` against authoritative sources (CLI schemas, type
+defs, OpenAPI specs, etc.). Each check is self-contained in its own subfolder.
+
+## Run
+
+```bash
+npm run check:docs              # all checks
+npm run check:docs:neonctl      # one check
+```
+
+Exits non-zero on any validation error.
+
+## Checks
+
+| Check                   | Validates                                    |
+| ----------------------- | -------------------------------------------- |
+| [`neonctl`](./neonctl/) | Every `neonctl`/`neon` CLI example is valid. |
+
+## Add a new check
+
+1. Create `scripts/docs-checks/<name>/` with:
+
+   ```text
+   <name>/
+     README.md
+     validate.js             # exports validate() -> { invocations, errors }
+     __tests__/
+       <name>-docs.test.js   # asserts errors.length === 0
+   ```
+
+2. Each error must be `{ kind, file, line, raw, message }`.
+3. Add to `package.json`:
+
+   ```json
+   "check:docs:<name>": "vitest run scripts/docs-checks/<name>/__tests__/<name>-docs.test.js"
+   ```
+
+   `check:docs` picks it up via glob.
+
+4. External inputs (cloned repos, API calls) run at **schema-generation time**
+   and emit a committed JSON file. Runtime needs only `node` + this repo. See
+   [`neonctl/generate-schema.js`](./neonctl/generate-schema.js).
+
+## Shared helpers
+
+None yet. When a second check arrives, lift duplicated code into
+`scripts/docs-checks/_lib/`. Don't pre-abstract.

--- a/scripts/docs-checks/neonctl/README.md
+++ b/scripts/docs-checks/neonctl/README.md
@@ -1,0 +1,62 @@
+# neonctl docs check
+
+Validates every `neonctl`/`neon` CLI example in `content/**/*.md` against a
+schema parsed from the [neonctl](https://github.com/neondatabase/neonctl)
+TypeScript source.
+
+## Run
+
+```bash
+npm run check:docs:neonctl
+```
+
+Fails on unknown commands, unknown options, or invalid `choices` values.
+
+For a local Markdown report:
+
+```bash
+node scripts/docs-checks/neonctl/validate.js --out /tmp/report.md
+```
+
+## Refresh `schema.json` after a neonctl release
+
+```bash
+git clone https://github.com/neondatabase/neonctl ~/src/neonctl        # or git pull
+node scripts/docs-checks/neonctl/generate-schema.js --src ~/src/neonctl
+npm run check:docs:neonctl                                             # fix any new misses
+git add scripts/docs-checks/neonctl/schema.json && git commit
+```
+
+`--src` is required (or set `NEONCTL_SRC`).
+
+## Files
+
+| File                             | Role                                                         |
+| -------------------------------- | ------------------------------------------------------------ |
+| `schema.json`                    | Committed schema. Canonical, version-pinned.                 |
+| `generate-schema.js`             | Parses neonctl's TS source → `schema.json`.                  |
+| `schema.js`                      | Loads schema; resolves argv to command node + valid options. |
+| `extract-examples.js`            | Scans Markdown for fenced bash blocks and inline backticks.  |
+| `validate.js`                    | Extractor + schema → Markdown report. CLI entry point.       |
+| `__tests__/neonctl-docs.test.js` | Integration test: runs `validate()`, asserts 0 errors.       |
+| `__tests__/units.test.js`        | Unit tests for parsing helpers.                              |
+
+## Why parse source instead of `neonctl --help`?
+
+yargs help is unreliable for a validator:
+
+- `neonctl roles create --help` falls back to the parent's help (missing `--name`).
+- `neonctl vpc endpoint list --help` same (missing `--org-id`).
+- Subcommand aliases (`sd` for `schema-diff`) aren't always reachable.
+
+The TypeScript source is canonical. CI only reads `schema.json`.
+
+## Known gaps
+
+- **Positional choices not validated.** Option-level `choices` lists are
+  checked; positional choices (e.g. `set-context`'s second arg) are not.
+- **Placeholders aren't checked semantically.** `--project-id <project-id>`
+  passes — we verify the option, not the value shape.
+- **Output-line heuristic is regex-based.** Fenced blocks mixing commands
+  and prose output without a `$` prompt may confuse the filter. See the
+  border-char filter in `extract-examples.js`.

--- a/scripts/docs-checks/neonctl/__tests__/neonctl-docs.test.js
+++ b/scripts/docs-checks/neonctl/__tests__/neonctl-docs.test.js
@@ -1,0 +1,38 @@
+import { createRequire } from 'module';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const { loadSchema } = require('../schema.js');
+const { validate } = require('../validate.js');
+
+const REPO_ROOT = path.join(import.meta.dirname, '..', '..', '..', '..');
+
+function relPath(file) {
+  return path.relative(REPO_ROOT, file) || file;
+}
+
+describe('neonctl docs validation', () => {
+  it('every neonctl/neon example in content/**/*.md uses real commands and options', () => {
+    const schema = loadSchema();
+    const { errors, invocations } = validate({ schema });
+
+    if (errors.length > 0) {
+      const lines = [
+        '',
+        `Checked ${invocations.length} invocations against neonctl ${schema.neonctlVersion}: ${errors.length} error(s).`,
+        'Fix the listed invocations, or refresh the schema:',
+        '  node scripts/docs-checks/neonctl/generate-schema.js --src <path-to-neonctl-clone>',
+        '',
+        ...errors.map((e) => `  ${relPath(e.file)}:${e.line}  ${e.message}`),
+        '',
+      ];
+       
+      console.error(lines.join('\n'));
+    }
+
+    expect(errors, `${errors.length} doc example(s) failed validation (see above)`).toEqual([]);
+  });
+});

--- a/scripts/docs-checks/neonctl/__tests__/units.test.js
+++ b/scripts/docs-checks/neonctl/__tests__/units.test.js
@@ -1,0 +1,195 @@
+import { createRequire } from 'module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  tokenize,
+  stripFrontmatter,
+  joinBackslashContinuations,
+  isLikelyCommand,
+  buildTopLevelCommands,
+} = require('../extract-examples.js');
+const { loadSchema, resolvePath, resolveValidOptions } = require('../schema.js');
+
+describe('tokenize', () => {
+  it('splits on whitespace', () => {
+    expect(tokenize('branches create --name foo')).toEqual(['branches', 'create', '--name', 'foo']);
+  });
+
+  it('splits --key=value into two tokens', () => {
+    expect(tokenize('connection-string --role-name=alice')).toEqual([
+      'connection-string',
+      '--role-name',
+      'alice',
+    ]);
+  });
+
+  it('respects single and double quotes', () => {
+    expect(tokenize('foo "a b" \'c d\' bar')).toEqual(['foo', 'a b', 'c d', 'bar']);
+  });
+
+  it('keeps placeholders intact', () => {
+    expect(tokenize('branches create --project-id <project-id> --name ${NAME}')).toEqual([
+      'branches',
+      'create',
+      '--project-id',
+      '<project-id>',
+      '--name',
+      '${NAME}',
+    ]);
+  });
+
+  it('preserves empty quoted string as a token', () => {
+    expect(tokenize('foo ""')).toEqual(['foo', '']);
+  });
+
+  it('handles escaped characters', () => {
+    expect(tokenize('foo bar\\ baz')).toEqual(['foo', 'bar baz']);
+  });
+});
+
+describe('stripFrontmatter', () => {
+  it('strips a leading YAML frontmatter block', () => {
+    const { body, offset } = stripFrontmatter('---\ntitle: Foo\n---\nhello\n');
+    expect(body).toBe('hello\n');
+    expect(offset).toBe(3);
+  });
+
+  it('leaves content without frontmatter untouched', () => {
+    const { body, offset } = stripFrontmatter('# Heading\nhello\n');
+    expect(body).toBe('# Heading\nhello\n');
+    expect(offset).toBe(0);
+  });
+
+  it('does nothing when the block is unterminated', () => {
+    const input = '---\ntitle: Foo\nhello\n';
+    const { body, offset } = stripFrontmatter(input);
+    expect(body).toBe(input);
+    expect(offset).toBe(0);
+  });
+});
+
+describe('joinBackslashContinuations', () => {
+  it('collapses continued lines and reports the start line', () => {
+    const out = joinBackslashContinuations([
+      'neon branches create \\',
+      '  --name foo \\',
+      '  --project-id bar',
+      'plain line',
+    ]);
+    expect(out).toEqual([
+      { text: 'neon branches create  --name foo --project-id bar', line: 0 },
+      { text: 'plain line', line: 3 },
+    ]);
+  });
+
+  it('passes through non-continued lines unchanged', () => {
+    const out = joinBackslashContinuations(['a', 'b']);
+    expect(out).toEqual([
+      { text: 'a', line: 0 },
+      { text: 'b', line: 1 },
+    ]);
+  });
+});
+
+describe('isLikelyCommand', () => {
+  const topLevel = new Set(['branches', 'projects']);
+
+  it('returns false for empty argv', () => {
+    expect(isLikelyCommand([])).toBe(false);
+  });
+
+  it('accepts options as a first token', () => {
+    expect(isLikelyCommand(['--help'])).toBe(true);
+  });
+
+  it('strict mode only accepts known top-level commands', () => {
+    expect(isLikelyCommand(['branches'], { strict: true, topLevel })).toBe(true);
+    expect(isLikelyCommand(['bananas'], { strict: true, topLevel })).toBe(false);
+  });
+
+  it('non-strict mode accepts any kebab-case token', () => {
+    expect(isLikelyCommand(['bananas'])).toBe(true);
+    expect(isLikelyCommand(['Nope'])).toBe(false);
+  });
+});
+
+describe('buildTopLevelCommands', () => {
+  it('includes every top-level command and its aliases', () => {
+    const schema = {
+      commands: {
+        branches: { aliases: ['branch'] },
+        projects: { aliases: [] },
+      },
+    };
+    const set = buildTopLevelCommands(schema);
+    expect(set.has('branches')).toBe(true);
+    expect(set.has('branch')).toBe(true);
+    expect(set.has('projects')).toBe(true);
+    expect(set.has('completion')).toBe(true);
+  });
+});
+
+describe('resolvePath', () => {
+  const schema = loadSchema();
+
+  it('resolves a top-level alias to the canonical command', () => {
+    const r = resolvePath(schema, ['branch', 'create']);
+    expect(r.path).toEqual(['branches', 'create']);
+    expect(r.remaining).toEqual([]);
+  });
+
+  it('stops at the deepest matching subcommand', () => {
+    const r = resolvePath(schema, ['branches', 'create', '--name', 'foo']);
+    expect(r.path).toEqual(['branches', 'create']);
+    expect(r.remaining).toEqual(['--name', 'foo']);
+  });
+
+  it('returns null node for an unknown top-level command', () => {
+    const r = resolvePath(schema, ['bananas', 'create']);
+    expect(r.node).toBeNull();
+    expect(r.remaining).toEqual(['bananas', 'create']);
+  });
+
+  it('handles empty argv', () => {
+    const r = resolvePath(schema, []);
+    expect(r.node).toBeNull();
+    expect(r.path).toEqual([]);
+  });
+
+  it('does not consume long positional ids as subcommands', () => {
+    const r = resolvePath(schema, ['vpc', 'endpoint', 'remove', 'vpce-1234567890abcdef0']);
+    expect(r.path).toEqual(['vpc', 'endpoint', 'remove']);
+    expect(r.remaining).toEqual(['vpce-1234567890abcdef0']);
+  });
+
+  it('is prototype-pollution safe', () => {
+    expect(resolvePath(schema, ['__proto__']).node).toBeNull();
+    expect(resolvePath(schema, ['constructor']).node).toBeNull();
+  });
+});
+
+describe('resolveValidOptions', () => {
+  const schema = loadSchema();
+
+  it('includes global options at every depth', () => {
+    const opts = resolveValidOptions(schema, ['branches', 'create']);
+    expect(opts.has('--output')).toBe(true);
+    expect(opts.has('--api-key')).toBe(true);
+    expect(opts.has('--help')).toBe(true);
+  });
+
+  it('registers short aliases with a single dash', () => {
+    const opts = resolveValidOptions(schema, []);
+    expect(opts.has('-o')).toBe(true);
+    const entry = opts.get('-o');
+    expect(entry.name).toBe('output');
+  });
+
+  it('exposes --no-<name> for boolean options', () => {
+    const opts = resolveValidOptions(schema, []);
+    const maybe = [...opts.keys()].find((k) => k.startsWith('--no-'));
+    expect(typeof maybe).toBe('string');
+  });
+});

--- a/scripts/docs-checks/neonctl/extract-examples.js
+++ b/scripts/docs-checks/neonctl/extract-examples.js
@@ -1,0 +1,299 @@
+// Line-based scanner that pulls `neonctl`/`neon` CLI invocations out of
+// `content/docs/**/*.md`. No Markdown AST — tracks fence state and frontmatter
+// with simple regexes, same style as other scripts in this repo.
+//
+// Output: [{ file, line, raw, binary, argv, source: 'fenced' | 'inline' }]
+//
+// Each argv is the tokenized command minus the leading binary name. Tokens
+// like `--key=value` are split into `--key`, `value`. Placeholder tokens
+// (`<project-id>`, `${VAR}`, etc.) are preserved verbatim.
+
+const fs = require('fs');
+const path = require('path');
+
+const { globSync } = require('glob');
+
+// Entire `content/` tree: docs, guides, changelog, postgresql tutorials, etc.
+// Anything the site ships to users is fair game for validation.
+const DEFAULT_ROOT = path.join(__dirname, '..', '..', '..', 'content');
+
+const FENCE_RE = /^(\s*)(```+|~~~+)\s*([\w.-]*)/;
+const CLI_LINE_RE = /^\s*(?:\$\s+)?(neon(?:ctl)?)\s+(.+?)\s*$/;
+const INLINE_RE = /`(neon(?:ctl)?\s+[^`]+)`/g;
+
+// Fenced blocks we scan for commands. Empty string = no language tag.
+const SHELL_LANGS = new Set(['', 'bash', 'shell', 'sh', 'console', 'text', 'shouldwrap']);
+
+// Exclude obvious non-command tokens that happen to start with `neon`.
+const NON_COMMAND_PREFIX = /^(neon[-.]|neondatabase|neon\+|neon_)/i;
+
+// Top-level command + alias set used by the strict (inline-prose) filter.
+// Derived from the committed schema so we never drift as neonctl evolves.
+// `completion` is appended because yargs injects it at runtime but the
+// source tree doesn't declare it.
+function buildTopLevelCommands(schema) {
+  const set = new Set(['completion']);
+  for (const [name, node] of Object.entries(schema.commands || {})) {
+    set.add(name);
+    for (const a of node.aliases || []) set.add(a);
+  }
+  return set;
+}
+
+let cachedTopLevel;
+function getTopLevelCommands() {
+  if (cachedTopLevel) return cachedTopLevel;
+  // Lazy require to avoid an import cycle with schema.js consumers that
+  // only need the extractor helpers (tokenize, stripFrontmatter, …).
+  const { loadSchema } = require('./schema.js');
+  cachedTopLevel = buildTopLevelCommands(loadSchema());
+  return cachedTopLevel;
+}
+
+function stripFrontmatter(content) {
+  // Remove the leading --- ... --- block (if any) and return the body plus
+  // the number of leading lines we stripped, so reported line numbers stay
+  // accurate.
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) {
+    return { body: content, offset: 0 };
+  }
+  const lines = content.split(/\r?\n/);
+  let end = -1;
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i] === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return { body: content, offset: 0 };
+  return {
+    body: lines.slice(end + 1).join('\n'),
+    offset: end + 1,
+  };
+}
+
+function joinBackslashContinuations(lines) {
+  // Returns an array of { text, line } where consecutive backslash-
+  // continued lines are collapsed into a single logical line, and the
+  // reported line is the first physical line of the run.
+  const out = [];
+  let buf = null;
+  let startLine = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.replace(/\s+$/, '');
+    const cont = trimmed.endsWith('\\');
+    const core = cont ? trimmed.slice(0, -1) : line;
+    if (buf === null) {
+      if (cont) {
+        buf = core;
+        startLine = i;
+      } else {
+        out.push({ text: line, line: i });
+      }
+    } else {
+      buf += ` ${core.trim()}`;
+      if (!cont) {
+        out.push({ text: buf, line: startLine });
+        buf = null;
+        startLine = -1;
+      }
+    }
+  }
+  if (buf !== null) out.push({ text: buf, line: startLine });
+  return out;
+}
+
+function tokenize(input) {
+  // Minimal POSIX-ish tokenizer: splits on whitespace, respects single
+  // and double quotes, strips surrounding quotes from the resulting
+  // tokens, and splits `--key=value` into two tokens. Keeps `<foo>`
+  // / `${FOO}` placeholders intact.
+  const tokens = [];
+  let cur = '';
+  let inSingle = false;
+  let inDouble = false;
+  let hasContent = false;
+  const push = () => {
+    if (hasContent) tokens.push(cur);
+    cur = '';
+    hasContent = false;
+  };
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i];
+    if (inSingle) {
+      if (ch === "'") inSingle = false;
+      else {
+        cur += ch;
+        hasContent = true;
+      }
+    } else if (inDouble) {
+      if (ch === '"') inDouble = false;
+      else {
+        cur += ch;
+        hasContent = true;
+      }
+    } else if (ch === "'") {
+      inSingle = true;
+      hasContent = true;
+    } else if (ch === '"') {
+      inDouble = true;
+      hasContent = true;
+    } else if (/\s/.test(ch)) {
+      push();
+    } else if (ch === '\\' && i + 1 < input.length) {
+      cur += input[i + 1];
+      hasContent = true;
+      i += 1;
+    } else {
+      cur += ch;
+      hasContent = true;
+    }
+  }
+  push();
+  const expanded = [];
+  for (const tok of tokens) {
+    if (tok.startsWith('--') && tok.includes('=')) {
+      const eq = tok.indexOf('=');
+      expanded.push(tok.slice(0, eq), tok.slice(eq + 1));
+    } else {
+      expanded.push(tok);
+    }
+  }
+  return expanded;
+}
+
+function isLikelyCommand(argv, { strict = false, topLevel } = {}) {
+  if (argv.length === 0) return false;
+  const first = argv[0];
+  if (first.startsWith('-')) return true;
+  // Inline prose is prone to false positives (e.g. `neon.new`, `neon_foo`)
+  // so we require the first token to look like a real top-level command
+  // name. Fenced code blocks get a softer filter: any kebab-case word is
+  // accepted, which lets the validator catch misspellings.
+  if (strict) return (topLevel || getTopLevelCommands()).has(first);
+  return /^[a-z][a-z0-9-]*$/.test(first);
+}
+
+function extractFromFile(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const { body, offset } = stripFrontmatter(raw);
+  const lines = body.split(/\r?\n/);
+  const results = [];
+
+  // Fenced code blocks.
+  let inFence = false;
+  let fenceMarker = null;
+  let fenceLang = null;
+  let fenceLines = [];
+  let fenceStartIndex = 0;
+
+  const flushFence = () => {
+    if (!SHELL_LANGS.has(fenceLang)) return;
+    const joined = joinBackslashContinuations(fenceLines);
+    for (const { text, line } of joined) {
+      const m = CLI_LINE_RE.exec(text);
+      if (!m) continue;
+      const binary = m[1];
+      const rest = m[2];
+      // Skip output-ish lines: table border chars, JSON, etc.
+      if (/^[│┌└├─┬┴┤┼┐┘]/u.test(rest)) continue;
+      // Skip lines where the token right after `neon(ctl)` is actually a
+      // hostname/URL continuation (`neon.tech/docs`).
+      if (NON_COMMAND_PREFIX.test(`${binary}${rest[0] || ''}`)) continue;
+      const argv = tokenize(rest);
+      if (!isLikelyCommand(argv, { strict: false })) continue;
+      results.push({
+        file,
+        line: offset + fenceStartIndex + line + 2,
+        raw: `${binary} ${rest}`,
+        binary,
+        argv,
+        source: 'fenced',
+      });
+    }
+  };
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const fence = FENCE_RE.exec(line);
+    if (fence) {
+      const marker = fence[2][0].repeat(3); // ``` or ~~~
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = marker;
+        fenceLang = (fence[3] || '').toLowerCase();
+        fenceLines = [];
+        fenceStartIndex = i;
+      } else if (marker === fenceMarker && fence[2].length >= 3) {
+        flushFence();
+        inFence = false;
+        fenceMarker = null;
+        fenceLang = null;
+        fenceLines = [];
+      }
+      continue;
+    }
+    if (inFence) {
+      fenceLines.push(line);
+    } else {
+      // Inline backticks in prose.
+      let m;
+      // Reset lastIndex for safety in case of previous calls on same string.
+      INLINE_RE.lastIndex = 0;
+
+      while ((m = INLINE_RE.exec(line)) !== null) {
+        const snippet = m[1];
+        const headMatch = CLI_LINE_RE.exec(snippet);
+        if (!headMatch) continue;
+        const binary = headMatch[1];
+        const rest = headMatch[2];
+        if (NON_COMMAND_PREFIX.test(`${binary}${rest[0] || ''}`)) continue;
+        const argv = tokenize(rest);
+        if (!isLikelyCommand(argv, { strict: true })) continue;
+        results.push({
+          file,
+          line: offset + i + 1,
+          raw: `${binary} ${rest}`,
+          binary,
+          argv,
+          source: 'inline',
+        });
+      }
+    }
+  }
+  if (inFence) flushFence();
+  return results;
+}
+
+function extract({ root = DEFAULT_ROOT } = {}) {
+  const files = globSync('**/*.md', { cwd: root, absolute: true });
+  const all = [];
+  for (const file of files) {
+    all.push(...extractFromFile(file));
+  }
+  return all;
+}
+
+module.exports = {
+  extract,
+  extractFromFile,
+  tokenize,
+  stripFrontmatter,
+  joinBackslashContinuations,
+  isLikelyCommand,
+  buildTopLevelCommands,
+  DEFAULT_ROOT,
+  SHELL_LANGS,
+};
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const root = args[0] || DEFAULT_ROOT;
+  const results = extract({ root });
+  for (const r of results) {
+    const rel = path.relative(process.cwd(), r.file);
+    console.log(`${rel}:${r.line}\t${r.binary} ${r.argv.join(' ')}`);
+  }
+  console.log(`\nExtracted ${results.length} invocations from ${root}`);
+}

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -1,0 +1,441 @@
+// Parses the neonctl TypeScript source and emits `schema.json`: an
+// authoritative description of every command, subcommand, option, alias,
+// and choice list.
+//
+// We use this instead of parsing `neonctl … --help` output because yargs
+// help has known bugs (`neonctl roles create --help` falls back to the
+// parent's help; `vpc endpoint list --help` does the same). The source
+// code is canonical.
+//
+// The source path is required — there is no default. Clone neonctl and
+// pass it explicitly so this script is reproducible across machines:
+//
+//   git clone https://github.com/neondatabase/neonctl ~/src/neonctl
+//   node scripts/docs-checks/neonctl/generate-schema.js --src ~/src/neonctl
+//
+// Or via environment variable:
+//
+//   NEONCTL_SRC=~/src/neonctl node scripts/docs-checks/neonctl/generate-schema.js
+//
+// Run this whenever you upgrade the neonctl pin. Commit `schema.json`.
+
+const fs = require('fs');
+const path = require('path');
+
+const ts = require('typescript');
+
+const DEFAULT_OUT = path.join(__dirname, 'schema.json');
+
+const COMMAND_FILES = [
+  'auth.ts',
+  'user.ts',
+  'orgs.ts',
+  'projects.ts',
+  'ip_allow.ts',
+  'vpc_endpoints.ts',
+  'branches.ts',
+  'databases.ts',
+  'roles.ts',
+  'operations.ts',
+  'connection_string.ts',
+  'set_context.ts',
+  'init.ts',
+];
+
+function readSource(file) {
+  return ts.createSourceFile(file, fs.readFileSync(file, 'utf8'), ts.ScriptTarget.Latest, true);
+}
+
+// Returns the string value of a (string-literal-ish) expression, or
+// undefined if the expression isn't a resolvable literal.
+function stringLiteralValue(node) {
+  if (!node) return undefined;
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  return undefined;
+}
+
+function arrayLiteralStrings(node) {
+  if (!node || !ts.isArrayLiteralExpression(node)) return undefined;
+  const out = [];
+  for (const el of node.elements) {
+    const v = stringLiteralValue(el);
+    if (v !== undefined) out.push(v);
+  }
+  return out;
+}
+
+// Grab the property named `name` from an ObjectLiteralExpression.
+function getProp(obj, name) {
+  for (const p of obj.properties) {
+    if (!ts.isPropertyAssignment(p) && !ts.isShorthandPropertyAssignment(p)) {
+      continue;
+    }
+    let keyName;
+    const key = p.name;
+    if (ts.isIdentifier(key)) keyName = key.text;
+    else if (ts.isStringLiteral(key)) keyName = key.text;
+    if (keyName === name) return p;
+  }
+  return undefined;
+}
+
+// Parse the argument to `.options({...})` into a map of
+// `{ name: { type, choices, alias, required } }`.
+function parseOptionsObject(obj) {
+  const out = {};
+  for (const p of obj.properties) {
+    if (!ts.isPropertyAssignment(p)) continue;
+    let optName;
+    if (ts.isIdentifier(p.name)) optName = p.name.text;
+    else if (ts.isStringLiteral(p.name)) optName = p.name.text;
+    if (!optName) continue;
+    // `name: branchCreateRequest['branch.name']` — external reference we
+    // can't resolve. Accept with unknown type.
+    if (!ts.isObjectLiteralExpression(p.initializer)) {
+      out[optName] = { type: 'unknown' };
+      continue;
+    }
+    const spec = { type: 'unknown' };
+    const typeProp = getProp(p.initializer, 'type');
+    if (typeProp) {
+      const t = stringLiteralValue(typeProp.initializer);
+      if (t) spec.type = t;
+    }
+    const booleanProp = getProp(p.initializer, 'boolean');
+    if (booleanProp && booleanProp.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+      spec.type = 'boolean';
+    }
+    const demand = getProp(p.initializer, 'demandOption');
+    if (demand && demand.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+      spec.required = true;
+    }
+    const aliasProp = getProp(p.initializer, 'alias');
+    if (aliasProp) {
+      const a = stringLiteralValue(aliasProp.initializer);
+      if (a) spec.alias = a;
+      else {
+        const arr = arrayLiteralStrings(aliasProp.initializer);
+        if (arr) spec.alias = arr;
+      }
+    }
+    const choicesProp = getProp(p.initializer, 'choices');
+    if (choicesProp) {
+      const arr = arrayLiteralStrings(choicesProp.initializer);
+      if (arr) spec.choices = arr;
+      // Object.values(Enum) — accept anything; we lose choice checking.
+      // Leaving `choices` undefined disables choice validation for this
+      // option, which is the safe fallback.
+    }
+    const hidden = getProp(p.initializer, 'hidden');
+    if (hidden && hidden.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+      spec.hidden = true;
+    }
+    out[optName] = spec;
+  }
+  return out;
+}
+
+// Given a `.command(...)` call, return { name, aliases, positionals,
+// options, commands }. Handles both the positional form
+// `.command('name', 'desc', builderFn, handlerFn)` and the object form
+// `.command({ command, aliases, builder, handler })`.
+function parseCommandCall(callArgs) {
+  if (callArgs.length === 0) return null;
+  const first = callArgs[0];
+
+  let commandString;
+  let aliases;
+  let builderNode;
+  if (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first)) {
+    commandString = first.text;
+    // Second arg is the description; third is the builder function.
+    builderNode = callArgs[2];
+  } else if (ts.isObjectLiteralExpression(first)) {
+    const cmdProp = getProp(first, 'command');
+    if (cmdProp) commandString = stringLiteralValue(cmdProp.initializer);
+    const aliasesProp = getProp(first, 'aliases');
+    if (aliasesProp) aliases = arrayLiteralStrings(aliasesProp.initializer);
+    const builderProp = getProp(first, 'builder');
+    if (builderProp) builderNode = builderProp.initializer;
+  } else {
+    return null;
+  }
+  if (!commandString) return null;
+
+  // Parse `name <pos> [pos]` → name + positional list.
+  const parts = commandString.trim().split(/\s+/);
+  const name = parts[0];
+  const positionals = parts.slice(1).map((p) => p.replace(/^[<[]/, '').replace(/[>\]]$/, ''));
+
+  // Clean up aliases: they can be written as `'update <id>'` — strip
+  // positional.
+  if (aliases) {
+    aliases = aliases.map((a) => a.split(/\s+/)[0]);
+  }
+
+  const node = {
+    name,
+    aliases: aliases || [],
+    positionals,
+    options: {},
+    commands: {},
+  };
+
+  if (builderNode) walkBuilder(builderNode, node);
+
+  return node;
+}
+
+// Walks an arrow-function / function builder body, collecting
+// `.options(...)` and `.command(...)` calls into the `node` accumulator.
+function walkBuilder(builderNode, node) {
+  let body;
+  if (ts.isArrowFunction(builderNode) || ts.isFunctionExpression(builderNode)) {
+    body = builderNode.body;
+  } else {
+    body = builderNode;
+  }
+  // The body is either a block (with a return and/or expression
+  // statements) or a single expression. Collect every candidate so we
+  // don't silently drop chained calls spread across multiple statements.
+  const exprs = [];
+  if (body && ts.isBlock(body)) {
+    for (const stmt of body.statements) {
+      if (ts.isReturnStatement(stmt) && stmt.expression) {
+        exprs.push(stmt.expression);
+      } else if (ts.isExpressionStatement(stmt)) {
+        exprs.push(stmt.expression);
+      } else if (ts.isVariableStatement(stmt)) {
+        for (const d of stmt.declarationList.declarations) {
+          if (d.initializer) exprs.push(d.initializer);
+        }
+      }
+    }
+  } else if (body) {
+    exprs.push(body);
+  }
+  if (exprs.length === 0) return;
+
+  // Follow the fluent call chain: `argv.options({...}).command(...).command(...)`.
+  // Unroll by recursing into the expression of each call's receiver.
+  const visit = (e) => {
+    if (!e) return;
+    if (ts.isCallExpression(e)) {
+      const callee = e.expression;
+      if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)) {
+        const method = callee.name.text;
+        if (method === 'options') {
+          // yargs.options({...}) or .options({...}). Merge argument into
+          // accumulator.
+          const arg = e.arguments[0];
+          if (arg && ts.isObjectLiteralExpression(arg)) {
+            const parsed = parseOptionsObject(arg);
+            Object.assign(node.options, parsed);
+          }
+        } else if (method === 'option') {
+          // .option('name', { ... }) single-form.
+          const nameArg = e.arguments[0];
+          const specArg = e.arguments[1];
+          const optName = stringLiteralValue(nameArg);
+          if (optName && specArg && ts.isObjectLiteralExpression(specArg)) {
+            const synth = ts.factory.createObjectLiteralExpression([
+              ts.factory.createPropertyAssignment(ts.factory.createStringLiteral(optName), specArg),
+            ]);
+            Object.assign(node.options, parseOptionsObject(synth));
+          }
+        } else if (method === 'command') {
+          const sub = parseCommandCall(e.arguments);
+          if (sub) node.commands[sub.name] = sub;
+        }
+        // Continue walking up the chain.
+        visit(callee.expression);
+      } else if (ts.isIdentifier(callee)) {
+        // Bare call like `yargs(...)` — stop.
+      } else {
+        visit(callee);
+      }
+    } else if (ts.isParenthesizedExpression(e)) {
+      visit(e.expression);
+    }
+  };
+  for (const e of exprs) visit(e);
+}
+
+function parseCommandFile(srcFile) {
+  const sf = readSource(srcFile);
+  const result = {
+    name: null,
+    aliases: [],
+    positionals: [],
+    options: {},
+    commands: {},
+  };
+
+  sf.forEachChild((node) => {
+    if (!ts.isVariableStatement(node)) return;
+    // TS 5 moved modifier access behind `ts.getModifiers`. Fall back to
+    // `node.modifiers` for older TS versions that ship transitively.
+    const mods =
+      typeof ts.canHaveModifiers === 'function' && ts.canHaveModifiers(node)
+        ? ts.getModifiers(node) || []
+        : node.modifiers || [];
+    const isExport = mods.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    if (!isExport) return;
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name)) continue;
+      const varName = decl.name.text;
+      if (varName === 'command') {
+        const v = stringLiteralValue(decl.initializer);
+        if (v) {
+          const parts = v.trim().split(/\s+/);
+          result.name = parts[0];
+          result.positionals = parts
+            .slice(1)
+            .map((p) => p.replace(/^[<[]/, '').replace(/[>\]]$/, ''));
+        }
+      } else if (varName === 'aliases') {
+        const arr = arrayLiteralStrings(decl.initializer);
+        if (arr) result.aliases = arr;
+      } else if (varName === 'builder') {
+        if (decl.initializer) walkBuilder(decl.initializer, result);
+      }
+    }
+  });
+
+  return result;
+}
+
+function parseGlobalOptions(cliSrc) {
+  // `src/index.ts` wires global options. We don't need the full command
+  // tree from it; just accumulate every `.option(...)` + `.options({...})`
+  // call (skipping hidden: true).
+  const sf = readSource(cliSrc);
+  const bag = { commands: {}, options: {} };
+
+  sf.forEachChild((node) => {
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (!decl.initializer) continue;
+        walkBuilder(decl.initializer, bag);
+      }
+    }
+    // Also handle expression statements `builder = builder.method()...`.
+    if (ts.isExpressionStatement(node)) {
+      if (
+        ts.isBinaryExpression(node.expression) &&
+        node.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken
+      ) {
+        walkBuilder(node.expression.right, bag);
+      }
+    }
+  });
+
+  // Strip hidden options from globals.
+  const filtered = {};
+  for (const [k, v] of Object.entries(bag.options)) {
+    if (v.hidden) continue;
+    filtered[k] = v;
+  }
+  return filtered;
+}
+
+function buildSchema({ src } = {}) {
+  if (!src) throw new Error('buildSchema requires a `src` path');
+  const pkgPath = path.join(src, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const commandsDir = path.join(src, 'src', 'commands');
+
+  const globalOptions = parseGlobalOptions(path.join(src, 'src', 'index.ts'));
+
+  const commands = {};
+  for (const file of COMMAND_FILES) {
+    const full = path.join(commandsDir, file);
+    if (!fs.existsSync(full)) continue;
+    const parsed = parseCommandFile(full);
+    if (!parsed.name) continue;
+    commands[parsed.name] = {
+      aliases: parsed.aliases,
+      positionals: parsed.positionals,
+      options: parsed.options,
+      commands: parsed.commands,
+    };
+  }
+
+  return {
+    neonctlVersion: pkg.version,
+    generatedAt: new Date().toISOString(),
+    globalOptions,
+    commands,
+  };
+}
+
+const USAGE = [
+  'Usage: node scripts/docs-checks/neonctl/generate-schema.js --src <path> [--out <file>]',
+  '',
+  '  --src <path>   Path to a local clone of https://github.com/neondatabase/neonctl',
+  '                 (or set the NEONCTL_SRC environment variable).',
+  '  --out <file>   Where to write the schema JSON. Defaults to the committed',
+  '                 schema.json next to this script.',
+].join('\n');
+
+function main() {
+  const args = process.argv.slice(2);
+  let src = process.env.NEONCTL_SRC || null;
+  let out = DEFAULT_OUT;
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '--src') {
+      src = args[i + 1];
+      i += 1;
+    } else if (args[i] === '--out') {
+      out = args[i + 1];
+      i += 1;
+    } else if (args[i] === '--help' || args[i] === '-h') {
+      console.log(USAGE);
+      process.exit(0);
+    }
+  }
+  if (!src) {
+    console.error(
+      'Missing --src (or NEONCTL_SRC env var). Point it at a local clone of https://github.com/neondatabase/neonctl.\n'
+    );
+    console.error(USAGE);
+    process.exit(2);
+  }
+  const resolvedSrc = path.resolve(src);
+  if (!fs.existsSync(path.join(resolvedSrc, 'src', 'commands'))) {
+    console.error(
+      `No neonctl source found at ${resolvedSrc}. Expected a clone of https://github.com/neondatabase/neonctl with a \`src/commands\` directory.`
+    );
+    process.exit(2);
+  }
+  const schema = buildSchema({ src: resolvedSrc });
+  fs.writeFileSync(out, `${JSON.stringify(schema, null, 2)}\n`);
+  const nCmds = Object.keys(schema.commands).length;
+  const nLeafs = countLeaves(schema.commands);
+  console.log(
+    `Wrote schema for neonctl ${schema.neonctlVersion}: ${nCmds} top-level commands, ${nLeafs} leafs, ${Object.keys(schema.globalOptions).length} global options.`
+  );
+  console.log(`Output: ${out}`);
+}
+
+function countLeaves(commands) {
+  let n = 0;
+  for (const v of Object.values(commands)) {
+    const children = v.commands || {};
+    if (Object.keys(children).length === 0) n += 1;
+    else n += countLeaves(children);
+  }
+  return n;
+}
+
+module.exports = {
+  buildSchema,
+  parseCommandFile,
+  parseGlobalOptions,
+  parseOptionsObject,
+  parseCommandCall,
+};
+
+if (require.main === module) main();

--- a/scripts/docs-checks/neonctl/schema.js
+++ b/scripts/docs-checks/neonctl/schema.js
@@ -1,0 +1,147 @@
+// Loads the committed schema.json (produced by generate-schema.js) and
+// exposes helpers for resolving a command path and getting the set of
+// valid options at each node.
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_SCHEMA_PATH = path.join(__dirname, 'schema.json');
+
+// Cache by resolved file path so passing a different schema to
+// `loadSchema()` actually reloads.
+const schemaCache = new Map();
+
+function validateSchemaShape(schema, file) {
+  if (!schema || typeof schema !== 'object') {
+    throw new Error(`Schema at ${file} is not an object`);
+  }
+  if (!schema.commands || typeof schema.commands !== 'object') {
+    throw new Error(`Schema at ${file} is missing a \`commands\` object`);
+  }
+  if (schema.globalOptions && typeof schema.globalOptions !== 'object') {
+    throw new Error(`Schema at ${file} has a non-object \`globalOptions\``);
+  }
+}
+
+function loadSchema(file = DEFAULT_SCHEMA_PATH) {
+  const abs = path.resolve(file);
+  if (schemaCache.has(abs)) return schemaCache.get(abs);
+  const raw = fs.readFileSync(abs, 'utf8');
+  const schema = JSON.parse(raw);
+  validateSchemaShape(schema, abs);
+  schemaCache.set(abs, schema);
+  return schema;
+}
+
+const hasOwn = Object.prototype.hasOwnProperty;
+
+// Convert the schema's `commands` map to a lookup that understands
+// top-level aliases (`role` -> `roles`, `cs` -> `connection-string`).
+function buildTopAliasMap(schema) {
+  const map = new Map();
+  for (const [name, node] of Object.entries(schema.commands)) {
+    map.set(name, name);
+    for (const a of node.aliases || []) map.set(a, name);
+  }
+  return map;
+}
+
+// Within a single parent node, resolve a possibly-aliased subcommand name.
+// Uses `hasOwn` so a schema entry named `__proto__` or `constructor` can't
+// reach Object.prototype.
+function resolveSubcommand(parent, token) {
+  if (!parent || !parent.commands) return null;
+  if (hasOwn.call(parent.commands, token)) return parent.commands[token];
+  for (const node of Object.values(parent.commands)) {
+    if ((node.aliases || []).includes(token)) return node;
+  }
+  return null;
+}
+
+// Walk from the root down to the deepest subcommand that matches the
+// provided argv tokens. Returns:
+//   { node: deepestNode, path: [names], remaining: [...unconsumed] }
+// If the first token is not a known command, returns { node: null }.
+function resolvePath(schema, argv) {
+  const top = buildTopAliasMap(schema);
+  if (argv.length === 0) return { node: null, path: [], remaining: argv.slice() };
+  const first = argv[0];
+  const canonicalFirst = top.get(first);
+  if (!canonicalFirst) return { node: null, path: [], remaining: argv.slice() };
+
+  const pathNames = [canonicalFirst];
+  let node = hasOwn.call(schema.commands, canonicalFirst) ? schema.commands[canonicalFirst] : null;
+  if (!node) return { node: null, path: [], remaining: argv.slice() };
+  let i = 1;
+  while (i < argv.length) {
+    const tok = argv[i];
+    // Only consider tokens that look like command names: kebab-case
+    // letters, no digits, no uppercase. This keeps positional ids like
+    // `vpce-1234567890abcdef0` from being misclassified as subcommands.
+    if (!/^[a-z][a-z-]*$/.test(tok) || tok.length > 20) break;
+    const next = resolveSubcommand(node, tok);
+    if (!next) break;
+    node = next;
+    pathNames.push(next.name);
+    i += 1;
+  }
+  return { node, path: pathNames, remaining: argv.slice(i) };
+}
+
+// Walk the same chain but accumulate ALL options visible at the deepest
+// node: globals + every parent's options + the leaf's options. Returns a
+// Map keyed by every valid surface form: `--long`, `-short`, `--no-xxx`
+// for booleans, to the canonical option spec.
+function resolveValidOptions(schema, pathNames) {
+  // Use a null-prototype object so malicious keys (__proto__, constructor)
+  // can't reach Object.prototype.
+  const collected = Object.create(null);
+  const merge = (src) => {
+    if (!src) return;
+    for (const key of Object.keys(src)) {
+      if (!hasOwn.call(src, key)) continue;
+      collected[key] = src[key];
+    }
+  };
+  merge(schema.globalOptions);
+  // Walk down.
+  let node = schema;
+  for (const name of pathNames) {
+    if (!node.commands || !hasOwn.call(node.commands, name)) break;
+    const child = node.commands[name];
+    merge(child.options);
+    node = child;
+  }
+
+  const byForm = new Map();
+  const register = (form, canonicalName, spec) => {
+    byForm.set(form, { name: canonicalName, spec });
+  };
+  for (const [name, spec] of Object.entries(collected)) {
+    register(`--${name}`, name, spec);
+    if (spec.type === 'boolean') {
+      register(`--no-${name}`, name, spec);
+    }
+    const alias = spec.alias;
+    if (typeof alias === 'string') {
+      register(alias.length === 1 ? `-${alias}` : `--${alias}`, name, spec);
+      if (spec.type === 'boolean' && alias.length > 1) {
+        register(`--no-${alias}`, name, spec);
+      }
+    } else if (Array.isArray(alias)) {
+      for (const a of alias) {
+        register(a.length === 1 ? `-${a}` : `--${a}`, name, spec);
+        if (spec.type === 'boolean' && a.length > 1) {
+          register(`--no-${a}`, name, spec);
+        }
+      }
+    }
+  }
+  return byForm;
+}
+
+module.exports = {
+  loadSchema,
+  resolvePath,
+  resolveValidOptions,
+};

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,0 +1,624 @@
+{
+  "neonctlVersion": "2.22.0",
+  "generatedAt": "2026-04-20T00:50:56.131Z",
+  "globalOptions": {
+    "help": {
+      "type": "boolean"
+    },
+    "api-key": {
+      "type": "string"
+    },
+    "context-file": {
+      "type": "string"
+    },
+    "color": {
+      "type": "boolean"
+    },
+    "analytics": {
+      "type": "boolean"
+    },
+    "config-dir": {
+      "type": "string"
+    },
+    "output": {
+      "type": "string",
+      "alias": "o",
+      "choices": ["json", "yaml", "table"]
+    }
+  },
+  "commands": {
+    "auth": {
+      "aliases": ["login"],
+      "positionals": [],
+      "options": {
+        "context-file": {
+          "type": "unknown",
+          "hidden": true
+        }
+      },
+      "commands": {}
+    },
+    "me": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "context-file": {
+          "type": "unknown",
+          "hidden": true
+        }
+      },
+      "commands": {}
+    },
+    "orgs": {
+      "aliases": ["org"],
+      "positionals": [],
+      "options": {},
+      "commands": {
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {}
+        }
+      }
+    },
+    "projects": {
+      "aliases": ["project"],
+      "positionals": [],
+      "options": {},
+      "commands": {
+        "get": {
+          "name": "get",
+          "aliases": [],
+          "positionals": ["id"],
+          "options": {},
+          "commands": {}
+        },
+        "recover": {
+          "name": "recover",
+          "aliases": [],
+          "positionals": ["id"],
+          "options": {},
+          "commands": {}
+        },
+        "delete": {
+          "name": "delete",
+          "aliases": [],
+          "positionals": ["id"],
+          "options": {},
+          "commands": {}
+        },
+        "update": {
+          "name": "update",
+          "aliases": [],
+          "positionals": ["id"],
+          "options": {
+            "block-vpc-connections": {
+              "type": "boolean"
+            },
+            "block-public-connections": {
+              "type": "boolean"
+            },
+            "hipaa": {
+              "type": "boolean"
+            },
+            "cu": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "commands": {}
+        },
+        "create": {
+          "name": "create",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "block-public-connections": {
+              "type": "boolean"
+            },
+            "block-vpc-connections": {
+              "type": "boolean"
+            },
+            "hipaa": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "region-id": {
+              "type": "string"
+            },
+            "org-id": {
+              "type": "string"
+            },
+            "psql": {
+              "type": "boolean"
+            },
+            "database": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string"
+            },
+            "set-context": {
+              "type": "boolean"
+            },
+            "cu": {
+              "type": "string"
+            }
+          },
+          "commands": {}
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "org-id": {
+              "type": "string"
+            },
+            "recoverable-only": {
+              "type": "boolean"
+            }
+          },
+          "commands": {}
+        }
+      }
+    },
+    "ip-allow": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string"
+        }
+      },
+      "commands": {
+        "reset": {
+          "name": "reset",
+          "aliases": [],
+          "positionals": ["ips..."],
+          "options": {},
+          "commands": {}
+        },
+        "remove": {
+          "name": "remove",
+          "aliases": [],
+          "positionals": ["ips..."],
+          "options": {},
+          "commands": {}
+        },
+        "add": {
+          "name": "add",
+          "aliases": [],
+          "positionals": ["ips..."],
+          "options": {
+            "protected-only": {
+              "type": "boolean"
+            }
+          },
+          "commands": {}
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {}
+        }
+      }
+    },
+    "vpc": {
+      "aliases": [],
+      "positionals": [],
+      "options": {},
+      "commands": {
+        "project": {
+          "name": "project",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "project-id": {
+              "type": "string"
+            }
+          },
+          "commands": {
+            "remove": {
+              "name": "remove",
+              "aliases": [],
+              "positionals": ["id"],
+              "options": {},
+              "commands": {}
+            },
+            "restrict": {
+              "name": "restrict",
+              "aliases": ["update"],
+              "positionals": ["id"],
+              "options": {
+                "label": {
+                  "type": "string"
+                }
+              },
+              "commands": {}
+            },
+            "list": {
+              "name": "list",
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {}
+            }
+          }
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "org-id": {
+              "type": "string"
+            },
+            "region-id": {
+              "type": "string",
+              "required": true
+            }
+          },
+          "commands": {
+            "status": {
+              "name": "status",
+              "aliases": [],
+              "positionals": ["id"],
+              "options": {},
+              "commands": {}
+            },
+            "remove": {
+              "name": "remove",
+              "aliases": [],
+              "positionals": ["id"],
+              "options": {},
+              "commands": {}
+            },
+            "assign": {
+              "name": "assign",
+              "aliases": ["update", "add"],
+              "positionals": ["id"],
+              "options": {
+                "label": {
+                  "type": "string"
+                }
+              },
+              "commands": {}
+            },
+            "list": {
+              "name": "list",
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {}
+            }
+          }
+        }
+      }
+    },
+    "branches": {
+      "aliases": ["branch"],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string"
+        }
+      },
+      "commands": {
+        "schema-diff": {
+          "name": "schema-diff",
+          "aliases": ["sd"],
+          "positionals": ["base-branch", "compare-source[@(timestamp|lsn)]"],
+          "options": {
+            "database": {
+              "type": "string",
+              "alias": "db"
+            }
+          },
+          "commands": {}
+        },
+        "get": {
+          "name": "get",
+          "aliases": [],
+          "positionals": ["id|name"],
+          "options": {},
+          "commands": {}
+        },
+        "delete": {
+          "name": "delete",
+          "aliases": [],
+          "positionals": ["id|name"],
+          "options": {},
+          "commands": {}
+        },
+        "add-compute": {
+          "name": "add-compute",
+          "aliases": [],
+          "positionals": ["id|name"],
+          "options": {
+            "type": {
+              "type": "string"
+            },
+            "cu": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "commands": {}
+        },
+        "set-expiration": {
+          "name": "set-expiration",
+          "aliases": [],
+          "positionals": ["id|name"],
+          "options": {
+            "expires-at": {
+              "type": "string"
+            }
+          },
+          "commands": {}
+        },
+        "set-default": {
+          "name": "set-default",
+          "aliases": [],
+          "positionals": ["id|name"],
+          "options": {},
+          "commands": {}
+        },
+        "rename": {
+          "name": "rename",
+          "aliases": [],
+          "positionals": ["id|name", "new-name"],
+          "options": {},
+          "commands": {}
+        },
+        "restore": {
+          "name": "restore",
+          "aliases": [],
+          "positionals": ["target-id|name", "source>[@(timestamp|lsn)"],
+          "options": {
+            "preserve-under-name": {
+              "type": "unknown"
+            }
+          },
+          "commands": {}
+        },
+        "reset": {
+          "name": "reset",
+          "aliases": [],
+          "positionals": ["id|name"],
+          "options": {
+            "parent": {
+              "type": "boolean"
+            },
+            "preserve-under-name": {
+              "type": "unknown"
+            }
+          },
+          "commands": {}
+        },
+        "create": {
+          "name": "create",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "name": {
+              "type": "unknown"
+            },
+            "parent": {
+              "type": "string"
+            },
+            "compute": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string"
+            },
+            "suspend-timeout": {
+              "type": "number"
+            },
+            "cu": {
+              "type": "string"
+            },
+            "psql": {
+              "type": "boolean"
+            },
+            "annotation": {
+              "type": "string",
+              "hidden": true
+            },
+            "schema-only": {
+              "type": "boolean"
+            },
+            "expires-at": {
+              "type": "string"
+            }
+          },
+          "commands": {}
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {}
+        }
+      }
+    },
+    "databases": {
+      "aliases": ["database", "db"],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        }
+      },
+      "commands": {
+        "delete": {
+          "name": "delete",
+          "aliases": [],
+          "positionals": ["database"],
+          "options": {},
+          "commands": {}
+        },
+        "create": {
+          "name": "create",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "name": {
+              "type": "string",
+              "required": true
+            },
+            "owner-name": {
+              "type": "string"
+            }
+          },
+          "commands": {}
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {}
+        }
+      }
+    },
+    "roles": {
+      "aliases": ["role"],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        }
+      },
+      "commands": {
+        "delete": {
+          "name": "delete",
+          "aliases": [],
+          "positionals": ["role"],
+          "options": {},
+          "commands": {}
+        },
+        "create": {
+          "name": "create",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "name": {
+              "type": "string",
+              "required": true
+            },
+            "no-login": {
+              "type": "boolean"
+            }
+          },
+          "commands": {}
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {}
+        }
+      }
+    },
+    "operations": {
+      "aliases": ["operation"],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string"
+        }
+      },
+      "commands": {
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {}
+        }
+      }
+    },
+    "connection-string": {
+      "aliases": ["cs"],
+      "positionals": ["branch"],
+      "options": {
+        "project-id": {
+          "type": "string"
+        },
+        "role-name": {
+          "type": "string"
+        },
+        "database-name": {
+          "type": "string"
+        },
+        "pooled": {
+          "type": "boolean"
+        },
+        "prisma": {
+          "type": "boolean"
+        },
+        "endpoint-type": {
+          "type": "string"
+        },
+        "extended": {
+          "type": "boolean"
+        },
+        "psql": {
+          "type": "boolean"
+        },
+        "ssl": {
+          "type": "string"
+        }
+      },
+      "commands": {}
+    },
+    "set-context": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string"
+        },
+        "org-id": {
+          "type": "string"
+        }
+      },
+      "commands": {}
+    },
+    "init": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "agent": {
+          "type": "string",
+          "alias": "a"
+        },
+        "context-file": {
+          "type": "unknown",
+          "hidden": true
+        }
+      },
+      "commands": {}
+    }
+  }
+}

--- a/scripts/docs-checks/neonctl/validate.js
+++ b/scripts/docs-checks/neonctl/validate.js
@@ -1,0 +1,228 @@
+// Cross-references extracted neonctl invocations against the committed
+// schema.json (generated from neonctl's TypeScript source by
+// `generate-schema.js`) and reports:
+//
+//   - Missing commands:   path that neonctl doesn't recognize
+//   - Unknown options:    --flag not present on the resolved command
+//   - Bad choice values:  value not in the option's choices list
+//
+// Writes a Markdown report (default: ~/docs-reviews/neonctl-doc-validation.md)
+// and exits non-zero on any error.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { extract, DEFAULT_ROOT } = require('./extract-examples.js');
+const { loadSchema, resolvePath, resolveValidOptions } = require('./schema.js');
+
+function isPlaceholder(token) {
+  if (!token) return false;
+  if (/^<[^>]+>$/.test(token)) return true;
+  if (/^\[[^\]]+\]$/.test(token)) return true;
+  if (/^\$\{[^}]+\}$/.test(token)) return true;
+  if (/^\$[A-Z_][A-Z0-9_]*$/.test(token)) return true;
+  if (/^[A-Z][A-Z0-9_-]+$/.test(token)) return true;
+  return false;
+}
+
+function validateInvocation(invocation, { schema }) {
+  const errors = [];
+  const { argv, file, line, raw } = invocation;
+
+  // `completion` is emitted by yargs at runtime but not declared as a
+  // regular subcommand in the source tree. Skip validation.
+  if (argv[0] === 'completion') return errors;
+
+  // Lone top-level flags (`neon --help`, `neon --version`).
+  if (argv.length > 0 && argv[0].startsWith('-')) {
+    const validForms = resolveValidOptions(schema, []);
+    return checkOptions(argv, { validForms, cmdPath: [], file, line, raw });
+  }
+
+  const { node, path: cmdPath, remaining } = resolvePath(schema, argv);
+  if (!node) {
+    errors.push({
+      kind: 'missing-command',
+      file,
+      line,
+      raw,
+      message: `Unknown neonctl command: \`${argv[0] || '(none)'}\``,
+    });
+    return errors;
+  }
+
+  const validForms = resolveValidOptions(schema, cmdPath);
+  errors.push(...checkOptions(remaining, { validForms, cmdPath, file, line, raw }));
+  return errors;
+}
+
+function checkOptions(tokens, { validForms, cmdPath, file, line, raw }) {
+  const errors = [];
+  const cmdDisplay = cmdPath.length ? `neonctl ${cmdPath.join(' ')}` : 'neonctl';
+  for (let i = 0; i < tokens.length; i += 1) {
+    const tok = tokens[i];
+    if (tok === '--') break;
+    if (!tok.startsWith('-')) continue;
+    if (/^-\d/.test(tok)) continue; // Negative number value.
+    const entry = validForms.get(tok);
+    if (!entry) {
+      errors.push({
+        kind: 'unknown-option',
+        file,
+        line,
+        raw,
+        message: `Unknown option \`${tok}\` for \`${cmdDisplay}\``,
+      });
+      continue;
+    }
+    // Choice value check.
+    const { spec } = entry;
+    if (spec.choices && spec.type !== 'boolean') {
+      const next = tokens[i + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        if (!isPlaceholder(next) && !spec.choices.includes(next)) {
+          errors.push({
+            kind: 'bad-choice',
+            file,
+            line,
+            raw,
+            message: `Value \`${next}\` for \`${tok}\` is not in {${spec.choices.join(', ')}} for \`${cmdDisplay}\``,
+          });
+        }
+        i += 1;
+      }
+    }
+  }
+  return errors;
+}
+
+function validate({ root = DEFAULT_ROOT, schema } = {}) {
+  const s = schema || loadSchema();
+  const invocations = extract({ root });
+  const errors = [];
+  for (const inv of invocations) {
+    errors.push(...validateInvocation(inv, { schema: s }));
+  }
+  return { invocations, errors, schema: s };
+}
+
+function formatReport({ invocations, errors, schema }) {
+  const grouped = {
+    'missing-command': [],
+    'unknown-option': [],
+    'bad-choice': [],
+  };
+  for (const err of errors) grouped[err.kind].push(err);
+
+  const lines = [];
+  lines.push('# neonctl docs validation report');
+  lines.push('');
+  lines.push(
+    `Scanned \`${invocations.length}\` \`neonctl\`/\`neon\` invocations across \`content/docs/**/*.md\`.`
+  );
+  if (schema && schema.neonctlVersion) {
+    lines.push('');
+    lines.push(
+      `Validated against \`neonctl ${schema.neonctlVersion}\` (from committed \`schema.json\`).`
+    );
+  }
+  lines.push('');
+  lines.push(
+    `Errors: ${errors.length} (missing commands: ${grouped['missing-command'].length}, unknown options: ${grouped['unknown-option'].length}, bad choice values: ${grouped['bad-choice'].length})`
+  );
+  lines.push('');
+
+  const sectionTitle = {
+    'missing-command': 'Missing commands',
+    'unknown-option': 'Unknown options',
+    'bad-choice': 'Bad choice values',
+  };
+
+  for (const kind of ['missing-command', 'unknown-option', 'bad-choice']) {
+    const bucket = grouped[kind];
+    if (bucket.length === 0) continue;
+    lines.push(`## ${sectionTitle[kind]}`);
+    lines.push('');
+    const byFile = new Map();
+    for (const err of bucket) {
+      if (!byFile.has(err.file)) byFile.set(err.file, []);
+      byFile.get(err.file).push(err);
+    }
+    const sortedFiles = [...byFile.keys()].sort();
+    for (const file of sortedFiles) {
+      const rel = path.relative(process.cwd(), file);
+      lines.push(`### \`${rel}\``);
+      lines.push('');
+      for (const err of byFile.get(file)) {
+        lines.push(`- [L${err.line}](${rel}#L${err.line}) — ${err.message}`);
+        lines.push(`  - \`${err.raw.trim()}\``);
+      }
+      lines.push('');
+    }
+  }
+
+  if (errors.length === 0) {
+    lines.push('All invocations validated successfully.');
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const opts = { out: null, root: DEFAULT_ROOT, quiet: false };
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--out') {
+      opts.out = args[i + 1];
+      i += 1;
+    } else if (a === '--root') {
+      opts.root = args[i + 1];
+      i += 1;
+    } else if (a === '--quiet') {
+      opts.quiet = true;
+    } else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: node scripts/docs-checks/neonctl/validate.js [--root <dir>] [--out <file>] [--quiet]'
+      );
+      process.exit(0);
+    }
+  }
+
+  const outPath = opts.out || path.join(os.homedir(), 'docs-reviews', 'neonctl-doc-validation.md');
+
+  const result = validate({ root: opts.root });
+  const report = formatReport(result);
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, report);
+
+  if (!opts.quiet) {
+    const { errors, invocations, schema } = result;
+    console.log(
+      `Checked ${invocations.length} invocations against neonctl ${schema.neonctlVersion}: ${errors.length} error${errors.length === 1 ? '' : 's'}.`
+    );
+    console.log(`Report: ${outPath}`);
+    if (errors.length > 0) {
+      for (const err of errors.slice(0, 15)) {
+        const rel = path.relative(process.cwd(), err.file);
+        console.log(`  ${rel}:${err.line}  ${err.message}`);
+      }
+      if (errors.length > 15) {
+        console.log(`  … ${errors.length - 15} more (see report).`);
+      }
+    }
+  }
+
+  if (result.errors.length > 0) process.exit(1);
+}
+
+module.exports = {
+  validate,
+  validateInvocation,
+  formatReport,
+  isPlaceholder,
+};
+
+if (require.main === module) main();


### PR DESCRIPTION
This scans every `neonctl`/`neon` CLI example across `content/**/*.md` and fails on unknown commands, unknown options, or invalid `choices` values. Execute with `npm run check:docs:neonctl`. This works well but is considered beta.

The bundled `schema.json` is generated from the neonctl TypeScript source, which we should plan to do with each neonctl release. The README explains how.

It found two issues, which I'll commit after. This PR was inspired by PR #4775