### PR TITLE
docs(auth): use @neondatabase/auth-ui directly for UI imports

### DIFF
--- a/content/docs/auth/quick-start/tanstack-router.md
+++ b/content/docs/auth/quick-start/tanstack-router.md
@@ -64,7 +64,7 @@ Install the Neon Auth SDK and UI library:
 <TwoColumnLayout.Block>
 
 ```bash filename="Terminal"
-cd my-app && npm install @neondatabase/neon-js@latest
+cd my-app && npm install @neondatabase/neon-js@latest @neondatabase/auth-ui
 ```
 
 </TwoColumnLayout.Block>

--- a/content/docs/auth/reference/ui-components.md
+++ b/content/docs/auth/reference/ui-components.md
@@ -11,12 +11,21 @@ updatedOn: '2026-05-06T12:48:49.000Z'
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
 
-Quick reference for Neon Auth UI components from `@neondatabase/neon-js`. These components are built with [Better Auth UI](https://legacy.better-auth-ui.com/) and work with Neon Auth.
+Quick reference for Neon Auth UI components from `@neondatabase/auth-ui`. These components are built with [Better Auth UI](https://legacy.better-auth-ui.com/) and work with Neon Auth.
+
+<Admonition type="note" title="Migrating from older imports">
+Older releases re-exported the UI from `@neondatabase/auth/react/ui` and `@neondatabase/neon-js/auth/react/ui`. Those entrypoints are deprecated and will be removed in the next major version. Install `@neondatabase/auth-ui` directly and run the codemod to update existing imports:
+
+```bash
+npx -p @neondatabase/auth neon-auth-codemod --write <path>
+```
+
+</Admonition>
 
 ## Installation
 
 ```bash
-npm install @neondatabase/neon-js@latest
+npm install @neondatabase/neon-js@latest @neondatabase/auth-ui
 ```
 
 ## Provider Setup


### PR DESCRIPTION
## Summary

Aligns the Neon Auth quick-start and reference docs with [`neondatabase/neon-js#111`](https://github.com/neondatabase/neon-js/pull/111), which deprecates the UI re-exports under `@neondatabase/auth/react/ui*`, `@neondatabase/auth/ui/*`, and `@neondatabase/neon-js/auth/react/ui*` / `@neondatabase/neon-js/ui/*`. Going forward users should install and import `@neondatabase/auth-ui` directly so the package resolves under pnpm strict isolation without relying on a transitive dependency.

## Files changed

- `content/docs/auth/quick-start/tanstack-router.md` — install line now includes `@neondatabase/auth-ui` alongside `@neondatabase/neon-js@latest`.
- `content/docs/auth/reference/ui-components.md` — install line now includes `@neondatabase/auth-ui`; reworded intro to point at `@neondatabase/auth-ui` directly; added a "Migrating from older imports" admonition near the top with a pointer to the `neon-auth-codemod` codemod.

All in-flight UI import lines in the docs were already on `@neondatabase/auth-ui/*` in earlier passes (see `content/docs/auth/reference/ui-components.md`, `content/docs/auth/quick-start/tanstack-router.md`, `content/docs/auth/migrate/from-legacy-auth.md`, `content/docs/auth/guides/plugins/email-otp.md`, etc.), so this PR only needed to update the install commands and add the migration callout.

## Why not the other direction?

`neon-js#111` explicitly deprecates `@neondatabase/auth/react/ui*`, `@neondatabase/auth/ui/*`, `@neondatabase/neon-js/auth/react/ui*`, and `@neondatabase/neon-js/ui/*`. Migrating docs back onto those entrypoints would point users at code paths that are slated for removal in the next major version and would break under pnpm strict isolation when `@neondatabase/auth-ui` is not a direct dependency. The codemod shipped with that PR (invocable as `npx -p @neondatabase/auth neon-auth-codemod --write <path>`) maps every deprecated path to `@neondatabase/auth-ui/*`, so this PR keeps the docs in sync with the codemod's target shape.

## Intentionally retained deprecated paths

- `content/docs/auth/reference/ui-components.md` — the new "Migrating from older imports" admonition references the deprecated entrypoints by name so users searching for them land on the upgrade instructions.

## Out of scope (not modified)

- `content/changelog/2025-12-12.md` — historical changelog entry referencing `@neondatabase/neon-js/auth/react/ui`. Left as-is since changelogs document what shipped at the time.
- `content/docs/unused/neon-auth-quick-start-react-ui-components.md` and `content/docs/unused/neon-auth-quick-start-nextjs-ui-components.md` — under `content/docs/unused/` and not part of the active docs sweep scope.

## Test plan

After the sweep, the verification greps return only the intentional callout in `ui-components.md` and the out-of-scope files above:

```bash
grep -rnE '@neondatabase/(auth|neon-js)/(react/ui|ui/(css|tailwind))' content/docs/auth/
# -> only content/docs/auth/reference/ui-components.md:17 (migration callout)

grep -rnE '@neondatabase/auth/react/ui' content/docs/auth/
# -> only content/docs/auth/reference/ui-components.md:17 (migration callout)

grep -rnE '@neondatabase/neon-js/auth/react/ui' content/docs/auth/
# -> only content/docs/auth/reference/ui-components.md:17 (migration callout)
```

Co-authored-by: Isaac