### PR TITLE
docs: improve agent readiness with MCP/skill discovery, MD parity, 404 fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2467,6 +2467,12 @@ const defaultConfig = {
       beforeFiles: [
         { source: '/docs/:path*/llms.txt', destination: '/docs/:path*/llms.txt' },
         { source: '/docs/llms-full.txt', destination: '/docs/llms-full.txt' },
+        // Skill discovery under /docs/ — must be beforeFiles to avoid the docs/[...slug] catch-all
+        { source: '/docs/skill.md', destination: '/docs/ai/skills/neon-postgres/SKILL.md' },
+        {
+          source: '/docs/.well-known/agent-skills/neon-postgres/SKILL.md',
+          destination: '/docs/ai/skills/neon-postgres/SKILL.md',
+        },
       ],
       // afterFiles: runs after checking pages/public files but before dynamic routes
       // This ensures physical .md files are served first, with fallback to public/md/
@@ -2474,7 +2480,7 @@ const defaultConfig = {
         // Serve /llms.txt and /llms-full.txt from /docs/ (canonical location is public/docs/)
         { source: '/llms.txt', destination: '/docs/llms.txt' },
         { source: '/llms-full.txt', destination: '/docs/llms-full.txt' },
-        // Agent skill discovery (agentskills.io 0.2.0)
+        // Agent skill discovery (agentskills.io 0.2.0) — site root
         {
           source: '/.well-known/agent-skills/neon-postgres/SKILL.md',
           destination: '/docs/ai/skills/neon-postgres/SKILL.md',

--- a/next.config.js
+++ b/next.config.js
@@ -2474,6 +2474,13 @@ const defaultConfig = {
         // Serve /llms.txt and /llms-full.txt from /docs/ (canonical location is public/docs/)
         { source: '/llms.txt', destination: '/docs/llms.txt' },
         { source: '/llms-full.txt', destination: '/docs/llms-full.txt' },
+        // Agent skill discovery (agentskills.io 0.2.0)
+        {
+          source: '/.well-known/agent-skills/neon-postgres/SKILL.md',
+          destination: '/docs/ai/skills/neon-postgres/SKILL.md',
+        },
+        // /skill.md at site root for checkers that probe this path
+        { source: '/skill.md', destination: '/docs/ai/skills/neon-postgres/SKILL.md' },
         { source: '/docs/changelog/:path*.md', destination: '/md/changelog/:path*.md' },
         ...indexRewrites,
         ...contentRewrites,

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "neon-postgres",
+      "type": "skill-md",
+      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers getting started, local development with Neon, choosing a connection method, Neon features, authentication (@neondatabase/auth), PostgREST-style data API (@neondatabase/neon-js), Neon CLI, and Neon's Platform API/SDKs. Use for any Neon-related questions.",
+      "url": "/.well-known/agent-skills/neon-postgres/SKILL.md",
+      "digest": "sha256:cab13155940ef1cf73d1a313fb0aaa11b94470e0e47ea9846cbf08b2dcb70a68"
+    }
+  ]
+}

--- a/public/docs/.well-known/agent-skills/index.json
+++ b/public/docs/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "neon-postgres",
+      "type": "skill-md",
+      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers getting started, local development with Neon, choosing a connection method, Neon features, authentication (@neondatabase/auth), PostgREST-style data API (@neondatabase/neon-js), Neon CLI, and Neon's Platform API/SDKs. Use for any Neon-related questions.",
+      "url": "/docs/.well-known/agent-skills/neon-postgres/SKILL.md",
+      "digest": "sha256:cab13155940ef1cf73d1a313fb0aaa11b94470e0e47ea9846cbf08b2dcb70a68"
+    }
+  ]
+}

--- a/scripts/check-agent-endpoints.js
+++ b/scripts/check-agent-endpoints.js
@@ -120,6 +120,42 @@ const CHECKS = [
       return desc ? desc.slice(0, 80).trim() : '';
     },
   },
+  {
+    name: '/docs/skill.md — skill at /docs/ path (Mintlify-style checkers)',
+    path: '/docs/skill.md',
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      if (!body.includes('name: neon-postgres')) return 'skill name mismatch';
+      return null;
+    },
+    summarize(body) {
+      const nameLine = body.split('\n').find((l) => l.startsWith('name:'));
+      return nameLine ? nameLine.trim() : '';
+    },
+  },
+  {
+    name: '/docs/.well-known/agent-skills/index.json — skills discovery at /docs/ path',
+    path: '/docs/.well-known/agent-skills/index.json',
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      let json;
+      try {
+        json = JSON.parse(body);
+      } catch {
+        return 'response is not valid JSON';
+      }
+      if (!json.skills?.[0]?.name) return 'skills[0].name missing';
+      return null;
+    },
+    summarize(body) {
+      try {
+        const j = JSON.parse(body);
+        return `${j.skills.length} skill(s): ${j.skills.map((s) => s.name).join(', ')}`;
+      } catch {
+        return '';
+      }
+    },
+  },
 ];
 
 async function fetchCheck(url) {

--- a/scripts/check-agent-endpoints.js
+++ b/scripts/check-agent-endpoints.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+// QA tool for verifying agent-readiness endpoints against a live site.
+//
+// Simulates an AI agent arriving at neon.com and probing all agent-facing
+// discovery paths: MCP server descriptors, skill.md, and agent-skills index.
+//
+// Usage: node scripts/check-agent-endpoints.js [base-url]
+// Example: node scripts/check-agent-endpoints.js http://localhost:3000
+//          node scripts/check-agent-endpoints.js https://neon.com
+//
+// Exit codes:
+//   0 — all checks passed
+//   1 — one or more checks failed
+
+const BASE_URL = process.argv[2] || 'http://localhost:3000';
+
+const CHECKS = [
+  {
+    name: '/mcp — MCP server descriptor at site root',
+    path: '/mcp',
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      let json;
+      try {
+        json = JSON.parse(body);
+      } catch {
+        return 'response is not valid JSON';
+      }
+      if (!json.$schema) return 'missing $schema field';
+      if (!json.remotes?.[0]?.url) return 'missing remotes[0].url';
+      return null;
+    },
+    summarize(body) {
+      try {
+        const j = JSON.parse(body);
+        return `name=${j.name}  url=${j.remotes?.[0]?.url}`;
+      } catch {
+        return '';
+      }
+    },
+  },
+  {
+    name: '/docs/mcp — docs-scoped MCP descriptor',
+    path: '/docs/mcp',
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      let json;
+      try {
+        json = JSON.parse(body);
+      } catch {
+        return 'response is not valid JSON';
+      }
+      if (!json.$schema) return 'missing $schema field';
+      if (!json.remotes?.[0]?.url) return 'missing remotes[0].url';
+      return null;
+    },
+    summarize(body) {
+      try {
+        const j = JSON.parse(body);
+        return `name=${j.name}  url=${j.remotes?.[0]?.url}`;
+      } catch {
+        return '';
+      }
+    },
+  },
+  {
+    name: '/skill.md — product skill at site root',
+    path: '/skill.md',
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      if (!body.includes('name:')) return 'missing frontmatter name: field';
+      if (!body.includes('description:')) return 'missing frontmatter description: field';
+      return null;
+    },
+    summarize(body) {
+      const nameLine = body.split('\n').find((l) => l.startsWith('name:'));
+      return nameLine ? nameLine.trim() : '';
+    },
+  },
+  {
+    name: '/.well-known/agent-skills/index.json — skills discovery manifest',
+    path: '/.well-known/agent-skills/index.json',
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      let json;
+      try {
+        json = JSON.parse(body);
+      } catch {
+        return 'response is not valid JSON';
+      }
+      if (!json.$schema) return 'missing $schema field';
+      if (!Array.isArray(json.skills) || json.skills.length === 0)
+        return 'skills array is empty or missing';
+      const skill = json.skills[0];
+      if (!skill.name) return 'skills[0].name missing';
+      if (!skill.url) return 'skills[0].url missing';
+      if (!skill.digest) return 'skills[0].digest missing';
+      return null;
+    },
+    summarize(body) {
+      try {
+        const j = JSON.parse(body);
+        return `${j.skills.length} skill(s): ${j.skills.map((s) => s.name).join(', ')}`;
+      } catch {
+        return '';
+      }
+    },
+  },
+  {
+    name: '/.well-known/agent-skills/neon-postgres/SKILL.md — skill file resolves',
+    path: '/.well-known/agent-skills/neon-postgres/SKILL.md',
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      if (!body.includes('name: neon-postgres')) return 'skill name mismatch';
+      return null;
+    },
+    summarize(body) {
+      const desc = body.split('\n').find((l) => l.startsWith('description:'));
+      return desc ? desc.slice(0, 80).trim() : '';
+    },
+  },
+];
+
+async function fetchCheck(url) {
+  const res = await fetch(url);
+  const body = await res.text();
+  return { status: res.status, body };
+}
+
+async function run() {
+  console.log(`\nAgent endpoint check: ${BASE_URL}\n`);
+  console.log('Acting as an agent arriving at neon.com and probing discovery paths...\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const check of CHECKS) {
+    const url = `${BASE_URL}${check.path}`;
+    let status, body;
+    try {
+      ({ status, body } = await fetchCheck(url));
+    } catch (err) {
+      console.log(`  FAIL  ${check.name}`);
+      console.log(`        fetch error: ${err.message}\n`);
+      failed++;
+      continue;
+    }
+
+    const error = check.validate(status, body);
+    if (error) {
+      console.log(`  FAIL  ${check.name}`);
+      console.log(`        ${error}\n`);
+      failed++;
+    } else {
+      const summary = check.summarize(body);
+      console.log(`  PASS  ${check.name}`);
+      if (summary) console.log(`        ${summary}`);
+      console.log();
+      passed++;
+    }
+  }
+
+  console.log(`─────────────────────────────────────`);
+  console.log(`${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch((err) => {
+  console.error('Unexpected error:', err.message);
+  process.exit(1);
+});

--- a/src/app/(docs)/docs/[...slug]/page.jsx
+++ b/src/app/(docs)/docs/[...slug]/page.jsx
@@ -77,7 +77,7 @@ const DocPost = async (props) => {
   const flatSidebar = await getFlatSidebar(sidebar);
 
   const isDocsIndex = currentSlug === 'introduction';
-  const isChangelogIndex = !!currentSlug.match('changelog')?.length;
+  const isChangelogIndex = currentSlug === 'changelog' || currentSlug.startsWith('changelog/');
   const allChangelogPosts = await getAllChangelogs();
 
   const breadcrumbs = getBreadcrumbs(currentSlug, flatSidebar);

--- a/src/app/(docs)/docs/mcp/route.js
+++ b/src/app/(docs)/docs/mcp/route.js
@@ -1,0 +1,51 @@
+export const dynamic = 'force-static';
+
+export async function GET() {
+  return Response.json({
+    $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+    name: 'com.neon/mcp',
+    title: 'Neon',
+    description:
+      'Official Neon MCP server. Features list_docs_resources and get_doc_resource for reading Neon docs.',
+    repository: {
+      url: 'https://github.com/neondatabase/mcp-server-neon',
+      source: 'github',
+      subfolder: 'landing',
+    },
+    version: '1.0.0',
+    websiteUrl: 'https://neon.com/docs/ai/neon-mcp-server',
+    icons: [
+      {
+        src: 'https://neon.com/brand/neon-logo-light-color.svg',
+        mimeType: 'image/svg+xml',
+        sizes: ['any'],
+        theme: 'light',
+      },
+      {
+        src: 'https://neon.com/brand/neon-logo-dark-color.svg',
+        mimeType: 'image/svg+xml',
+        sizes: ['any'],
+        theme: 'dark',
+      },
+    ],
+    remotes: [
+      {
+        type: 'streamable-http',
+        url: 'https://mcp.neon.tech/mcp',
+        headers: [
+          {
+            name: 'Authorization',
+            description: 'Optional Bearer token with a Neon API key.',
+            isSecret: true,
+          },
+          {
+            name: 'x-read-only',
+            description: 'Optional header to enable read-only mode for tool filtering.',
+            format: 'boolean',
+            default: 'false',
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/src/app/(docs)/layout.jsx
+++ b/src/app/(docs)/layout.jsx
@@ -20,6 +20,10 @@ const NeonDocsLayout = async ({ children }) => {
       hasThemesSupport
     >
       <div className="flex flex-1 safe-paddings dark:bg-black-pure dark:text-white lg:flex-col">
+        <aside aria-label="Agent directive" className="sr-only">
+          Full Neon documentation index:{' '}
+          <a href="https://neon.com/docs/llms.txt">https://neon.com/docs/llms.txt</a>
+        </aside>
         <Container
           className="flex w-full flex-1 gap-x-24 pt-12 2xl:gap-x-8 xl:pt-9 lg:block sm:pt-7"
           size="1920"

--- a/src/app/mcp/route.js
+++ b/src/app/mcp/route.js
@@ -1,0 +1,50 @@
+export const dynamic = 'force-static';
+
+export async function GET() {
+  return Response.json({
+    $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+    name: 'com.neon/mcp',
+    title: 'Neon',
+    description: 'Official Neon MCP server for managing Neon projects and Postgres databases.',
+    repository: {
+      url: 'https://github.com/neondatabase/mcp-server-neon',
+      source: 'github',
+      subfolder: 'landing',
+    },
+    version: '1.0.0',
+    websiteUrl: 'https://neon.tech/docs/ai/neon-mcp-server',
+    icons: [
+      {
+        src: 'https://neon.com/brand/neon-logo-light-color.svg',
+        mimeType: 'image/svg+xml',
+        sizes: ['any'],
+        theme: 'light',
+      },
+      {
+        src: 'https://neon.com/brand/neon-logo-dark-color.svg',
+        mimeType: 'image/svg+xml',
+        sizes: ['any'],
+        theme: 'dark',
+      },
+    ],
+    remotes: [
+      {
+        type: 'streamable-http',
+        url: 'https://mcp.neon.tech/mcp',
+        headers: [
+          {
+            name: 'Authorization',
+            description: 'Optional Bearer token with a Neon API key.',
+            isSecret: true,
+          },
+          {
+            name: 'x-read-only',
+            description: 'Optional header to enable read-only mode for tool filtering.',
+            format: 'boolean',
+            default: 'false',
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/src/scripts/process-md-for-llms.js
+++ b/src/scripts/process-md-for-llms.js
@@ -21,7 +21,9 @@
  * - <a> with href/description -> markdown link
  * - <details>/<summary> -> preserved as HTML
  * - CTA -> blockquote with title, description, command, link
- * - CopyPrompt, NeedHelp, Comment -> removed (UI-only)
+ * - CopyPrompt -> description text (buttons/icons omitted)
+ * - RequestForm -> title + description (form controls omitted)
+ * - NeedHelp, Comment -> removed (UI-only)
  *
  * Dependencies: unified, remark-parse, remark-gfm, unist-util-visit, gray-matter, js-yaml (direct); remark-mdx and mdast-util-* (transitive). We pin the direct ones so version conflicts (e.g. remark-gfm v4 needing unified v11 while another dep had v10) don’t break the build.
  */
@@ -76,12 +78,10 @@ const SHARED_CONTENT_COMPONENTS = {
  * To add a new one, just add an entry here.
  */
 const IGNORED_COMPONENTS = [
-  'CopyPrompt', // UI copy button
   'NeedHelp', // UI help widget
   'Comment', // MDX comments
   'Video', // HTML5 video (no text content)
   'UserButton', // Auth UI element
-  'RequestForm', // Interactive form
   'Suspense', // React utility
   'SqlToRestConverter', // Interactive app
   'LogosSection', // Decorative logos
@@ -1074,7 +1074,7 @@ const componentHandlers = {
     };
   },
 
-  // CopyPrompt, NeedHelp -> registered via IGNORED_COMPONENTS below
+  // NeedHelp -> registered via IGNORED_COMPONENTS below
   /**
    * YoutubeIframe -> YouTube link
    */
@@ -1331,9 +1331,114 @@ const componentHandlers = {
       });
     }
 
-    if (paragraphs.length === 0) return null;
+    // Bare <CTA /> with no props falls back to the same defaults the React
+    // component renders (src/components/shared/doc-cta/doc-cta.jsx DEFAULT_DATA),
+    // so markdown and HTML stay in parity.
+    if (paragraphs.length === 0) {
+      const defaultTitle = 'Try it on Neon!';
+      const defaultDescription =
+        'Neon is Serverless Postgres built for the cloud. Explore Postgres features and functions in our user-friendly SQL editor. Sign up for a free account to get started.';
+      const defaultButtonText = 'Sign Up';
+      const defaultButtonUrl = 'https://console.neon.tech/signup';
+      return {
+        type: 'blockquote',
+        children: [
+          {
+            type: 'paragraph',
+            children: [{ type: 'strong', children: [{ type: 'text', value: defaultTitle }] }],
+          },
+          {
+            type: 'paragraph',
+            children: [{ type: 'text', value: defaultDescription }],
+          },
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'link',
+                url: defaultButtonUrl,
+                children: [{ type: 'text', value: defaultButtonText }],
+              },
+            ],
+          },
+        ],
+      };
+    }
 
     return { type: 'blockquote', children: paragraphs };
+  },
+
+  /**
+   * CopyPrompt -> emit the description text and a link to the prompt source.
+   * The copy button and icon are UI-only and are intentionally omitted.
+   */
+  CopyPrompt(node) {
+    const description = getAttr(node, 'description');
+    const src = getAttr(node, 'src');
+    const children = [];
+    if (description) {
+      children.push({ type: 'text', value: description });
+    }
+    if (src) {
+      if (description) children.push({ type: 'text', value: ' ' });
+      const absoluteSrc = src.startsWith('http') ? src : `${BASE_URL}${src}`;
+      children.push({
+        type: 'link',
+        url: absoluteSrc,
+        children: [{ type: 'text', value: 'View prompt' }],
+      });
+    }
+    if (children.length === 0) return null;
+    return { type: 'paragraph', children };
+  },
+
+  /**
+   * RequestForm -> emit actionable text so markdown stays in parity with HTML.
+   * Descriptions are rewritten to remove "select below" phrasing (no form exists
+   * in markdown) and replaced with links to support and Discord.
+   * The combobox / submit button are UI-only and are omitted.
+   */
+  RequestForm(node) {
+    const type = getAttr(node, 'type');
+    const FORM_INTROS = {
+      region: 'Looking for Neon in a different cloud provider or region?',
+      extension: 'Looking for a specific Postgres extension in Neon?',
+    };
+    const intro = type && FORM_INTROS[type];
+    if (!intro) return null;
+
+    const FORM_TITLES = {
+      region: 'Request a new Provider / Region',
+      extension: 'Request a new extension',
+    };
+
+    return {
+      type: 'blockquote',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'strong', children: [{ type: 'text', value: FORM_TITLES[type] }] }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: `${intro} Submit a request through ` },
+            {
+              type: 'link',
+              url: `${BASE_URL}/docs/introduction/support`,
+              children: [{ type: 'text', value: 'Neon support' }],
+            },
+            { type: 'text', value: ' or let us know in the ' },
+            {
+              type: 'link',
+              url: 'https://discord.gg/92vNTzKDGp',
+              children: [{ type: 'text', value: 'Neon Discord' }],
+            },
+            { type: 'text', value: '.' },
+          ],
+        },
+      ],
+    };
   },
 };
 

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -49,7 +49,7 @@ const CUSTOM_MARKDOWN_PATHS = {
 
 // Paths under content routes that are static files in public/ (not generated into public/md/).
 // The middleware should pass these through so Next.js serves them directly.
-const STATIC_DOC_PREFIXES = ['docs/ai/'];
+const STATIC_DOC_PREFIXES = ['docs/ai/skills/'];
 
 // Convert URL path to markdown file path
 // Example: /docs/introduction -> /md/docs/introduction.md (maps to public/md/)

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -45,11 +45,12 @@ export function isAIAgentRequest(request) {
 const CUSTOM_MARKDOWN_PATHS = {
   pricing: '/pricing.md', // Hand-written, served from public/pricing.md (no CONTENT_ROUTES entry)
   'docs/changelog': '/md/docs/changelog.md',
+  'docs/skill.md': '/docs/ai/skills/neon-postgres/SKILL.md',
 };
 
 // Paths under content routes that are static files in public/ (not generated into public/md/).
 // The middleware should pass these through so Next.js serves them directly.
-const STATIC_DOC_PREFIXES = ['docs/ai/skills/'];
+const STATIC_DOC_PREFIXES = ['docs/ai/skills/', 'docs/.well-known/'];
 
 // Convert URL path to markdown file path
 // Example: /docs/introduction -> /md/docs/introduction.md (maps to public/md/)


### PR DESCRIPTION
Improves AI agent discoverability of Neon docs and fixes two pre-existing afdocs failures.

**Agent discovery**

- Added `/mcp` and `/docs/mcp`: MCP Foundation-spec server descriptors pointing to `mcp.neon.tech`
- Added `/skill.md` and `/.well-known/agent-skills/`: agentskills.io 0.2.0 discovery for the `neon-postgres` skill
- Added `sr-only` llms.txt directive to every docs page (HTML agent signal)
- Narrowed a middleware exclusion so `/docs/ai/` pages now respond to `Accept: text/markdown`

**Bug fixes**

- Fixed changelog soft-404: slugs containing `"changelog"` (e.g. `changelog-nonexistent`) returned 200 instead of 404

**Markdown quality**

- `<CTA />` with no props now emits the default sign-up callout instead of nothing
- `<CopyPrompt>` now emits the description and a link to the prompt file
- `<RequestForm>` now emits actionable links to support/Discord instead of "select below"

**New tool**

- `scripts/check-agent-endpoints.js`: verifies these agent-facing endpoints; CI-friendly

## Test plan

- [x] `node scripts/check-agent-endpoints.js http://localhost:3000` passes all 5 checks
- [x] `/docs/changelog` returns 200; `/docs/changelog-nonexistent` returns 404
- [x] `curl -H "Accept: text/markdown" /docs/ai/agent-skills` returns `text/markdown`
- [x] `/docs/extensions/xml2.md` includes CTA callout
- [x] `/docs/guides/symfony.md` includes prompt description and `[View prompt]` link
- [x] `/docs/introduction/regions.md` includes region request blockquote with support/Discord links