### PR TITLE
fix(docs) : Fixing the environment variable & Vercel Deployment Build command

### DIFF
--- a/content/docs/guides/neon-managed-vercel-integration.md
+++ b/content/docs/guides/neon-managed-vercel-integration.md
@@ -156,7 +156,7 @@ This isolation allows you to test data and schema changes safely in each pull re
 1. Go to **Vercel Dashboard → Settings → Build and Deployment Settings**
 2. Enable **Override** and add your build commands, including migrations, for example:
    ```bash
-   npx prisma migrate deploy && npm run build
+   npx prisma generate && npx prisma migrate deploy && npm run build
    ```
 
 This ensures schema changes in your commits are applied to each preview deployment's database branch.

--- a/content/docs/guides/prisma-migrations.md
+++ b/content/docs/guides/prisma-migrations.md
@@ -47,8 +47,8 @@ Add both connection strings to your `.env` file. Get these from your Neon Consol
 # Pooled connection for your application (note the -pooler suffix)
 DATABASE_URL="postgresql://[user]:[password]@[endpoint]-pooler.[region].aws.neon.tech/[dbname]?sslmode=require"
 
-# Direct connection for Prisma CLI (migrations, introspection)
-DIRECT_URL="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
+# Direct(Unpooled) connection for Prisma CLI (migrations, introspection)
+DATABASE_URL_UNPOOLED="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
 ```
 
 <Admonition type="important">
@@ -66,7 +66,7 @@ import { defineConfig, env } from 'prisma/config'
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   datasource: {
-    url: env('DIRECT_URL'),
+    url: env('DATABASE_URL_UNPOOLED'),
   },
 })
 ```

--- a/content/docs/guides/prisma-migrations.md
+++ b/content/docs/guides/prisma-migrations.md
@@ -47,7 +47,7 @@ Add both connection strings to your `.env` file. Get these from your Neon Consol
 # Pooled connection for your application (note the -pooler suffix)
 DATABASE_URL="postgresql://[user]:[password]@[endpoint]-pooler.[region].aws.neon.tech/[dbname]?sslmode=require"
 
-# Direct(Unpooled) connection for Prisma CLI (migrations, introspection)
+# Direct (unpooled) connection for Prisma CLI (migrations, introspection)
 DATABASE_URL_UNPOOLED="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
 ```
 

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -39,7 +39,7 @@ npm install prisma tsx --save-dev
 From your Neon Console, click **Connect** and copy both connection strings:
 
 - **Pooled connection** (has `-pooler` in the hostname): for your application
-- **Direct connection**: for Prisma CLI commands (migrations, introspection)
+- **Direct(Unpooled) connection**: for Prisma CLI commands (migrations, introspection)
 
 ![Connection details modal](/docs/connect/connection_details.png)
 
@@ -49,12 +49,12 @@ Add them to your `.env` file:
 # Pooled connection for your application
 DATABASE_URL="postgresql://[user]:[password]@[endpoint]-pooler.[region].aws.neon.tech/[dbname]?sslmode=require"
 
-# Direct connection for Prisma CLI
-DIRECT_URL="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
+# Direct(Unpooled) connection for Prisma CLI
+DATABASE_URL_UNPOOLED="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
 ```
 
 <Admonition type="tip">
-The pooled connection has `-pooler` in the hostname. The direct connection does not. Both are available in your Neon Console.
+The pooled connection has `-pooler` in the hostname. The direct(Unpooled) connection does not. Both are available in your Neon Console.
 </Admonition>
 
 ### Step 3: Configure your Prisma schema
@@ -94,7 +94,7 @@ import { defineConfig, env } from 'prisma/config'
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   datasource: {
-    url: env('DIRECT_URL'),
+    url: env('DATABASE_URL_UNPOOLED'),
   },
 })
 ```
@@ -179,7 +179,7 @@ npx tsx src/main.ts
 Neon uses connection pooling to efficiently manage database connections in serverless environments:
 
 - **Pooled connection (`DATABASE_URL`)**: Your application connects through Neon's connection pooler, which is optimal for serverless functions that create many short-lived connections.
-- **Direct connection (`DIRECT_URL`)**: Prisma CLI commands like `prisma migrate` and `prisma db push` need a direct connection for schema operations.
+- **Direct(Unpooled) connection (`DATABASE_URL_UNPOOLED`)**: Prisma CLI commands like `prisma migrate` and `prisma db push` need a direct connection for schema operations.
 
 ## Advanced configuration
 
@@ -250,7 +250,7 @@ In Prisma 6 and earlier, you configure the connection directly in `schema.prisma
 datasource db {
   provider  = "postgresql"
   url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
+  directUrl = env("DATABASE_URL_UNPOOLED")
 }
 ```
 
@@ -275,7 +275,7 @@ The `directUrl` property is available in Prisma 4.10.0 and higher.
 - Import `PrismaClient` from `./generated/prisma` (or your configured `output` path), not from `@prisma/client`. The import path changed in Prisma 7.
 - Do not install `@neondatabase/serverless` or `ws` as separate packages. The `@prisma/adapter-neon` package bundles everything needed for the Neon connection.
 - In Prisma 7+, do not include a `url` property in the `prisma/schema.prisma` datasource block. The connection is configured via `prisma.config.ts` and the adapter.
-- You need both a pooled connection (`DATABASE_URL`) for your application and a direct connection (`DIRECT_URL`) for Prisma CLI commands.
+- You need both a pooled connection (`DATABASE_URL`) for your application and a direct(Unpooled) connection (`DATABASE_URL_UNPOOLED`) for Prisma CLI commands.
 - Call `prisma.$disconnect()` in a `.finally()` block when running standalone scripts. Omitting this can leave connections open.
 
 </details>

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -39,7 +39,7 @@ npm install prisma tsx --save-dev
 From your Neon Console, click **Connect** and copy both connection strings:
 
 - **Pooled connection** (has `-pooler` in the hostname): for your application
-- **Direct(Unpooled) connection**: for Prisma CLI commands (migrations, introspection)
+- **Direct (unpooled) connection**: for Prisma CLI commands (migrations, introspection)
 
 ![Connection details modal](/docs/connect/connection_details.png)
 
@@ -49,12 +49,12 @@ Add them to your `.env` file:
 # Pooled connection for your application
 DATABASE_URL="postgresql://[user]:[password]@[endpoint]-pooler.[region].aws.neon.tech/[dbname]?sslmode=require"
 
-# Direct(Unpooled) connection for Prisma CLI
+# Direct (unpooled) connection for Prisma CLI
 DATABASE_URL_UNPOOLED="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
 ```
 
 <Admonition type="tip">
-The pooled connection has `-pooler` in the hostname. The direct(Unpooled) connection does not. Both are available in your Neon Console.
+The pooled connection has `-pooler` in the hostname. The direct (unpooled) connection does not. Both are available in your Neon Console.
 </Admonition>
 
 ### Step 3: Configure your Prisma schema
@@ -179,7 +179,7 @@ npx tsx src/main.ts
 Neon uses connection pooling to efficiently manage database connections in serverless environments:
 
 - **Pooled connection (`DATABASE_URL`)**: Your application connects through Neon's connection pooler, which is optimal for serverless functions that create many short-lived connections.
-- **Direct(Unpooled) connection (`DATABASE_URL_UNPOOLED`)**: Prisma CLI commands like `prisma migrate` and `prisma db push` need a direct connection for schema operations.
+- **Direct (unpooled) connection (`DATABASE_URL_UNPOOLED`)**: Prisma CLI commands like `prisma migrate` and `prisma db push` need a direct connection for schema operations.
 
 ## Advanced configuration
 
@@ -275,7 +275,7 @@ The `directUrl` property is available in Prisma 4.10.0 and higher.
 - Import `PrismaClient` from `./generated/prisma` (or your configured `output` path), not from `@prisma/client`. The import path changed in Prisma 7.
 - Do not install `@neondatabase/serverless` or `ws` as separate packages. The `@prisma/adapter-neon` package bundles everything needed for the Neon connection.
 - In Prisma 7+, do not include a `url` property in the `prisma/schema.prisma` datasource block. The connection is configured via `prisma.config.ts` and the adapter.
-- You need both a pooled connection (`DATABASE_URL`) for your application and a direct(Unpooled) connection (`DATABASE_URL_UNPOOLED`) for Prisma CLI commands.
+- You need both a pooled connection (`DATABASE_URL`) for your application and a direct (unpooled) connection (`DATABASE_URL_UNPOOLED`) for Prisma CLI commands.
 - Call `prisma.$disconnect()` in a `.finally()` block when running standalone scripts. Omitting this can leave connections open.
 
 </details>

--- a/public/prompts/prisma-prompt.md
+++ b/public/prompts/prisma-prompt.md
@@ -53,7 +53,7 @@ DATABASE_URL="postgresql://[user]:[password]@[endpoint]-pooler.[region].aws.neon
 
 # Direct connection for Prisma CLI (migrations, db push, introspection)
 # Get this from Neon Console -> Connect -> Connection string (direct)
-DIRECT_URL="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
+DATABASE_URL_UNPOOLED="postgresql://[user]:[password]@[endpoint].[region].aws.neon.tech/[dbname]?sslmode=require"
 ```
 
 **Important:** The pooled URL has `-pooler` in the hostname. The direct URL does not.
@@ -69,7 +69,7 @@ import { defineConfig, env } from 'prisma/config'
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   datasource: {
-    url: env('DIRECT_URL'),
+    url: env('DATABASE_URL_UNPOOLED'),
   },
 })
 ```
@@ -162,7 +162,7 @@ main()
 
 Once the setup is complete:
 
-1.  Verify the user has correctly set both `DATABASE_URL` and `DIRECT_URL` in `.env`.
+1.  Verify the user has correctly set both `DATABASE_URL` and `DATABASE_URL_UNPOOLED` in `.env`.
 2.  Generate the Prisma Client:
     ```bash
     npx prisma generate
@@ -183,8 +183,8 @@ Once the setup is complete:
 
 Before suggesting code or making edits, ensure:
 - The `package.json` contains `prisma` (dev), `@prisma/client` (prod), `@prisma/adapter-neon` (prod), and `tsx` (dev).
-- The `.env` file has both `DATABASE_URL` (pooled) and `DIRECT_URL` (direct).
-- The `prisma.config.ts` file exists and points to `DIRECT_URL`.
+- The `.env` file has both `DATABASE_URL` (pooled) and `DATABASE_URL_UNPOOLED` (direct(Unpooled)).
+- The `prisma.config.ts` file exists and points to `DATABASE_URL_UNPOOLED`.
 - The `prisma/schema.prisma` does NOT have a `url` property in the datasource block.
 - The Prisma Client import uses the generated path: `./generated/prisma`.
 - The `PrismaNeon` adapter is instantiated with `{ connectionString: process.env.DATABASE_URL! }`.

--- a/public/prompts/prisma-prompt.md
+++ b/public/prompts/prisma-prompt.md
@@ -183,7 +183,7 @@ Once the setup is complete:
 
 Before suggesting code or making edits, ensure:
 - The `package.json` contains `prisma` (dev), `@prisma/client` (prod), `@prisma/adapter-neon` (prod), and `tsx` (dev).
-- The `.env` file has both `DATABASE_URL` (pooled) and `DATABASE_URL_UNPOOLED` (direct(Unpooled)).
+- The `.env` file has both `DATABASE_URL` (pooled) and `DATABASE_URL_UNPOOLED` (direct (unpooled)).
 - The `prisma.config.ts` file exists and points to `DATABASE_URL_UNPOOLED`.
 - The `prisma/schema.prisma` does NOT have a `url` property in the datasource block.
 - The Prisma Client import uses the generated path: `./generated/prisma`.


### PR DESCRIPTION
# There are two changes to the documentation:

## 1. Environment Variable name mismatch between code and Vercel
The neon-managed vercel integration automatically sets the environment variables in Vercel like this :
<img width="2264" height="600" alt="image" src="https://github.com/user-attachments/assets/fc7cb899-83e4-4b88-845d-1b89c32d7a1e" />

So the build fails because it is not able to detect the `DIRECT_URL` variable and hence fails to find datasource.url 
<img width="2232" height="1018" alt="brave_screenshot_vercel com (1)" src="https://github.com/user-attachments/assets/8475053c-3a75-4093-9586-510ffb9b25ff" />

Therefore it is safe to change it to `DATABASE_URL_UNPOOLED` since for other deployment platforms there would be no such auto env variable naming. And if there is, we might need to change from vercel part of the code to give correct variable names


## 2. Pre-requisite command for Vercel Build
Current command for build override (`npx prisma migrate deploy && npm run build`) fails because it is not able to detect the client from the generated schema folder because there is no schema generate without the` prisma generate `command.
<img width="2228" height="1106" alt="brave_screenshot_vercel com" src="https://github.com/user-attachments/assets/d3e4a54b-1b58-43fd-a00f-a4a1bf31c992" />

