### PR TITLE
docs: add configure_neon_auth and get_neon_auth_config to MCP tools list

### DIFF
--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-02-12T19:25:43.000Z'
+updatedOn: '2026-05-13T12:08:01.154Z'
 ---
 
 ## Supported actions (tools)
@@ -46,7 +46,9 @@ The Neon MCP Server provides the following actions, which are exposed as "tools"
 
 **Neon Auth:**
 
-- `provision_neon_auth`: Provisions Neon Auth for a Neon project. It allows developers to easily set up authentication infrastructure by creating an integration with an Auth provider.
+- `provision_neon_auth`: Provisions [Neon Auth](/docs/auth/overview) for a project's branch so you can add authentication to your app without standing up a separate auth service. If Neon Auth is already provisioned, this returns the existing configuration instead of erroring.
+- `get_neon_auth_config`: Returns the Neon Auth configuration for a branch, including the auth `base_url`, `jwks_url`, trusted origins, allowed auth methods (for example email and password), configured OAuth providers, and email provider settings. Secrets such as OAuth client secrets and SMTP passwords are redacted.
+- `configure_neon_auth`: Updates the Neon Auth configuration for a branch. Use it to manage trusted origins, toggle localhost, enable or tune email and password sign-in, add or update OAuth providers (such as Google, GitHub, or Microsoft), configure the email provider, and send a test email.
 
 **Neon Data API:**
 

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-05-13T12:08:01.154Z'
+updatedOn: '2026-05-13T12:49:16.911Z'
 ---
 
 ## Supported actions (tools)
@@ -48,7 +48,7 @@ The Neon MCP Server provides the following actions, which are exposed as "tools"
 
 - `provision_neon_auth`: Provisions [Neon Auth](/docs/auth/overview) for a project's branch so you can add authentication to your app without standing up a separate auth service. If Neon Auth is already provisioned, this returns the existing configuration instead of erroring.
 - `get_neon_auth_config`: Returns the Neon Auth configuration for a branch, including the auth `base_url`, `jwks_url`, trusted origins, allowed auth methods (for example email and password), configured OAuth providers, and email provider settings. Secrets such as OAuth client secrets and SMTP passwords are redacted.
-- `configure_neon_auth`: Updates the Neon Auth configuration for a branch. Use it to manage trusted origins, toggle localhost, enable or tune email and password sign-in, add or update OAuth providers (such as Google, GitHub, or Microsoft), configure the email provider, and send a test email.
+- `configure_neon_auth`: Updates the Neon Auth configuration for a branch. Use it to manage trusted origins, toggle localhost, enable or tune email and password sign-in, add or update OAuth providers, configure the email provider, and send a test email.
 
 **Neon Data API:**
 


### PR DESCRIPTION
## Summary

Updates the [Supported actions (tools)](https://neon.com/docs/ai/neon-mcp-server#supported-actions-tools) section on the Neon MCP Server overview to reflect recent changes in `mcp-server-neon`:

- Adds `get_neon_auth_config` — returns the Neon Auth config for a branch (URLs, JWKS, trusted origins, auth methods, OAuth providers, email provider). Secrets are redacted.
- Adds `configure_neon_auth` — updates the Neon Auth config (trusted origins, localhost toggle, email/password methods, OAuth providers, email provider, test email).
- Updates `provision_neon_auth` — clarifies it provisions Neon Auth for a branch and is idempotent (returns the existing config when Neon Auth is already provisioned).

Edit is in `content/docs/shared-content/mcp-tools.md`, which is the shared partial rendered into the page via `<MCPTools />`.

## Upstream PRs

- `configure_neon_auth`: [neondatabase/mcp-server-neon#242](https://github.com/neondatabase/mcp-server-neon/pull/242), [#246](https://github.com/neondatabase/mcp-server-neon/pull/246), [#247](https://github.com/neondatabase/mcp-server-neon/pull/247)
- `get_neon_auth_config`: [#242](https://github.com/neondatabase/mcp-server-neon/pull/242), [#243](https://github.com/neondatabase/mcp-server-neon/pull/243)
- `provision_neon_auth` (idempotency): [#244](https://github.com/neondatabase/mcp-server-neon/pull/244)

## Test plan

- [x] `markdownlint-cli2` passes on the modified file
- [x] `prettier --write` leaves the file unchanged
- [ ] Vercel preview: verify the Neon Auth tools appear correctly under [Supported actions (tools)](https://neon.com/docs/ai/neon-mcp-server#supported-actions-tools)
- [ ] Confirm `/docs/auth/overview` link resolves on the preview