### PR TITLE
docs: tune ESLint and markdownlint auto-fix rules

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,13 @@
   "no-inline-html": false,
   "no-trailing-punctuation": false,
   "no-duplicate-heading": false,
-  "first-line-heading": false
+  "first-line-heading": false,
+  "no-bare-urls": false,
+  "no-hard-tabs": false,
+  "no-emphasis-as-heading": false,
+  "code-block-style": false,
+  "heading-increment": false,
+  "no-trailing-spaces": false,
+  "table-column-style": false,
+  "commands-show-output": false
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,21 +65,8 @@ export default [
     },
     rules: {
       'react/prop-types': 'error',
-      'react/function-component-definition': [
-        'error',
-        {
-          namedComponents: 'arrow-function',
-          unnamedComponents: 'arrow-function',
-        },
-      ],
-      'react/jsx-sort-props': [
-        'error',
-        {
-          callbacksLast: true,
-          shorthandLast: true,
-          noSortAlphabetically: true,
-        },
-      ],
+      'react/function-component-definition': 'off',
+      'react/jsx-sort-props': 'off',
       'import/no-unresolved': 'off',
       'import/named': 'off',
       'import/order': [
@@ -102,6 +89,13 @@ export default [
         'error',
         { required: { some: ['nesting', 'id'] } },
       ],
+      // Suppress rules that produce false positives on marketing/docs site patterns
+      'jsx-a11y/click-events-have-key-events': 'off',
+      'jsx-a11y/no-static-element-interactions': 'off',
+      'jsx-a11y/mouse-events-have-key-events': 'off',
+      'jsx-a11y/no-noninteractive-element-interactions': 'off',
+      'jsx-a11y/media-has-caption': 'off',
+      'jsx-a11y/no-autofocus': 'off',
     },
   },
 


### PR DESCRIPTION
Stops `npm run lint:fix` from making unintended mass rewrites across the codebase.

## ESLint (`eslint.config.mjs`)

Two auto-fixable rules were causing chaos when `lint:fix` ran, they rewrote code rather than catching bugs:

- `react/jsx-sort-props` -> off (was reordering JSX props across all files)
- `react/function-component-definition` -> off (was converting function declarations to arrow functions across all files)

Six `jsx-a11y` rules suppressed that produce false positives on a marketing/docs site (click handlers on non-interactive elements, videos without captions, `autoFocus`):

`click-events-have-key-events`, `no-static-element-interactions`, `mouse-events-have-key-events`, `no-noninteractive-element-interactions`, `media-has-caption`, `no-autofocus`

## markdownlint (`.markdownlint.json`)

- `no-bare-urls` → disabled (was wrapping `https://...` in angle brackets)
- `no-hard-tabs`, `no-trailing-spaces`, `table-column-style`, `code-block-style` -> disabled (Prettier handles these, will re-evaluate later)
- `heading-increment`, `no-emphasis-as-heading`, `commands-show-output` -> disabled (too strict / intentional in docs)