### PR TITLE
Clarify usage of 'persons' table for exporting data

### DIFF
--- a/content/postgresql/tutorial/export-postgresql-table-to-csv-file.md
+++ b/content/postgresql/tutorial/export-postgresql-table-to-csv-file.md
@@ -16,7 +16,7 @@ nextLink:
 
 **Summary**: in this tutorial, you will learn various techniques to export data from PostgreSQL tables to CSV files.
 
-In the previous tutorial, we showed you how to [import data from a CSV file into a table](import-csv-file-into-posgresql-table). We will use the same `persons` table for importing data from a CSV file.
+In the previous tutorial, we showed you how to [import data from a CSV file into a table](import-csv-file-into-posgresql-table). We will use the same `persons` table for exporting data to a CSV file.
 
 ![postgresql export csv](/postgresqltutorial/posgresql-import-csv.jpg)
 The following statement retrieves the data from the `persons` table.


### PR DESCRIPTION
Updated the tutorial to clarify that the 'persons' table is used for exporting data to a CSV file instead of importing.