### PR TITLE
docs: update Neon Auth UI import paths

### DIFF
--- a/content/docs/auth/quick-start/tanstack-router.md
+++ b/content/docs/auth/quick-start/tanstack-router.md
@@ -102,7 +102,7 @@ See [UI Component Styles](/docs/auth/reference/ui-components#styling) for altern
 <TwoColumnLayout.Block label="Add to src/styles.css">
 
 ```css
-@import '@neondatabase/auth-ui/tailwind';
+@import '@neondatabase/neno-js/ui/tailwind';
 ```
 
 </TwoColumnLayout.Block>
@@ -192,7 +192,7 @@ Create a route to handle authentication views (sign in, sign up, etc.). Create `
 
 ```tsx filename="src/routes/auth.$pathname.tsx"
 import { createFileRoute } from '@tanstack/react-router';
-import { AuthView } from '@neondatabase/auth-ui';
+import { AuthView } from '@neondatabase/neno-js/auth/react/ui';
 
 export const Route = createFileRoute('/auth/$pathname')({
   component: Auth,


### PR DESCRIPTION
## Problem

The current Neon Auth UI documentation imports styles and components directly from `@neondatabase/auth-ui`:

```css
@import "@neondatabase/auth-ui/tailwind";
```

```ts
import { AuthView } from "@neondatabase/auth-ui";
```

When using pnpm, this can fail with:

```txt
Can't resolve '@neondatabase/auth-ui/tailwind'
```

## Cause

`@neondatabase/auth-ui` is installed as a transitive dependency of `@neondatabase/neon-js` / `@neondatabase/auth`, so it is not always resolvable directly from application source code under pnpm's dependency isolation.

## Fix

Use the public exports from `@neondatabase/neon-js` instead:

```css
@import "@neondatabase/neon-js/ui/tailwind";
```

```ts
import { AuthView } from "@neondatabase/neon-js/auth/react/ui";
```

## Verification

I reproduced the issue in a Vite + React + Tailwind v4 + pnpm project.

After changing the imports above, the project builds successfully with:

```bash
pnpm build
```