### PR TITLE
docs: add org spend limits to roadmap shipped section

### DIFF
--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -77,6 +77,7 @@ And here's an overview of what we're looking at next:
 
 ## What we've shipped recently 🚢
 
+- **Organization spend limits**: Set a monthly spending limit for your organization from the Billing page and receive email alerts when you reach 80% and 100% of that limit. [Learn more](/docs/introduction/spending-limit).
 - **Neon plugin for OpenAI Codex**: The Neon Postgres plugin is now available in the OpenAI Codex plugin directory, adding the Neon MCP Server and Agent Skills to Codex so you can manage projects, branches, and databases from chat. [Learn more](/docs/ai/ai-codex-plugin)
 - **Neon Postgres in Stripe Projects**: Neon is now part of Stripe Projects, so you can provision a Neon database as part of a Stripe CLI app setup alongside other services. [Read the announcement](/blog/neon-works-with-stripe-projects-for-agentic-provisioning)
 - **Automatic cache prewarming**: Neon now prewarns your compute's in-memory cache during scheduled compute updates, protecting query performance immediately after the update restarts Postgres. [Read the blog post](https://neon.com/blog/prewarming)


### PR DESCRIPTION
## Summary

- Adds **Organization spend limits** to the "What we've shipped recently" section of the roadmap, reflecting the feature shipped in the 2026-04-24 changelog.
- No items moved out of "What we're working on now" — Neon Auth GA, Postgres 18 GA, large compute perf optimizations, and large object storage are all still in progress.

## Test plan

- [ ] Verify the new bullet renders correctly on the roadmap page
- [ ] Confirm the `/docs/introduction/spending-limit` link resolves

This pull request and its description were written by Isaac.