### PR TITLE
feat(components): add spending limits to pricing plan table

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -223,6 +223,16 @@ export default {
       scale: 'Included',
     },
     {
+      rows: '2',
+      feature: {
+        title: 'Spending limits',
+        subtitle: 'Control your monthly spend',
+      },
+      free: false,
+      launch: true,
+      scale: true,
+    },
+    {
       rows: '1',
       feature: {
         title: 'HIPAA Compliance',


### PR DESCRIPTION
Launch and Scale show included; Free does not. Subtitle: Control your
monthly spend. Row sits after Metrics and Logs export.
