### PR TITLE
Add Neon Auth Phone Number plugin documentation

### DIFF
--- a/content/docs/auth/guides/manage-auth-api.md
+++ b/content/docs/auth/guides/manage-auth-api.md
@@ -125,17 +125,18 @@ Setting `delete_data` to `true` permanently removes all auth data from the datab
 
 The Neon API also provides endpoints for managing auth configuration at the branch level. These are available at `https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/...`:
 
-| Endpoint              | Methods                  | Description                                                  |
-| --------------------- | ------------------------ | ------------------------------------------------------------ |
-| `/domains`            | GET, POST, DELETE        | Manage trusted redirect domains                              |
-| `/oauth_providers`    | GET, POST, PATCH, DELETE | Configure OAuth providers (Google, GitHub, etc.)             |
-| `/email_provider`     | GET, PATCH               | Configure the email provider                                 |
-| `/email_and_password` | GET, PATCH               | Configure email/password authentication                      |
-| `/users`              | POST, DELETE, PUT        | Create, delete, and manage user roles                        |
-| `/plugins`            | GET, PATCH               | View and configure [auth plugins](/docs/auth/guides/plugins) |
-| `/webhooks`           | GET, PUT                 | Configure webhook notifications                              |
-| `/allow_localhost`    | GET, PATCH               | Toggle localhost access for development                      |
-| `/send_test_email`    | POST                     | Send a test email to verify email configuration              |
+| Endpoint                | Methods                  | Description                                                                 |
+| ----------------------- | ------------------------ | --------------------------------------------------------------------------- |
+| `/domains`              | GET, POST, DELETE        | Manage trusted redirect domains                                             |
+| `/oauth_providers`      | GET, POST, PATCH, DELETE | Configure OAuth providers (Google, GitHub, etc.)                            |
+| `/email_provider`       | GET, PATCH               | Configure the email provider                                                |
+| `/email_and_password`   | GET, PATCH               | Configure email/password authentication                                     |
+| `/users`                | POST, DELETE, PUT        | Create, delete, and manage user roles                                       |
+| `/plugins`              | GET, PATCH               | View and configure [auth plugins](/docs/auth/guides/plugins)                |
+| `/plugins/phone_number` | GET, PATCH               | Configure the [Phone Number plugin](/docs/auth/guides/plugins/phone-number) |
+| `/webhooks`             | GET, PUT                 | Configure webhook notifications                                             |
+| `/allow_localhost`      | GET, PATCH               | Toggle localhost access for development                                     |
+| `/send_test_email`      | POST                     | Send a test email to verify email configuration                             |
 
 For full request/response details on these endpoints, see the [interactive API reference](https://api-docs.neon.tech/reference/getting-started).
 

--- a/content/docs/auth/guides/plugins.md
+++ b/content/docs/auth/guides/plugins.md
@@ -30,8 +30,9 @@ The following Better Auth plugins are currently supported in Neon Auth:
 | [JWT](/docs/auth/guides/plugins/jwt)                   | ✅ Supported                                    |
 | [Organization](/docs/auth/guides/plugins/organization) | ⚠️ Partial (JWT token claims under development) |
 | [Open API](/docs/auth/guides/plugins/openapi)          | ✅ Supported                                    |
+| [Phone Number](/docs/auth/guides/plugins/phone-number) | ✅ Supported                                    |
 
-For more runnable Neon Auth samples, see [Example applications](/docs/auth/overview#example-applications). The **Organization** plugin demo is **[neon-auth-orgs-example](https://github.com/neondatabase/neon-js/tree/main/examples/neon-auth-orgs-example)**; see the [Organization plugin](/docs/auth/guides/plugins/organization) page for context.
+For more runnable Neon Auth samples, see [Example applications](/docs/auth/overview#example-applications). The **Organization** plugin demo is **[neon-auth-orgs-example](https://github.com/neondatabase/neon-js/tree/main/examples/neon-auth-orgs-example)** and the **Phone Number** demo is **[nextjs-phone-login](https://github.com/neondatabase/neon-js/tree/main/examples/nextjs-phone-login)**.
 
 For the latest status (including what’s coming next), see the [Neon Auth roadmap](/docs/auth/roadmap).
 

--- a/content/docs/auth/guides/plugins/phone-number.md
+++ b/content/docs/auth/guides/plugins/phone-number.md
@@ -135,7 +135,7 @@ export async function POST(request: Request) {
   const payload = await request.json(); // verify the signature first in production
 
   if (payload.event_type === 'send.otp' && payload.event_data.delivery_preference === 'sms') {
-    const toNumber = payload.user?.phone_number ?? payload.event_data.phone_number;
+    const toNumber = payload.user?.phone_number;
     if (!toNumber) {
       return NextResponse.json({ error: 'missing phone number' }, { status: 400 });
     }
@@ -154,7 +154,7 @@ export async function POST(request: Request) {
 ```
 
 <Admonition type="note" title="User context for first OTPs">
-If an unauthenticated user requests their first OTP against a phone number that is not yet linked to any account, the webhook `user` object may only contain `phone_number`. Your handler should fall back to `event_data.phone_number` when the user has not been resolved, as shown above.
+When an unauthenticated user requests their first phone OTP (no prior account linked to that phone number), the webhook `user` object contains the `phone_number` only. Do not rely on `user.name`, `user.email`, or other profile fields when templating the SMS for first-time sends.
 </Admonition>
 
 For a runnable Next.js handler, signature verification, and a local tunneling setup, see the [nextjs-phone-login example](https://github.com/neondatabase/neon-js/tree/main/examples/nextjs-phone-login).
@@ -194,7 +194,7 @@ For a complete working form with resend, error handling, and attempt-budget awar
 
 ## Use Phone Number alongside UI components
 
-Unlike Email OTP and Magic Link, `NeonAuthUIProvider` does not expose a `phoneNumber` prop, and the pre-built `AuthView` does not render a phone sign-in UI. If you're using Neon Auth UI components, render your own phone sign-in form next to `AuthView` on the sign-in route:
+Unlike Email OTP, `NeonAuthUIProvider` does not expose a `phoneNumber` prop, and the pre-built `AuthView` does not render a phone sign-in UI. If you're using Neon Auth UI components, render your own phone sign-in form next to `AuthView` on the sign-in route:
 
 ```tsx shouldWrap filename="app/auth/[path]/page.tsx"
 import { AuthView } from '@neondatabase/neon-js/auth/react/ui';

--- a/content/docs/auth/guides/plugins/phone-number.md
+++ b/content/docs/auth/guides/plugins/phone-number.md
@@ -1,0 +1,247 @@
+---
+title: Phone Number
+subtitle: Sign in existing users with phone OTP codes delivered via your SMS provider
+summary: >-
+  Covers the setup of the Phone Number plugin in Neon Auth, enabling existing
+  users to sign in with a one-time password delivered over SMS through a
+  webhook-connected SMS provider that you control.
+enableTableOfContents: true
+updatedOn: '2026-04-20T00:00:00.000Z'
+---
+
+<FeatureBetaProps feature_name="Neon Auth with Better Auth" />
+
+Neon Auth is built on [Better Auth](https://www.better-auth.com/) and supports the [Phone Number](https://www.better-auth.com/docs/plugins/phone-number) plugin through the Neon SDK. You don't need to install or configure the Better Auth Phone Number plugin directly.
+
+Phone Number lets an existing user sign in with a one-time password (OTP) delivered to their phone. The flow works like this:
+
+1. The user enters their phone number in E.164 format (for example, `+15551234567`).
+2. Neon Auth generates a 6-digit OTP and fires the `send.otp` webhook with `delivery_preference: "sms"`. Your webhook handler delivers the code via your SMS provider.
+3. The user enters the code. Neon Auth verifies it, creates a session, and signs them in.
+
+<Admonition type="important">
+The Phone Number plugin is **sign-in only**. A user must already exist in your project, with a phone number linked to their account, before they can sign in by phone. There is no phone-first sign-up path. See [How users get a phone number on their account](#how-users-get-a-phone-number-on-their-account) below.
+
+Neon Auth does **not** deliver SMS for you. Enabling the plugin also requires a `send.otp` webhook that forwards the code to your SMS provider (Twilio, MessageBird, Vonage, etc.). See [Deliver OTPs via your SMS provider (required)](#deliver-otps-via-your-sms-provider-required).
+</Admonition>
+
+## Prerequisites
+
+- A Neon project with **Auth enabled**
+- An existing user who has a phone number linked to their account (see [How users get a phone number on their account](#how-users-get-a-phone-number-on-their-account))
+- The **Phone Number plugin enabled** (see [Enable Phone Number](#enable-phone-number) below)
+- A configured webhook subscribed to the `send.otp` event that forwards the code to your SMS provider (see [Deliver OTPs via your SMS provider (required)](#deliver-otps-via-your-sms-provider-required) and the [Webhooks guide](/docs/auth/guides/webhooks))
+
+## How users get a phone number on their account
+
+Because the plugin is sign-in only, users need to first sign up and sign in through another method (email and password, a social provider, and so on). Once they have an authenticated session, your app can link a phone number to their account by calling `authClient.phoneNumber.verify()` with `updatePhoneNumber: true`.
+
+```ts shouldWrap filename="src/link-phone-number.ts"
+import { authClient } from '@/lib/auth/client';
+
+export async function sendLinkingOtp(phoneNumber: string) {
+  const { error } = await authClient.phoneNumber.sendOtp({ phoneNumber });
+  if (error) throw error;
+}
+
+export async function linkPhoneNumber(phoneNumber: string, code: string) {
+  const { data, error } = await authClient.phoneNumber.verify({
+    phoneNumber,
+    code,
+    updatePhoneNumber: true,
+  });
+
+  if (error) throw error;
+  return data;
+}
+```
+
+For a complete "Add phone number" form with session-aware state (no number, unverified, verified), see the `AddPhoneForm` component in the [nextjs-phone-login example](https://github.com/neondatabase/neon-js/tree/main/examples/nextjs-phone-login).
+
+## Enable Phone Number
+
+<Tabs labels={["Console", "API"]}>
+
+<TabItem>
+
+1. Open the [Neon Console](https://console.neon.tech).
+2. Select your project and go to **Auth** > **Plugins**.
+3. Toggle **Phone Number** on.
+4. Configure the options:
+   - **OTP Expiration** (60-600 seconds, default: 300) controls how long a generated OTP stays valid.
+   - **Allowed Attempts** (1-10, default: 3) is the maximum number of verification attempts against a single OTP before it is invalidated.
+
+![Neon Console Auth Plugins tab with Phone Number settings](/docs/auth/neon_auth_plugins_phone_number.png)
+
+</TabItem>
+
+<TabItem>
+
+Send a `PATCH` request to configure the Phone Number plugin. All request body fields are optional; send only the fields you want to change.
+
+```bash shouldWrap
+curl -X PATCH \
+  "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/plugins/phone_number" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "otp_expires_in": 300,
+    "allowed_attempts": 3
+  }'
+```
+
+A `GET` request returns the current configuration:
+
+```bash shouldWrap
+curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/plugins/phone_number" \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+```json
+{
+  "enabled": true,
+  "otp_expires_in": 300,
+  "allowed_attempts": 3
+}
+```
+
+| Field              | Type    | Default | Description                                                      |
+| ------------------ | ------- | ------- | ---------------------------------------------------------------- |
+| `enabled`          | boolean | `false` | Whether the Phone Number plugin is active                        |
+| `otp_expires_in`   | integer | `300`   | Seconds before the OTP expires (60-600)                          |
+| `allowed_attempts` | integer | `3`     | Verification attempts against a single OTP before lockout (1-10) |
+
+</TabItem>
+
+</Tabs>
+
+## Deliver OTPs via your SMS provider (required)
+
+Neon Auth does not send SMS messages itself. When an OTP needs to be delivered, Neon Auth fires the `send.otp` webhook with `delivery_preference: "sms"`. You must subscribe to this event and deliver the code through your own SMS provider (for example, Twilio, MessageBird, or Vonage). If no webhook is configured, calls to `authClient.phoneNumber.sendOtp()` fail.
+
+Configure a webhook subscribed to `send.otp` (see the [Webhooks guide](/docs/auth/guides/webhooks) for full setup and signature verification), then branch on `delivery_preference` in your handler:
+
+```ts shouldWrap filename="app/api/webhooks/neon-auth/route.ts"
+import { NextResponse } from 'next/server';
+import twilio from 'twilio';
+
+const twilioClient = twilio(
+  process.env.TWILIO_ACCOUNT_SID!,
+  process.env.TWILIO_AUTH_TOKEN!
+);
+
+export async function POST(request: Request) {
+  const payload = await request.json(); // verify the signature first in production
+
+  if (payload.event_type === 'send.otp' && payload.event_data.delivery_preference === 'sms') {
+    const toNumber = payload.user?.phone_number ?? payload.event_data.phone_number;
+    if (!toNumber) {
+      return NextResponse.json({ error: 'missing phone number' }, { status: 400 });
+    }
+
+    await twilioClient.messages.create({
+      from: process.env.TWILIO_FROM_NUMBER!,
+      to: toNumber,
+      body: `Your code is ${payload.event_data.otp_code}. It expires in ${Math.round(
+        (new Date(payload.event_data.expires_at).getTime() - Date.now()) / 1000
+      )} seconds.`,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+```
+
+<Admonition type="note" title="User context for first OTPs">
+If an unauthenticated user requests their first OTP against a phone number that is not yet linked to any account, the webhook `user` object may only contain `phone_number`. Your handler should fall back to `event_data.phone_number` when the user has not been resolved, as shown above.
+</Admonition>
+
+For a runnable Next.js handler, signature verification, and a local tunneling setup, see the [nextjs-phone-login example](https://github.com/neondatabase/neon-js/tree/main/examples/nextjs-phone-login).
+
+## Sign in an existing user with phone OTP
+
+Build a two-step phone sign-in form using the [Neon SDK](/docs/reference/javascript-sdk). First, send an OTP:
+
+```ts shouldWrap filename="src/send-phone-otp.ts"
+import { authClient } from '@/lib/auth/client';
+
+export async function sendPhoneOtp(phoneNumber: string) {
+  const { error } = await authClient.phoneNumber.sendOtp({ phoneNumber });
+  if (error) throw error;
+}
+```
+
+Then, after the user enters the code they received over SMS, verify it. Do **not** pass `updatePhoneNumber` here — omitting it tells Better Auth to treat the verification as a sign-in, look up the existing user by phone number, and create a session:
+
+```ts shouldWrap filename="src/verify-phone-otp.ts"
+import { authClient } from '@/lib/auth/client';
+
+export async function signInWithPhoneOtp(phoneNumber: string, code: string) {
+  const { data, error } = await authClient.phoneNumber.verify({
+    phoneNumber,
+    code,
+  });
+
+  if (error) throw error;
+  return data;
+}
+```
+
+Phone numbers must be in E.164 format (for example, `+15551234567`). Numbers in other formats are rejected.
+
+For a complete working form with resend, error handling, and attempt-budget awareness, see the [nextjs-phone-login example](https://github.com/neondatabase/neon-js/tree/main/examples/nextjs-phone-login).
+
+## Use Phone Number alongside UI components
+
+Unlike Email OTP and Magic Link, `NeonAuthUIProvider` does not expose a `phoneNumber` prop, and the pre-built `AuthView` does not render a phone sign-in UI. If you're using Neon Auth UI components, render your own phone sign-in form next to `AuthView` on the sign-in route:
+
+```tsx shouldWrap filename="app/auth/[path]/page.tsx"
+import { AuthView } from '@neondatabase/neon-js/auth/react/ui';
+import { authViewPaths } from '@neondatabase/neon-js/auth/react/ui/server';
+import { PhoneSignInSection } from './phone-sign-in-section';
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return Object.values(authViewPaths).map((path) => ({ path }));
+}
+
+export default async function AuthPage({ params }: { params: Promise<{ path: string }> }) {
+  const { path } = await params;
+  const isSignIn = path === authViewPaths.SIGN_IN;
+
+  return (
+    <div className="flex justify-center py-8">
+      <div className="w-full max-w-sm space-y-6">
+        <AuthView path={path} />
+        {isSignIn && <PhoneSignInSection />}
+      </div>
+    </div>
+  );
+}
+```
+
+The `PhoneSignInSection` is a small custom component that wraps your phone OTP form and renders only on the sign-in path. See the [nextjs-phone-login example](https://github.com/neondatabase/neon-js/tree/main/examples/nextjs-phone-login) for a complete implementation.
+
+> If you haven't set up Neon Auth UI components yet, see the [UI components reference](/docs/auth/reference/ui-components) for setup, or the [Next.js](/docs/auth/quick-start/nextjs-api-only) or [React](/docs/auth/quick-start/react) quick start for building custom forms instead.
+
+## Webhook events
+
+The Phone Number plugin uses two webhook events:
+
+- `send.otp` with `delivery_preference: "sms"` — blocking. Your handler must deliver the code over SMS. See [Deliver OTPs via your SMS provider (required)](#deliver-otps-via-your-sms-provider-required).
+- `phone_number.verified` — non-blocking. Fires after a user successfully verifies a phone number.
+
+See the [Webhooks guide](/docs/auth/guides/webhooks) for payload structure, signature verification, and retry behavior.
+
+## Limitations
+
+- **Sign-in only.** Users must already exist in the project with a verified phone number linked to their account. The plugin does not currently create new users from a phone OTP flow.
+- **Bring your own SMS provider.** Neon Auth does not include SMS delivery. A `send.otp` webhook that forwards the code to an SMS provider is required for the plugin to function.
+- **E.164 format required.** Phone numbers must match `^\+[1-9]\d{1,14}$` (for example, `+15551234567`). Numbers with spaces, dashes, or parentheses are rejected.
+- **OTP length is fixed at 6 digits.** This is not configurable.
+- **Rate limit.** Calls to `/phone-number/*` endpoints are limited to 10 requests per 60 seconds per IP, in addition to Neon Auth's global rate limits.
+- **Attempt lockout.** `allowed_attempts` controls how many times a user can guess a single OTP before it is invalidated. After lockout, the user must request a new OTP.
+
+<NeedHelp/>

--- a/content/docs/auth/guides/webhooks.md
+++ b/content/docs/auth/guides/webhooks.md
@@ -18,12 +18,13 @@ For a step-by-step Next.js walkthrough that implements signature verification, c
 
 ## Supported events
 
-| Event                | Type         | Trigger                                          | Use case                                            |
-| -------------------- | ------------ | ------------------------------------------------ | --------------------------------------------------- |
-| `send.otp`           | Blocking     | OTP code needs delivery                          | Custom OTP delivery via SMS or email service        |
-| `send.magic_link`    | Blocking     | Magic link needs delivery                        | Custom link delivery via any channel                |
-| `user.before_create` | Blocking     | User attempts to sign up (before database write) | Signup validation, allowlists, user data enrichment |
-| `user.created`       | Non-blocking | User created in the database                     | Sync to CRM, analytics, post-signup workflows       |
+| Event                   | Type         | Trigger                                          | Use case                                            |
+| ----------------------- | ------------ | ------------------------------------------------ | --------------------------------------------------- |
+| `send.otp`              | Blocking     | OTP code needs delivery                          | Custom OTP delivery via SMS or email service        |
+| `send.magic_link`       | Blocking     | Magic link needs delivery                        | Custom link delivery via any channel                |
+| `user.before_create`    | Blocking     | User attempts to sign up (before database write) | Signup validation, allowlists, user data enrichment |
+| `user.created`          | Non-blocking | User created in the database                     | Sync to CRM, analytics, post-signup workflows       |
+| `phone_number.verified` | Non-blocking | User successfully verified a phone number        | Post-verification workflows for phone OTP sign-in   |
 
 **Blocking** events pause the auth flow until your server responds (or the timeout expires). **Non-blocking** events are fire-and-forget; failures do not affect the user.
 
@@ -44,7 +45,7 @@ Both endpoints use the following fields:
 | ----------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `enabled`         | boolean (required) | Enable or disable webhook delivery                                                                                                                  |
 | `webhook_url`     | string             | HTTPS endpoint to receive webhook POST requests                                                                                                     |
-| `enabled_events`  | string[]           | Event types to subscribe to: `send.otp`, `send.magic_link`, `user.before_create`, `user.created`                                                    |
+| `enabled_events`  | string[]           | Event types to subscribe to: `send.otp`, `send.magic_link`, `user.before_create`, `user.created`, `phone_number.verified`                           |
 | `timeout_seconds` | integer (1-10)     | Per-attempt timeout in seconds. Default: 5. Total delivery time across all attempts is capped at 15 seconds. See [Retry behavior](#retry-behavior). |
 
 ### Set or update configuration
@@ -56,7 +57,7 @@ curl -X PUT "https://console.neon.tech/api/v2/projects/{project_id}/branches/{br
   -d '{
     "enabled": true,
     "webhook_url": "https://your-app.com/webhooks/neon-auth",
-    "enabled_events": ["send.otp", "send.magic_link", "user.before_create", "user.created"],
+    "enabled_events": ["send.otp", "send.magic_link", "user.before_create", "user.created", "phone_number.verified"],
     "timeout_seconds": 5
   }'
 ```
@@ -78,7 +79,8 @@ Both endpoints return the configuration in the same format:
     "send.otp",
     "send.magic_link",
     "user.before_create",
-    "user.created"
+    "user.created",
+    "phone_number.verified"
   ],
   "timeout_seconds": 5
 }
@@ -140,6 +142,8 @@ The `user` object fields are all optional and vary by event. Available fields: `
 | `ip_address`          | string            | Requester's IP address                                      |
 | `user_agent`          | string            | Requester's user agent                                      |
 
+When `delivery_preference` is `"sms"`, the event is fired by the [Phone Number plugin](/docs/auth/guides/plugins/phone-number). Your handler is responsible for delivering the OTP through your SMS provider. Because Neon Auth does not deliver SMS, a subscribed `send.otp` webhook is a hard requirement for the Phone Number plugin.
+
 ### `send.magic_link` event data
 
 | Field        | Type         | Description                                   |
@@ -162,6 +166,17 @@ These events fire only when a new user record is created in the database. They d
 | `auth_provider` | string | `"credential"`, `"google"`, `"github"`, or `"vercel"` |
 | `ip_address`    | string | Requester's IP address                                |
 | `user_agent`    | string | Requester's user agent                                |
+
+### `phone_number.verified` event data
+
+Fires non-blocking after a user successfully verifies a phone number via the [Phone Number plugin](/docs/auth/guides/plugins/phone-number). The `user` object includes the full user context, including `phone_number` and `phone_number_verified`.
+
+| Field             | Type    | Description                                                                       |
+| ----------------- | ------- | --------------------------------------------------------------------------------- |
+| `phone_number`    | string  | The phone number that was verified, in E.164 format (for example, `+15551234567`) |
+| `is_phone_update` | boolean | Reserved for future use; currently always `false`                                 |
+| `ip_address`      | string  | Requester's IP address                                                            |
+| `user_agent`      | string  | Requester's user agent                                                            |
 
 ## Signature verification
 

--- a/content/docs/auth/overview.md
+++ b/content/docs/auth/overview.md
@@ -151,7 +151,7 @@ See [Branching authentication](/docs/auth/branching-authentication) for details 
 
 ## Example applications
 
-Beyond the quick starts on this site, the [neondatabase/neon-js](https://github.com/neondatabase/neon-js) monorepo ships **more runnable Neon Auth and `neon-js` samples** under [`examples/`](https://github.com/neondatabase/neon-js/tree/main/examples). It includes Next.js and React apps, cross-subdomain setups, the Organization plugin, alternative UI stacks, and Data API patterns. Each folder includes its own README (many workflows use **bun** from the repository root). Browse there when you want a full project to clone next to the guides here.
+Beyond the quick starts on this site, the [neondatabase/neon-js](https://github.com/neondatabase/neon-js) monorepo ships **more runnable Neon Auth and `neon-js` samples** under [`examples/`](https://github.com/neondatabase/neon-js/tree/main/examples), including the [Organization plugin](https://github.com/neondatabase/neon-js/tree/main/examples/neon-auth-orgs-example) and [Phone Number](https://github.com/neondatabase/neon-js/tree/main/examples/nextjs-phone-login) demos, Next.js and React apps, cross-subdomain setups, alternative UI stacks, and Data API patterns. Each folder includes its own README (many workflows use **bun** from the repository root). Browse there when you want a full project to clone next to the guides here.
 
 ## Availability
 

--- a/content/docs/auth/roadmap.md
+++ b/content/docs/auth/roadmap.md
@@ -56,6 +56,7 @@ Neon Auth is built on [Better Auth](https://www.better-auth.com/). Not all Bette
 | [Organization](/docs/auth/guides/plugins/organization)                             | ⚠️ Partial (JWT token claims under development) |
 | [JWT](/docs/auth/guides/plugins/jwt)                                               | ✅ Supported                                    |
 | [Open API](/docs/auth/guides/plugins/openapi)                                      | ✅ Supported                                    |
+| [Phone Number](/docs/auth/guides/plugins/phone-number)                             | ✅ Supported                                    |
 
 See [Set up OAuth](/docs/auth/guides/setup-oauth) for Neon-specific OAuth configuration (including Vercel). Email flows such as verification and password reset are covered in [Email verification](/docs/auth/guides/email-verification), [Password reset](/docs/auth/guides/password-reset), and [User management](/docs/auth/guides/user-management).
 
@@ -76,7 +77,6 @@ Branch-aware auth (separate auth state per Neon branch) is supported; see [Branc
 | Plugin                                                            | Status          |
 | ----------------------------------------------------------------- | --------------- |
 | [Magic link](https://www.better-auth.com/docs/plugins/magic-link) | 🔜 Coming soon  |
-| Phone number (bring your own SMS provider)                        | 🔜 Coming soon  |
 | MFA support                                                       | 🔜 Coming soon  |
 | [Admin](/docs/auth/guides/plugins/admin) plugin customization     | 🔜 Coming soon  |
 | Other plugins                                                     | Based on demand |

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -486,6 +486,8 @@
                       slug: auth/guides/plugins/openapi
                     - title: Organization
                       slug: auth/guides/plugins/organization
+                    - title: Phone Number
+                      slug: auth/guides/plugins/phone-number
 
             - section: Reference
               items:


### PR DESCRIPTION
## Summary

Adds Neon Auth docs for the upcoming Phone Number plugin (LKB-11605), mirroring the scope of the Magic Link PR (#4750).

- New plugin page at `content/docs/auth/guides/plugins/phone-number.md` covering intro, prerequisites, how users link a phone to an existing account, Console + API enablement, SMS provider webhook integration (required), the two-step SDK sign-in flow, integration with `AuthView`, webhook events, and limitations.
- Plugins index (`content/docs/auth/guides/plugins.md`): adds Phone Number row and links the `nextjs-phone-login` example.
- Roadmap (`content/docs/auth/roadmap.md`): moves Phone Number from "On the roadmap" to Supported.
- Manage Auth API (`content/docs/auth/guides/manage-auth-api.md`): adds `/plugins/phone_number` row.
- Webhooks (`content/docs/auth/guides/webhooks.md`): adds `phone_number.verified` event (non-blocking), documents the SMS `delivery_preference` on `send.otp`, and updates the `enabled_events` list and example payload.
- Overview (`content/docs/auth/overview.md`): links the `nextjs-phone-login` example.
- Navigation (`content/docs/navigation.yaml`): adds Phone Number under Plugins (alphabetical).

Two things the page makes unmistakable:

1. The plugin is **sign-in only**. A user must already exist in the project with a phone number linked to their account before they can sign in by phone.
2. Neon Auth does **not** deliver SMS. A `send.otp` webhook that forwards the code to your SMS provider is a hard requirement.

## Related PRs

- neon-cloud: `[neon-auth/be] feat: support partial phone number plugin config updates` (LKB-11605) -- initial endpoint + partial-update (PUT -> PATCH)
- universe: `[lakebase/web] feat: Add phone number plugin UI with feature flag` (LKB-11605) -- Console card behind a feature flag
- neon-js #74: `feat: add phoneNumber client plugin for phone OTP sign-in`
- neon-js #75: `misc: add phone number login example app` -- `examples/nextjs-phone-login`
- neon-js #76: `[auth] fix: refresh session_data cookie cache on mutation responses`
- neon-js #78: `fix(auth): normalize adapter errors to AuthApiError (.status + .code)`

## Do not merge until

1. Staging OpenAPI at `/projects/{project_id}/branches/{branch_id}/auth/plugins/phone_number` shows `PATCH` (not `PUT`) with a partial-update body schema. Staging currently exposes `PUT` with the full-object body.
2. The Console feature-flag-gated Phone Number card is on by default.
3. A published `neon-js` version includes `phoneNumberClient()` (#74) and the two bugfixes (#76, #78).
4. Replace the placeholder screenshot at `public/docs/auth/neon_auth_plugins_phone_number.png` with a real Console capture (the page references this path but the asset is not committed yet).

## Test plan

- [ ] Run `npm run dev` and visually review the new plugin page under `/docs/auth/guides/plugins/phone-number`.
- [ ] Confirm the left nav shows Phone Number under Plugins in alphabetical order.
- [ ] Click through every internal link on the new page (Webhooks guide, UI components reference, quick starts, Neon SDK reference).
- [ ] Once the release-gate conditions above are true, run `examples/nextjs-phone-login` end-to-end against a flag-enabled project with a `send.otp` webhook wired to Twilio (or similar) and confirm the docs match the observed flow.

## Follow-ups

- **SDK import path consistency.** This page uses `@neondatabase/neon-js/auth/react/ui` to match the existing convention in `email-otp.md` and the Magic Link PR (#4750). The `examples/nextjs-phone-login` app in `neondatabase/neon-js` imports from `@neondatabase/auth/react/ui`. These should be reconciled before GA — either update the example to use the documented path, or switch the Neon Auth plugin pages over to `@neondatabase/auth/react/ui` for consistency with the shipping SDK.
