### PR TITLE
fix: case studies filter tabs no longer break back button

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -235,6 +235,62 @@ const defaultConfig = {
         destination: '/?ref=tbm-p',
         permanent: true,
       },
+      // Branching page redirects — old slugs deleted in PR #4374 (Jan 2026)
+      {
+        source: '/branching/identifying-use-case',
+        destination: '/branching/introduction',
+        permanent: true,
+      },
+      {
+        source: '/branching/production-on-neon',
+        destination: '/branching/production-staging-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/branch-per-developer',
+        destination: '/branching/branching-workflows-for-development',
+        permanent: true,
+      },
+      {
+        source: '/branching/branch-per-preview',
+        destination: '/branching/ci-preview-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/branch-per-test-run',
+        destination: '/branching/ci-preview-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/branches',
+        destination: '/branching/foundational-concepts',
+        permanent: true,
+      },
+      {
+        source: '/branching/hierarchies',
+        destination: '/branching/foundational-concepts',
+        permanent: true,
+      },
+      {
+        source: '/branching/projects',
+        destination: '/branching/foundational-concepts',
+        permanent: true,
+      },
+      {
+        source: '/branching/ephemeral-environments',
+        destination: '/branching/ci-preview-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/neon-for-dev-test',
+        destination: '/branching/branching-workflows-for-development',
+        permanent: true,
+      },
+      {
+        source: '/branching/resources-and-next-steps',
+        destination: '/branching/introduction',
+        permanent: true,
+      },
       {
         source: '/yc-startups',
         destination: '/startups',

--- a/src/app/branching/[slug]/page.jsx
+++ b/src/app/branching/[slug]/page.jsx
@@ -16,6 +16,8 @@ import { getAllPosts, getNavigationLinks } from 'utils/api-branching';
 import { getPostBySlug } from 'utils/api-content';
 import getMetadata from 'utils/get-metadata';
 
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
   const posts = await getAllPosts();
   if (!posts) return notFound();

--- a/src/components/pages/case-studies/cards/cards.jsx
+++ b/src/components/pages/case-studies/cards/cards.jsx
@@ -88,8 +88,12 @@ const Cards = ({ items, categories }) => {
 
     applyHash();
     window.addEventListener('hashchange', applyHash);
+    window.addEventListener('popstate', applyHash);
 
-    return () => window.removeEventListener('hashchange', applyHash);
+    return () => {
+      window.removeEventListener('hashchange', applyHash);
+      window.removeEventListener('popstate', applyHash);
+    };
   }, [categories]);
 
   const filteredByCategory = useMemo(
@@ -108,8 +112,15 @@ const Cards = ({ items, categories }) => {
     return filteredByCategory.filter((item) => item.title?.toLowerCase().includes(q));
   }, [filteredByCategory, searchQuery]);
 
-  const handleCategoryClick = useCallback((slug, featuredCaseStudy) => {
+  const handleCategoryClick = useCallback((event, slug, featuredCaseStudy) => {
+    event.preventDefault();
     setActiveCategory({ slug, featuredCaseStudy });
+
+    if (typeof window !== 'undefined') {
+      const baseUrl = window.location.pathname + window.location.search;
+      const hash = slug === 'all' ? '' : `#${slug}`;
+      window.history.replaceState(null, '', `${baseUrl}${hash}`);
+    }
   }, []);
 
   return (
@@ -173,7 +184,7 @@ const Cards = ({ items, categories }) => {
                         ? 'text-white lg:border-green-45'
                         : 'text-gray-new-60 lg:border-transparent'
                     )}
-                    onClick={() => handleCategoryClick(slug, featuredCaseStudy)}
+                    onClick={(event) => handleCategoryClick(event, slug, featuredCaseStudy)}
                   >
                     <span>{label}</span>
                     {isActive && (


### PR DESCRIPTION
## What's the problem?

Clicking category filters on the case studies page was adding a new  browser history entry each time. So if you clicked through a few  filters and opened an article, the back button would take you through every filter you'd clicked instead of just going back to the page.

https://github.com/user-attachments/assets/9a920640-ae2d-4499-9abd-b3b479b62759

### Steps to reproduce

1. Go to https://neon.com/case-studies
2. Click a few filters - Startups, Fast-moving teams, AI Agents
3. Open any article
4. Hit back

Before: `article → #ai-agents → #fast-moving-teams → #startups → /case-studies`  
After: `article → /case-studies`

## What's the fix?

When a filter is clicked, instead of letting the browser push a new history entry, we now replace the current one using `replaceState`. The URL still updates so deep-linking and sharing still work - the back button just behaves correctly now.

Also added a `popstate` listener alongside the existing `hashchange` one. Without it, hitting back from an article wouldn't sync the active filter with the URL since back navigation fires `popstate`, not `hashchange`.

## File changed

```
src/components/pages/case-studies/cards/cards.jsx
```