### PR TITLE
Fix wording on CASCADE delete action explanation

### DIFF
--- a/content/postgresql/tutorial/foreign-key.md
+++ b/content/postgresql/tutorial/foreign-key.md
@@ -221,7 +221,7 @@ The output indicates that the values of customer id 1 changed to `NULL`.
 
 The `ON DELETE CASCADE` automatically deletes all the referencing rows in the child table when the referenced rows in the parent table are deleted. In practice, the `ON DELETE CASCADE` is the most commonly used option.
 
-The following statements recreate the sample tables with the delete action of the `fk_customer` changes to `CASCADE`:
+The following statements recreate the sample tables with the delete action of the `fk_customer` changed to `CASCADE`:
 
 ```sql
 DROP TABLE IF EXISTS contacts;


### PR DESCRIPTION
Corrected the wording for clarity regarding the 'fk_customer' delete action.