### PR TITLE
Add backend platform get-access form to the roadmap

### DIFF
--- a/src/components/shared/request-form/data.js
+++ b/src/components/shared/request-form/data.js
@@ -165,9 +165,19 @@ const EXTENSIONS = {
   },
 };
 
+const BACKEND_PLATFORM = {
+  title: 'Get early access to the Neon backend platform',
+  description:
+    "We're expanding Neon into a complete backend platform. Drop your email and we'll reach out as new components become available.",
+  buttonText: 'Get access',
+  confirmation: "You're on the list. We'll be in touch as new components become available.",
+  eventName: 'Backend Platform Access Requested',
+};
+
 const DATA = {
   region: REGIONS,
   extension: EXTENSIONS,
+  'backend-platform': BACKEND_PLATFORM,
 };
 
 export default DATA;

--- a/src/components/shared/request-form/request-form.jsx
+++ b/src/components/shared/request-form/request-form.jsx
@@ -30,7 +30,9 @@ function getCookie(name) {
 }
 
 const RequestForm = ({ type }) => {
-  const { title, description, placeholder, buttonText, options, extendedOptions } = DATA[type];
+  const { title, description, placeholder, buttonText, confirmation, options, extendedOptions } =
+    DATA[type];
+  const hasOptions = Array.isArray(options) && options.length > 0;
 
   const isRecognized = !!getCookie('ajs_user_id');
   const [selected, setSelected] = useState('');
@@ -40,13 +42,14 @@ const RequestForm = ({ type }) => {
   const [isSent, setIsSent] = useState(false);
 
   const filteredOptions = useMemo(() => {
+    if (!hasOptions) return [];
     if (query === '') return options;
     return options.filter(
       (option) =>
         option.name.toLowerCase().includes(query.toLowerCase()) ||
         option.id?.toLowerCase().includes(query.toLowerCase())
     );
-  }, [options, query]);
+  }, [hasOptions, options, query]);
 
   const matchingOption = useMemo(
     () => filteredOptions.find((option) => option.name.toLowerCase() === query.toLowerCase()),
@@ -54,9 +57,9 @@ const RequestForm = ({ type }) => {
   );
 
   useEffect(() => {
-    // Form is valid if an option is selected and either user is recognized or valid email is given
-    setIsValid(!!selected && (isRecognized || emailRegexp.test(email)));
-  }, [selected, email, isRecognized]);
+    const hasSelection = hasOptions ? !!selected : true;
+    setIsValid(hasSelection && (isRecognized || emailRegexp.test(email)));
+  }, [hasOptions, selected, email, isRecognized]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -64,11 +67,12 @@ const RequestForm = ({ type }) => {
     if (isValid) {
       if (window.zaraz) {
         const { eventName, eventProps } = DATA[type];
-        const eventData = {
-          [eventProps.name]: selected.name,
-        };
-        if (eventProps.id && selected.id) {
-          eventData[eventProps.id] = selected.id;
+        const eventData = {};
+        if (hasOptions && selected && eventProps?.name) {
+          eventData[eventProps.name] = selected.name;
+          if (eventProps.id && selected.id) {
+            eventData[eventProps.id] = selected.id;
+          }
         }
         if (!isRecognized && email) {
           sendGtagEvent('identify', { email });
@@ -105,78 +109,80 @@ const RequestForm = ({ type }) => {
             className="mt-6 flex items-end gap-4 md:flex-col md:items-start"
             onSubmit={handleSubmit}
           >
-            <div className="flex-1 md:w-full">
-              <Combobox
-                value={selected}
-                immediate
-                onChange={(value) => {
-                  setSelected(value);
-                }}
-                onClose={() => setQuery('')}
-              >
-                <div className="relative">
-                  <ComboboxInput
-                    className={cn(
-                      'h-11 w-full border border-gray-new-80 bg-white py-2 pr-8 pl-4 text-[15px] leading-snug tracking-extra-tight placeholder:text-gray-new-40 xl:text-sm',
-                      'focus:outline-none data-focus:outline-1 data-focus:-outline-offset-1 data-focus:outline-gray-new-70',
-                      'dark:border-gray-new-30 dark:bg-gray-new-15 dark:placeholder:text-gray-new-60 dark:data-focus:outline-gray-new-30'
-                    )}
-                    displayValue={(option) => option?.name}
-                    autoComplete="off"
-                    placeholder={placeholder}
-                    onChange={(event) => setQuery(event.target.value)}
-                  />
-                  <ComboboxButton className="group absolute inset-y-0 right-0 px-2.5">
-                    <ChevronIcon className="size-4 stroke-black-new dark:stroke-white" />
-                  </ComboboxButton>
-                </div>
-                <ComboboxOptions
-                  anchor="bottom"
-                  className={cn(
-                    'z-50 max-h-[200px]! w-(--input-width) border border-gray-new-80 bg-white',
-                    '[--anchor-gap:var(--spacing-1)] [--anchor-max-height:50vh] empty:invisible',
-                    'transition duration-100 ease-in data-leave:data-closed:opacity-0',
-                    'dark:border-gray-new-30 dark:bg-gray-new-10 dark:text-white'
-                  )}
-                  modal={false}
-                  transition
+            {hasOptions && (
+              <div className="flex-1 md:w-full">
+                <Combobox
+                  value={selected}
+                  immediate
+                  onChange={(value) => {
+                    setSelected(value);
+                  }}
+                  onClose={() => setQuery('')}
                 >
-                  {filteredOptions.map((option, index) => (
-                    <ComboboxOption
-                      key={index}
-                      value={option}
+                  <div className="relative">
+                    <ComboboxInput
                       className={cn(
-                        'group flex min-h-10 cursor-pointer flex-wrap items-center gap-1.5 px-4 py-2 text-sm select-none data-focus:bg-gray-new-94',
-                        'dark:data-focus:bg-gray-new-15'
+                        'h-11 w-full border border-gray-new-80 bg-white py-2 pr-8 pl-4 text-[15px] leading-snug tracking-extra-tight placeholder:text-gray-new-40 xl:text-sm',
+                        'focus:outline-none data-focus:outline-1 data-focus:-outline-offset-1 data-focus:outline-gray-new-70',
+                        'dark:border-gray-new-30 dark:bg-gray-new-15 dark:placeholder:text-gray-new-60 dark:data-focus:outline-gray-new-30'
                       )}
-                    >
-                      {option.name}
-                      {option.id && (
-                        <code
-                          className={cn(
-                            'rounded bg-gray-new-90 px-1.5 py-0.5 font-mono text-sm leading-tight font-normal tracking-tight whitespace-nowrap text-black-pure',
-                            'dark:bg-gray-new-20 dark:text-white'
-                          )}
-                        >
-                          {option.id}
-                        </code>
-                      )}
-                    </ComboboxOption>
-                  ))}
-                  {extendedOptions && query !== '' && !matchingOption && (
-                    <ComboboxOption
-                      value={{ name: query }}
-                      className={cn(
-                        'group flex min-h-10 cursor-pointer flex-wrap items-center gap-1.5 px-4 py-2 text-sm select-none data-focus:bg-gray-new-94',
-                        'dark:data-focus:bg-gray-new-15'
-                      )}
-                    >
-                      Other: {query}
-                    </ComboboxOption>
-                  )}
-                </ComboboxOptions>
-              </Combobox>
-            </div>
+                      displayValue={(option) => option?.name}
+                      autoComplete="off"
+                      placeholder={placeholder}
+                      onChange={(event) => setQuery(event.target.value)}
+                    />
+                    <ComboboxButton className="group absolute inset-y-0 right-0 px-2.5">
+                      <ChevronIcon className="size-4 stroke-black-new dark:stroke-white" />
+                    </ComboboxButton>
+                  </div>
+                  <ComboboxOptions
+                    anchor="bottom"
+                    className={cn(
+                      'z-50 max-h-[200px]! w-(--input-width) border border-gray-new-80 bg-white',
+                      '[--anchor-gap:var(--spacing-1)] [--anchor-max-height:50vh] empty:invisible',
+                      'transition duration-100 ease-in data-leave:data-closed:opacity-0',
+                      'dark:border-gray-new-30 dark:bg-gray-new-10 dark:text-white'
+                    )}
+                    modal={false}
+                    transition
+                  >
+                    {filteredOptions.map((option, index) => (
+                      <ComboboxOption
+                        key={index}
+                        value={option}
+                        className={cn(
+                          'group flex min-h-10 cursor-pointer flex-wrap items-center gap-1.5 px-4 py-2 text-sm select-none data-focus:bg-gray-new-94',
+                          'dark:data-focus:bg-gray-new-15'
+                        )}
+                      >
+                        {option.name}
+                        {option.id && (
+                          <code
+                            className={cn(
+                              'rounded bg-gray-new-90 px-1.5 py-0.5 font-mono text-sm leading-tight font-normal tracking-tight whitespace-nowrap text-black-pure',
+                              'dark:bg-gray-new-20 dark:text-white'
+                            )}
+                          >
+                            {option.id}
+                          </code>
+                        )}
+                      </ComboboxOption>
+                    ))}
+                    {extendedOptions && query !== '' && !matchingOption && (
+                      <ComboboxOption
+                        value={{ name: query }}
+                        className={cn(
+                          'group flex min-h-10 cursor-pointer flex-wrap items-center gap-1.5 px-4 py-2 text-sm select-none data-focus:bg-gray-new-94',
+                          'dark:data-focus:bg-gray-new-15'
+                        )}
+                      >
+                        Other: {query}
+                      </ComboboxOption>
+                    )}
+                  </ComboboxOptions>
+                </Combobox>
+              </div>
+            )}
             {!isRecognized && (
               <input
                 type="email"
@@ -210,7 +216,9 @@ const RequestForm = ({ type }) => {
         ) : (
           <div className="mt-6 flex min-h-10 items-center gap-2 sm:min-h-0 sm:items-start">
             <CheckIcon className="-mt-1 size-4 shrink-0 text-green-45 sm:mt-1" aria-hidden />
-            <p className="text-[17px] font-light">Request logged. We appreciate your feedback!</p>
+            <p className="text-[17px] font-light">
+              {confirmation || 'Request logged. We appreciate your feedback!'}
+            </p>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Reframe the first section of the roadmap page around Neon becoming a complete backend platform (File Storage, Functions, Cron, Neon SDK as coming soon)
- Embed a new `<RequestForm type="backend-platform" />` below the coming-soon list to capture interest via email
- Move Neon Auth GA and large-compute perf into a new "Also in progress" subsection so the lead section stays focused on the backend platform story
- Extend the shared `RequestForm` component so a type can omit the component-select dropdown — useful for simple email-only interest forms (existing `region` and `extension` forms still require a selection)

## Test plan

- [ ] Load `/docs/introduction/roadmap` and verify the first section renders the new framing and the form
- [ ] Submit the form (signed-in and signed-out) and verify the GA event `Backend Platform Access Requested` fires
- [ ] Confirm the `region` and `extension` request forms (e.g. in `/docs/auth/roadmap`) still behave as before
- [ ] Check the form's submitted-state confirmation renders

This pull request and its description were written by Isaac.