### PR TITLE
feat: support excludeFromBlog frontmatter for guides

### DIFF
--- a/content/guides/README.md
+++ b/content/guides/README.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-02-15T11:43:50.000Z'
+updatedOn: '2026-05-13T19:04:49.209Z'
 ---
 
 # Guides
@@ -25,6 +25,7 @@ Right now Markdown files accept the following fields:
 5. `isDraft`: flag that says the page is not ready yet. It won't appear in production but will appear in the development mode.
 6. `enableTableOfContents`: flag that turns on the display of the outline for the page. The outline gets built out of second and third-level headings ([`h2`, `h3`]), thus appears as two-level nested max.
 7. `ogImage` - the social preview image of the page.
+8. `excludeFromBlog`: flag that hides the guide from the blog's guides listing and the "All posts" feed. The guide page itself is still published at its `/guides/...` URL — use this for guides that should remain accessible but not be surfaced alongside blog content.
 
 > ⚠️ Please note that the project won't build if at least one of the Markdown files is missing a required field.
 

--- a/src/utils/api-blog.js
+++ b/src/utils/api-blog.js
@@ -239,7 +239,7 @@ export const getCategoryBySlug = async (slug, options = {}) => {
 
 export const getPostsByCategorySlug = async (slug, options = {}) => {
   if (!options.previewBranch) {
-    if (slug === 'guides') return getAllGuides();
+    if (slug === 'guides') return (await getAllGuides()).filter((guide) => !guide.excludeFromBlog);
     if (slug === 'changelog') return getAllChangelogs();
   }
 
@@ -251,7 +251,9 @@ export const getPostsByCategorySlug = async (slug, options = {}) => {
 export const getAllPosts = async (options = {}) => {
   const [blogPosts, guides, changelogs] = await Promise.all([
     getAllBlogPosts(options),
-    options.previewBranch ? Promise.resolve([]) : getAllGuides(),
+    options.previewBranch
+      ? Promise.resolve([])
+      : getAllGuides().then((items) => items.filter((guide) => !guide.excludeFromBlog)),
     options.previewBranch ? Promise.resolve([]) : getAllChangelogs(),
   ]);
 

--- a/src/utils/api-guides.js
+++ b/src/utils/api-guides.js
@@ -39,7 +39,16 @@ const getAllGuides = async () => {
 
       const slugWithoutFirstSlash = slug.slice(1);
       const {
-        data: { title, subtitle, createdAt, updatedOn, isDraft, redirectFrom, author },
+        data: {
+          title,
+          subtitle,
+          createdAt,
+          updatedOn,
+          isDraft,
+          redirectFrom,
+          author,
+          excludeFromBlog,
+        },
         excerpt,
       } = data;
       const authorData = getAuthor(author);
@@ -56,6 +65,7 @@ const getAllGuides = async () => {
         excerpt,
         isDraft,
         redirectFrom,
+        excludeFromBlog,
       };
     })
     .filter((item) => process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production' || !item.isDraft)


### PR DESCRIPTION
Lets guide authors hide a page from the blog's guides listing and the all-posts feed while keeping it published at its /guides/... URL.

Co-authored-by: Isaac