### PR TITLE
feat: add image zoom for blog

### DIFF
--- a/src/components/pages/blog-post/blog-post-page/blog-post-page.jsx
+++ b/src/components/pages/blog-post/blog-post-page/blog-post-page.jsx
@@ -17,6 +17,7 @@ import AnchorHeading from 'components/shared/anchor-heading';
 import BlogQuote from 'components/shared/blog-quote';
 import ChangelogForm from 'components/shared/changelog-form';
 import EmbedTweet from 'components/shared/embed-tweet';
+import ImageZoom from 'components/shared/image-zoom';
 import { DEFAULT_BLOG_ROUTE_CONFIG } from 'constants/blog';
 import getFormattedDate from 'utils/get-formatted-date';
 import getMarkdownTableOfContents from 'utils/get-markdown-table-of-contents';
@@ -31,9 +32,24 @@ const renderBlogCodeBlockFromPre = async (props) => {
   return <CodeBlock language={languageMatch ? languageMatch[1] : 'bash'}>{rawCode}</CodeBlock>;
 };
 
+/* eslint-disable @next/next/no-img-element */
+const renderBlogImage = ({ src, alt = '', ...props }) => {
+  if (!src) {
+    return <img alt={alt} {...props} />;
+  }
+
+  return (
+    <ImageZoom src={src} isDark>
+      <img src={src} alt={alt} {...props} />
+    </ImageZoom>
+  );
+};
+/* eslint-enable @next/next/no-img-element */
+
 const mdxComponents = {
   h2: AnchorHeading('h2'),
   h3: AnchorHeading('h3'),
+  img: renderBlogImage,
   pre: renderBlogCodeBlockFromPre,
   table: (props) => (
     <div className="table-wrapper">


### PR DESCRIPTION
## Summary
- Wrap blog Markdown images with the existing shared ImageZoom component.
- Keep raw blog images intact to avoid changing sizing behavior for existing remote content.

## Validation
- check [preview](https://neon-next-git-blog-image-zoom-pixelpoint.vercel.app/blog/turning-off-fpw-for-faster-writes) page