### PR TITLE
fix: Change table name from actual_sales to sales_stats in PERCENT_RANK

### DIFF
--- a/content/postgresql/window-function/percent_rank-function.md
+++ b/content/postgresql/window-function/percent_rank-function.md
@@ -68,7 +68,7 @@ SELECT
 	name,
 	amount
 FROM
-	actual_sales
+	sales_stats
 ORDER BY
 	year, name;
 ```


### PR DESCRIPTION
This pull request makes a minor fix to the SQL example in the `percent_rank-function.md` documentation. The change updates the table name in the `SELECT` statement from `actual_sales` to `sales_stats` for consistency or correctness.