### PR TITLE
docs: add unauthenticated docs MCP proxy at /docs/mcp

### DIFF
--- a/scripts/check-agent-endpoints.js
+++ b/scripts/check-agent-endpoints.js
@@ -41,7 +41,7 @@ const CHECKS = [
     },
   },
   {
-    name: '/docs/mcp — docs-scoped MCP descriptor',
+    name: '/docs/mcp — docs-scoped MCP descriptor (GET)',
     path: '/docs/mcp',
     validate(status, body) {
       if (status !== 200) return `expected 200, got ${status}`;
@@ -53,12 +53,59 @@ const CHECKS = [
       }
       if (!json.$schema) return 'missing $schema field';
       if (!json.remotes?.[0]?.url) return 'missing remotes[0].url';
+      if (!json.remotes[0].url.includes('?category=docs'))
+        return `remotes[0].url should include ?category=docs (got ${json.remotes[0].url})`;
+      if (json.remotes[0].headers)
+        return 'remotes[0].headers should be absent — this endpoint is unauthenticated';
       return null;
     },
     summarize(body) {
       try {
         const j = JSON.parse(body);
         return `name=${j.name}  url=${j.remotes?.[0]?.url}`;
+      } catch {
+        return '';
+      }
+    },
+  },
+  {
+    name: '/docs/mcp — MCP initialize POST (proxy to unauthenticated docs endpoint)',
+    path: '/docs/mcp',
+    method: 'POST',
+    requestBody: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'check-agent-endpoints', version: '1.0' },
+      },
+    }),
+    requestHeaders: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    validate(status, body) {
+      if (status !== 200)
+        return `expected 200, got ${status} — MCP server PR may not be merged yet`;
+      const dataLine = body.split('\n').find((l) => l.startsWith('data: '));
+      if (!dataLine) return 'no SSE data line in response';
+      let parsed;
+      try {
+        parsed = JSON.parse(dataLine.slice(6));
+      } catch {
+        return 'SSE data line is not valid JSON';
+      }
+      if (!parsed.result?.serverInfo) return 'missing result.serverInfo in initialize response';
+      return null;
+    },
+    summarize(body) {
+      const dataLine = body.split('\n').find((l) => l.startsWith('data: '));
+      if (!dataLine) return '';
+      try {
+        const d = JSON.parse(dataLine.slice(6));
+        return `serverInfo=${JSON.stringify(d.result?.serverInfo)}`;
       } catch {
         return '';
       }
@@ -158,10 +205,10 @@ const CHECKS = [
   },
 ];
 
-async function fetchCheck(url) {
-  const res = await fetch(url);
-  const body = await res.text();
-  return { status: res.status, body };
+async function fetchCheck(url, { method = 'GET', body = undefined, headers = {} } = {}) {
+  const res = await fetch(url, { method, body, headers });
+  const responseBody = await res.text();
+  return { status: res.status, body: responseBody };
 }
 
 async function run() {
@@ -175,7 +222,11 @@ async function run() {
     const url = `${BASE_URL}${check.path}`;
     let status, body;
     try {
-      ({ status, body } = await fetchCheck(url));
+      ({ status, body } = await fetchCheck(url, {
+        method: check.method ?? 'GET',
+        body: check.requestBody,
+        headers: check.requestHeaders ?? {},
+      }));
     } catch (err) {
       console.log(`  FAIL  ${check.name}`);
       console.log(`        fetch error: ${err.message}\n`);

--- a/src/app/(docs)/docs/mcp/route.js
+++ b/src/app/(docs)/docs/mcp/route.js
@@ -1,51 +1,87 @@
-export const dynamic = 'force-static';
+// GET returns the MCP Foundation server.json descriptor (publicly cacheable).
+// POST proxies MCP protocol requests (initialize, tools/list, tools/call) to
+// the unauthenticated docs-scoped endpoint at mcp.neon.tech so agents can
+// connect directly to neon.com/docs/mcp without OAuth.
+//
+// NOTE: force-static is intentionally absent. The POST handler is dynamic
+// (proxies live requests). Adding force-static would break POST at build time.
+//
+// The ?category=docs parameter scopes the server to two read-only tools
+// (list_docs_resources, get_doc_resource) and bypasses OAuth — both behaviors
+// are server-side features of mcp.neon.tech, not enforced here.
+const UPSTREAM_URL = 'https://mcp.neon.tech/mcp?category=docs';
 
 export async function GET() {
-  return Response.json({
-    $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
-    name: 'com.neon/mcp',
-    title: 'Neon',
-    description:
-      'Official Neon MCP server. Features list_docs_resources and get_doc_resource for reading Neon docs.',
-    repository: {
-      url: 'https://github.com/neondatabase/mcp-server-neon',
-      source: 'github',
-      subfolder: 'landing',
+  return Response.json(
+    {
+      $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+      name: 'com.neon/docs-mcp',
+      title: 'Neon Docs',
+      description:
+        'Read Neon documentation pages. Provides list_docs_resources and get_doc_resource tools.',
+      repository: {
+        url: 'https://github.com/neondatabase/mcp-server-neon',
+        source: 'github',
+        subfolder: 'landing',
+      },
+      version: '1.0.0',
+      websiteUrl: 'https://neon.com/docs/ai/neon-mcp-server',
+      icons: [
+        {
+          src: 'https://neon.com/brand/neon-logo-light-color.svg',
+          mimeType: 'image/svg+xml',
+          sizes: ['any'],
+          theme: 'light',
+        },
+        {
+          src: 'https://neon.com/brand/neon-logo-dark-color.svg',
+          mimeType: 'image/svg+xml',
+          sizes: ['any'],
+          theme: 'dark',
+        },
+      ],
+      remotes: [
+        {
+          type: 'streamable-http',
+          url: UPSTREAM_URL,
+        },
+      ],
     },
-    version: '1.0.0',
-    websiteUrl: 'https://neon.com/docs/ai/neon-mcp-server',
-    icons: [
-      {
-        src: 'https://neon.com/brand/neon-logo-light-color.svg',
-        mimeType: 'image/svg+xml',
-        sizes: ['any'],
-        theme: 'light',
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
       },
-      {
-        src: 'https://neon.com/brand/neon-logo-dark-color.svg',
-        mimeType: 'image/svg+xml',
-        sizes: ['any'],
-        theme: 'dark',
+    }
+  );
+}
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.text();
+  } catch {
+    return Response.json({ error: 'Failed to read request body' }, { status: 400 });
+  }
+
+  let upstream;
+  try {
+    upstream = await fetch(UPSTREAM_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': request.headers.get('Content-Type') ?? 'application/json',
+        Accept: request.headers.get('Accept') ?? 'application/json, text/event-stream',
       },
-    ],
-    remotes: [
-      {
-        type: 'streamable-http',
-        url: 'https://mcp.neon.tech/mcp',
-        headers: [
-          {
-            name: 'Authorization',
-            description: 'Optional Bearer token with a Neon API key.',
-            isSecret: true,
-          },
-          {
-            name: 'x-read-only',
-            description: 'Optional header to enable read-only mode for tool filtering.',
-            format: 'boolean',
-            default: 'false',
-          },
-        ],
-      },
-    ],
+      body,
+    });
+  } catch {
+    return Response.json({ error: 'Upstream MCP server unavailable' }, { status: 502 });
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json',
+      'Cache-Control': 'no-store',
+    },
   });
 }

--- a/src/app/(docs)/docs/mcp/route.test.js
+++ b/src/app/(docs)/docs/mcp/route.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+let GET, POST;
+
+describe('/docs/mcp route', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mod = await import('./route.js');
+    GET = mod.GET;
+    POST = mod.POST;
+  });
+
+  // ─── GET ─────────────────────────────────────────────────────────────────
+
+  describe('GET', () => {
+    it('returns 200 with valid MCP Foundation server.json', async () => {
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.$schema).toBe(
+        'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json'
+      );
+      expect(json.name).toBe('com.neon/docs-mcp');
+      expect(json.version).toBe('1.0.0');
+    });
+
+    it('remotes[0] points to the docs-scoped unauthenticated endpoint', async () => {
+      const res = await GET();
+      const json = await res.json();
+      expect(json.remotes).toHaveLength(1);
+      expect(json.remotes[0].type).toBe('streamable-http');
+      expect(json.remotes[0].url).toBe('https://mcp.neon.tech/mcp?category=docs');
+      // No auth headers — this endpoint is intentionally unauthenticated
+      expect(json.remotes[0].headers).toBeUndefined();
+    });
+
+    it('includes a public cache-control header', async () => {
+      const res = await GET();
+      const cc = res.headers.get('Cache-Control');
+      expect(cc).toMatch(/public/);
+      expect(cc).toMatch(/max-age/);
+    });
+  });
+
+  // ─── POST ────────────────────────────────────────────────────────────────
+
+  describe('POST — proxy to upstream', () => {
+    const makeRequest = (body = {}, headers = {}) =>
+      new Request('https://neon.com/docs/mcp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          ...headers,
+        },
+        body: JSON.stringify(body),
+      });
+
+    it('proxies initialize to mcp.neon.tech/mcp?category=docs', async () => {
+      global.fetch.mockResolvedValueOnce(
+        new Response('event: message\ndata: {"result":{"protocolVersion":"2025-03-26"}}\n\n', {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      );
+
+      const req = makeRequest({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0' },
+        },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toMatch(/text\/event-stream/);
+
+      const [url, opts] = global.fetch.mock.calls[0];
+      expect(url).toBe('https://mcp.neon.tech/mcp?category=docs');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body).method).toBe('initialize');
+    });
+
+    it('forwards Accept and Content-Type headers to upstream', async () => {
+      global.fetch.mockResolvedValueOnce(
+        new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+      );
+
+      const req = makeRequest(
+        {},
+        { Accept: 'application/json, text/event-stream', 'Content-Type': 'application/json' }
+      );
+      await POST(req);
+
+      const [, opts] = global.fetch.mock.calls[0];
+      expect(opts.headers['Content-Type']).toBe('application/json');
+      expect(opts.headers['Accept']).toBe('application/json, text/event-stream');
+    });
+
+    it('passes upstream status through unchanged', async () => {
+      global.fetch.mockResolvedValueOnce(
+        new Response('{"error":"invalid_token"}', {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      const res = await POST(
+        makeRequest({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 502 when upstream is unreachable', async () => {
+      global.fetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      const res = await POST(makeRequest());
+      expect(res.status).toBe(502);
+      const json = await res.json();
+      expect(json.error).toBeDefined();
+    });
+
+    it('sets no-store cache-control on proxied responses', async () => {
+      global.fetch.mockResolvedValueOnce(
+        new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+      );
+
+      const res = await POST(makeRequest());
+      expect(res.headers.get('Cache-Control')).toBe('no-store');
+    });
+  });
+});

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -48,9 +48,13 @@ const CUSTOM_MARKDOWN_PATHS = {
   'docs/skill.md': '/docs/ai/skills/neon-postgres/SKILL.md',
 };
 
-// Paths under content routes that are static files in public/ (not generated into public/md/).
-// The middleware should pass these through so Next.js serves them directly.
-const STATIC_DOC_PREFIXES = ['docs/ai/skills/', 'docs/.well-known/'];
+// Paths that must bypass the middleware's markdown-serving logic entirely.
+// Includes:
+// - Static files in public/ not generated into public/md/ (docs/ai/skills/, docs/.well-known/)
+// - Route handlers that accept non-GET requests (docs/mcp), where the middleware
+//   would otherwise detect the non-HTML Accept header, try to serve /md/docs/mcp.md,
+//   fail with 404, and return a markdown error before the route handler fires.
+const STATIC_DOC_PREFIXES = ['docs/ai/skills/', 'docs/.well-known/', 'docs/mcp'];
 
 // Convert URL path to markdown file path
 // Example: /docs/introduction -> /md/docs/introduction.md (maps to public/md/)


### PR DESCRIPTION
## Summary

Makes `/docs/mcp` a real MCP server endpoint (not just a discovery descriptor) by proxying requests to `mcp.neon.tech/mcp?category=docs`, which exposes `list_docs_resources` and `get_doc_resource` without requiring OAuth.

- **GET** — unchanged, returns the MCP Foundation server.json descriptor pointing to `?category=docs`
- **POST** — new: proxies MCP protocol requests (initialize, tools/list, tools/call) to the unauthenticated docs endpoint
- **Middleware fix** — adds `docs/mcp` to the static prefix exclusions so the middleware doesn't intercept MCP protocol POSTs before they reach the route handler

Depends on https://github.com/neondatabase/mcp-server-neon/pull/230 adding unauthenticated support for `?category=docs`. The check script will show 1 failure until that PR merges to production.

## Test plan

- [x] `node scripts/check-agent-endpoints.js http://localhost:3000` — 8/9 pass (POST 401 until MCP PR merges)
- [x] After MCP PR merges: all 9 pass
- [x] `npx vitest run src/app/\(docs\)/docs/mcp/route.test.js` — 8/8 pass