### PR TITLE
fix: Change table name from actual_sales to sales_stats for NTILE() tutorial

### DIFF
--- a/content/postgresql/window-function/ntile-function.md
+++ b/content/postgresql/window-function/ntile-function.md
@@ -70,7 +70,7 @@ SELECT
 	name,
 	amount
 FROM
-	actual_sales
+	sales_stats
 ORDER BY
 	year, name;
 ```


### PR DESCRIPTION
This pull request makes a minor fix to the SQL example in the `content/postgresql/window-function/ntile-function.md` documentation. The change sets the correct table name used in the `SELECT` statement.

- Changed the table referenced in the SQL example from `actual_sales` to `sales_stats` in the documentation.