### PR TITLE
docs: remove inaccurate NAT gateway IP count claim

### DIFF
--- a/content/docs/introduction/regions.md
+++ b/content/docs/introduction/regions.md
@@ -47,7 +47,7 @@ After you select a region for a Neon project, it cannot be changed for that proj
 
 ## NAT Gateway IP addresses
 
-A NAT gateway has a public IP address that external systems see when private resources initiate outbound connections. Neon uses 3 to 6 IP addresses per region for this outbound communication, corresponding to each availability zone in the region. To ensure proper connectivity for setups such as replicating data to Neon, you should allow access to all the NAT gateway IP addresses associated with your Neon project's region.
+A NAT gateway has a public IP address that external systems see when private resources initiate outbound connections. Neon uses multiple IP addresses per region for this outbound communication, with the number varying by region. To ensure proper connectivity for setups such as replicating data to Neon, you should allow access to all the NAT gateway IP addresses associated with your Neon project's region.
 
 If you are unsure of your project's region, you can find this information in the **Settings** widget on the **Project Dashboard**.
 
@@ -60,7 +60,7 @@ If you are unsure of your project's region, you can find this information in the
 | `aws-us-west-2`      | 34.213.87.149, 35.164.221.218, 35.83.202.11, 44.235.241.217, 44.236.56.140, 52.32.22.241, 52.37.48.254, 52.40.99.9, 54.186.210.201, 54.213.57.47                                                                                                                                                                          |
 | `aws-eu-central-1`   | 18.156.24.144, 18.158.63.175, 18.194.181.241, 18.198.137.195, 3.123.76.138, 3.125.234.79, 3.125.57.42, 3.66.63.165, 52.58.17.95                                                                                                                                                                                           |
 | `aws-eu-west-2`      | 18.133.205.39, 3.10.42.8, 52.56.191.86                                                                                                                                                                                                                                                                                    |
-| `aws-ap-southeast-1` | 3.1.239.32, 47.131.90.115, 52.76.51.78, 54.254.50.26, 54.254.92.70, 54.255.161.23 |
+| `aws-ap-southeast-1` | 3.1.239.32, 47.131.90.115, 52.76.51.78, 54.254.50.26, 54.254.92.70, 54.255.161.23                                                                                                                                                                                                                                         |
 | `aws-ap-southeast-2` | 13.237.134.148, 13.55.152.144, 54.153.185.87                                                                                                                                                                                                                                                                              |
 | `aws-sa-east-1`      | 18.230.1.215, 52.67.202.176, 54.232.117.41                                                                                                                                                                                                                                                                                |
 


### PR DESCRIPTION
## Summary

- Removes the inaccurate "3 to 6 IP addresses per region" claim from the NAT gateway IP addresses section
- `aws-us-east-1` has 21 addresses; other regions range from 3 to 13
- Replaced with "multiple IP addresses per region, with the number varying by region" — language that won't become stale as infrastructure scales

Fixes LKB-11822.

## Test plan

- [ ] Verify the updated sentence reads correctly at `/docs/introduction/regions#nat-gateway-ip-addresses`
- [ ] Confirm the IP address tables are unchanged