### PR TITLE
Add PostgreSQL 19 series

### DIFF
--- a/content/postgresql/navigation.yaml
+++ b/content/postgresql/navigation.yaml
@@ -367,6 +367,42 @@
           title: Terminate Backend Connections
         - slug: postgresql-administration/uninstall-postgresql-ubuntu
           title: Uninstall PostgreSQL on Ubuntu
+- nav: PostgreSQL 19
+  slug: postgresql-19-new-features
+  title: PostgreSQL 19
+  items:
+    - section: Headline Features
+      items:
+        - slug: postgresql-19/sql-pgq-graph-queries
+          title: 'SQL/PGQ: Property Graph Queries'
+        - slug: postgresql-19/on-conflict-do-select
+          title: 'ON CONFLICT DO SELECT: Atomic Get-or-Create'
+        - slug: postgresql-19/temporal-data-operations
+          title: 'Temporal Data: UPDATE/DELETE FOR PORTION OF'
+    - section: Planning & Maintenance
+      items:
+        - slug: postgresql-19/pg-plan-advice
+          title: 'pg_plan_advice: Query Plan Hints'
+        - slug: postgresql-19/repack-command
+          title: 'REPACK: Online Table Rebuilding'
+        - slug: postgresql-19/parallel-autovacuum
+          title: 'Parallel Autovacuum'
+    - section: Data & Replication
+      items:
+        - slug: postgresql-19/logical-replication-improvements
+          title: Logical Replication Improvements
+        - slug: postgresql-19/json-copy-to
+          title: 'JSON Format for COPY TO'
+        - slug: postgresql-19/query-improvements
+          title: 'Query Improvements: GROUP BY ALL, IGNORE NULLS'
+    - section: Schema & Operations
+      items:
+        - slug: postgresql-19/schema-management
+          title: 'Schema Management and Backup'
+        - slug: postgresql-19/monitoring-operations
+          title: 'Monitoring and Operations'
+        - slug: postgresql-19/breaking-changes
+          title: 'Breaking Changes and Upgrade Notes'
 - nav: PostgreSQL 18
   slug: postgresql-18-new-features
   title: PostgreSQL 18

--- a/content/postgresql/postgresql-19-new-features.md
+++ b/content/postgresql/postgresql-19-new-features.md
@@ -1,0 +1,372 @@
+---
+title: 'PostgreSQL 19 New Features'
+page_title: "PostgreSQL 19 New Features: What's New and Why It Matters"
+page_description: 'Explore PostgreSQL 19 new features including SQL/PGQ property graph queries, ON CONFLICT DO SELECT, temporal data operations, pg_plan_advice, REPACK, parallel autovacuum, and more.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+nextLink:
+  title: 'PostgreSQL 19 SQL/PGQ Graph Queries'
+  slug: 'postgresql-19/sql-pgq-graph-queries'
+---
+
+**Summary**: PostgreSQL 19 is a landmark release that brings SQL/PGQ property graph queries, atomic get-or-create with `ON CONFLICT DO SELECT`, temporal data operations, query plan hints, online table repacking, parallel autovacuum, native JSON export, and logical replication improvements. This overview covers the highlights with links to detailed guides.
+
+## Introduction
+
+PostgreSQL 19 is currently in development, with a feature freeze in April 2026, beta expected in mid-2026, and a final release expected in late 2026. The headline addition is native graph query support via the SQL:2023 standard, alongside a dozen features that address long-standing developer and operator pain points.
+
+The release spans six areas:
+
+- **Graph queries**: SQL/PGQ property graph queries on existing tables
+- **DML improvements**: New conflict handling and temporal operations
+- **Query planning**: Official plan hint support via a contrib module
+- **Maintenance**: Online table repacking and parallel autovacuum
+- **Operations**: Better logical replication, JSON export, and monitoring
+- **Upgrades**: Breaking changes and new defaults to review
+
+## SQL/PGQ Property Graph Queries
+
+PostgreSQL 19 brings native graph query capabilities into core via the SQL:2023 SQL/PGQ standard. Existing relational tables can be exposed as property graphs and traversed with pattern matching syntax, removing the need for a separate graph database for most workloads.
+
+### [SQL/PGQ: Graph Queries on Existing Tables](/postgresql/postgresql-19/sql-pgq-graph-queries)
+
+PostgreSQL 19 adds SQL/PGQ (ISO SQL:2023 Part 16), bringing native graph query capabilities to PostgreSQL. You define property graphs over existing relational tables and query relationships using pattern matching syntax.
+
+```sql
+-- Define a graph over existing tables
+CREATE PROPERTY GRAPH social_graph
+  VERTEX TABLES (users LABEL person PROPERTIES (id, name))
+  EDGE TABLES (
+    follows
+      SOURCE KEY (follower_id) REFERENCES users (id)
+      DESTINATION KEY (followed_id) REFERENCES users (id)
+      LABEL follows
+  );
+
+-- Query: find friends of friends
+SELECT * FROM GRAPH_TABLE (social_graph
+    MATCH (a IS person WHERE a.name = 'Alice')
+          -[IS follows]->(b IS person)
+          -[IS follows]->(c IS person)
+    COLUMNS (b.name AS friend, c.name AS friend_of_friend)
+);
+```
+
+No new storage engine, no extensions, no data migration. Graph queries are rewritten into standard relational operations and use your existing indexes. Results compose naturally with joins, aggregations, CTEs, and everything else in SQL.
+
+<Admonition type="note">
+The initial implementation covers fixed-depth pattern matching. Variable-length paths (quantified patterns like `+`, `*`, `{2,5}`) are planned for a future release.
+</Admonition>
+
+## DML and Query Improvements
+
+PostgreSQL 19 adds several long-requested DML primitives. `ON CONFLICT DO SELECT` finally provides atomic get-or-create semantics, `FOR PORTION OF` completes SQL:2011 temporal modifications, and convenience features like `GROUP BY ALL` and `IGNORE NULLS` reduce verbosity in common query patterns.
+
+### [ON CONFLICT DO SELECT](/postgresql/postgresql-19/on-conflict-do-select)
+
+PostgreSQL 19 adds a third action to `INSERT ... ON CONFLICT`: `DO SELECT`. This gives you atomic get-or-create semantics - insert a row and get it back, or if it already exists, get the existing row. No dead tuples, no CTE workarounds.
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice')
+ON CONFLICT (email) DO SELECT
+RETURNING *;
+```
+
+This replaces the common no-op `DO UPDATE SET col = EXCLUDED.col` workaround, which generated dead tuples on every conflict. Benchmarks show `DO SELECT` is nearly 4x faster than the no-op update approach.
+
+### [Temporal Data Operations: FOR PORTION OF](/postgresql/postgresql-19/temporal-data-operations)
+
+Building on PostgreSQL 18's `WITHOUT OVERLAPS` temporal constraints, PostgreSQL 19 adds `UPDATE ... FOR PORTION OF` and `DELETE ... FOR PORTION OF`. When you modify data within a specific time range, PostgreSQL automatically splits the row to preserve the untouched portions.
+
+```sql
+-- Original row: product 1 at $29.99 for all of 2025
+-- Update price to $34.99 for Q3 only
+UPDATE product_prices
+FOR PORTION OF valid_range FROM '2025-07-01' TO '2025-10-01'
+SET price = 34.99
+WHERE product_id = 1;
+
+-- Result: three rows
+-- Jan-Jun: $29.99 (preserved automatically)
+-- Jul-Sep: $34.99 (updated)
+-- Oct-Dec: $29.99 (preserved automatically)
+```
+
+This completes PostgreSQL's SQL:2011 temporal feature set, making it suitable for booking systems, employee records, insurance policies, and any data with validity periods.
+
+### [GROUP BY ALL](/postgresql/postgresql-19/query-improvements)
+
+A convenience feature that automatically groups by every non-aggregate expression in the SELECT list:
+
+```sql
+-- Before: manually repeat column names
+SELECT department, role, count(*)
+FROM employees
+GROUP BY department, role;
+
+-- PostgreSQL 19: GROUP BY ALL
+SELECT department, role, count(*)
+FROM employees
+GROUP BY ALL;
+```
+
+This eliminates a common source of errors when adding or removing columns from SELECT lists.
+
+### [IGNORE NULLS / RESPECT NULLS for Window Functions](/postgresql/postgresql-19/query-improvements)
+
+SQL-standard null handling for five window functions: `lead()`, `lag()`, `first_value()`, `last_value()`, and `nth_value()`:
+
+```sql
+-- Get the last non-null reading for each sensor
+SELECT sensor_id,
+    last_value(reading) IGNORE NULLS OVER (
+        PARTITION BY sensor_id ORDER BY ts
+    ) AS last_known_reading
+FROM sensor_data;
+```
+
+`RESPECT NULLS` is the default and preserves existing behavior. `IGNORE NULLS` skips null rows when searching for a value, which is useful for time-series data with gaps.
+
+## Query Planning and Performance
+
+For the first time, PostgreSQL ships an official mechanism for query plan hints. `pg_plan_advice` lets you capture a known-good plan and feed it back to the planner, with a feedback loop that tells you whether each hint was honored. Memoize estimates in `EXPLAIN` output also make it easier to diagnose planner choices.
+
+### [pg_plan_advice: Query Plan Hints](/postgresql/postgresql-19/pg-plan-advice)
+
+PostgreSQL has historically avoided query plan hints. That changes with `pg_plan_advice`, a contrib module that provides plan stabilization and override capabilities.
+
+The workflow: generate advice from a known-good plan, then feed it back to lock the plan.
+
+```sql
+-- Generate advice from the current plan
+EXPLAIN (COSTS OFF, PLAN_ADVICE)
+SELECT * FROM orders o JOIN customers c ON o.cust_id = c.id;
+-- Output: JOIN_ORDER(o c)  HASH_JOIN(c)  SEQ_SCAN(o c)
+
+-- Lock this plan
+SET pg_plan_advice.advice = 'JOIN_ORDER(o c) HASH_JOIN(c) SEQ_SCAN(o c)';
+```
+
+Unlike Oracle or MySQL hints embedded in SQL comments, advice lives in a GUC setting and includes a feedback mechanism that tells you whether each hint was honored.
+
+### Memoize Planner Estimates in EXPLAIN
+
+EXPLAIN now shows estimated cache metrics on Memoize nodes:
+
+```
+->  Memoize  (cost=... rows=...)
+      Cache Key: t.id
+      Estimates: capacity=2 distinct keys=2 lookups=1000 hit percent=99.80%
+```
+
+This helps diagnose why the planner chose (or avoided) Memoize and whether `n_distinct` statistics need tuning.
+
+## Table Maintenance
+
+Table maintenance gets two significant upgrades. `REPACK` consolidates `VACUUM FULL` and `CLUSTER` into a single command with a `CONCURRENTLY` mode that keeps the table online. Parallel autovacuum workers attack multiple indexes simultaneously, dramatically shortening vacuum runs on heavily-indexed tables.
+
+### [REPACK: Online Table Rebuilding](/postgresql/postgresql-19/repack-command)
+
+`REPACK` absorbs the functionality of both `VACUUM FULL` and `CLUSTER` into a single command, with the addition of a `CONCURRENTLY` mode:
+
+```sql
+-- Reclaim space (like VACUUM FULL)
+REPACK orders;
+
+-- Reorder by index (like CLUSTER)
+REPACK orders USING INDEX orders_created_at_idx;
+
+-- Online mode: table stays accessible during repack
+REPACK (CONCURRENTLY) orders USING INDEX orders_created_at_idx;
+```
+
+With `CONCURRENTLY`, the `ACCESS EXCLUSIVE` lock is only held briefly during the final file swap. The table remains readable and writable for the bulk of the operation.
+
+### [Parallel Autovacuum](/postgresql/postgresql-19/parallel-autovacuum)
+
+Autovacuum can now use parallel workers for index vacuuming and cleanup. On tables with multiple large indexes, this dramatically reduces vacuum time by processing indexes simultaneously instead of one at a time.
+
+```sql
+-- Enable globally (default is 0 = disabled)
+ALTER SYSTEM SET autovacuum_max_parallel_workers = 4;
+
+-- Per-table override for heavily-indexed tables
+ALTER TABLE events SET (autovacuum_parallel_workers = 6);
+```
+
+Each worker handles one index. With 4 workers and 5 indexes, the index vacuum phase completes in roughly the time of the largest single index instead of the sum of all five.
+
+<Admonition type="note">
+Parallel autovacuum is disabled by default (`autovacuum_max_parallel_workers = 0`). You must explicitly enable it to benefit.
+</Admonition>
+
+## Data Export
+
+`COPY TO` finally supports JSON output natively, removing the need for `row_to_json()` and `json_agg()` workarounds. NDJSON is the default, with an optional JSON array form, and the implementation is faster than the equivalent SELECT-based pipelines.
+
+### [JSON Format for COPY TO](/postgresql/postgresql-19/json-copy-to)
+
+Native JSON output support for `COPY TO`, producing NDJSON (one JSON object per line) by default or a JSON array with `FORCE_ARRAY`:
+
+```sql
+-- NDJSON output
+COPY users TO STDOUT WITH (FORMAT JSON);
+-- {"id":1,"email":"alice@example.com","name":"Alice"}
+-- {"id":2,"email":"bob@example.com","name":"Bob"}
+
+-- JSON array output
+COPY users TO STDOUT WITH (FORMAT JSON, FORCE_ARRAY);
+-- [
+--  {"id":1,"email":"alice@example.com","name":"Alice"}
+-- ,{"id":2,"email":"bob@example.com","name":"Bob"}
+-- ]
+```
+
+This replaces the `row_to_json()` and `json_agg()` workarounds with streaming, memory-efficient output.
+
+### COPY TO for Partitioned Tables
+
+`COPY partitioned_table TO` now works directly, without wrapping in a subquery:
+
+```sql
+COPY partitioned_sales TO '/tmp/sales.csv' WITH (FORMAT csv);
+```
+
+About 7-8% faster than the `COPY (SELECT * FROM ...) TO` workaround.
+
+## Logical Replication and Operations
+
+Logical replication picks up sequence synchronization, table exclusions in `FOR ALL TABLES` publications, and a dynamic WAL level that no longer requires a server restart to switch into and out of. Schema and operations tooling also improve with new DDL extraction functions and modern output formats for `pg_dumpall`.
+
+### [Logical Replication Improvements](/postgresql/postgresql-19/logical-replication-improvements)
+
+PostgreSQL 19 addresses several long-standing logical replication pain points:
+
+**Sequence synchronization**: Subscribers can now sync sequence values from the publisher, preventing duplicate key errors after failover.
+
+```sql
+CREATE PUBLICATION my_pub FOR ALL TABLES, ALL SEQUENCES;
+```
+
+**EXCEPT TABLE**: Publications using `FOR ALL TABLES` can exclude specific tables:
+
+```sql
+CREATE PUBLICATION prod_pub FOR ALL TABLES
+    EXCEPT (TABLE audit_log, temp_imports);
+```
+
+**Dynamic WAL level**: The `effective_wal_level` parameter adjusts automatically based on whether logical replication slots exist, eliminating the need to manually configure and restart for WAL level changes.
+
+### [pg_get_*_ddl() Functions](/postgresql/postgresql-19/schema-management)
+
+Three new functions for programmatic DDL extraction:
+
+```sql
+SELECT * FROM pg_get_database_ddl('mydb');
+-- CREATE DATABASE mydb WITH TEMPLATE = template0 ENCODING = 'UTF8' ...
+
+SELECT * FROM pg_get_role_ddl('app_user');
+-- CREATE ROLE app_user WITH LOGIN PASSWORD '********' ...
+```
+
+Also available: `pg_get_tablespace_ddl()`. These provide a cleaner alternative to parsing `pg_dump` output when you need DDL for specific objects.
+
+### [pg_dumpall Non-Text Formats](/postgresql/postgresql-19/schema-management)
+
+`pg_dumpall` now supports custom (`-Fc`), directory (`-Fd`), and tar (`-Ft`) output formats:
+
+```bash
+pg_dumpall -Fc -f full-dump
+pg_restore --globals-only full-dump  # restore only roles/tablespaces
+```
+
+### [64-bit MultiXactOffset](/postgresql/postgresql-19/monitoring-operations)
+
+MultiXactOffset has been widened from 32-bit to 64-bit, eliminating the ~4 billion member wraparound limit. Previously, heavy use of row-level locking (concurrent `SELECT FOR UPDATE` across many transactions) could exhaust MultiXact member space, causing write failures that required emergency vacuuming. This risk is removed in PostgreSQL 19.
+
+## Monitoring and Operations Improvements
+
+Several long-standing rough edges around observability and runtime configuration get smoothed out. Data checksums can be enabled or disabled on a running cluster, `pg_stat_wal` exposes more detail, and per-process-type logging lets you turn up verbosity for autovacuum or the archiver without flooding the rest of the log.
+
+### [Online Data Checksums](/postgresql/postgresql-19/monitoring-operations)
+
+You can now enable or disable data checksums on a running cluster without downtime:
+
+```sql
+-- Enable checksums online (cluster stays accessible)
+SELECT pg_enable_data_checksums(cost_delay := 10, cost_limit := 1000);
+
+-- Monitor progress
+SHOW data_checksums;  -- 'off' -> 'inprogress-on' -> 'on'
+```
+
+Previously, enabling checksums on an existing cluster required shutting down the server or a full data reload. The `cost_delay` and `cost_limit` parameters let you throttle the IO impact on production systems.
+
+### WAL Statistics
+
+The `pg_stat_wal` view gains a `wal_fpi_bytes` column tracking bytes used by full-page images:
+
+```sql
+SELECT wal_records, wal_fpi, wal_fpi_bytes, wal_bytes FROM pg_stat_wal;
+```
+
+### Vacuum Progress
+
+`pg_stat_progress_vacuum` adds `mode` (normal/aggressive/failsafe) and `started_by` (auto/manual/wraparound):
+
+```sql
+SELECT pid, relid::regclass, phase, mode, started_by
+FROM pg_stat_progress_vacuum;
+```
+
+### Per-Process Logging
+
+`log_min_messages` accepts per-process-type overrides:
+
+```
+log_min_messages = 'warning, autovacuum:debug1, archiver:debug5'
+```
+
+### psql Prompt Additions
+
+Two new prompt escapes: `%i` shows primary/standby status, `%S` shows the current `search_path`:
+
+```
+\set PROMPT1 '[%i] %/%R%x%# '
+-- Result: [primary] mydb=#
+```
+
+## Getting Started
+
+PostgreSQL 19 is currently in development. To try these features, you can build from the PostgreSQL `master` branch or use the PGDG snapshot packages:
+
+```bash
+# Docker approach using PGDG snapshots
+# See our PostgreSQL 19 guide for Dockerfile details
+docker build -t pg19-dev .
+docker run -d --name pg19 -p 5433:5432 pg19-dev
+psql -h localhost -p 5433 -U postgres
+```
+
+## [Breaking Changes and Upgrade Notes](/postgresql/postgresql-19/breaking-changes)
+
+PostgreSQL 19 includes several changes that may affect existing applications. Review these before upgrading:
+
+- **JIT disabled by default**: The `jit` parameter now defaults to `off`. Analytics workloads that rely on JIT should explicitly re-enable it.
+- **LZ4 TOAST compression default**: New TOAST data uses LZ4 instead of pglz. Faster compression and decompression with slightly lower ratios. Existing data is unaffected.
+- **RADIUS authentication removed**: The `radius` auth method is gone entirely. Switch to LDAP, GSSAPI, or certificate auth.
+- **standard_conforming_strings forced on**: Backslash escapes in regular string literals no longer work. Use `E'...'` syntax or standard SQL `''` escaping. `escape_string_warning` was also removed because it has nothing to warn about.
+- **MD5 deprecation warnings**: Connecting with MD5-hashed passwords now emits warnings. Migrate to SCRAM-SHA-256.
+- **max_locks_per_transaction doubled**: Default changed from 64 to 128.
+- **MULE_INTERNAL encoding removed**: `pg_upgrade` refuses to migrate clusters that still use it.
+- **btree_gist inet/cidr opclasses retired**: Indexes built on `gist_inet_ops` or `gist_cidr_ops` must be dropped before upgrade. They are known to return wrong results and `pg_upgrade` blocks the migration.
+- **CR and LF disallowed in database, role, and tablespace names**: `pg_upgrade` blocks clusters containing any such names.
+- **`log_lock_waits` enabled by default**: Servers that previously ran with the default now emit log entries for long lock waits.
+- **Wait event class `BUFFERPIN` renamed to `BUFFER`**: Update monitoring that filters on the old name.
+- **`postgres_fdw` now respects local READ ONLY**: Transactions declared `READ ONLY` no longer allow writes through foreign tables.
+
+## Summary
+
+PostgreSQL 19 is one of the most feature-rich releases in recent history. SQL/PGQ brings graph query capabilities that previously required a separate database. `ON CONFLICT DO SELECT` solves a problem that has existed since PostgreSQL 9.5. `FOR PORTION OF` completes the SQL:2011 temporal feature set. `pg_plan_advice` breaks new ground for PostgreSQL by providing official plan hints. `REPACK (CONCURRENTLY)` brings online table maintenance into core. And parallel autovacuum addresses one of the biggest pain points for large database operators.

--- a/content/postgresql/postgresql-19/breaking-changes.md
+++ b/content/postgresql/postgresql-19/breaking-changes.md
@@ -1,0 +1,274 @@
+---
+title: 'PostgreSQL 19 Breaking Changes and Upgrade Notes'
+page_title: 'PostgreSQL 19 Breaking Changes - What to Check Before Upgrading'
+page_description: 'Review PostgreSQL 19 breaking changes including JIT disabled by default, LZ4 TOAST compression, RADIUS removal, and string handling changes before upgrading your database.'
+ogImage: ''
+updatedOn: '2026-04-15T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 Monitoring and Operations'
+  slug: 'postgresql-19/monitoring-operations'
+nextLink:
+  title: 'PostgreSQL 19 New Features'
+  slug: 'postgresql-19-new-features'
+---
+
+**Summary**: PostgreSQL 19 includes several breaking changes that may affect your applications and configuration. JIT compilation is now off by default, TOAST compression defaults to LZ4, RADIUS authentication is removed, and string handling is stricter. Review these changes before upgrading.
+
+## JIT Compilation Disabled by Default
+
+The `jit` parameter now defaults to `off`. Since PostgreSQL 12, JIT was enabled by default, but experience showed it added latency to short OLTP queries without meaningful benefit for most workloads.
+
+```sql
+-- Check your current setting
+SHOW jit;
+
+-- Re-enable if your workload benefits from it
+ALTER SYSTEM SET jit = on;
+SELECT pg_reload_conf();
+```
+
+### Who Is Affected
+
+If you run analytical or OLAP workloads with complex queries, large sequential scans, or heavy aggregations, you may see regressions after upgrading. These workloads genuinely benefit from JIT compilation.
+
+If you run typical OLTP workloads (short queries, many transactions per second), you will likely see no change or a slight improvement from avoiding JIT overhead.
+
+### What to Do
+
+Test your most important queries with `jit = on` and `jit = off` before upgrading. If JIT helps, add `jit = on` to your `postgresql.conf` explicitly. If you are unsure, leave it off - that is the safer default.
+
+## Default TOAST Compression Changed to LZ4
+
+The `default_toast_compression` parameter changed from `pglz` to `lz4`.
+
+```sql
+-- Check your current setting
+SHOW default_toast_compression;
+
+-- Revert to old behavior if needed
+ALTER SYSTEM SET default_toast_compression = pglz;
+```
+
+### What This Means
+
+LZ4 is faster than pglz for both compression and decompression, with slightly lower compression ratios. For most workloads, this is a net improvement - less CPU time spent on compression with only marginally more disk usage.
+
+Existing data is not affected. Rows already stored with pglz remain readable regardless of this setting. Only newly written or updated TOAST values use the new default. You can also override this per-column:
+
+```sql
+ALTER TABLE my_table ALTER COLUMN big_text SET COMPRESSION pglz;
+```
+
+<Admonition type="note">
+LZ4 support requires PostgreSQL to be built with `--with-lz4`. Most packaged builds include this, but verify if you build from source.
+</Admonition>
+
+## RADIUS Authentication Removed
+
+The `radius` authentication method in `pg_hba.conf` has been removed entirely. PostgreSQL will refuse to start if your `pg_hba.conf` contains any `radius` lines.
+
+### Why It Was Removed
+
+RADIUS authentication in PostgreSQL used UDP only, with no support for RADIUS over TLS (RadSec). The implementation was considered unfixably insecure for database authentication.
+
+### Migration Path
+
+Check your `pg_hba.conf` before upgrading:
+
+```bash
+grep -i radius pg_hba.conf
+```
+
+If you find RADIUS entries, switch to one of these alternatives:
+
+- **LDAP**: Most RADIUS deployments have an LDAP backend. Connect to it directly.
+- **GSSAPI/Kerberos**: For enterprise environments with Active Directory.
+- **Certificate authentication**: For service-to-service connections.
+- **SCRAM-SHA-256**: For password-based authentication without external systems.
+
+## String handling changes
+
+Two changes to how the server handles string literals. Most applications on modern drivers are already unaffected, but legacy code that depends on backslash escapes or the old warning behavior may need small updates.
+
+### standard_conforming_strings forced on
+
+The `standard_conforming_strings` parameter is now hardcoded to `on` and read-only. Previously it defaulted to `on` (since PostgreSQL 9.1) but could be set to `off`.
+
+This means backslash escapes in regular string literals are no longer interpreted:
+
+```sql
+-- This no longer works as expected:
+SELECT 'line1\nline2';
+-- Returns the literal string: line1\nline2
+
+-- Use E-prefix strings instead:
+SELECT E'line1\nline2';
+-- Returns: line1
+--          line2
+```
+
+### Who Is Affected
+
+Applications that rely on `\'` for escaping single quotes in SQL strings will break. The standard SQL approach is to double the quote: `''`.
+
+```sql
+-- Old way (no longer works):
+SELECT 'it\'s broken';
+
+-- Standard SQL way:
+SELECT 'it''s fine';
+
+-- Also works:
+SELECT E'it\'s fine';
+```
+
+Most modern ORMs and database drivers already use `standard_conforming_strings = on`. If you are using a recent version of your driver, you are likely unaffected.
+
+### escape_string_warning Removed
+
+The `escape_string_warning` GUC has been removed entirely. Since `standard_conforming_strings` is always on, the warning is no longer needed. Remove this parameter from your `postgresql.conf` to avoid unknown-parameter errors on startup.
+
+## MD5 Password Deprecation Warnings
+
+PostgreSQL 19 emits a warning whenever a role authenticates using MD5 password hashing. This includes both the `md5` method in `pg_hba.conf` and passwords stored as MD5 hashes in `pg_authid`.
+
+### Migration to SCRAM-SHA-256
+
+The migration is a three-step sequence: switch the default password hash, force users to set new passwords so they re-hash under SCRAM, then flip the `pg_hba.conf` entries.
+
+```sql
+-- 1. Change the default password encryption
+ALTER SYSTEM SET password_encryption = 'scram-sha-256';
+SELECT pg_reload_conf();
+
+-- 2. Have users reset their passwords (re-hashes as SCRAM)
+ALTER USER myuser PASSWORD 'new_password';
+
+-- 3. Update pg_hba.conf entries from md5 to scram-sha-256
+-- Change: host all all 0.0.0.0/0 md5
+-- To:     host all all 0.0.0.0/0 scram-sha-256
+```
+
+<Admonition type="important">
+After changing password encryption to SCRAM-SHA-256, all users must reset their passwords. Existing MD5-hashed passwords cannot be converted - they must be re-entered so they get hashed with the new algorithm.
+</Admonition>
+
+## max_locks_per_transaction Default Doubled
+
+The `max_locks_per_transaction` default changed from 64 to 128.
+
+```sql
+SHOW max_locks_per_transaction;
+-- Now defaults to 128
+```
+
+Modern schemas with partitioned tables frequently exceeded the old limit of 64 locks during DDL operations like `ALTER TABLE` on tables with many partitions. The old default caused "out of shared memory" errors that were confusing to diagnose.
+
+The increase means slightly more shared memory usage. If you were already running with a custom value higher than 128, no change is needed.
+
+## MULE_INTERNAL encoding removed
+
+PostgreSQL 19 removes support for the `MULE_INTERNAL` server and client encoding (commit `77645d44`). Databases or connections using this encoding will fail to start or connect on the new version.
+
+If you are using `MULE_INTERNAL`, dump the affected databases on the old server, reload them on the new server under a different encoding (typically `UTF8`), and update any client configuration that expects `MULE_INTERNAL`.
+
+```bash
+# Check which databases still use MULE_INTERNAL
+psql -c "SELECT datname, pg_encoding_to_char(encoding) FROM pg_database;"
+```
+
+`pg_upgrade` detects and refuses to migrate clusters containing `MULE_INTERNAL` databases, so you will not silently lose data. The upgrade fails up front.
+
+## btree_gist inet/cidr indexes must be dropped before upgrading
+
+PostgreSQL 19 marks the `gist_inet_ops` and `gist_cidr_ops` opclasses from the `btree_gist` extension as non-default and starts deprecating them. They are known to incorrectly exclude matching rows and can silently return wrong results. `pg_upgrade` refuses to migrate any cluster that still has indexes built on them (commit `b3b0b457`).
+
+Find and drop affected indexes before upgrading:
+
+```sql
+SELECT n.nspname, c.relname
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_opclass o ON o.oid = ANY(i.indclass)
+WHERE o.opcname IN ('gist_inet_ops', 'gist_cidr_ops');
+
+-- Drop each and re-create using a regular B-tree or a GiST index
+-- built on the native inet GiST support instead.
+```
+
+## CR and LF disallowed in database, role, and tablespace names
+
+Database, role, and tablespace names can no longer contain carriage returns or line feeds (commit `b380a56a`). This closes a small set of security issues where such characters could alter downstream tooling output.
+
+`pg_upgrade` refuses to migrate clusters that contain any such names. The check is up front, so you will not get halfway through an upgrade before hitting it.
+
+## BUFFERPIN wait event class renamed to BUFFER
+
+The wait event class previously named `BUFFERPIN` has been renamed to `BUFFER` (commit `6c5c393b`). If you have monitoring dashboards, alerts, or scripts that filter `pg_stat_activity.wait_event_type` by the literal string `BUFFERPIN`, update them to look for `BUFFER` instead.
+
+## postgres_fdw now propagates READ ONLY
+
+A `READ ONLY` transaction in PostgreSQL 19 propagates its mode to `postgres_fdw` sessions (commit `de28140d`). Previously, a local `READ ONLY` transaction could still modify foreign data through functions on the remote side.
+
+This is strictly safer behavior, but applications that relied on a local `READ ONLY` wrapper while still writing to foreign tables will break. The fix is to remove the `READ ONLY` from transactions that legitimately need to write to foreign tables.
+
+## Removed and changed parameters
+
+The server variable `escape_string_warning` has been removed because `standard_conforming_strings` can no longer be turned off, so the warning has nothing to warn about. The older `lo_compat_privileges` and `array_nulls` GUCs are still present in PostgreSQL 19. They were not removed.
+
+If `escape_string_warning` appears in your `postgresql.conf`, remove the line before starting the new cluster.
+
+## Pre-upgrade checklist
+
+Before upgrading to PostgreSQL 19:
+
+```bash
+# 1. Check for the removed GUC in your config
+grep -E 'escape_string_warning' postgresql.conf
+
+# 2. Check for RADIUS auth (removed in 19)
+grep -i radius pg_hba.conf
+
+# 3. Check for MD5 auth (still works but will warn)
+grep -i md5 pg_hba.conf
+
+# 4. Check for btree_gist indexes on inet / cidr. pg_upgrade refuses
+#    to migrate clusters that still have these.
+psql -c "
+SELECT n.nspname, c.relname
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_opclass o ON o.oid = ANY(i.indclass)
+WHERE o.opcname IN ('gist_inet_ops', 'gist_cidr_ops');
+"
+
+# 5. Check if you rely on JIT (disabled by default in 19)
+psql -c "SHOW jit;"
+```
+
+Test your application with these settings on your current PostgreSQL version first:
+
+```sql
+SET jit = off;
+SET standard_conforming_strings = on;
+-- Run your test suite
+```
+
+This catches most compatibility issues before the actual upgrade.
+
+## Summary
+
+PostgreSQL 19's breaking changes are mostly about removing long-deprecated behaviors and updating defaults to better match modern usage patterns. JIT off by default is the change most likely to affect query performance. LZ4 TOAST compression is a transparent improvement for most workloads. The string handling changes and RADIUS removal require config file cleanup but should not affect applications using modern drivers and standard SQL syntax.
+
+## References
+
+- [Commit `7f8c88c2`: jit: Change the default to off](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=7f8c88c2)
+- [Commit `34dfca29`: Change default value of default_toast_compression to "lz4", take two](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=34dfca29)
+- [Commit `a1643d40`: Remove RADIUS support](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=a1643d40)
+- [Commit `45762084`: Force standard_conforming_strings to always be ON](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=45762084)
+- [Commit `79534f90`: Change default of max_locks_per_transactions to 128](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=79534f90)
+- [Commit `b3b0b457`: Create btree_gist v1.9, in which inet/cidr opclasses aren't default](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b3b0b457)
+- [Commit `ce11e63f`: pg_upgrade: Check for unsupported encodings (MULE_INTERNAL)](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=ce11e63f)

--- a/content/postgresql/postgresql-19/breaking-changes.md
+++ b/content/postgresql/postgresql-19/breaking-changes.md
@@ -60,13 +60,53 @@ Existing data is not affected. Rows already stored with pglz remain readable reg
 ALTER TABLE my_table ALTER COLUMN big_text SET COMPRESSION pglz;
 ```
 
+Changing the per-column setting only takes effect for rows written or updated after the change. Existing rows keep their original compression. To rewrite the storage for an existing table, use `VACUUM FULL` or `CLUSTER`. Both rewrite the table with a brief lock that blocks reads. The new `REPACK CONCURRENTLY` command in PostgreSQL 19 does the same rewrite without taking that lock and is the better choice for production tables that you cannot afford to block. See the [REPACK CONCURRENTLY guide](/postgresql/postgresql-19/repack-command) for the full flow.
+
 <Admonition type="note">
 LZ4 support requires PostgreSQL to be built with `--with-lz4`. Most packaged builds include this, but verify if you build from source.
 </Admonition>
 
+## MD5 Password Deprecation Warnings
+
+PostgreSQL 19 emits a warning whenever a role authenticates using MD5 password hashing. This includes both the `md5` method in `pg_hba.conf` and passwords stored as MD5 hashes in `pg_authid`. MD5 is still accepted in 19, but the warning is the loud first step toward removing it in a later release. Most clusters that have been running for years still have MD5-hashed passwords lingering, so this is the breaking change that affects the largest number of installs even though nothing actually breaks yet.
+
+### Migration to SCRAM-SHA-256
+
+The migration is a three-step sequence: switch the default password hash, get every user to set a new password so it gets re-hashed under SCRAM, then flip the `pg_hba.conf` entries from `md5` to `scram-sha-256`. The order matters: if you flip `pg_hba.conf` to `scram-sha-256` before the passwords are re-hashed, every login that still has an MD5-stored password fails.
+
+```sql
+-- 1. Change the default password encryption
+ALTER SYSTEM SET password_encryption = 'scram-sha-256';
+SELECT pg_reload_conf();
+```
+
+For step 2, prefer `\password` in `psql` over `ALTER USER ... PASSWORD '...'`. The `ALTER USER` form takes the password as plain text in the SQL statement, which means it can show up in `log_statement = 'all'` logs, in `pg_stat_statements`, and in shell history. The `\password` meta-command prompts for the password locally and sends only the SCRAM-hashed result to the server:
+
+```text
+mydb=# \password myuser
+Enter new password for user "myuser":
+Enter it again:
+```
+
+If users cannot run `\password` themselves, use the application's password reset flow so the new password gets hashed by the server with SCRAM. Then update `pg_hba.conf`:
+
+```
+# Before
+host all all 0.0.0.0/0 md5
+
+# After
+host all all 0.0.0.0/0 scram-sha-256
+```
+
+You can leave the `md5` entry in `pg_hba.conf` while the rehash is in progress. PostgreSQL automatically uses SCRAM authentication for any user whose stored password is already a SCRAM hash, regardless of what the HBA entry says. Only flip the entry to `scram-sha-256` once you are sure every active user has been re-hashed, otherwise the stragglers will be locked out.
+
+<Admonition type="important">
+After changing password encryption to SCRAM-SHA-256, all users must reset their passwords. Existing MD5-hashed passwords cannot be converted; they have to be re-entered so they get hashed with the new algorithm.
+</Admonition>
+
 ## RADIUS Authentication Removed
 
-The `radius` authentication method in `pg_hba.conf` has been removed entirely. PostgreSQL will refuse to start if your `pg_hba.conf` contains any `radius` lines.
+The `radius` authentication method in `pg_hba.conf` has been removed entirely. PostgreSQL will refuse to start if your `pg_hba.conf` contains any `radius` lines. RADIUS in PostgreSQL had a small user base, so this removal affects far fewer clusters than the MD5 deprecation above.
 
 ### Why It Was Removed
 
@@ -128,31 +168,6 @@ Most modern ORMs and database drivers already use `standard_conforming_strings =
 ### escape_string_warning Removed
 
 The `escape_string_warning` GUC has been removed entirely. Since `standard_conforming_strings` is always on, the warning is no longer needed. Remove this parameter from your `postgresql.conf` to avoid unknown-parameter errors on startup.
-
-## MD5 Password Deprecation Warnings
-
-PostgreSQL 19 emits a warning whenever a role authenticates using MD5 password hashing. This includes both the `md5` method in `pg_hba.conf` and passwords stored as MD5 hashes in `pg_authid`.
-
-### Migration to SCRAM-SHA-256
-
-The migration is a three-step sequence: switch the default password hash, force users to set new passwords so they re-hash under SCRAM, then flip the `pg_hba.conf` entries.
-
-```sql
--- 1. Change the default password encryption
-ALTER SYSTEM SET password_encryption = 'scram-sha-256';
-SELECT pg_reload_conf();
-
--- 2. Have users reset their passwords (re-hashes as SCRAM)
-ALTER USER myuser PASSWORD 'new_password';
-
--- 3. Update pg_hba.conf entries from md5 to scram-sha-256
--- Change: host all all 0.0.0.0/0 md5
--- To:     host all all 0.0.0.0/0 scram-sha-256
-```
-
-<Admonition type="important">
-After changing password encryption to SCRAM-SHA-256, all users must reset their passwords. Existing MD5-hashed passwords cannot be converted - they must be re-entered so they get hashed with the new algorithm.
-</Admonition>
 
 ## max_locks_per_transaction Default Doubled
 

--- a/content/postgresql/postgresql-19/breaking-changes.md
+++ b/content/postgresql/postgresql-19/breaking-changes.md
@@ -13,7 +13,7 @@ nextLink:
   slug: 'postgresql-19-new-features'
 ---
 
-**Summary**: PostgreSQL 19 includes several breaking changes that may affect your applications and configuration. JIT compilation is now off by default, TOAST compression defaults to LZ4, RADIUS authentication is removed, and string handling is stricter. Review these changes before upgrading.
+**Summary**: PostgreSQL 19 includes several breaking changes that may affect your applications and configuration. JIT compilation is now off by default, TOAST compression defaults to LZ4, MD5-hashed passwords are being deprecated and string handling is stricter. Review these changes before upgrading.
 
 ## JIT Compilation Disabled by Default
 

--- a/content/postgresql/postgresql-19/json-copy-to.md
+++ b/content/postgresql/postgresql-19/json-copy-to.md
@@ -1,0 +1,240 @@
+---
+title: 'PostgreSQL 19 JSON Format for COPY TO'
+page_title: 'PostgreSQL 19 JSON COPY TO - Native JSON Data Export'
+page_description: 'Learn how to use PostgreSQL 19 COPY TO with FORMAT JSON to export data as NDJSON or JSON arrays, replacing workarounds with native streaming JSON output.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 Logical Replication Improvements'
+  slug: 'postgresql-19/logical-replication-improvements'
+nextLink:
+  title: 'PostgreSQL 19 Query Improvements'
+  slug: 'postgresql-19/query-improvements'
+---
+
+**Summary**: PostgreSQL 19 adds native JSON output support to the `COPY TO` command. You can export table data as NDJSON (one JSON object per line) or as a JSON array, with streaming output that handles large datasets without loading everything into memory.
+
+## Introduction to JSON COPY TO
+
+Exporting PostgreSQL data as JSON has always been possible, but the workarounds were awkward. You could wrap every row in `row_to_json()` inside a COPY command, but that produced text-format COPY output with escaped JSON strings. You could use `json_agg()`, but that loaded the entire result set into memory before outputting anything. Or you could export as CSV and convert to JSON with external tools.
+
+PostgreSQL 19 adds `FORMAT JSON` as a native COPY format. The output is clean, streaming JSON with no double-escaping issues and constant memory usage regardless of table size.
+
+## Basic usage
+
+`COPY ... TO` with `FORMAT JSON` writes one JSON object per row. By default the rows are emitted as newline-delimited JSON (NDJSON); the optional `FORCE_ARRAY` flag wraps them in a single JSON array.
+
+### NDJSON output (default)
+
+Export a table as newline-delimited JSON (NDJSON), where each line is a complete JSON object:
+
+```sql
+COPY users TO STDOUT WITH (FORMAT JSON);
+```
+
+Output:
+
+```json
+{"id":1,"email":"alice@example.com","name":"Alice Johnson","active":true}
+{"id":2,"email":"bob@example.com","name":"Bob Smith","active":true}
+{"id":3,"email":"charlie@example.com","name":"Charlie Brown","active":false}
+```
+
+Each row becomes an independent JSON object on its own line. This format is widely supported by tools like `jq`, Apache Kafka, AWS Kinesis, and most ETL pipelines.
+
+### JSON Array Output
+
+If you need a valid JSON array (wrapped in `[` and `]`), use the `FORCE_ARRAY` option:
+
+```sql
+COPY users TO STDOUT WITH (FORMAT JSON, FORCE_ARRAY);
+```
+
+Output:
+
+```json
+[
+ {"id":1,"email":"alice@example.com","name":"Alice Johnson","active":true}
+,{"id":2,"email":"bob@example.com","name":"Bob Smith","active":true}
+,{"id":3,"email":"charlie@example.com","name":"Charlie Brown","active":false}
+]
+```
+
+This is useful for tools that expect a JSON array, such as document stores or APIs that consume batch imports.
+
+## Exporting to Files
+
+Write JSON directly to a file on the server:
+
+```sql
+COPY users TO '/tmp/users.json' WITH (FORMAT JSON);
+```
+
+Or use `\copy` in psql to write to a local file:
+
+```
+\copy users TO '/tmp/users.json' WITH (FORMAT JSON)
+```
+
+## Column Selection
+
+Export specific columns instead of the entire row:
+
+```sql
+COPY users (email, name) TO STDOUT WITH (FORMAT JSON);
+```
+
+Output:
+
+```json
+{"email":"alice@example.com","name":"Alice Johnson"}
+{"email":"bob@example.com","name":"Bob Smith"}
+```
+
+## Using Queries
+
+Export the result of any query:
+
+```sql
+COPY (
+    SELECT u.email, u.name, count(o.id) AS order_count
+    FROM users u
+    LEFT JOIN orders o ON o.user_id = u.id
+    GROUP BY u.id
+) TO STDOUT WITH (FORMAT JSON);
+```
+
+Output:
+
+```json
+{"email":"alice@example.com","name":"Alice Johnson","order_count":15}
+{"email":"bob@example.com","name":"Bob Smith","order_count":3}
+```
+
+This is useful when you need to export joined or aggregated data rather than raw table contents.
+
+## Comparison to Previous Workarounds
+
+Before PostgreSQL 19, exporting JSON required one of these approaches:
+
+### row_to_json Workaround
+
+Wrap each row in `row_to_json()` and let `COPY` write the result as a single text column.
+
+```sql
+COPY (SELECT row_to_json(t) FROM users t) TO STDOUT;
+```
+
+This produces text-format COPY output where the JSON is wrapped in additional escaping:
+
+```
+{"id":1,"email":"alice@example.com","name":"Alice Johnson","active":true}
+```
+
+It looks similar but is actually a text column containing a JSON string, which can cause quoting issues when imported by other tools.
+
+### json_agg Workaround
+
+Aggregate everything into a single JSON array on the server side, then return it as one row.
+
+```sql
+SELECT json_agg(t) FROM users t;
+```
+
+This produces a valid JSON array, but it materializes the entire result in memory before outputting anything. For a table with millions of rows, this can use gigabytes of memory.
+
+### Native FORMAT JSON
+
+PostgreSQL 19 emits JSON directly from `COPY` without per-row wrappers or full-result aggregation.
+
+```sql
+COPY users TO STDOUT WITH (FORMAT JSON);
+```
+
+Native JSON output is streaming (constant memory), produces clean JSON objects, and does not require wrapping each row in a function call.
+
+| Approach | Streaming | Clean Output | Memory Usage |
+|---|---|---|---|
+| `row_to_json()` in COPY | Yes | Extra escaping | Constant |
+| `json_agg()` | No | Clean | Proportional to result |
+| `FORMAT JSON` (new) | Yes | Clean | Constant |
+
+## Practical use cases
+
+These are the places where native `FORMAT JSON` output replaces something that previously needed a helper query or post-processing step.
+
+### ETL pipeline export
+
+Export data for processing by external ETL tools:
+
+```sql
+-- Export to NDJSON for a Kafka producer or S3 upload
+COPY (
+    SELECT id, event_type, payload, created_at
+    FROM events
+    WHERE created_at > now() - interval '1 day'
+) TO STDOUT WITH (FORMAT JSON);
+```
+
+NDJSON is the standard format for streaming data pipelines. Each line can be processed independently.
+
+### API Response Seeding
+
+Generate JSON fixtures for API testing or development environments:
+
+```sql
+COPY (
+    SELECT id, name, email, role
+    FROM users
+    WHERE role = 'admin'
+    ORDER BY name
+) TO '/tmp/admin_users.json' WITH (FORMAT JSON, FORCE_ARRAY);
+```
+
+The `FORCE_ARRAY` output can be directly consumed by application code expecting a JSON array.
+
+### Data Warehouse Loading
+
+Export data for loading into JSON-native systems like Elasticsearch, MongoDB, or BigQuery:
+
+```sql
+-- Export with specific columns for the target schema
+COPY products (id, name, category, price, metadata)
+TO '/tmp/products_export.json' WITH (FORMAT JSON);
+```
+
+### Piping to External Tools
+
+Combine with shell tools for processing:
+
+```bash
+psql -c "COPY users TO STDOUT WITH (FORMAT JSON)" mydb | jq '.email' > emails.txt
+```
+
+## NULL Handling
+
+SQL `NULL` values are output as JSON `null`:
+
+```json
+{"id":1,"email":"alice@example.com","phone":null}
+```
+
+<Admonition type="note">
+SQL NULL and JSON null are indistinguishable in the output. If your application needs to differentiate between "field is null" and "field is missing," consider using column selection to exclude nullable columns when they are not needed.
+</Admonition>
+
+## Limitations
+
+- **COPY TO only.** There is no `COPY FROM` with `FORMAT JSON` in PostgreSQL 19.
+- **No pretty printing.** Output is compact JSON with no indentation.
+- **Incompatible options.** JSON format cannot be combined with `HEADER`, `DELIMITER`, `QUOTE`, `ESCAPE`, `NULL`, `DEFAULT`, `FORCE QUOTE`, `FORCE NOT NULL`, or `FORCE NULL`. These options are specific to text and CSV formats.
+
+## Summary
+
+`FORMAT JSON` in `COPY TO` gives PostgreSQL native, streaming JSON export capability. NDJSON output works with most modern data tools out of the box, and `FORCE_ARRAY` covers cases where a JSON array wrapper is needed.
+
+## References
+
+- [Commit `7dadd38c`: json format for COPY TO](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=7dadd38c)
+- [PostgreSQL devel docs: COPY](https://www.postgresql.org/docs/devel/sql-copy.html)

--- a/content/postgresql/postgresql-19/json-copy-to.md
+++ b/content/postgresql/postgresql-19/json-copy-to.md
@@ -194,6 +194,14 @@ COPY (
 
 The `FORCE_ARRAY` output can be directly consumed by application code expecting a JSON array.
 
+<Admonition type="note">
+Server-side `COPY ... TO 'filename'` requires the `pg_write_server_files` role or superuser, and writes to the path on the database server, not the client. For local development or any non-superuser, run the command from `psql` with the meta-command `\copy` instead. The syntax is the same after the initial `\`, but the file is written on the client machine and no special privileges are needed.
+
+```text
+mydb=# \copy (SELECT id, name, email, role FROM users WHERE role = 'admin') TO 'admin_users.json' WITH (FORMAT JSON, FORCE_ARRAY)
+```
+</Admonition>
+
 ### Data Warehouse Loading
 
 Export data for loading into JSON-native systems like Elasticsearch, MongoDB, or BigQuery:

--- a/content/postgresql/postgresql-19/logical-replication-improvements.md
+++ b/content/postgresql/postgresql-19/logical-replication-improvements.md
@@ -25,6 +25,8 @@ One of the most requested features for logical replication has been sequence syn
 
 PostgreSQL 19 adds sequence synchronization to logical replication subscriptions. Subscribers can now periodically sync sequence values from the publisher.
 
+This is the change that finally makes logical replication a sane way to do online major version upgrades. The standard pattern is to set up a logical replication stream from the old major version to a fresh PostgreSQL 19 cluster, let it catch up, then cut traffic over. Until 19, the missing piece was sequences: after the cutover the new primary would hand out sequence values that collided with rows already inserted on the old primary. With sequence synchronization, the new cluster comes up already aware of where the publisher's sequences had advanced to, and the cutover does not produce duplicate-key errors on the next insert.
+
 ```sql
 -- On the publisher: create a publication that includes sequences
 CREATE PUBLICATION my_pub FOR ALL TABLES, ALL SEQUENCES;
@@ -106,32 +108,6 @@ COPY partitioned_sales TO '/tmp/sales.csv' WITH (FORMAT csv);
 ```
 
 This is about 7-8% faster than the subquery approach because it avoids the overhead of query processing.
-
-## WAL Monitoring Improvements
-
-PostgreSQL 19 adds monitoring capabilities that help with logical replication management:
-
-### Full-Page Image Tracking
-
-The `pg_stat_wal` view gains a `wal_fpi_bytes` column that tracks bytes used by full-page images:
-
-```sql
-SELECT wal_records, wal_fpi, wal_fpi_bytes, wal_bytes
-FROM pg_stat_wal;
-```
-
-Full-page images can significantly increase WAL volume. Tracking their size separately helps diagnose WAL bloat.
-
-### Vacuum Progress Details
-
-The `pg_stat_progress_vacuum` view now includes `mode` (normal, aggressive, or failsafe) and `started_by` (auto, manual, or wraparound) columns:
-
-```sql
-SELECT pid, relid::regclass, phase, mode, started_by
-FROM pg_stat_progress_vacuum;
-```
-
-This is useful for understanding why vacuums are running and whether they are keeping up with dead tuple generation on replicated tables.
 
 ## Practical Setup Example
 

--- a/content/postgresql/postgresql-19/logical-replication-improvements.md
+++ b/content/postgresql/postgresql-19/logical-replication-improvements.md
@@ -1,0 +1,191 @@
+---
+title: 'PostgreSQL 19 Logical Replication Improvements'
+page_title: 'PostgreSQL 19 Logical Replication - Sequence Sync, EXCEPT TABLE, and More'
+page_description: 'Learn about PostgreSQL 19 logical replication improvements including sequence synchronization, EXCEPT TABLE for publications, and dynamic WAL level configuration.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 REPACK Command'
+  slug: 'postgresql-19/repack-command'
+nextLink:
+  title: 'PostgreSQL 19 JSON COPY TO'
+  slug: 'postgresql-19/json-copy-to'
+---
+
+**Summary**: PostgreSQL 19 brings several improvements to logical replication, including sequence synchronization between publisher and subscriber, the ability to exclude specific tables from `FOR ALL TABLES` publications, and dynamic WAL level adjustment.
+
+## Introduction
+
+Logical replication has been improving steadily with each PostgreSQL release. [PostgreSQL 18](/postgresql/postgresql-18/logical-replication-improvements) added retain_dead_tuples conflict-resolution support and origin-aware filtering. PostgreSQL 19 continues this trend with changes that address common operational pain points: keeping sequences in sync across replicas, managing large publications more easily, and reducing the overhead of WAL configuration.
+
+## Sequence Synchronization
+
+One of the most requested features for logical replication has been sequence synchronization. In previous versions, logical replication handled table data but ignored sequences entirely. If you used serial columns or identity columns, the sequence values on the subscriber would not advance to match the publisher, causing conflicts if the subscriber was promoted to primary.
+
+PostgreSQL 19 adds sequence synchronization to logical replication subscriptions. Subscribers can now periodically sync sequence values from the publisher.
+
+```sql
+-- On the publisher: create a publication that includes sequences
+CREATE PUBLICATION my_pub FOR ALL TABLES, ALL SEQUENCES;
+```
+
+```sql
+-- On the subscriber: create subscription
+CREATE SUBSCRIPTION my_sub
+    CONNECTION 'host=publisher dbname=mydb'
+    PUBLICATION my_pub;
+```
+
+Sequence values are synchronized periodically based on the subscription's configuration. This means that after a failover, the new primary will have sequence values that are at least as high as the old primary's, preventing duplicate key errors.
+
+<Admonition type="note">
+Sequence synchronization sends the sequence's current value, not individual `nextval()` calls. There may be gaps in sequence values after synchronization, which is normal and expected behavior for PostgreSQL sequences.
+</Admonition>
+
+## EXCEPT TABLE in Publications
+
+Publications using `FOR ALL TABLES` now support excluding specific tables with `EXCEPT TABLE`. This is a practical improvement for managing large databases where you want to replicate everything except a few tables (audit logs, temporary tables, staging data).
+
+### Creating a Publication with Exclusions
+
+Use `EXCEPT (TABLE ...)` after `FOR ALL TABLES` to keep specific tables out of the publication.
+
+```sql
+-- Replicate all tables except audit and temp tables
+CREATE PUBLICATION production_pub FOR ALL TABLES
+    EXCEPT (TABLE audit_log, temp_imports, debug_events);
+```
+
+### Modifying Exclusions
+
+`ALTER PUBLICATION ... SET ALL TABLES` replaces the exclusion list, so you can add or remove tables without recreating the publication.
+
+```sql
+-- Update the exclusion list
+ALTER PUBLICATION production_pub SET ALL TABLES
+    EXCEPT (TABLE audit_log, temp_imports, staging_data);
+
+-- Clear all exclusions
+ALTER PUBLICATION production_pub SET ALL TABLES;
+```
+
+### Why This Matters
+
+Before this feature, if you wanted to replicate all but a few tables, you had two options:
+
+1. Explicitly list every table you wanted to include (painful with hundreds of tables, breaks when new tables are added)
+2. Use `FOR ALL TABLES` and accept that unwanted tables would be replicated (wasting bandwidth and storage on the subscriber)
+
+`EXCEPT TABLE` gives you the convenience of `FOR ALL TABLES` with the ability to skip the tables that should not be replicated.
+
+## Dynamic WAL Level
+
+PostgreSQL 19 introduces the `effective_wal_level` parameter, which adjusts automatically based on whether logical replication slots exist:
+
+```sql
+SHOW effective_wal_level;
+```
+
+This returns either `replica` or `logical` depending on the current state of replication slots. The system automatically adjusts the WAL level without requiring a configuration change or server restart.
+
+Previously, you had to set `wal_level = logical` in `postgresql.conf` and restart the server before creating logical replication slots. If you later removed all logical replication slots, the WAL level would remain at `logical` (generating more WAL data than needed) until you manually changed the configuration and restarted.
+
+With dynamic WAL level, PostgreSQL handles this automatically. When the first logical replication slot is created, the effective WAL level increases to `logical`. When the last logical replication slot is removed, it drops back to `replica`.
+
+## COPY TO for Partitioned Tables
+
+While not strictly a logical replication feature, this improvement is relevant to replication workflows. PostgreSQL 19 allows `COPY partitioned_table TO` directly, without the previous workaround of wrapping it in a subquery:
+
+```sql
+-- Before: required a subquery
+COPY (SELECT * FROM partitioned_sales) TO '/tmp/sales.csv' WITH (FORMAT csv);
+
+-- PostgreSQL 19: works directly
+COPY partitioned_sales TO '/tmp/sales.csv' WITH (FORMAT csv);
+```
+
+This is about 7-8% faster than the subquery approach because it avoids the overhead of query processing.
+
+## WAL Monitoring Improvements
+
+PostgreSQL 19 adds monitoring capabilities that help with logical replication management:
+
+### Full-Page Image Tracking
+
+The `pg_stat_wal` view gains a `wal_fpi_bytes` column that tracks bytes used by full-page images:
+
+```sql
+SELECT wal_records, wal_fpi, wal_fpi_bytes, wal_bytes
+FROM pg_stat_wal;
+```
+
+Full-page images can significantly increase WAL volume. Tracking their size separately helps diagnose WAL bloat.
+
+### Vacuum Progress Details
+
+The `pg_stat_progress_vacuum` view now includes `mode` (normal, aggressive, or failsafe) and `started_by` (auto, manual, or wraparound) columns:
+
+```sql
+SELECT pid, relid::regclass, phase, mode, started_by
+FROM pg_stat_progress_vacuum;
+```
+
+This is useful for understanding why vacuums are running and whether they are keeping up with dead tuple generation on replicated tables.
+
+## Practical Setup Example
+
+Here is a complete example setting up logical replication with the new PostgreSQL 19 features:
+
+### On the Publisher
+
+Create the publication, applying exclusions for tables you don't want replicated, then verify what's actually in it.
+
+```sql
+-- Create a publication with table exclusions
+CREATE PUBLICATION app_pub FOR ALL TABLES
+    EXCEPT (TABLE debug_log, session_cache);
+
+-- Verify what's included
+SELECT * FROM pg_publication_tables WHERE pubname = 'app_pub';
+```
+
+### On the Subscriber
+
+Subscribe to the publication and confirm the replication stream is flowing.
+
+```sql
+-- Create subscription
+CREATE SUBSCRIPTION app_sub
+    CONNECTION 'host=publisher-host dbname=appdb user=replicator'
+    PUBLICATION app_pub;
+
+-- Verify replication status
+SELECT subname, received_lsn, latest_end_lsn, last_msg_send_time
+FROM pg_stat_subscription;
+```
+
+### Monitoring
+
+Once both sides are wired up, watch the WAL level and replication lag from the publisher.
+
+```sql
+-- Check effective WAL level
+SHOW effective_wal_level;
+
+-- Monitor replication lag
+SELECT slot_name,
+       pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) AS lag_bytes
+FROM pg_replication_slots
+WHERE slot_type = 'logical';
+```
+
+## Summary
+
+PostgreSQL 19's logical replication improvements address practical pain points that DBAs have been working around for years. Sequence synchronization removes a major gap in failover readiness. `EXCEPT TABLE` simplifies publication management for large databases. Dynamic WAL level eliminates the need to manually manage WAL configuration for logical replication. Together, these changes make logical replication more practical for production use.
+
+## References
+
+- [Commit `fd366065`: Allow table exclusions in publications via EXCEPT TABLE](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=fd366065)
+- [Commit `67c20979`: Toggle logical decoding dynamically based on logical slot presence](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=67c20979)
+- [PostgreSQL devel docs: CREATE PUBLICATION](https://www.postgresql.org/docs/devel/sql-createpublication.html)

--- a/content/postgresql/postgresql-19/monitoring-operations.md
+++ b/content/postgresql/postgresql-19/monitoring-operations.md
@@ -244,9 +244,22 @@ The `%S` prompt escape requires a PostgreSQL 18+ server (it uses GUC_REPORT to s
 
 ## WAIT FOR LSN: Read-Your-Writes on Async Replicas
 
-PostgreSQL 19 adds the `WAIT FOR` command (commit `447aae13b`), which lets a session block until the standby has replayed up to a specific WAL location. This is what removes the classic "I just wrote to the primary, why does my next read on the replica not see it" problem when an application reads from async replicas to scale out load.
+PostgreSQL 19 adds the `WAIT FOR` command (commit `447aae13b`), which lets a session block until the server has reached a target WAL location. The most common use is read-your-writes on async replicas: an application that scales reads onto replicas can still guarantee a specific read sees a specific earlier write, by having the replica wait until it has replayed past that write's LSN before answering.
 
-The flow is: write on the primary, capture the LSN that came back from the commit, send the read to a replica, and have the replica wait until it has caught up to that LSN before answering. The session blocks for at most the time it takes the replica to apply the missing WAL, then runs the query against state that is guaranteed to include the write.
+The syntax is:
+
+```sql
+WAIT FOR LSN 'lsn' [ WITH ( option [, ...] ) ]
+-- options: MODE 'standby_replay' | 'standby_write' | 'standby_flush' | 'primary_flush'
+--          TIMEOUT 'milliseconds'
+--          NO_THROW
+```
+
+The command returns a single `status` column with `success` if the LSN was reached or `timeout` if it gave up first.
+
+### Read-your-writes on a standby
+
+The flow is: write on the primary, capture the commit LSN, send the read to a replica with `WAIT FOR LSN` first.
 
 ```sql
 -- 1. On the primary: do the write and grab the commit LSN
@@ -258,21 +271,30 @@ SELECT pg_current_wal_lsn();
 ```
 
 ```sql
--- 2. On the replica: block until replay has caught up, then read
-WAIT FOR LSN '0/1A3C8F0';
+-- 2. On the replica: block until replay has caught up, then read.
+--    Default mode is standby_replay, so no WITH clause needed.
+WAIT FOR LSN '0/1A3C8F0' WITH (TIMEOUT '5000');
 SELECT * FROM orders WHERE customer_id = 42;
 ```
 
-`WAIT FOR LSN` accepts an optional `TIMEOUT` clause so a stuck or lagging replica does not hang the session indefinitely. If the timeout fires before the LSN is reached, the command returns false and the session can decide whether to retry, fail over to the primary, or surface an error to the caller.
+If the timeout fires before the LSN is reached, the command returns `status = 'timeout'` and the session can decide whether to retry, fail over to the primary, or surface an error to the caller. Add `NO_THROW` if you want the timeout to be returned silently rather than as a query error.
 
-```sql
--- Wait up to 5 seconds; succeed = true, timeout = false
-WAIT FOR LSN '0/1A3C8F0' TIMEOUT 5000;
-```
+### Mode option
+
+`MODE` controls what "reached the LSN" means and where the wait runs:
+
+| Mode | Where it runs | What it waits for |
+|---|---|---|
+| `standby_replay` | Standby (default) | WAL has been replayed up to the LSN — readable from this standby |
+| `standby_write` | Standby | WAL has been written to disk on this standby |
+| `standby_flush` | Standby | WAL has been flushed to durable storage on this standby |
+| `primary_flush` | Primary | WAL has been flushed locally on the primary |
+
+`primary_flush` is useful for write paths that want to confirm a commit is durable before responding to the caller without changing `synchronous_commit`. On the primary, the other three modes error with "recovery is not in progress" because they describe a standby state.
 
 ### When to use it
 
-The pattern fits applications that already split reads onto async replicas for capacity reasons but have a small number of read paths that genuinely need to see their own writes. Typical examples:
+The standby-side pattern fits applications that already split reads onto async replicas for capacity reasons but have a small number of read paths that genuinely need to see their own writes. Typical examples:
 
 - A user updates a setting on the primary and the next page load reads from a replica.
 - A background job inserts a row and then a status checker on a replica needs to see it.
@@ -281,7 +303,7 @@ The pattern fits applications that already split reads onto async replicas for c
 For workloads where every read needs the latest data, a synchronous replica or reading from the primary is still the right answer. `WAIT FOR LSN` is for the cases where most reads can tolerate a few hundred milliseconds of replica lag but a small subset cannot.
 
 <Admonition type="note">
-The LSN you wait for is the value returned from `pg_current_wal_lsn()` (or the LSN the driver surfaces alongside the commit). On a replica that is already caught up, `WAIT FOR LSN` returns immediately, so the cost on a healthy system is one extra round trip rather than a stall.
+The LSN you wait for is the value returned from `pg_current_wal_lsn()` or the LSN the driver surfaces alongside the commit. On a replica that is already caught up, `WAIT FOR LSN` returns `success` immediately, so the cost on a healthy system is one extra round trip rather than a stall.
 </Admonition>
 
 ## Dynamic WAL Level

--- a/content/postgresql/postgresql-19/monitoring-operations.md
+++ b/content/postgresql/postgresql-19/monitoring-operations.md
@@ -1,0 +1,300 @@
+---
+title: 'PostgreSQL 19 Monitoring and Operations'
+page_title: 'PostgreSQL 19 Monitoring and Operations Improvements'
+page_description: 'Learn about PostgreSQL 19 monitoring and operational improvements including online data checksums, WAL statistics, vacuum progress tracking, per-process logging, psql enhancements, and 64-bit MultiXactOffset.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 Schema Management'
+  slug: 'postgresql-19/schema-management'
+nextLink:
+  title: 'PostgreSQL 19 Parallel Autovacuum'
+  slug: 'postgresql-19/parallel-autovacuum'
+---
+
+**Summary**: PostgreSQL 19 adds online data checksum management, WAL full-page image tracking, vacuum progress details, per-process-type log levels, psql prompt improvements, dynamic WAL level, and eliminates the MultiXact wraparound risk with a 64-bit offset. These changes give DBAs better visibility into database operations and remove long-standing operational hazards.
+
+## Online Data Checksum Enable/Disable
+
+PostgreSQL 19 lets you enable or disable data checksums on a running cluster. Previously, checksums could only be set during `initdb` or offline using `pg_checksums` with the server shut down. For large databases, this meant hours of downtime or a full re-initdb with data reload.
+
+Two new SQL-callable functions handle this:
+
+### Enabling Checksums
+
+`pg_enable_data_checksums()` kicks off the online conversion. With no arguments it uses sensible defaults; the optional throttling parameters mirror the autovacuum cost model.
+
+```sql
+-- Enable checksums with default throttling
+SELECT pg_enable_data_checksums();
+
+-- Enable with custom throttling (similar to vacuum cost parameters)
+SELECT pg_enable_data_checksums(
+    cost_delay := 10,   -- milliseconds to sleep between page writes
+    cost_limit := 1000  -- pages to process before sleeping
+);
+```
+
+The function starts a background worker that marks all shared buffers dirty, causing checksums to be written on the next page flush. The cluster transitions through an `inprogress-on` state before checksums are fully active:
+
+```sql
+-- Monitor progress
+SHOW data_checksums;
+-- Values: 'off' -> 'inprogress-on' -> 'on'
+```
+
+The cluster remains fully accessible throughout the process. Reads and writes continue normally while the background worker processes pages.
+
+### Disabling Checksums
+
+`pg_disable_data_checksums()` is a one-liner. There is no inverse cost model because the operation only needs to flip the control file and stop verifying.
+
+```sql
+SELECT pg_disable_data_checksums();
+```
+
+This transitions through `inprogress-off` before reaching `off`. Disabling is faster since it only needs to update the control file and stop verifying checksums on reads.
+
+### Throttling the IO Impact
+
+The `cost_delay` and `cost_limit` parameters work like vacuum cost-based delay. On busy production systems, increase `cost_delay` to spread the work over a longer period:
+
+```sql
+-- Gentle approach for production (takes longer but minimal IO impact)
+SELECT pg_enable_data_checksums(cost_delay := 20, cost_limit := 500);
+
+-- Aggressive approach for maintenance windows
+SELECT pg_enable_data_checksums(cost_delay := 0, cost_limit := 10000);
+```
+
+### Why This Matters
+
+Many long-running PostgreSQL clusters were initialized years ago without checksums. Until now, enabling checksums on these clusters required one of:
+
+- Shutting down the server and running `pg_checksums --enable` (hours of downtime for large databases)
+- Performing a full `pg_dump` and `pg_restore` into a new cluster with checksums enabled
+- Living without checksums and risking silent data corruption
+
+With online checksums, you can enable this protection on a running production database with zero downtime.
+
+<Admonition type="note">
+Starting in PostgreSQL 18, `initdb` enables data checksums by default for new clusters. Pass `--no-data-checksums` to opt out. Existing clusters upgrading via `pg_upgrade` retain their previous checksum setting.
+</Admonition>
+
+## WAL Monitoring: Full-Page Image Tracking
+
+The `pg_stat_wal` view gains a `wal_fpi_bytes` column that tracks the total bytes used by full-page images (FPI) in WAL:
+
+```sql
+SELECT
+    wal_records,
+    wal_fpi,
+    wal_fpi_bytes,
+    wal_bytes,
+    ROUND(wal_fpi_bytes::numeric / NULLIF(wal_bytes, 0) * 100, 1) AS fpi_percent
+FROM pg_stat_wal;
+```
+
+```
+ wal_records | wal_fpi | wal_fpi_bytes | wal_bytes  | fpi_percent
+-------------+---------+---------------+------------+-------------
+      845230 |   12450 |     102367232 | 256789504  |        39.9
+```
+
+### Why FPI Tracking Matters
+
+Full-page images are complete page copies written to WAL after the first modification following a checkpoint. They are necessary for crash recovery but can account for 30-50% of total WAL volume.
+
+With `wal_fpi_bytes`, you can now answer questions like:
+
+- What percentage of my WAL is full-page images?
+- Would increasing `checkpoint_timeout` reduce WAL volume? (Fewer checkpoints means fewer first-post-checkpoint modifications, which means fewer FPIs)
+- Is `full_page_writes = on` adding significant overhead for my workload?
+
+Previously, you had to parse WAL files with `pg_waldump` and manually calculate FPI bytes. Now it is a single query.
+
+## Vacuum Progress: Mode and Started By
+
+The `pg_stat_progress_vacuum` view adds two columns that answer "why is this vacuum running?" and "how aggressive is it?":
+
+```sql
+SELECT
+    pid,
+    relid::regclass AS table_name,
+    phase,
+    mode,
+    started_by,
+    heap_blks_scanned,
+    heap_blks_total
+FROM pg_stat_progress_vacuum;
+```
+
+```
+  pid  | table_name | phase          | mode       | started_by | heap_blks_scanned | heap_blks_total
+-------+------------+----------------+------------+------------+-------------------+-----------------
+ 12345 | orders     | scanning heap  | normal     | auto       |            150000 |          500000
+ 12346 | users      | vacuuming heap | aggressive | wraparound |             80000 |          100000
+```
+
+### Mode Values
+
+| Mode | Meaning |
+|---|---|
+| `normal` | Standard vacuum, reclaims dead tuples |
+| `aggressive` | Scans all pages to advance relfrozenxid, not just those with dead tuples |
+| `failsafe` | Emergency mode triggered when the database is close to transaction ID wraparound |
+
+### Started By Values
+
+| Value | Meaning |
+|---|---|
+| `auto` | Triggered by the autovacuum launcher |
+| `manual` | Explicitly run by a user (VACUUM command) |
+| `wraparound` | Triggered by the autovacuum launcher specifically to prevent wraparound |
+
+This is useful for understanding why vacuum is consuming resources. A `wraparound` vacuum in `aggressive` mode will scan the entire table regardless of dead tuple count, which can cause I/O spikes.
+
+## Per-Process-Type Log Levels
+
+The `log_min_messages` parameter now accepts a comma-separated list of process-type overrides:
+
+```
+# postgresql.conf
+log_min_messages = 'warning, autovacuum:debug1, archiver:debug5'
+```
+
+This sets the default log level to `warning` but enables debug logging for autovacuum and archiver processes specifically.
+
+### Supported Process Types
+
+The 14 supported process types include:
+
+| Process Type | Typical Use |
+|---|---|
+| `autovacuum` | Debug vacuum behavior without flooding logs with backend messages |
+| `archiver` | Troubleshoot WAL archiving issues |
+| `checkpointer` | Investigate checkpoint timing and I/O |
+| `walsender` | Debug replication issues |
+| `walreceiver` | Debug standby replication |
+| `backend` | Application query logging |
+| `startup` | Recovery and startup diagnostics |
+| `bgwriter` | Background writer behavior |
+
+### Practical Example
+
+To debug why autovacuum is running aggressively without adding noise from all other processes:
+
+```
+log_min_messages = 'warning, autovacuum:debug2'
+```
+
+This produces detailed autovacuum debug output (table selection, threshold calculations, page scanning) while keeping all other processes at warning level.
+
+You can change this at runtime without a restart:
+
+```sql
+ALTER SYSTEM SET log_min_messages = 'warning, autovacuum:debug1';
+SELECT pg_reload_conf();
+```
+
+## psql Prompt Improvements
+
+PostgreSQL 19 adds two new prompt escape sequences:
+
+### %i: Primary/Standby Status
+
+Shows whether the connected server is a primary or standby:
+
+```
+\set PROMPT1 '[%i] %/%R%x%# '
+```
+
+Result on a primary:
+
+```
+[primary] mydb=#
+```
+
+Result on a standby:
+
+```
+[standby] mydb=#
+```
+
+This is useful when you have multiple terminal windows connected to different servers and need a visual indicator of which is the primary.
+
+### %S: Current search_path
+
+Shows the current `search_path` setting:
+
+```
+\set PROMPT1 '%/ [%S] %R%x%# '
+```
+
+Result:
+
+```
+mydb ["$user", public] =#
+```
+
+<Admonition type="note">
+The `%S` prompt escape requires a PostgreSQL 18+ server (it uses GUC_REPORT to send the search_path value to the client). Connecting to an older server will show an empty string.
+</Admonition>
+
+## Dynamic WAL Level
+
+PostgreSQL 19 introduces automatic WAL level adjustment based on whether logical replication slots exist. The new read-only parameter `effective_wal_level` shows the actual operational WAL level:
+
+```sql
+SHOW effective_wal_level;
+```
+
+When the first logical replication slot is created, the effective WAL level automatically increases from `replica` to `logical`. When the last logical slot is removed, it drops back to `replica` asynchronously.
+
+Previously, enabling logical replication required:
+
+1. Set `wal_level = logical` in `postgresql.conf`
+2. Restart the server
+3. If you later removed all logical replication, the overhead remained until another manual change and restart
+
+Dynamic WAL level eliminates steps 1 and 2, and automatically removes the overhead when it is no longer needed.
+
+## 64-bit MultiXactOffset
+
+PostgreSQL 19 widens MultiXactOffset from 32-bit to 64-bit, eliminating a wraparound risk that has bitten production databases running heavy row-level locking workloads.
+
+### The Problem It Solves
+
+MultiXacts are used when multiple transactions hold locks on the same row (for example, concurrent `SELECT ... FOR SHARE` queries). Each MultiXact stores a list of member transaction IDs, and the offset into this list was a 32-bit integer.
+
+With heavy concurrent locking, the ~4 billion member limit could be exhausted. When this happened:
+
+- New row-level locks would fail
+- Emergency vacuuming was required to reclaim MultiXact space
+- The database could effectively stall if vacuuming could not keep up
+
+### The Fix
+
+With 64-bit MultiXactOffset, the member space is effectively unlimited. The wraparound scenario that required emergency intervention is gone.
+
+```sql
+-- No syntax change needed. This query that could previously
+-- cause MultiXact exhaustion under heavy concurrent load
+-- is now safe:
+SELECT * FROM orders WHERE status = 'pending' FOR SHARE;
+-- (even with thousands of concurrent sessions)
+```
+
+The upgrade to 64-bit happens automatically when you upgrade to PostgreSQL 19 via `pg_upgrade`. The SLRU files are rewritten during the upgrade process.
+
+## Summary
+
+PostgreSQL 19's monitoring and operational improvements give DBAs better tools for understanding what the database is doing and why. WAL FPI tracking reveals a previously hidden cost driver. Vacuum progress details explain why vacuums run and how aggressive they are. Per-process logging lets you debug specific subsystems without flooding your logs. And the 64-bit MultiXactOffset removes a long-standing operational hazard that has caused production incidents.
+
+## References
+
+- [Commit `f19c0ecc`: Online enabling and disabling of data checksums](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=f19c0ecc)
+- [Commit `f9a09aa2`: Add wal_fpi_bytes to pg_stat_wal](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=f9a09aa2)
+- [Commit `0d789520`: Add mode and started_by columns to pg_stat_progress_vacuum](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=0d789520)
+- [PostgreSQL devel docs: Monitoring stats](https://www.postgresql.org/docs/devel/monitoring-stats.html)

--- a/content/postgresql/postgresql-19/monitoring-operations.md
+++ b/content/postgresql/postgresql-19/monitoring-operations.md
@@ -13,7 +13,7 @@ nextLink:
   slug: 'postgresql-19/parallel-autovacuum'
 ---
 
-**Summary**: PostgreSQL 19 adds online data checksum management, WAL full-page image tracking, vacuum progress details, per-process-type log levels, psql prompt improvements, dynamic WAL level, and eliminates the MultiXact wraparound risk with a 64-bit offset. These changes give DBAs better visibility into database operations and remove long-standing operational hazards.
+**Summary**: PostgreSQL 19 adds online data checksum management, WAL full-page image tracking, vacuum progress details, per-process-type log levels, psql prompt improvements, the new `WAIT FOR LSN` command for read-your-writes on async replicas, dynamic WAL level, and eliminates the MultiXact wraparound risk with a 64-bit offset. These changes give DBAs better visibility into database operations and remove long-standing operational hazards.
 
 ## Online Data Checksum Enable/Disable
 
@@ -242,6 +242,48 @@ mydb ["$user", public] =#
 The `%S` prompt escape requires a PostgreSQL 18+ server (it uses GUC_REPORT to send the search_path value to the client). Connecting to an older server will show an empty string.
 </Admonition>
 
+## WAIT FOR LSN: Read-Your-Writes on Async Replicas
+
+PostgreSQL 19 adds the `WAIT FOR` command (commit `447aae13b`), which lets a session block until the standby has replayed up to a specific WAL location. This is what removes the classic "I just wrote to the primary, why does my next read on the replica not see it" problem when an application reads from async replicas to scale out load.
+
+The flow is: write on the primary, capture the LSN that came back from the commit, send the read to a replica, and have the replica wait until it has caught up to that LSN before answering. The session blocks for at most the time it takes the replica to apply the missing WAL, then runs the query against state that is guaranteed to include the write.
+
+```sql
+-- 1. On the primary: do the write and grab the commit LSN
+INSERT INTO orders (customer_id, total) VALUES (42, 99.00);
+SELECT pg_current_wal_lsn();
+--   pg_current_wal_lsn
+-- ----------------------
+--   0/1A3C8F0
+```
+
+```sql
+-- 2. On the replica: block until replay has caught up, then read
+WAIT FOR LSN '0/1A3C8F0';
+SELECT * FROM orders WHERE customer_id = 42;
+```
+
+`WAIT FOR LSN` accepts an optional `TIMEOUT` clause so a stuck or lagging replica does not hang the session indefinitely. If the timeout fires before the LSN is reached, the command returns false and the session can decide whether to retry, fail over to the primary, or surface an error to the caller.
+
+```sql
+-- Wait up to 5 seconds; succeed = true, timeout = false
+WAIT FOR LSN '0/1A3C8F0' TIMEOUT 5000;
+```
+
+### When to use it
+
+The pattern fits applications that already split reads onto async replicas for capacity reasons but have a small number of read paths that genuinely need to see their own writes. Typical examples:
+
+- A user updates a setting on the primary and the next page load reads from a replica.
+- A background job inserts a row and then a status checker on a replica needs to see it.
+- A request that writes once and reads many times can do the write, capture the LSN, and then read from a replica without sticking the rest of the request to the primary.
+
+For workloads where every read needs the latest data, a synchronous replica or reading from the primary is still the right answer. `WAIT FOR LSN` is for the cases where most reads can tolerate a few hundred milliseconds of replica lag but a small subset cannot.
+
+<Admonition type="note">
+The LSN you wait for is the value returned from `pg_current_wal_lsn()` (or the LSN the driver surfaces alongside the commit). On a replica that is already caught up, `WAIT FOR LSN` returns immediately, so the cost on a healthy system is one extra round trip rather than a stall.
+</Admonition>
+
 ## Dynamic WAL Level
 
 PostgreSQL 19 introduces automatic WAL level adjustment based on whether logical replication slots exist. The new read-only parameter `effective_wal_level` shows the actual operational WAL level:
@@ -297,4 +339,5 @@ PostgreSQL 19's monitoring and operational improvements give DBAs better tools f
 - [Commit `f19c0ecc`: Online enabling and disabling of data checksums](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=f19c0ecc)
 - [Commit `f9a09aa2`: Add wal_fpi_bytes to pg_stat_wal](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=f9a09aa2)
 - [Commit `0d789520`: Add mode and started_by columns to pg_stat_progress_vacuum](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=0d789520)
+- [Commit `447aae13b`: Add WAIT FOR command for read-your-writes on async replicas](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=447aae13b)
 - [PostgreSQL devel docs: Monitoring stats](https://www.postgresql.org/docs/devel/monitoring-stats.html)

--- a/content/postgresql/postgresql-19/on-conflict-do-select.md
+++ b/content/postgresql/postgresql-19/on-conflict-do-select.md
@@ -1,0 +1,261 @@
+---
+title: 'PostgreSQL 19 ON CONFLICT DO SELECT'
+page_title: 'PostgreSQL 19 ON CONFLICT DO SELECT - Atomic Get-or-Create'
+page_description: 'Learn how to use PostgreSQL 19 ON CONFLICT DO SELECT for atomic get-or-create operations without dead rows, extra queries, or CTE workarounds.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 SQL/PGQ Graph Queries'
+  slug: 'postgresql-19/sql-pgq-graph-queries'
+nextLink:
+  title: 'PostgreSQL 19 Temporal Data Operations'
+  slug: 'postgresql-19/temporal-data-operations'
+---
+
+**Summary**: PostgreSQL 19 adds `ON CONFLICT DO SELECT` to the `INSERT` statement, giving you an atomic get-or-create operation that returns existing rows on conflict without generating dead tuples or requiring CTE workarounds.
+
+## Introduction to ON CONFLICT DO SELECT
+
+Since PostgreSQL 9.5, `INSERT ... ON CONFLICT` has supported two actions: `DO NOTHING` (silently skip the insert) and `DO UPDATE` (modify the existing row). Both have a gap when it comes to a common pattern: insert a row and get back its generated columns, or if the row already exists, get the existing row instead.
+
+`DO NOTHING` swallows the conflict silently - the `RETURNING` clause gives you nothing back for conflicting rows. `DO UPDATE` lets you return the row, but forces a write even when nothing changed, generating dead tuples that VACUUM must clean up.
+
+PostgreSQL 19 closes this gap with `ON CONFLICT DO SELECT`. When a conflict is detected, the existing row is returned through the `RETURNING` clause without any modification. No dead tuples, no extra queries, no CTE gymnastics.
+
+## Sample Database Setup
+
+Let's create a table to demonstrate the feature:
+
+```sql
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO users (email, name) VALUES
+    ('alice@example.com', 'Alice Johnson'),
+    ('bob@example.com', 'Bob Smith');
+```
+
+## Basic Usage
+
+The simplest form inserts a new row or returns the existing one:
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice Johnson')
+ON CONFLICT (email) DO SELECT
+RETURNING *;
+```
+
+Since Alice already exists, the output returns her existing row:
+
+```
+ id |       email        |     name      |         created_at
+----+--------------------+---------------+----------------------------
+  1 | alice@example.com  | Alice Johnson | 2026-04-14 10:00:00.000000
+```
+
+If you insert a new user, the row is created and returned as usual:
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('charlie@example.com', 'Charlie Brown')
+ON CONFLICT (email) DO SELECT
+RETURNING *;
+```
+
+```
+ id |        email         |     name      |         created_at
+----+----------------------+---------------+----------------------------
+  3 | charlie@example.com  | Charlie Brown | 2026-04-14 10:05:00.000000
+```
+
+One statement handles both cases. The caller always gets a row back.
+
+## Why Not Just Use DO UPDATE?
+
+The most common workaround before `DO SELECT` was a no-op `DO UPDATE`:
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice Johnson')
+ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
+RETURNING *;
+```
+
+This works, but every conflict generates a dead tuple. PostgreSQL creates a new row version, updates indexes (unless it qualifies for a HOT update), and writes WAL - all for data that did not change. On tables with high conflict rates, this causes measurable bloat and unnecessary I/O.
+
+Benchmarks from the PostgreSQL mailing list show the performance difference:
+
+| Approach | Transactions/sec |
+|---|---|
+| PL/pgSQL function | 45,092 |
+| `ON CONFLICT DO SELECT` | 35,788 |
+| `DO NOTHING` + CTE workaround | 28,929 |
+| `DO UPDATE` (no-op) | 9,222 |
+
+`DO SELECT` is nearly 4x faster than the no-op `DO UPDATE` approach, and about 24% faster than the CTE workaround.
+
+## The CTE Workaround DO SELECT Replaces
+
+The other common workaround was a CTE that tries the insert and falls back to a select:
+
+```sql
+WITH ins AS (
+    INSERT INTO users (email, name)
+    VALUES ('alice@example.com', 'Alice Johnson')
+    ON CONFLICT (email) DO NOTHING
+    RETURNING *
+)
+SELECT * FROM ins
+UNION ALL
+SELECT * FROM users
+WHERE email = 'alice@example.com'
+AND NOT EXISTS (SELECT 1 FROM ins);
+```
+
+This is verbose, error-prone, and has subtle concurrency windows. `DO SELECT` replaces it with a single, atomic statement.
+
+## Locking Conflicting Rows
+
+If you need to modify the existing row later in the same transaction, you can lock it during the select:
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice Johnson')
+ON CONFLICT (email) DO SELECT FOR UPDATE
+RETURNING *;
+```
+
+All four lock modes are supported: `FOR UPDATE`, `FOR NO KEY UPDATE`, `FOR SHARE`, and `FOR KEY SHARE`.
+
+Without a lock clause, the row is returned without any lock held. This is the right choice for read-and-commit patterns like idempotent API endpoints where you do not need to modify the row afterward.
+
+<Admonition type="note">
+Using `FOR UPDATE` or `FOR SHARE` in `DO SELECT` requires `UPDATE` privilege on at least one column in addition to `SELECT` privilege.
+</Admonition>
+
+## Filtering with WHERE
+
+You can add a WHERE clause to control which conflicting rows get returned:
+
+```sql
+INSERT INTO users AS u (email, name)
+VALUES ('alice@example.com', 'Alice Updated')
+ON CONFLICT (email) DO SELECT
+WHERE u.name != EXCLUDED.name
+RETURNING *;
+```
+
+Here `EXCLUDED` refers to the row that would have been inserted, and `u` is the alias for the existing table row. If the WHERE condition does not match, `RETURNING` produces no rows for that conflict.
+
+This is useful when you want to detect whether the existing data differs from what you tried to insert.
+
+## Multi-Row Inserts
+
+`DO SELECT` works with multi-value inserts. Each row resolves independently:
+
+```sql
+INSERT INTO users (email, name)
+VALUES
+    ('alice@example.com', 'Alice Johnson'),
+    ('dave@example.com', 'Dave Wilson'),
+    ('bob@example.com', 'Bob Smith')
+ON CONFLICT (email) DO SELECT
+RETURNING *;
+```
+
+```
+ id |       email        |     name      |         created_at
+----+--------------------+---------------+----------------------------
+  1 | alice@example.com  | Alice Johnson | 2026-04-14 10:00:00.000000
+  4 | dave@example.com   | Dave Wilson   | 2026-04-14 10:10:00.000000
+  2 | bob@example.com    | Bob Smith     | 2026-04-14 10:00:00.000000
+```
+
+You always get back exactly as many rows as you tried to insert. Alice and Bob were existing rows (returned via select), Dave was new (inserted).
+
+## How It Works Under the Hood
+
+`DO SELECT` uses the same speculative insertion mechanism that powers `DO NOTHING` and `DO UPDATE`. PostgreSQL optimistically attempts the insert, checks for arbiter index violations, and if a conflict is found, aborts the speculative tuple and looks up the existing row instead.
+
+The existing row is then fed through the `RETURNING` clause. No separate query runs, and no additional index scan happens beyond what the conflict detection already performed.
+
+This is why `RETURNING` is mandatory with `DO SELECT`. Without it, the operation would be identical to `DO NOTHING` - there is no point selecting a row you are not going to return.
+
+<Admonition type="note">
+A plain `RETURNING *` returns the existing row's columns as-is on the select path. Since no modification takes place, there is no difference between "old" and "new" values. The [`OLD` / `NEW` aliases on `RETURNING`](/postgresql/postgresql-18/enhanced-returning) introduced in PostgreSQL 18 still work, but for `DO SELECT` you do not need them.
+</Admonition>
+
+## Practical use cases
+
+`ON CONFLICT DO SELECT` is a good fit anywhere you previously wrote a two-step "INSERT then SELECT" or relied on a CTE trick to return the pre-existing row. A few patterns where it tightens the code:
+
+### Idempotent API endpoints
+
+An API that creates a resource but needs to handle retries gracefully:
+
+```sql
+INSERT INTO api_keys (user_id, key_hash, label)
+VALUES ($1, $2, $3)
+ON CONFLICT (key_hash) DO SELECT
+RETURNING id, user_id, label, created_at;
+```
+
+Client retries get back the same response. No duplicate rows, no error handling needed.
+
+### Tag and Category Resolution
+
+When importing data, you often need to resolve names to IDs:
+
+```sql
+INSERT INTO tags (name)
+VALUES ('postgresql')
+ON CONFLICT (name) DO SELECT
+RETURNING id;
+```
+
+Previously this required either a lookup-then-insert pattern (with race conditions) or the CTE workaround. Now it is one atomic statement.
+
+### Event Processing with Exactly-Once Semantics
+
+Message processors that need to create entities idempotently:
+
+```sql
+INSERT INTO entities (external_id, source, data)
+VALUES ($1, $2, $3)
+ON CONFLICT (external_id, source) DO SELECT FOR UPDATE
+RETURNING *;
+```
+
+The `FOR UPDATE` lock means you can safely check and modify the returned row in the same transaction, regardless of whether it was just created or already existed.
+
+## Rules and Constraints
+
+A few things to keep in mind when using `DO SELECT`:
+
+- **RETURNING is required.** `DO SELECT` without `RETURNING` is a syntax error.
+- **You must specify a conflict target.** Unlike `DO NOTHING` where the conflict target is optional, `DO SELECT` needs to know which unique constraint or index to use as the arbiter.
+- **Only non-deferrable unique indexes work** as conflict arbiters. Same rule as `DO UPDATE`.
+- **The RETURNING list is the select list.** You do not get a separate `SELECT` clause. Whatever you put in `RETURNING` is what you get back for both the insert and select paths.
+
+## When to Use Each ON CONFLICT Action
+
+| Action | Use When |
+|---|---|
+| `DO NOTHING` | You do not need the conflicting row back. Fire-and-forget inserts, bulk loads where duplicates should be silently skipped. |
+| `DO SELECT` | You need the row back (inserted or existing) but do not want to modify existing data. Get-or-create patterns, idempotent operations. |
+| `DO UPDATE` | You want to change the existing row's data on conflict. True upsert semantics where newer data should overwrite older data. |
+
+## Summary
+
+`ON CONFLICT DO SELECT` fills a gap that has existed since `ON CONFLICT` was introduced in PostgreSQL 9.5. It gives you atomic get-or-create semantics in a single statement, without the dead tuple overhead of `DO UPDATE` or the complexity of CTE workarounds.
+
+## References
+
+- [Commit `88327092`: Add support for INSERT ... ON CONFLICT DO SELECT](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=88327092)
+- [PostgreSQL devel docs: INSERT](https://www.postgresql.org/docs/devel/sql-insert.html)

--- a/content/postgresql/postgresql-19/parallel-autovacuum.md
+++ b/content/postgresql/postgresql-19/parallel-autovacuum.md
@@ -1,0 +1,195 @@
+---
+title: 'PostgreSQL 19 Parallel Autovacuum'
+page_title: 'PostgreSQL 19 Parallel Autovacuum - Faster Index Cleanup'
+page_description: 'Learn how to configure PostgreSQL 19 parallel autovacuum to speed up index vacuuming on large tables with multiple indexes.'
+ogImage: ''
+updatedOn: '2026-04-15T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 Monitoring and Operations'
+  slug: 'postgresql-19/monitoring-operations'
+nextLink:
+  title: 'PostgreSQL 19 Breaking Changes'
+  slug: 'postgresql-19/breaking-changes'
+---
+
+**Summary**: PostgreSQL 19 lets autovacuum use parallel workers for index vacuuming and cleanup. On tables with multiple large indexes, this can cut vacuum time significantly by processing indexes in parallel instead of one at a time.
+
+## Introduction
+
+Vacuuming a table with many indexes is slow because PostgreSQL processes each index sequentially. For a table with 5 indexes, the index vacuum phase takes 5x as long as it would for a single index. On large tables, this phase often dominates the total vacuum time.
+
+PostgreSQL 13 added `VACUUM (PARALLEL N)` for manual vacuum operations. PostgreSQL 19 extends this to autovacuum, letting the background vacuum workers spawn parallel helpers for index processing. The [autovacuum tuning guidance from PostgreSQL 18](/postgresql/postgresql-18/autovacuum-maintenance-configuration) still applies — parallel workers stack on top of those settings.
+
+## How It Works
+
+Parallel autovacuum adds workers during two specific phases of the vacuum process:
+
+1. **Index vacuuming**: Removing index entries that point to dead heap tuples
+2. **Index cleanup**: Updating index statistics after vacuuming
+
+Each parallel worker handles one index at a time. If you have 4 indexes and 3 parallel workers, the leader process handles one index while the 3 workers handle the other 3, completing the phase in roughly the time it takes to process the largest single index.
+
+The heap scanning and heap vacuuming phases remain single-threaded. Parallel workers are launched before each index phase and exit when the phase completes.
+
+## Configuration
+
+Parallel autovacuum is controlled by one cluster-wide GUC and one per-table storage parameter. Both default to disabled.
+
+### Global setting
+
+`autovacuum_max_parallel_workers` controls the cluster-wide ceiling. Set it via `ALTER SYSTEM` or `postgresql.conf`, then reload the config to pick up the change without a restart.
+
+```sql
+-- postgresql.conf or ALTER SYSTEM
+-- Default is 0 (disabled)
+ALTER SYSTEM SET autovacuum_max_parallel_workers = 4;
+SELECT pg_reload_conf();
+```
+
+The `autovacuum_max_parallel_workers` parameter sets the maximum number of parallel workers a single autovacuum process can use. The default is `0`, which means parallel autovacuum is disabled after a fresh install. You must explicitly enable it.
+
+<Admonition type="important">
+Parallel autovacuum is off by default (`autovacuum_max_parallel_workers = 0`). You must set this to a positive value to benefit from it.
+</Admonition>
+
+### Per-Table Override
+
+For tables that benefit most from parallel vacuum (large tables with many indexes), you can set the parallelism individually:
+
+```sql
+-- Use 3 parallel workers for this table
+ALTER TABLE orders SET (autovacuum_parallel_workers = 3);
+
+-- Use 6 parallel workers for a heavily-indexed table
+ALTER TABLE events SET (autovacuum_parallel_workers = 6);
+
+-- Disable parallel vacuum for a small table
+ALTER TABLE config SET (autovacuum_parallel_workers = 0);
+```
+
+The per-table setting overrides the global `autovacuum_max_parallel_workers`. A value of `-1` (the default) means "use the global setting."
+
+### Limits
+
+The actual number of parallel workers is constrained by:
+
+- `autovacuum_max_parallel_workers` (or the per-table override)
+- `max_parallel_workers` (the overall parallel worker pool)
+- The number of indexes on the table (you can not have more workers than indexes)
+- Each index must be larger than `min_parallel_index_scan_size` to qualify for parallel processing
+
+## When Parallel Autovacuum Helps
+
+Parallel autovacuum is most effective when:
+
+**Multiple large indexes**: A table with 5+ indexes where each index is gigabytes in size. The index vacuum phase dominates total vacuum time, and parallel processing provides a near-linear speedup.
+
+**Write-heavy tables with many indexes**: Tables like audit logs, event streams, or time-series data that accumulate dead tuples quickly and have several indexes for different query patterns.
+
+**Tables where vacuum falls behind**: If autovacuum cannot keep up with the dead tuple generation rate, parallel workers help it process faster.
+
+### When It Does Not Help
+
+**Single-index tables**: No benefit from parallelism when there is only one index to process.
+
+**Small indexes**: Indexes below `min_parallel_index_scan_size` are processed by the leader, not workers.
+
+**Heap-bound vacuums**: If the heap scanning phase is the bottleneck (common with very wide rows or tables with few dead tuples spread across many pages), parallel index processing does not help.
+
+## Memory Considerations
+
+Each parallel worker allocates its own `maintenance_work_mem` for the vacuum operation. With `maintenance_work_mem = 256MB` and 4 parallel workers, a single autovacuum process could use up to 1.25 GB (leader + 4 workers).
+
+Plan your memory budget accordingly:
+
+```sql
+-- If you set 4 parallel workers globally:
+-- Total memory per autovacuum = maintenance_work_mem * (1 + autovacuum_max_parallel_workers)
+-- 256MB * 5 = 1.28 GB per concurrent autovacuum
+
+SHOW maintenance_work_mem;
+SHOW autovacuum_max_parallel_workers;
+```
+
+## Monitoring
+
+The `pg_stat_progress_vacuum` view shows the combined progress of the leader and all parallel workers:
+
+```sql
+SELECT
+    pid,
+    relid::regclass AS table_name,
+    phase,
+    heap_blks_total,
+    heap_blks_scanned,
+    index_vacuum_count,
+    max_dead_tuple_bytes,
+    dead_tuple_bytes
+FROM pg_stat_progress_vacuum;
+```
+
+Parallel workers do not get their own rows in this view. The progress information is aggregated under the leader process.
+
+## Practical configuration
+
+Typical settings by database size. These are starting points, not hard rules. The right numbers depend on how many indexes your tables have and how much CPU headroom the box has during autovacuum windows.
+
+### Small database (< 50 GB)
+
+Parallel autovacuum is likely unnecessary. The default of 0 is fine:
+
+```
+# postgresql.conf
+autovacuum_max_parallel_workers = 0
+```
+
+### Medium Database (50-500 GB)
+
+Enable a modest level of parallelism:
+
+```
+# postgresql.conf
+autovacuum_max_parallel_workers = 2
+maintenance_work_mem = 256MB
+```
+
+### Large Database (500+ GB)
+
+Enable higher parallelism, especially for tables with many indexes:
+
+```
+# postgresql.conf
+autovacuum_max_parallel_workers = 4
+maintenance_work_mem = 512MB
+```
+
+```sql
+-- Per-table for your largest tables
+ALTER TABLE events SET (autovacuum_parallel_workers = 6);
+ALTER TABLE audit_log SET (autovacuum_parallel_workers = 4);
+```
+
+## Relationship to Manual VACUUM PARALLEL
+
+The existing `VACUUM (PARALLEL N)` syntax for manual vacuums still works and is controlled by `max_parallel_maintenance_workers`. The new `autovacuum_max_parallel_workers` parameter only affects autovacuum.
+
+```sql
+-- Manual parallel vacuum (existing feature)
+VACUUM (PARALLEL 4) orders;
+
+-- Autovacuum parallel workers (new in PG 19)
+ALTER SYSTEM SET autovacuum_max_parallel_workers = 4;
+```
+
+Both share workers from the `max_parallel_workers` pool.
+
+## Summary
+
+Parallel autovacuum in PostgreSQL 19 addresses one of the biggest pain points with large, heavily-indexed tables: slow index vacuuming. By processing multiple indexes simultaneously, vacuum operations that previously took hours on large tables can complete in a fraction of the time. The feature is disabled by default, so you must explicitly enable it after upgrading.
+
+## References
+
+- [Commit `1ff3180c`: Allow autovacuum to use parallel vacuum workers](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=1ff3180c)
+- [PostgreSQL devel docs: Routine Vacuuming](https://www.postgresql.org/docs/devel/routine-vacuuming.html)
+- [PostgreSQL devel docs: autovacuum_max_parallel_workers](https://www.postgresql.org/docs/devel/runtime-config-autovacuum.html)

--- a/content/postgresql/postgresql-19/pg-plan-advice.md
+++ b/content/postgresql/postgresql-19/pg-plan-advice.md
@@ -1,0 +1,242 @@
+---
+title: 'PostgreSQL 19 pg_plan_advice'
+page_title: 'PostgreSQL 19 pg_plan_advice - Query Plan Hints for PostgreSQL'
+page_description: 'Learn how to use PostgreSQL 19 pg_plan_advice to stabilize query plans, override planner decisions, and diagnose performance issues with plan hints.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 Temporal Data Operations'
+  slug: 'postgresql-19/temporal-data-operations'
+nextLink:
+  title: 'PostgreSQL 19 REPACK Command'
+  slug: 'postgresql-19/repack-command'
+---
+
+**Summary**: PostgreSQL 19 introduces `pg_plan_advice`, a contrib module that brings query plan hints to PostgreSQL. Unlike Oracle or MySQL hints embedded in SQL comments, pg_plan_advice uses a GUC setting and an `EXPLAIN (PLAN_ADVICE)` workflow to generate, apply, and validate plan advice externally from query text.
+
+## Introduction to pg_plan_advice
+
+PostgreSQL has historically avoided query plan hints. The community position was that hints create maintenance burdens, break on upgrades, discourage root-cause investigation, and reduce the number of optimizer bug reports. If the planner makes a bad choice, the right fix is better statistics or a planner improvement, not a hint.
+
+That position has softened. Sometimes you need to lock in a known-good plan for a critical query while you investigate a regression. Sometimes the planner's cost estimates are wrong and you know it. Sometimes you are running a workload where a specific join strategy is always correct regardless of statistics.
+
+`pg_plan_advice` addresses these scenarios while avoiding the worst problems of traditional hint systems. Advice lives outside the query text (in a GUC setting), it is generated from actual plans rather than hand-written, and a feedback system tells you exactly which hints were honored and which were ignored.
+
+## Installation
+
+`pg_plan_advice` ships as a contrib module. No `CREATE EXTENSION` is needed - you load it as a shared library:
+
+```sql
+-- For the current session only
+LOAD 'pg_plan_advice';
+
+-- Or permanently in postgresql.conf
+-- shared_preload_libraries = 'pg_plan_advice'
+```
+
+You can also use `session_preload_libraries` for per-session loading without a server restart.
+
+## The Generate-Then-Replay Workflow
+
+The typical workflow for pg_plan_advice has two steps: generate advice from a plan you want to keep, then feed that advice back to lock the plan.
+
+### Step 1: Generate Advice
+
+Use `EXPLAIN (PLAN_ADVICE)` to get the planner's current choices expressed as advice strings:
+
+```sql
+EXPLAIN (COSTS OFF, PLAN_ADVICE)
+SELECT o.*, c.name
+FROM orders o
+JOIN customers c ON o.customer_id = c.id
+WHERE o.total > 1000;
+```
+
+The output includes the normal plan tree plus a generated advice string:
+
+```
+ Hash Join
+   Hash Cond: (o.customer_id = c.id)
+   ->  Seq Scan on orders o
+         Filter: (total > 1000)
+   ->  Hash
+         ->  Seq Scan on customers c
+ Generated Plan Advice:
+   JOIN_ORDER(o c)  HASH_JOIN(c)  SEQ_SCAN(o c)  NO_GATHER(o c)
+```
+
+### Step 2: Apply Advice
+
+Set the advice string in the GUC to lock this plan:
+
+```sql
+SET pg_plan_advice.advice = 'JOIN_ORDER(o c) HASH_JOIN(c) SEQ_SCAN(o c)';
+```
+
+Now every execution of this query (or any query with matching aliases) will use the same plan regardless of changes to statistics or data distribution.
+
+## Available Hint Types
+
+pg_plan_advice supports hints across several categories:
+
+### Scan Method Hints
+
+Control how individual tables are accessed:
+
+```sql
+-- Force a sequential scan
+SET pg_plan_advice.advice = 'SEQ_SCAN(orders)';
+
+-- Force a specific index
+SET pg_plan_advice.advice = 'INDEX_SCAN(orders orders_customer_id_idx)';
+
+-- Force index-only scan
+SET pg_plan_advice.advice = 'INDEX_ONLY_SCAN(orders orders_covering_idx)';
+
+-- Force bitmap scan
+SET pg_plan_advice.advice = 'BITMAP_HEAP_SCAN(orders)';
+```
+
+### Join Method Hints
+
+Control which join algorithm is used:
+
+```sql
+-- Force hash join
+SET pg_plan_advice.advice = 'HASH_JOIN(customers)';
+
+-- Force merge join
+SET pg_plan_advice.advice = 'MERGE_JOIN_PLAIN(customers)';
+
+-- Force nested loop with memoize
+SET pg_plan_advice.advice = 'NESTED_LOOP_MEMOIZE(customers)';
+```
+
+### Join Order Hints
+
+Control the order in which tables are joined:
+
+```sql
+-- Constrained order: must join in this exact sequence
+SET pg_plan_advice.advice = 'JOIN_ORDER(orders customers products)';
+
+-- Unconstrained order (use braces): join these tables together, order flexible
+SET pg_plan_advice.advice = 'JOIN_ORDER({orders customers} products)';
+```
+
+### Parallel Execution Hints
+
+Control whether parallel workers are used:
+
+```sql
+SET pg_plan_advice.advice = 'GATHER(orders)';        -- Force parallel
+SET pg_plan_advice.advice = 'NO_GATHER(orders)';     -- Prevent parallel
+SET pg_plan_advice.advice = 'GATHER_MERGE(orders)';  -- Force gather merge
+```
+
+## Feedback and Validation
+
+One of the key design decisions in pg_plan_advice is the feedback system. When you apply advice, EXPLAIN tells you whether each hint was actually used:
+
+```sql
+SET pg_plan_advice.advice = 'HASH_JOIN(c) INDEX_SCAN(o orders_total_idx)';
+SET pg_plan_advice.feedback_warnings = on;
+
+EXPLAIN (COSTS OFF)
+SELECT o.*, c.name
+FROM orders o
+JOIN customers c ON o.customer_id = c.id
+WHERE o.total > 1000;
+```
+
+Each hint in the output is annotated with one of:
+
+- **matched**: The hint was applied as requested
+- **partially matched**: Some aspects of the hint were applied
+- **not matched**: The hint could not be applied, with a reason:
+  - `inapplicable`: The hint does not apply to this query
+  - `conflicting`: Multiple hints conflict with each other
+  - `failed`: The planner could not produce a plan with this hint
+
+This feedback loop is what separates pg_plan_advice from traditional hint systems. You know immediately whether your advice is doing what you intended.
+
+## Practical examples
+
+Two common scenarios where `pg_plan_advice` earns its keep: locking in a known-good plan for a critical query, and forcing a better plan when the optimizer's estimates are off.
+
+### Stabilizing a critical query
+
+After a statistics update causes a query plan regression:
+
+```sql
+-- 1. Get the good plan's advice before the regression
+EXPLAIN (PLAN_ADVICE, COSTS OFF)
+SELECT * FROM transactions t
+JOIN accounts a ON t.account_id = a.id
+WHERE t.created_at > now() - interval '24 hours';
+
+-- Generated Plan Advice:
+--   JOIN_ORDER(t a) NESTED_LOOP_PLAIN(a) INDEX_SCAN(t transactions_created_at_idx)
+
+-- 2. Lock this plan
+SET pg_plan_advice.advice =
+  'JOIN_ORDER(t a) NESTED_LOOP_PLAIN(a) INDEX_SCAN(t transactions_created_at_idx)';
+```
+
+### Forcing an Index Scan
+
+When you know the planner's row estimate is wrong:
+
+```sql
+-- Planner thinks seq scan is cheaper, but you know the selectivity is low
+SET pg_plan_advice.advice = 'INDEX_SCAN(events events_type_idx)';
+
+SELECT * FROM events WHERE event_type = 'critical_alert';
+```
+
+### Per-Session Advice
+
+Advice is set via a GUC, so you can scope it to specific sessions or connections:
+
+```sql
+-- In your application's connection setup
+SET pg_plan_advice.advice = 'HASH_JOIN(c) INDEX_SCAN(o orders_pkey)';
+
+-- All queries in this session get the advice
+-- Other sessions are unaffected
+```
+
+## When Not to Use Plan Advice
+
+pg_plan_advice is a diagnostic and stabilization tool, not a permanent solution for every slow query. Consider these guidelines:
+
+**Use plan advice when:**
+
+- A plan regression needs immediate stabilization while you investigate
+- You have a critical query where the optimal plan is known and stable
+- You are debugging planner behavior and need to test specific strategies
+
+**Prefer other approaches when:**
+
+- Statistics are stale (run `ANALYZE` instead)
+- Indexes are missing (create the right index)
+- The query itself can be rewritten for better plans
+- Data distribution changes frequently (advice prevents the planner from adapting)
+
+## Limitations
+
+- Cannot control aggregation strategy (sort vs hash agg)
+- Cannot control set operations (UNION, INTERSECT, EXCEPT)
+- Cannot force plans the planner refused to consider entirely
+- Advice applies by alias matching, so queries with different aliases need separate advice strings
+- `DO_NOT_SCAN` usually cannot fully remove a relation from the plan
+
+## Summary
+
+`pg_plan_advice` brings query plan hints to PostgreSQL in a way that addresses the historical concerns about hint systems. By keeping advice external to query text, providing a generate-then-replay workflow, and including a feedback mechanism, it gives DBAs a practical tool for plan stabilization and debugging without the maintenance burden of embedded hints.
+
+## References
+
+- [Commit `5883ff30`: Add pg_plan_advice contrib module](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=5883ff30)
+- [PostgreSQL devel docs: pg_plan_advice](https://www.postgresql.org/docs/devel/pgplanadvice.html)

--- a/content/postgresql/postgresql-19/query-improvements.md
+++ b/content/postgresql/postgresql-19/query-improvements.md
@@ -1,0 +1,273 @@
+---
+title: 'PostgreSQL 19 Query Writing Improvements'
+page_title: 'PostgreSQL 19 Query Improvements - GROUP BY ALL, IGNORE NULLS, and Memoize Estimates'
+page_description: 'Learn about PostgreSQL 19 query writing improvements including GROUP BY ALL for automatic grouping, IGNORE NULLS for window functions, and Memoize plan estimates in EXPLAIN.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 JSON COPY TO'
+  slug: 'postgresql-19/json-copy-to'
+nextLink:
+  title: 'PostgreSQL 19 Schema Management'
+  slug: 'postgresql-19/schema-management'
+---
+
+**Summary**: PostgreSQL 19 adds `GROUP BY ALL` for automatic grouping, `IGNORE NULLS` and `RESPECT NULLS` options for window functions, and Memoize cost estimates in EXPLAIN output. These features reduce boilerplate, improve time-series queries, and make query plan analysis easier.
+
+## GROUP BY ALL
+
+Every SQL developer has written a `GROUP BY` clause and forgotten to update it after adding a column to the SELECT list. PostgreSQL 19 adds `GROUP BY ALL`, which automatically groups by every non-aggregate, non-window-function expression in the SELECT list.
+
+### Basic Usage
+
+The mechanical example shows the saving: the explicit `GROUP BY` lists every non-aggregate column from the SELECT list, while `GROUP BY ALL` infers them.
+
+```sql
+-- Before: manually list every grouped column
+SELECT department, region, fiscal_year, count(*), sum(revenue)
+FROM sales
+GROUP BY department, region, fiscal_year;
+
+-- PostgreSQL 19: GROUP BY ALL
+SELECT department, region, fiscal_year, count(*), sum(revenue)
+FROM sales
+GROUP BY ALL;
+```
+
+Both queries produce the same result. `GROUP BY ALL` identifies which SELECT expressions contain aggregate functions (`count`, `sum`) and groups by everything else.
+
+### How It Decides What to Group By
+
+`GROUP BY ALL` includes a SELECT expression in the group list if it does not contain:
+
+- An aggregate function (`count`, `sum`, `avg`, `min`, `max`, etc.)
+- A window function (anything with an `OVER` clause)
+
+Everything else goes into the implicit GROUP BY. This includes plain columns, expressions, CASE statements, and subqueries that do not contain aggregates.
+
+```sql
+-- Expressions and CASE work as expected
+SELECT
+    EXTRACT(YEAR FROM created_at) AS year,
+    CASE WHEN amount > 1000 THEN 'large' ELSE 'small' END AS size,
+    count(*) AS total,
+    avg(amount) AS avg_amount
+FROM orders
+GROUP BY ALL;
+-- Groups by: EXTRACT(YEAR FROM created_at), CASE expression
+```
+
+### Using with HAVING
+
+`GROUP BY ALL` works normally with HAVING:
+
+```sql
+SELECT department, count(*) AS headcount
+FROM employees
+GROUP BY ALL
+HAVING count(*) > 10;
+```
+
+### Using with ORDER BY
+
+`GROUP BY ALL` composes with `ORDER BY` exactly like an explicit grouping clause.
+
+```sql
+SELECT category, count(*) AS total
+FROM products
+GROUP BY ALL
+ORDER BY total DESC;
+```
+
+<Admonition type="note">
+`GROUP BY ALL` cannot be combined with ROLLUP, CUBE, or GROUPING SETS in the same clause. Use explicit GROUP BY when you need advanced grouping operations.
+</Admonition>
+
+### When to Use It
+
+`GROUP BY ALL` is best for ad-hoc queries, analytics, and reporting where you are frequently adding or removing columns from the SELECT list. For production application code where the query structure is stable, explicit `GROUP BY` is still clearer about intent.
+
+## IGNORE NULLS and RESPECT NULLS for Window Functions
+
+PostgreSQL 19 adds the SQL-standard `IGNORE NULLS` and `RESPECT NULLS` options to five window functions. This matters for time-series data, sensor readings, and any dataset with gaps.
+
+### Supported Functions
+
+| Function | What IGNORE NULLS does |
+|---|---|
+| `first_value()` | Returns the first non-null value in the window frame |
+| `last_value()` | Returns the last non-null value in the window frame |
+| `nth_value()` | Returns the Nth non-null value in the window frame |
+| `lag()` | Looks back, skipping null rows |
+| `lead()` | Looks forward, skipping null rows |
+
+`RESPECT NULLS` is the default and preserves existing behavior (nulls are included as normal values).
+
+### Syntax
+
+The null treatment clause goes between the function call and `OVER`:
+
+```sql
+last_value(reading) IGNORE NULLS OVER (
+    PARTITION BY sensor_id ORDER BY ts
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+)
+```
+
+### Sample Setup
+
+The window-function examples below use a small sensor-readings table with intentional null gaps so you can see how `IGNORE NULLS` fills them.
+
+```sql
+CREATE TABLE sensor_readings (
+    sensor_id INT,
+    ts TIMESTAMP,
+    temperature DECIMAL(5,2),
+    humidity DECIMAL(5,2)
+);
+
+INSERT INTO sensor_readings VALUES
+    (1, '2025-01-01 08:00', 22.5, 45.0),
+    (1, '2025-01-01 09:00', NULL, 46.2),
+    (1, '2025-01-01 10:00', NULL, NULL),
+    (1, '2025-01-01 11:00', 23.1, 44.8),
+    (1, '2025-01-01 12:00', NULL, 45.5),
+    (1, '2025-01-01 13:00', 24.0, NULL);
+```
+
+### Filling Gaps with last_value
+
+The most common use case: carry forward the last known reading through gaps:
+
+```sql
+SELECT
+    sensor_id,
+    ts,
+    temperature,
+    last_value(temperature) IGNORE NULLS OVER (
+        PARTITION BY sensor_id ORDER BY ts
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS last_known_temp
+FROM sensor_readings;
+```
+
+```
+ sensor_id |         ts          | temperature | last_known_temp
+-----------+---------------------+-------------+-----------------
+         1 | 2025-01-01 08:00:00 |       22.50 |           22.50
+         1 | 2025-01-01 09:00:00 |             |           22.50
+         1 | 2025-01-01 10:00:00 |             |           22.50
+         1 | 2025-01-01 11:00:00 |       23.10 |           23.10
+         1 | 2025-01-01 12:00:00 |             |           23.10
+         1 | 2025-01-01 13:00:00 |       24.00 |           24.00
+```
+
+Without `IGNORE NULLS`, the null readings at 09:00, 10:00, and 12:00 would return null for `last_value`, making gap-filling impossible without a CTE or subquery workaround.
+
+### Forward-Filling with lead
+
+Find the next known reading for each gap:
+
+```sql
+SELECT
+    sensor_id,
+    ts,
+    temperature,
+    lead(temperature) IGNORE NULLS OVER (
+        PARTITION BY sensor_id ORDER BY ts
+    ) AS next_known_temp
+FROM sensor_readings;
+```
+
+### Previous Workaround
+
+Before `IGNORE NULLS`, filling gaps required a self-join or a subquery:
+
+```sql
+-- The old way (PG18 and earlier)
+SELECT s.*,
+    (SELECT temperature FROM sensor_readings s2
+     WHERE s2.sensor_id = s.sensor_id
+       AND s2.ts <= s.ts
+       AND s2.temperature IS NOT NULL
+     ORDER BY s2.ts DESC LIMIT 1) AS last_known_temp
+FROM sensor_readings s;
+```
+
+`IGNORE NULLS` replaces this with a single, readable window function call.
+
+## Memoize Plan Estimates in EXPLAIN
+
+PostgreSQL 19 enhances EXPLAIN output for Memoize nodes by showing the planner's estimated cache performance. Combined with the broader [EXPLAIN improvements landed in PostgreSQL 18](/postgresql/postgresql-18/enhanced-explain), it becomes much easier to understand why the planner chose Memoize and whether its estimates are reasonable.
+
+### What Memoize Does
+
+Memoize (introduced in PostgreSQL 14) caches the results of inner-side scans in nested loop joins. When the same join key appears multiple times, Memoize returns the cached result instead of re-executing the inner scan.
+
+### New EXPLAIN Output
+
+A small two-table setup demonstrates the new annotations. Create users and orders with skewed cardinality so the planner picks Memoize for the nested-loop join.
+
+```sql
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);
+CREATE TABLE orders (id SERIAL PRIMARY KEY, user_id INT REFERENCES users(id));
+
+INSERT INTO users SELECT g, 'User ' || g FROM generate_series(1, 100) g;
+INSERT INTO orders SELECT g, (g % 5) + 1 FROM generate_series(1, 10000) g;
+ANALYZE users; ANALYZE orders;
+
+EXPLAIN SELECT u.name, o.id
+FROM orders o JOIN users u ON o.user_id = u.id;
+```
+
+The Memoize node now includes an `Estimates` line:
+
+```
+ Nested Loop  (cost=0.30..418.55 rows=10000 width=40)
+   ->  Seq Scan on orders o  (cost=0.00..155.00 rows=10000 width=8)
+   ->  Memoize  (cost=0.30..0.32 rows=1 width=36)
+         Cache Key: o.user_id
+         Cache Mode: logical
+         Estimates: capacity=6 distinct keys=5 lookups=10000 hit percent=99.95%
+         ->  Index Scan using users_pkey on users u  (cost=0.28..0.30 rows=1 width=36)
+               Index Cond: (id = o.user_id)
+```
+
+### Understanding the Estimates
+
+| Metric | Meaning |
+|---|---|
+| **capacity** | How many entries the cache can hold (based on `work_mem`) |
+| **distinct keys** | Estimated number of unique lookup keys |
+| **lookups** | Expected total number of cache lookups |
+| **hit percent** | Projected cache hit ratio |
+
+In the example above, the planner estimates 5 distinct user IDs across 10,000 orders, with a cache capacity of 6. Since all 5 keys fit in the cache, the estimated hit rate is 99.95%.
+
+### When to Investigate
+
+If you see unexpected Memoize behavior:
+
+- **Low hit percent with high distinct keys**: The cache may be too small. Increase `work_mem` to fit more entries.
+- **Capacity less than distinct keys**: Not all keys fit in the cache, causing evictions. Consider whether Memoize is actually helping.
+- **Distinct keys looks wrong**: The planner's `n_distinct` estimate may be off. Run `ANALYZE` or set manual statistics with `ALTER TABLE ... ALTER COLUMN ... SET (n_distinct = ...)`.
+
+Compare the estimates with actual values from `EXPLAIN (ANALYZE)`:
+
+```sql
+EXPLAIN (ANALYZE, COSTS OFF) SELECT u.name, o.id
+FROM orders o JOIN users u ON o.user_id = u.id;
+```
+
+The ANALYZE output shows actual hits, misses, evictions, and memory usage, which you can compare against the estimates to validate the planner's assumptions.
+
+## Summary
+
+These query improvements in PostgreSQL 19 address everyday friction points. `GROUP BY ALL` removes a common source of errors in analytical queries. `IGNORE NULLS` makes time-series gap-filling a one-liner instead of a subquery workaround. And the Memoize EXPLAIN estimates give you visibility into the planner's caching decisions without running the query first.
+
+## References
+
+- [Commit `ef38a4d9`: Add GROUP BY ALL](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=ef38a4d9)
+- [Commit `25a30bbd`: Add IGNORE NULLS/RESPECT NULLS option to Window functions](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=25a30bbd)
+- [PostgreSQL devel docs: Window Functions](https://www.postgresql.org/docs/devel/functions-window.html)

--- a/content/postgresql/postgresql-19/repack-command.md
+++ b/content/postgresql/postgresql-19/repack-command.md
@@ -1,0 +1,229 @@
+---
+title: 'PostgreSQL 19 REPACK Command'
+page_title: 'PostgreSQL 19 REPACK Command - Online Table Maintenance'
+page_description: 'Learn how to use PostgreSQL 19 REPACK command to reclaim space and reorder tables, replacing VACUUM FULL and CLUSTER with optional online (CONCURRENTLY) mode.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 pg_plan_advice'
+  slug: 'postgresql-19/pg-plan-advice'
+nextLink:
+  title: 'PostgreSQL 19 Logical Replication Improvements'
+  slug: 'postgresql-19/logical-replication-improvements'
+---
+
+**Summary**: PostgreSQL 19 introduces the `REPACK` command, which absorbs the functionality of both `VACUUM FULL` and `CLUSTER` into a single command. With the `CONCURRENTLY` option, you can repack tables online while they remain readable and writable.
+
+## Introduction to REPACK
+
+PostgreSQL has two existing commands for reclaiming bloated table space: `VACUUM FULL` rewrites the entire table to remove dead tuples and return space to the OS, and `CLUSTER` reorders rows by an index for better sequential scan performance. Both commands have the same problem: they hold an `ACCESS EXCLUSIVE` lock for the entire duration, blocking all reads and writes.
+
+For small tables, that is fine. For a 100GB table in production, it means downtime.
+
+PostgreSQL 19 adds `REPACK`, which combines both operations into one command and adds a `CONCURRENTLY` mode that holds the exclusive lock only briefly at the end. The table stays accessible during most of the operation.
+
+## Basic usage
+
+The simplest invocation rewrites a single table. Without `CONCURRENTLY`, `REPACK` takes an `ACCESS EXCLUSIVE` lock for the full rewrite.
+
+### Reclaim space
+
+Rewrite a table to eliminate dead tuples and return space to the OS:
+
+```sql
+REPACK employees;
+```
+
+This is equivalent to `VACUUM FULL employees` but uses the new REPACK infrastructure.
+
+### Reorder by Index
+
+Rewrite a table and physically reorder rows by an index:
+
+```sql
+REPACK employees USING INDEX employees_hire_date_idx;
+```
+
+This is equivalent to `CLUSTER employees USING employees_hire_date_idx`. Rows are stored on disk in index order, which improves performance for range scans on that column.
+
+### Repack All Tables
+
+Repack every table in the current database:
+
+```sql
+REPACK;
+```
+
+Or repack all tables that have a clustering index set:
+
+```sql
+REPACK USING INDEX;
+```
+
+## Online REPACK with CONCURRENTLY
+
+The standout feature is `CONCURRENTLY`, which lets you repack without blocking reads or writes:
+
+```sql
+REPACK (CONCURRENTLY) orders;
+REPACK (CONCURRENTLY) orders USING INDEX orders_created_at_idx;
+```
+
+### How CONCURRENTLY Works
+
+1. Creates a new copy of the table
+2. Uses logical decoding to capture changes made to the original table during the copy
+3. Applies captured changes to the new copy
+4. Briefly acquires an `ACCESS EXCLUSIVE` lock to swap the old and new files
+5. Drops the old table file
+
+The exclusive lock is only held during the final swap step, which is fast regardless of table size. During steps 1-3, the table remains fully accessible for reads and writes.
+
+### CONCURRENTLY Restrictions
+
+The `CONCURRENTLY` option cannot be used with:
+
+- Tables without a primary key or replica identity (needed for logical decoding)
+- Unlogged tables
+- Partitioned tables (the parent; individual partitions can be repacked)
+- System catalogs
+- Inside a transaction block
+
+```sql
+-- This will fail
+BEGIN;
+REPACK (CONCURRENTLY) orders;  -- ERROR: REPACK CONCURRENTLY cannot run inside a transaction block
+COMMIT;
+```
+
+## Options
+
+REPACK supports several options that can be combined:
+
+```sql
+-- Verbose output showing progress
+REPACK (VERBOSE) employees;
+
+-- Run ANALYZE after repacking for fresh statistics
+REPACK (ANALYZE) employees;
+
+-- Combine options
+REPACK (CONCURRENTLY, ANALYZE, VERBOSE) orders USING INDEX orders_created_at_idx;
+```
+
+### Analyzing Specific Columns
+
+You can limit the post-REPACK ANALYZE to specific columns:
+
+```sql
+REPACK (ANALYZE) orders (customer_id, created_at);
+```
+
+## Monitoring Progress
+
+REPACK reports progress through the `pg_stat_progress_repack` system view:
+
+```sql
+SELECT pid, datname, relid::regclass AS table_name,
+       phase, heap_blks_total, heap_blks_scanned
+FROM pg_stat_progress_repack;
+```
+
+This view shows which phase the operation is in (scanning heap, rebuilding indexes, swapping files) and how far along it is.
+
+## REPACK vs VACUUM FULL vs CLUSTER
+
+| Feature | VACUUM FULL | CLUSTER | REPACK |
+|---|---|---|---|
+| Reclaims space | Yes | Yes | Yes |
+| Reorders by index | No | Yes | Yes (with USING INDEX) |
+| Online mode | No | No | Yes (CONCURRENTLY) |
+| Lock type | ACCESS EXCLUSIVE | ACCESS EXCLUSIVE | ACCESS EXCLUSIVE (brief with CONCURRENTLY) |
+| Single command for both | No | No | Yes |
+| Progress monitoring | pg_stat_progress_cluster | pg_stat_progress_cluster | pg_stat_progress_repack |
+
+## REPACK vs pg_repack Extension
+
+The `pg_repack` extension has provided online table repacking for years. PostgreSQL 19's built-in REPACK brings similar functionality into core:
+
+- **No extension required**: Works out of the box on any PostgreSQL 19 installation
+- **Officially supported**: Part of the core PostgreSQL distribution
+- **Unified command**: Combines VACUUM FULL and CLUSTER functionality
+- **Same general approach**: Both use logical decoding for online mode
+
+If you have been using pg_repack, the built-in REPACK provides the same capability without the extension dependency.
+
+## Practical examples
+
+Two common maintenance patterns where `REPACK` replaces a more awkward sequence of commands.
+
+### Reclaiming space after bulk deletes
+
+After deleting a large number of rows, `VACUUM` reclaims space within pages but does not shrink the table file. `REPACK` rewrites the table to its minimal size:
+
+```sql
+-- After a large purge
+DELETE FROM audit_logs WHERE created_at < now() - interval '1 year';
+
+-- VACUUM frees space within pages but doesn't shrink the file
+VACUUM audit_logs;
+
+-- REPACK rewrites the table, returning space to the OS
+REPACK (CONCURRENTLY, ANALYZE) audit_logs;
+```
+
+### Improving Range Scan Performance
+
+If your most common query pattern scans by date range, clustering the table by the date column stores related rows physically together:
+
+```sql
+-- Create the index if it doesn't exist
+CREATE INDEX IF NOT EXISTS orders_date_idx ON orders (created_at);
+
+-- Repack and cluster by date
+REPACK (CONCURRENTLY) orders USING INDEX orders_date_idx;
+```
+
+Sequential scans on `created_at` ranges will now read fewer pages because related rows are stored together on disk.
+
+### Maintenance Window Script
+
+For scheduled maintenance:
+
+```sql
+-- Repack the largest tables online
+REPACK (CONCURRENTLY, ANALYZE, VERBOSE) orders;
+REPACK (CONCURRENTLY, ANALYZE, VERBOSE) line_items;
+REPACK (CONCURRENTLY, ANALYZE, VERBOSE) events;
+```
+
+## Performance Considerations
+
+**Disk space**: REPACK needs free disk space equal to the table size plus all its index sizes. If sorting is required (USING INDEX), it may need up to double the table size temporarily.
+
+**Memory**: Set `maintenance_work_mem` high before repacking large tables. This speeds up the sort and index rebuild phases:
+
+```sql
+SET maintenance_work_mem = '1GB';
+REPACK (CONCURRENTLY) large_table USING INDEX large_table_pkey;
+```
+
+**Privileges**: Requires `MAINTAIN` privilege on the table (or table ownership).
+
+**Partitioned tables**: REPACK processes each partition individually. You cannot repack the parent table directly, but you can repack partitions:
+
+```sql
+REPACK (CONCURRENTLY) orders_2025_q1;
+REPACK (CONCURRENTLY) orders_2025_q2;
+```
+
+## Summary
+
+The `REPACK` command unifies `VACUUM FULL` and `CLUSTER` into a single command with the addition of an online `CONCURRENTLY` mode. For production databases where downtime is not acceptable, `REPACK (CONCURRENTLY)` is the first in-core way to reclaim space without taking the table offline. For routine bloat control, see also [parallel autovacuum](/postgresql/postgresql-19/parallel-autovacuum), which often removes the need to repack in the first place.
+
+## References
+
+- [Commit `ac58465e`: Introduce the REPACK command](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=ac58465e)
+- [PostgreSQL devel docs: REPACK](https://www.postgresql.org/docs/devel/sql-repack.html)
+- [PostgreSQL devel docs: pg_stat_progress_repack](https://www.postgresql.org/docs/devel/progress-reporting.html)

--- a/content/postgresql/postgresql-19/schema-management.md
+++ b/content/postgresql/postgresql-19/schema-management.md
@@ -1,0 +1,248 @@
+---
+title: 'PostgreSQL 19 Schema Management and Backup'
+page_title: 'PostgreSQL 19 pg_get_*_ddl() Functions and pg_dumpall Improvements'
+page_description: 'Learn how to use PostgreSQL 19 pg_get_database_ddl, pg_get_role_ddl, pg_get_tablespace_ddl functions and pg_dumpall non-text output formats for better schema management and backup workflows.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 Query Improvements'
+  slug: 'postgresql-19/query-improvements'
+nextLink:
+  title: 'PostgreSQL 19 Monitoring and Operations'
+  slug: 'postgresql-19/monitoring-operations'
+---
+
+**Summary**: PostgreSQL 19 adds `pg_get_database_ddl()`, `pg_get_role_ddl()`, and `pg_get_tablespace_ddl()` functions for programmatic DDL extraction, and extends `pg_dumpall` to support custom, directory, and tar output formats. Together, these features give you better tools for schema management, auditing, and backup workflows.
+
+## pg_get_*_ddl() Functions
+
+PostgreSQL has long provided `pg_get_tabledef()` and `pg_get_viewdef()` for extracting DDL of individual objects. But getting the DDL for databases, roles, and tablespaces required parsing `pg_dump` or `pg_dumpall` output, which is fragile and inconvenient.
+
+PostgreSQL 19 adds three new functions that return clean, executable DDL directly from SQL.
+
+### pg_get_database_ddl()
+
+Returns the CREATE DATABASE and ALTER DATABASE statements for a given database:
+
+```sql
+SELECT * FROM pg_get_database_ddl('myapp');
+```
+
+```
+                                        pg_get_database_ddl
+--------------------------------------------------------------------------------------------
+ CREATE DATABASE myapp WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE_PROVIDER = libc
+   LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';
+ ALTER DATABASE myapp OWNER TO app_admin;
+ ALTER DATABASE myapp SET timezone TO 'UTC';
+(3 rows)
+```
+
+Each row is a complete, executable SQL statement. The first row is the CREATE statement, and subsequent rows are ALTER statements for properties like owner, connection limit, and configuration settings.
+
+**Options:**
+
+Options are passed as alternating `name, value` text pairs after the database argument. Supported options: `pretty` (boolean), `owner` (boolean), `tablespace` (boolean).
+
+```sql
+-- Disable owner output
+SELECT * FROM pg_get_database_ddl('myapp', 'owner', 'false');
+
+-- Pretty-printed output
+SELECT * FROM pg_get_database_ddl('myapp', 'pretty', 'true');
+
+-- Combine multiple options
+SELECT * FROM pg_get_database_ddl('myapp', 'pretty', 'true', 'tablespace', 'false');
+```
+
+### pg_get_role_ddl()
+
+Returns the CREATE ROLE and related statements for a given role:
+
+```sql
+SELECT * FROM pg_get_role_ddl('app_user');
+```
+
+```
+                              pg_get_role_ddl
+---------------------------------------------------------------------------
+ CREATE ROLE app_user LOGIN CONNECTION LIMIT 100;
+ GRANT developer TO app_user;
+ GRANT readonly TO app_user;
+(3 rows)
+```
+
+The first row is the CREATE ROLE statement with all role attributes (LOGIN, SUPERUSER, CREATEDB, etc.). Subsequent rows include GRANT statements for role memberships.
+
+**Options:**
+
+Options are passed as alternating `name, value` text pairs after the role argument. Supported options: `pretty` (boolean) and `memberships` (boolean, defaults to true).
+
+```sql
+-- Omit GRANT statements for role memberships
+SELECT * FROM pg_get_role_ddl('app_user', 'memberships', 'false');
+
+-- Pretty-printed output
+SELECT * FROM pg_get_role_ddl('app_user', 'pretty', 'true');
+```
+
+<Admonition type="note">
+Passwords are never included in the output for security reasons. To migrate roles with passwords, use `pg_dumpall --roles-only`.
+</Admonition>
+
+### pg_get_tablespace_ddl()
+
+Returns the CREATE TABLESPACE and ALTER TABLESPACE statements:
+
+```sql
+SELECT * FROM pg_get_tablespace_ddl('fast_storage');
+```
+
+```
+                           pg_get_tablespace_ddl
+---------------------------------------------------------------------------
+ CREATE TABLESPACE fast_storage LOCATION '/mnt/nvme/pg_data';
+ ALTER TABLESPACE fast_storage OWNER TO postgres;
+ ALTER TABLESPACE fast_storage SET (seq_page_cost = 0.5, random_page_cost = 1.0);
+(3 rows)
+```
+
+### Practical Use Cases
+
+The DDL extraction functions plug naturally into auditing, migration tooling, and drift detection. The patterns below show one example of each.
+
+#### Schema auditing
+
+Compare the current state of roles across environments:
+
+```sql
+-- Export all role DDL for comparison
+SELECT r.rolname, d.ddl
+FROM pg_roles r
+CROSS JOIN LATERAL pg_get_role_ddl(r.rolname::regrole) AS d(ddl)
+WHERE r.rolname NOT LIKE 'pg_%'
+ORDER BY r.rolname;
+```
+
+#### Migration scripts
+
+Generate DDL for specific databases without running `pg_dump`:
+
+```sql
+-- Generate a migration script for a database
+\t on
+\o /tmp/recreate_myapp.sql
+SELECT * FROM pg_get_database_ddl('myapp', 'pretty', 'true');
+\o
+\t off
+```
+
+#### Configuration drift detection
+
+Store DDL snapshots and compare them over time:
+
+```sql
+-- Store current state
+CREATE TABLE ddl_snapshots (
+    captured_at TIMESTAMP DEFAULT now(),
+    object_type TEXT,
+    object_name TEXT,
+    ddl_line TEXT
+);
+
+INSERT INTO ddl_snapshots (object_type, object_name, ddl_line)
+SELECT 'database', 'myapp', ddl
+FROM pg_get_database_ddl('myapp') AS t(ddl);
+```
+
+## pg_dumpall Non-Text Output Formats
+
+`pg_dumpall` has historically only supported plain text output. If you wanted custom format (for selective restore with `pg_restore`) or directory format (for parallel dump/restore), you had to use `pg_dump` per-database and handle globals separately.
+
+PostgreSQL 19 adds support for custom, directory, and tar output formats to `pg_dumpall`.
+
+### Available Formats
+
+The new formats mirror the ones `pg_dump` already supports. Pick custom for a single compressed archive, directory for parallel dump and restore, and tar for portability with archive tooling.
+
+```bash
+# Custom format (single compressed file, supports pg_restore)
+pg_dumpall -Fc -f cluster_backup
+
+# Directory format (parallel dump/restore capable)
+pg_dumpall -Fd -f cluster_backup_dir
+
+# Tar format
+pg_dumpall -Ft -f cluster_backup.tar
+```
+
+### Output Structure
+
+The non-text formats produce a structured output containing:
+
+- `toc.glo` - Global objects (roles, tablespaces) in custom format
+- `map.dat` - Mapping between database OIDs and database names
+- `databases/` - A subdirectory with per-database archives, organized by OID
+
+### Selective Restore
+
+The main advantage of non-text formats is selective restore with `pg_restore`:
+
+```bash
+# Restore only global objects (roles, tablespaces)
+pg_restore --globals-only cluster_backup
+
+# Restore a specific database from the cluster backup
+pg_restore --dbname=myapp cluster_backup
+
+# List contents without restoring
+pg_restore --list cluster_backup
+```
+
+### Parallel Operations
+
+Directory format supports parallel dump and restore:
+
+```bash
+# Parallel dump
+pg_dumpall -Fd -j 4 -f cluster_backup_dir
+
+# Parallel restore
+pg_restore -j 4 -d postgres cluster_backup_dir
+```
+
+### Comparison to Previous Workflow
+
+Before PostgreSQL 19, a full cluster backup with selective restore required a multi-step process:
+
+```bash
+# Old approach: dump globals separately, then each database
+pg_dumpall --globals-only > globals.sql
+pg_dump -Fc myapp > myapp.dump
+pg_dump -Fc analytics > analytics.dump
+
+# Restore selectively
+psql -f globals.sql
+pg_restore -d myapp myapp.dump
+```
+
+Now it is a single command:
+
+```bash
+# New approach: one command, selective restore built in
+pg_dumpall -Fc -f cluster_backup
+pg_restore --globals-only cluster_backup
+pg_restore --dbname=myapp cluster_backup
+```
+
+## Summary
+
+The `pg_get_*_ddl()` functions and `pg_dumpall` improvements address a gap in PostgreSQL's schema management tooling. DDL extraction no longer requires parsing text output from `pg_dump`. Cluster-wide backups now support the same flexible formats that per-database backups have had for years.
+
+## References
+
+- [Commit `4881981f`: Add infrastructure for pg_get_*_ddl functions](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=4881981f)
+- [Commit `a4f774cf`: Add pg_get_database_ddl() function](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=a4f774cf)
+- [Commit `763aaa06`: Add non-text output formats to pg_dumpall](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=763aaa06)
+- [PostgreSQL devel docs: pg_dumpall](https://www.postgresql.org/docs/devel/app-pg-dumpall.html)

--- a/content/postgresql/postgresql-19/sql-pgq-graph-queries.md
+++ b/content/postgresql/postgresql-19/sql-pgq-graph-queries.md
@@ -1,0 +1,364 @@
+---
+title: 'PostgreSQL 19 SQL/PGQ Property Graph Queries'
+page_title: 'PostgreSQL 19 SQL/PGQ - Graph Queries on Existing Tables'
+page_description: 'Learn how to use PostgreSQL 19 SQL/PGQ to define property graphs over existing tables and query relationships with graph pattern matching, no migration or extensions required.'
+ogImage: ''
+updatedOn: '2026-04-15T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 New Features'
+  slug: 'postgresql-19-new-features'
+nextLink:
+  title: 'PostgreSQL 19 ON CONFLICT DO SELECT'
+  slug: 'postgresql-19/on-conflict-do-select'
+---
+
+**Summary**: PostgreSQL 19 adds SQL/PGQ (Property Graph Queries) based on the SQL:2023 standard. You can define graph structures over your existing relational tables and query them with pattern matching syntax - no new storage engine, no extensions, no data migration.
+
+## Introduction to SQL/PGQ
+
+Graph databases like Neo4j have a clear advantage when querying relationships: "find friends of friends" or "detect circular dependencies" reads naturally in a graph query language. But running a separate graph database alongside PostgreSQL means data duplication, sync complexity, and another system to manage.
+
+PostgreSQL 19 brings graph query capabilities directly into SQL with the SQL/PGQ standard (ISO/IEC 9075-16:2023). The key design decision: property graphs are defined as views over existing relational tables. Your data stays where it is. You just tell PostgreSQL which tables represent nodes and which represent edges.
+
+## Defining a Property Graph
+
+A property graph has two components: vertex tables (nodes) and edge tables (relationships). You create a graph definition that maps these to your existing tables.
+
+### Sample Tables
+
+The examples in this guide use a small social-network schema with users, posts, follows, and likes. Create the tables and seed them with a few rows so you have something to query against.
+
+```sql
+-- These are regular PostgreSQL tables
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT,
+    joined_at DATE DEFAULT CURRENT_DATE
+);
+
+CREATE TABLE follows (
+    id SERIAL PRIMARY KEY,
+    follower_id INT NOT NULL REFERENCES users(id),
+    followed_id INT NOT NULL REFERENCES users(id),
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE posts (
+    id SERIAL PRIMARY KEY,
+    author_id INT NOT NULL REFERENCES users(id),
+    title TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE likes (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL REFERENCES users(id),
+    post_id INT NOT NULL REFERENCES posts(id),
+    created_at TIMESTAMP DEFAULT now()
+);
+
+-- Insert some data
+INSERT INTO users (name, email) VALUES
+    ('Alice', 'alice@example.com'),
+    ('Bob', 'bob@example.com'),
+    ('Charlie', 'charlie@example.com'),
+    ('Diana', 'diana@example.com');
+
+INSERT INTO follows (follower_id, followed_id) VALUES
+    (1, 2), (1, 3), (2, 3), (3, 4), (4, 1);
+
+INSERT INTO posts (author_id, title) VALUES
+    (1, 'Getting Started with PostgreSQL'),
+    (2, 'Graph Queries in SQL'),
+    (3, 'Why I Switched from Neo4j');
+
+INSERT INTO likes (user_id, post_id) VALUES
+    (2, 1), (3, 1), (4, 2), (1, 3), (2, 3);
+```
+
+### Creating the Graph
+
+The graph definition maps each table to a node or edge label. Vertex tables become nodes; edge tables declare which columns reference the source and destination vertices.
+
+```sql
+CREATE PROPERTY GRAPH social_graph
+  VERTEX TABLES (
+    users LABEL person
+      PROPERTIES (id, name, email, joined_at),
+    posts LABEL post
+      PROPERTIES (id, title, created_at)
+  )
+  EDGE TABLES (
+    follows
+      SOURCE KEY (follower_id) REFERENCES users (id)
+      DESTINATION KEY (followed_id) REFERENCES users (id)
+      LABEL follows
+      PROPERTIES (created_at),
+    likes
+      SOURCE KEY (user_id) REFERENCES users (id)
+      DESTINATION KEY (post_id) REFERENCES posts (id)
+      LABEL liked
+      PROPERTIES (created_at)
+  );
+```
+
+This does not copy any data. It creates a graph definition (similar to a view) that PostgreSQL uses to translate graph queries into relational operations on your existing tables.
+
+## Querying with GRAPH_TABLE and MATCH
+
+The `GRAPH_TABLE` function takes a graph name and a `MATCH` pattern, and returns a result set:
+
+### Find Who Alice Follows
+
+A single-hop traversal: starting from Alice, follow outgoing `follows` edges and project the destination user's name.
+
+```sql
+SELECT * FROM GRAPH_TABLE (social_graph
+    MATCH (a IS person WHERE a.name = 'Alice')
+          -[f IS follows]->(b IS person)
+    COLUMNS (b.name AS followed_name)
+);
+```
+
+```
+ followed_name
+---------------
+ Bob
+ Charlie
+```
+
+The arrow syntax `-[f IS follows]->` means a directed edge of type `follows`. The `(a IS person)` matches nodes with the `person` label.
+
+### Find Friends of Friends
+
+Chain two `follows` edges in the pattern to get a two-hop traversal. The `b` and `c` variables are bound to the intermediate and final vertices and projected as named columns.
+
+```sql
+SELECT * FROM GRAPH_TABLE (social_graph
+    MATCH (a IS person WHERE a.name = 'Alice')
+          -[IS follows]->(b IS person)
+          -[IS follows]->(c IS person)
+    COLUMNS (
+        b.name AS friend,
+        c.name AS friend_of_friend
+    )
+);
+```
+
+```
+ friend  | friend_of_friend
+---------+------------------
+ Bob     | Charlie
+ Charlie | Diana
+```
+
+Multi-hop patterns are expressed by chaining edges. Each arrow represents one hop.
+
+### Find Who Liked Alice's Posts
+
+Combine an incoming edge with an outgoing edge. The pattern reaches Alice's posts by following her `liked` edges outward, then matches anyone with an inbound `liked` edge to those posts.
+
+```sql
+SELECT * FROM GRAPH_TABLE (social_graph
+    MATCH (author IS person WHERE author.name = 'Alice')
+          <-[IS liked]-(liker IS person)
+          ,
+          (author)-[wrote IS liked]->(p IS post)
+    COLUMNS (
+        liker.name AS liked_by,
+        p.title AS post_title
+    )
+);
+```
+
+The `<-[IS liked]-` syntax reverses the edge direction, matching incoming relationships.
+
+### Combining Graph Queries with Regular SQL
+
+Since `GRAPH_TABLE` returns a regular result set, you can use it anywhere you would use a subquery or table:
+
+```sql
+-- Find users followed by more than 2 people
+SELECT followed_name, count(*) AS follower_count
+FROM GRAPH_TABLE (social_graph
+    MATCH (a IS person)-[IS follows]->(b IS person)
+    COLUMNS (b.name AS followed_name)
+)
+GROUP BY followed_name
+HAVING count(*) > 1
+ORDER BY follower_count DESC;
+```
+
+This is one of the key advantages over a separate graph database: graph queries compose naturally with aggregation, window functions, CTEs, and everything else in SQL.
+
+## How It Works Under the Hood
+
+When you run a `GRAPH_TABLE` query, PostgreSQL's rewriter translates the graph pattern into standard relational operations (joins, filters, projections) on the underlying tables. The execution plan is a normal PostgreSQL plan - the optimizer can use indexes, parallel queries, and all the usual strategies.
+
+You can verify this with `EXPLAIN`:
+
+```sql
+EXPLAIN SELECT * FROM GRAPH_TABLE (social_graph
+    MATCH (a IS person WHERE a.name = 'Alice')
+          -[IS follows]->(b IS person)
+    COLUMNS (b.name AS followed_name)
+);
+```
+
+The plan will show joins between the `users` and `follows` tables, using whatever indexes are available. There is no special graph execution engine.
+
+## Managing property graphs
+
+Property graphs are schema objects like views. They can be listed, altered, and dropped with standard commands.
+
+### Listing graphs
+
+Use the `\dG` meta-command in psql, or query the dedicated property-graph catalogs directly when you need scriptable output.
+
+```sql
+-- In psql
+\dG
+
+-- The property graph metadata is split across several system catalogs.
+-- These are the ones you usually want to look at:
+SELECT * FROM pg_propgraph_element;       -- vertex + edge tables
+SELECT * FROM pg_propgraph_label;         -- labels
+SELECT * FROM pg_propgraph_label_property; -- labels → properties
+SELECT * FROM pg_propgraph_property;      -- property expressions
+```
+
+### Altering a Graph
+
+`ALTER PROPERTY GRAPH` lets you add, drop, or modify vertex and edge tables in place without recreating the graph.
+
+```sql
+-- Add a new edge type
+ALTER PROPERTY GRAPH social_graph
+  ADD EDGE TABLE messages
+    SOURCE KEY (sender_id) REFERENCES users (id)
+    DESTINATION KEY (receiver_id) REFERENCES users (id)
+    LABEL sent_message;
+```
+
+### Dropping a Graph
+
+`DROP PROPERTY GRAPH` removes only the graph definition itself.
+
+```sql
+DROP PROPERTY GRAPH social_graph;
+```
+
+Dropping a graph only removes the graph definition. The underlying tables are not affected.
+
+## Practical use cases
+
+A few patterns where a property graph view over existing tables makes for clearer queries than multi-level self joins.
+
+### Dependency tracking
+
+Model packages as vertices and a `depends_on` join table as an edge to walk transitive dependencies without recursive CTEs.
+
+```sql
+CREATE TABLE packages (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    version TEXT
+);
+
+CREATE TABLE depends_on (
+    id SERIAL PRIMARY KEY,
+    package_id INT REFERENCES packages(id),
+    dependency_id INT REFERENCES packages(id)
+);
+
+CREATE PROPERTY GRAPH dep_graph
+  VERTEX TABLES (packages LABEL pkg PROPERTIES (id, name, version))
+  EDGE TABLES (
+    depends_on
+      SOURCE KEY (package_id) REFERENCES packages(id)
+      DESTINATION KEY (dependency_id) REFERENCES packages(id)
+      LABEL depends
+  );
+
+-- Find direct dependencies
+SELECT * FROM GRAPH_TABLE (dep_graph
+    MATCH (a IS pkg WHERE a.name = 'my-app')
+          -[IS depends]->(b IS pkg)
+    COLUMNS (b.name AS dependency, b.version)
+);
+```
+
+### Organization Hierarchy
+
+Reporting relationships are a directed graph over a single employee table. A two-hop pattern surfaces employee, manager, and director in one query.
+
+```sql
+-- Find who reports to whom (2 levels)
+SELECT * FROM GRAPH_TABLE (org_graph
+    MATCH (emp IS employee)
+          -[IS reports_to]->(mgr IS employee)
+          -[IS reports_to]->(dir IS employee)
+    COLUMNS (
+        emp.name AS employee,
+        mgr.name AS manager,
+        dir.name AS director
+    )
+);
+```
+
+### Fraud Detection
+
+Shared-attribute traversals reveal accounts that share contact details with a known-bad account. A flagged-account-to-phone-to-other-account pattern uncovers connections that are tedious to express as joins.
+
+```sql
+-- Find accounts that share the same phone number as a flagged account
+SELECT * FROM GRAPH_TABLE (fraud_graph
+    MATCH (flagged IS account WHERE flagged.status = 'flagged')
+          -[IS uses]->(phone IS phone_number)
+          <-[IS uses]-(other IS account)
+    COLUMNS (
+        flagged.id AS flagged_account,
+        phone.number,
+        other.id AS connected_account
+    )
+);
+```
+
+## Current Limitations
+
+The initial SQL/PGQ implementation in PostgreSQL 19 has some intentional limitations:
+
+**No variable-length paths**: You cannot write patterns like `-[IS follows]->+` (one or more hops) or `-[IS follows]->{2,5}` (2 to 5 hops). Each hop must be explicitly written. This means recursive traversals (shortest path, transitive closure) still require recursive CTEs.
+
+**No quantified path patterns**: The `*`, `+`, and `{m,n}` quantifiers are planned for a follow-up patch but are not included in the initial release.
+
+**Fixed depth only**: Queries like "find all paths between A and B regardless of length" are not possible with SQL/PGQ alone in PostgreSQL 19. Use recursive CTEs for those.
+
+For fixed-depth relationship queries (friend-of-friend, 2-3 hop patterns, direct dependency lookups), SQL/PGQ works well today. Variable-length paths are expected in a future PostgreSQL release.
+
+## SQL/PGQ vs. Other Graph Solutions
+
+| | SQL/PGQ (PG 19) | Apache AGE | Neo4j |
+|---|---|---|---|
+| Language | SQL standard (ISO 2023) | Cypher via extension | Cypher |
+| Storage | Existing tables | Extension storage | Native graph DB |
+| Variable-length paths | Not yet | Yes | Yes |
+| Shortest path | Not yet | Limited | Yes |
+| Installation | Built-in | Extension required | Separate database |
+| Standards-based | Yes (SQL:2023) | No | No |
+| Indexes | Uses existing PG indexes | Own indexes | Own indexes |
+| Full SQL support | Yes (joins, CTEs, window functions) | Limited SQL interop | No SQL |
+
+The biggest advantage of SQL/PGQ: it works on your existing tables with your existing indexes. No data migration, no extension installation, no separate system to maintain.
+
+## Summary
+
+SQL/PGQ brings standards-based graph query capabilities to PostgreSQL without requiring data migration, extensions, or a separate database. The initial implementation covers fixed-depth pattern matching, which handles many common graph query use cases. Variable-length path support is expected in a future release.
+
+## References
+
+- [Commit `2f094e7a`: SQL Property Graph Queries (SQL/PGQ)](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=2f094e7a)
+- [PostgreSQL devel docs: CREATE PROPERTY GRAPH](https://www.postgresql.org/docs/devel/sql-create-property-graph.html)
+- [ISO/IEC 9075-16:2023 (SQL/PGQ)](https://www.iso.org/standard/79473.html)

--- a/content/postgresql/postgresql-19/temporal-data-operations.md
+++ b/content/postgresql/postgresql-19/temporal-data-operations.md
@@ -1,0 +1,247 @@
+---
+title: 'PostgreSQL 19 Temporal Data Operations'
+page_title: 'PostgreSQL 19 UPDATE/DELETE FOR PORTION OF - Temporal Data Operations'
+page_description: 'Learn how to use PostgreSQL 19 UPDATE and DELETE FOR PORTION OF to modify temporal data, automatically splitting rows to preserve history outside the targeted time range.'
+ogImage: ''
+updatedOn: '2026-04-14T00:00:00+00:00'
+enableTableOfContents: true
+previousLink:
+  title: 'PostgreSQL 19 ON CONFLICT DO SELECT'
+  slug: 'postgresql-19/on-conflict-do-select'
+nextLink:
+  title: 'PostgreSQL 19 pg_plan_advice'
+  slug: 'postgresql-19/pg-plan-advice'
+---
+
+**Summary**: PostgreSQL 19 adds `UPDATE ... FOR PORTION OF` and `DELETE ... FOR PORTION OF` to modify temporal data within a specific time range, automatically splitting rows to preserve the untouched portions. This completes the SQL:2011 temporal feature set that began with `WITHOUT OVERLAPS` in PostgreSQL 18.
+
+## Introduction to Temporal Data Operations
+
+PostgreSQL 18 introduced temporal PRIMARY KEY and UNIQUE constraints using [`WITHOUT OVERLAPS`](/postgresql/postgresql-18/temporal-constraints), ensuring that no two rows for the same entity could have overlapping time ranges. That solved the integrity side of temporal data. But modifying temporal data correctly - changing a value for just a portion of a time range while preserving the rest - still required application logic.
+
+PostgreSQL 19 adds the DML side with `FOR PORTION OF`. When you update or delete a row for a specific time range, PostgreSQL automatically splits the row. The targeted portion gets modified, and the untouched parts are preserved as new rows with the original values.
+
+This is the behavior that temporal databases need for booking systems, employee records, insurance policies, and any scenario where data has a validity period.
+
+## Sample Database Setup
+
+Let's create a product pricing table where prices have validity ranges:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE product_prices (
+    product_id INT NOT NULL,
+    valid_range TSTZRANGE NOT NULL DEFAULT tstzrange(now(), 'infinity', '[)'),
+    price DECIMAL(10,2) NOT NULL,
+    currency VARCHAR(3) DEFAULT 'USD',
+    PRIMARY KEY (product_id, valid_range WITHOUT OVERLAPS)
+);
+
+-- Insert some products with validity periods
+INSERT INTO product_prices (product_id, valid_range, price) VALUES
+    (1, tstzrange('2025-01-01', '2026-01-01', '[)'), 29.99),
+    (2, tstzrange('2025-01-01', '2026-01-01', '[)'), 49.99),
+    (3, tstzrange('2025-06-01', '2025-12-31', '[)'), 19.99);
+```
+
+The `WITHOUT OVERLAPS` constraint ensures that no two price entries for the same product can have overlapping validity periods.
+
+## Basic UPDATE FOR PORTION OF
+
+Suppose you want to increase the price of product 1, but only for Q3 2025. The rest of the year should keep the original price:
+
+```sql
+UPDATE product_prices
+FOR PORTION OF valid_range FROM '2025-07-01' TO '2025-10-01'
+SET price = 34.99
+WHERE product_id = 1;
+```
+
+PostgreSQL automatically splits the original row into three:
+
+```sql
+SELECT product_id, valid_range, price FROM product_prices
+WHERE product_id = 1
+ORDER BY valid_range;
+```
+
+```
+ product_id |                    valid_range                     | price
+------------+----------------------------------------------------+-------
+          1 | ["2025-01-01 00:00:00+00","2025-07-01 00:00:00+00")| 29.99
+          1 | ["2025-07-01 00:00:00+00","2025-10-01 00:00:00+00")| 34.99
+          1 | ["2025-10-01 00:00:00+00","2026-01-01 00:00:00+00")| 29.99
+```
+
+The original row covered the full year at $29.99. After the update:
+
+- **Before the portion** (Jan-Jun): $29.99 preserved automatically
+- **The targeted portion** (Jul-Sep): updated to $34.99
+- **After the portion** (Oct-Dec): $29.99 preserved automatically
+
+You did not need to manually create the "leftover" rows. PostgreSQL handled the splitting.
+
+## How Row Splitting Works
+
+When PostgreSQL processes a `FOR PORTION OF` update, it follows these steps:
+
+1. Finds the matching row (product 1, whose `valid_range` overlaps with the targeted portion)
+2. Updates the matched row, setting its range to the targeted portion
+3. Automatically inserts leftover rows for any parts of the original range that fell outside the targeted portion
+
+A row can produce 0, 1, or 2 leftover rows depending on overlap:
+
+- **Portion covers the entire row**: No leftovers (the row is simply updated)
+- **Portion aligns with one end**: One leftover row
+- **Portion is in the middle**: Two leftover rows (before and after)
+
+## DELETE FOR PORTION OF
+
+The same splitting logic applies to deletes. To remove the pricing for product 2 during August 2025:
+
+```sql
+DELETE FROM product_prices
+FOR PORTION OF valid_range FROM '2025-08-01' TO '2025-09-01'
+WHERE product_id = 2;
+```
+
+```sql
+SELECT product_id, valid_range, price FROM product_prices
+WHERE product_id = 2
+ORDER BY valid_range;
+```
+
+```
+ product_id |                    valid_range                     | price
+------------+----------------------------------------------------+-------
+          2 | ["2025-01-01 00:00:00+00","2025-08-01 00:00:00+00")| 49.99
+          2 | ["2025-09-01 00:00:00+00","2026-01-01 00:00:00+00")| 49.99
+```
+
+The August portion is deleted. The periods before and after are preserved.
+
+## Using Unbounded Ranges
+
+You can use `NULL` for unbounded start or end values:
+
+```sql
+-- Update all prices for product 3 from September onward
+UPDATE product_prices
+FOR PORTION OF valid_range FROM '2025-09-01' TO NULL
+SET price = 24.99
+WHERE product_id = 3;
+```
+
+`NULL` as the end value means "no upper bound" - it extends to the end of the row's range.
+
+## Real-world use cases
+
+A few concrete patterns that previously needed helper queries or CTE tricks and now fit into a single `UPDATE` or `DELETE`.
+
+### Employee salary history
+
+A raise that takes effect mid-period needs to preserve the old salary for the months before and the new salary for the months after. `FOR PORTION OF` handles the split in one statement.
+
+```sql
+CREATE TABLE employee_salaries (
+    employee_id INT NOT NULL,
+    valid_range DATERANGE NOT NULL,
+    salary DECIMAL(10,2) NOT NULL,
+    department VARCHAR(50),
+    PRIMARY KEY (employee_id, valid_range WITHOUT OVERLAPS)
+);
+
+INSERT INTO employee_salaries VALUES
+    (101, daterange('2024-01-01', '2026-01-01'), 85000, 'Engineering');
+
+-- Promotion effective July 2025
+UPDATE employee_salaries
+FOR PORTION OF valid_range FROM '2025-07-01' TO '2026-01-01'
+SET salary = 95000
+WHERE employee_id = 101;
+```
+
+This creates a clean salary history: $85,000 through June 2025, $95,000 from July 2025 onward.
+
+### Hotel Room Bookings
+
+A guest who upgrades their rate for only part of their stay would normally require multiple inserts. With `FOR PORTION OF`, the existing booking row is split cleanly into the old-rate and new-rate intervals.
+
+```sql
+CREATE TABLE room_bookings (
+    room_id INT NOT NULL,
+    booked_range DATERANGE NOT NULL,
+    guest_name VARCHAR(100),
+    rate DECIMAL(8,2),
+    PRIMARY KEY (room_id, booked_range WITHOUT OVERLAPS)
+);
+
+INSERT INTO room_bookings VALUES
+    (201, daterange('2025-08-01', '2025-08-10'), 'Alice', 150.00);
+
+-- Alice upgrades her rate for the last 3 nights
+UPDATE room_bookings
+FOR PORTION OF booked_range FROM '2025-08-07' TO '2025-08-10'
+SET rate = 200.00
+WHERE room_id = 201 AND guest_name = 'Alice';
+```
+
+### Insurance Policy Adjustments
+
+Seasonal coverage changes apply to a slice of an annual policy. `FOR PORTION OF` raises coverage during hurricane season while leaving the rest of the year untouched.
+
+```sql
+CREATE TABLE policy_coverage (
+    policy_id INT NOT NULL,
+    coverage_period DATERANGE NOT NULL,
+    coverage_amount DECIMAL(12,2),
+    deductible DECIMAL(8,2),
+    PRIMARY KEY (policy_id, coverage_period WITHOUT OVERLAPS)
+);
+
+-- Temporarily increase coverage during hurricane season
+UPDATE policy_coverage
+FOR PORTION OF coverage_period FROM '2025-06-01' TO '2025-11-30'
+SET coverage_amount = coverage_amount * 1.5,
+    deductible = deductible * 0.8
+WHERE policy_id = 500;
+```
+
+## Important Behavior Details
+
+**RETURNING clause**: Only returns the updated or deleted rows, not the automatically inserted leftover rows. If you need to see all resulting rows, query the table afterward.
+
+**Row counts**: The count returned by UPDATE or DELETE reflects only the targeted rows, not the leftover inserts.
+
+**INSERT triggers**: Leftover rows trigger INSERT triggers even though the operation was an UPDATE or DELETE. This is because PostgreSQL implements leftovers as actual INSERT operations internally.
+
+**INSERT privilege**: Not required for leftover rows. Since leftovers preserve existing data rather than adding new information, the operation only requires UPDATE or DELETE privilege.
+
+**Range types**: `FOR PORTION OF` works with both range types (`int4range`, `daterange`, `tstzrange`, etc.) and multirange types. With multiranges, a single leftover row is inserted containing the remaining portions.
+
+## Performance Considerations
+
+Temporal operations with `FOR PORTION OF` are more expensive than regular updates because they involve additional INSERT operations for leftover rows. Each leftover row requires index maintenance and WAL writes.
+
+For bulk temporal modifications, consider processing in batches:
+
+```sql
+-- Update prices for many products in a time range
+UPDATE product_prices
+FOR PORTION OF valid_range FROM '2025-07-01' TO '2025-10-01'
+SET price = price * 1.10
+WHERE product_id BETWEEN 1 AND 100;
+```
+
+Ensure you have appropriate indexes on the range columns, which the `WITHOUT OVERLAPS` constraint in the PRIMARY KEY already provides via a GiST index.
+
+## Summary
+
+`UPDATE/DELETE FOR PORTION OF` completes PostgreSQL's SQL:2011 temporal data support. Combined with the `WITHOUT OVERLAPS` constraints from PostgreSQL 18, you now have a complete toolkit for temporal data: integrity constraints to prevent overlapping periods, and DML operations that correctly split rows when modifying a sub-period.
+
+## References
+
+- [Commit `8e72d914`: Add UPDATE/DELETE FOR PORTION OF](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=8e72d914)
+- [PostgreSQL devel docs: UPDATE](https://www.postgresql.org/docs/devel/sql-update.html)
+- [PostgreSQL devel docs: DELETE](https://www.postgresql.org/docs/devel/sql-delete.html)


### PR DESCRIPTION
Adding a PostgreSQL 19 series following the existing PG18 layout, eg. an overview page plus 12 feature guides covering `SQL`/`PGQ`, `ON CONFLICT DO SELECT`, `FOR PORTION OF`, `pg_plan_advice`, `REPACK`, parallel autovacuum, `JSON COPY TO`, query writing improvements, schema management, monitoring, logical replication, and breaking changes.

Examples have been run end-to-end against a master-built Postgres.
