### PR TITLE
feat: cache github stars in generated snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ public/md
 public/docs/**/llms.txt
 public/docs/llms-full.txt
 public/pricing.md
+src/utils/data/github-stars.generated.json
 
 # Mac files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "npm": ">=8.6.0"
   },
   "scripts": {
-    "prebuild": "node src/scripts/generate-docs-icons-config.js && npm run check:content-data && npm run generate:pricing",
-    "predev": "node src/scripts/generate-docs-icons-config.js && npm run check:content-data && npm run generate:pricing",
+    "prebuild": "node src/scripts/update-github-stars.js && node src/scripts/generate-docs-icons-config.js && npm run check:content-data && npm run generate:pricing",
+    "predev": "node src/scripts/update-github-stars.js && node src/scripts/generate-docs-icons-config.js && npm run check:content-data && npm run generate:pricing",
     "dev": "next dev",
     "build": "next build",
     "dev:build": "next build",

--- a/src/scripts/update-github-stars.js
+++ b/src/scripts/update-github-stars.js
@@ -8,6 +8,7 @@ const path = require('path');
 const API_URL = 'https://api.github.com/repos/neondatabase/neon';
 const SNAPSHOT_PATH = path.join(process.cwd(), 'src/utils/data/github-stars.generated.json');
 const SNAPSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const FAILED_FETCH_RETRY_DELAY_MS = 60 * 60 * 1000;
 const DEFAULT_STARS_COUNT = 21500;
 const FETCH_TIMEOUT_MS = 10000;
 
@@ -134,7 +135,9 @@ async function main() {
     }
   } catch (error) {
     await writeSnapshot({
-      checked_at: snapshot?.checked_at ?? null,
+      checked_at: new Date(
+        Date.now() - (SNAPSHOT_MAX_AGE_MS - FAILED_FETCH_RETRY_DELAY_MS)
+      ).toISOString(),
       stargazers_count: currentStarsCount,
     });
     console.warn(`GitHub stars: ${error.message}`);

--- a/src/scripts/update-github-stars.js
+++ b/src/scripts/update-github-stars.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+require('dotenv').config({ path: '.env' });
+
+const fs = require('fs/promises');
+const path = require('path');
+
+const API_URL = 'https://api.github.com/repos/neondatabase/neon';
+const SNAPSHOT_PATH = path.join(process.cwd(), 'src/utils/data/github-stars.generated.json');
+const SNAPSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_STARS_COUNT = 21500;
+const FETCH_TIMEOUT_MS = 10000;
+
+function getHeaders() {
+  const token = process.env.GITHUB_TOKEN;
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'neon-next-github-stars-updater',
+  };
+
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+async function readSnapshot() {
+  try {
+    const rawSnapshot = await fs.readFile(SNAPSHOT_PATH, 'utf8');
+    const snapshot = JSON.parse(rawSnapshot);
+
+    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+      throw new Error('Generated snapshot did not contain a snapshot object');
+    }
+
+    return snapshot;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+
+    console.warn(`GitHub stars: failed to read snapshot ${SNAPSHOT_PATH}: ${error.message}`);
+    return null;
+  }
+}
+
+function normalizeSnapshot(snapshot) {
+  return {
+    checked_at: snapshot?.checked_at ?? null,
+    stargazers_count: Number.isFinite(snapshot?.stargazers_count)
+      ? snapshot.stargazers_count
+      : DEFAULT_STARS_COUNT,
+  };
+}
+
+function isFresh(snapshot) {
+  if (!snapshot?.checked_at) {
+    return false;
+  }
+
+  const checkedAt = Date.parse(snapshot.checked_at);
+
+  if (Number.isNaN(checkedAt)) {
+    return false;
+  }
+
+  return Date.now() - checkedAt < SNAPSHOT_MAX_AGE_MS;
+}
+
+async function writeSnapshot(snapshot) {
+  await fs.mkdir(path.dirname(SNAPSHOT_PATH), { recursive: true });
+  await fs.writeFile(SNAPSHOT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+}
+
+async function fetchStarsCount() {
+  let response;
+
+  try {
+    response = await fetch(API_URL, {
+      headers: getHeaders(),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error?.name === 'TimeoutError' || error?.name === 'AbortError') {
+      throw new Error(`GitHub API request timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+
+    throw error;
+  }
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status}: ${text.slice(0, 200)}`);
+  }
+
+  const payload = JSON.parse(text);
+  const starsCount = payload?.stargazers_count;
+
+  if (!Number.isFinite(starsCount)) {
+    throw new Error('GitHub API response did not include a numeric stargazers_count');
+  }
+
+  return starsCount;
+}
+
+async function main() {
+  const snapshot = normalizeSnapshot(await readSnapshot());
+
+  if (isFresh(snapshot)) {
+    console.log(`GitHub stars: using cached snapshot from ${snapshot.checked_at}`);
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const currentStarsCount = snapshot.stargazers_count;
+
+  try {
+    const starsCount = await fetchStarsCount();
+    const nextSnapshot = {
+      stargazers_count: starsCount,
+      checked_at: now,
+    };
+
+    await writeSnapshot(nextSnapshot);
+
+    if (starsCount !== currentStarsCount) {
+      console.log(
+        `GitHub stars: updated tracked fallback from ${currentStarsCount} to ${starsCount}`
+      );
+    } else {
+      console.log(`GitHub stars: count unchanged at ${starsCount}`);
+    }
+  } catch (error) {
+    await writeSnapshot({
+      checked_at: snapshot?.checked_at ?? null,
+      stargazers_count: currentStarsCount,
+    });
+    console.warn(`GitHub stars: ${error.message}`);
+    console.warn(`GitHub stars: keeping tracked fallback at ${currentStarsCount} stars`);
+  }
+}
+
+main().catch((error) => {
+  console.error(`GitHub stars: unexpected failure: ${error.message}`);
+  process.exit(1);
+});

--- a/src/utils/get-github-data.js
+++ b/src/utils/get-github-data.js
@@ -1,15 +1,41 @@
 const API_URL = 'https://api.github.com/repos/neondatabase/neon';
+const DEFAULT_GITHUB_STARS_COUNT = 21500;
+
+const readGitHubStarsSnapshot = async () => {
+  try {
+    // This helper sits under a shared header import graph that Next/Turbopack may
+    // still analyze for client traces, so keep Node-only modules out of the top level.
+    const [{ default: fs }, { default: path }] = await Promise.all([
+      import('node:fs/promises'),
+      import('node:path'),
+    ]);
+    const snapshotPath = path.join(process.cwd(), 'src/utils/data/github-stars.generated.json');
+    const rawSnapshot = await fs.readFile(snapshotPath, 'utf8');
+    const snapshot = JSON.parse(rawSnapshot);
+
+    if (!Number.isFinite(snapshot?.stargazers_count)) {
+      return null;
+    }
+
+    return snapshot;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+
+    console.warn(`GitHub stars: failed to read snapshot: ${error.message}`);
+    return null;
+  }
+};
 
 const getGitHubStars = async () => {
-  if (process.env.NODE_ENV === 'production') {
-    const response = await fetch(API_URL, { next: { revalidate: 60 * 60 * 12 } });
-    const json = await response.json();
-    if (response.status >= 400) {
-      throw new Error('Error fetching GitHub stars');
-    }
-    return json.stargazers_count;
+  const githubStarsSnapshot = await readGitHubStarsSnapshot();
+
+  if (githubStarsSnapshot) {
+    return githubStarsSnapshot.stargazers_count;
   }
-  return 16000;
+
+  return DEFAULT_GITHUB_STARS_COUNT;
 };
 
 const getGitHubContributors = async () => {


### PR DESCRIPTION
## Summary
- cache GitHub stars in a generated local snapshot instead of fetching them during page rendering
- update the snapshot during `predev` and `prebuild` with a 24-hour freshness window
- fall back to the last local snapshot/default value when GitHub is unavailable

## Why
This avoids GitHub API failures during local development and builds, especially when unauthenticated rate limits are hit.

## Tradeoff
We lose `revalidate`-driven freshness for the GitHub stars count because the value is no longer fetched at render time. Instead, the snapshot is refreshed ahead of time, which makes the result slightly less fresh but much more reliable during local development.

## Preview
- open [preview](https://neon-next-git-update-github-stars-pixelpoint.vercel.app/) and check GitHub stars