### PR TITLE
fix(docs): correct getSession example to use data.user.email

### DIFF
--- a/content/docs/reference/javascript-sdk.md
+++ b/content/docs/reference/javascript-sdk.md
@@ -286,7 +286,7 @@ console.error('Sign out error:', error.message)
 const { data, error } = await client.auth.getSession()
 
 if (data.session) {
-console.log('User is logged in:', data.session.user.email)
+console.log('User is logged in:', data.user.email)
 } else {
 console.log('No active session')
 }


### PR DESCRIPTION
**Related Issue: https://github.com/neondatabase/neon/issues/12846**

## Summary

Fixes incorrect code example in the `getSession()` docs. The example was accessing `data.session.user.email`, but user is a top-level sibling of session on the returned data object, not nested inside it, as explained in https://github.com/neondatabase/neon/issues/12846#issuecomment-4331663708. Corrected to `data.user.email`.

## Tests

Verified update via local host.