### PR TITLE
docs: fix extra whitespace in numbered lists on docs pages (#4841)

### DIFF
--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -111,6 +111,10 @@
     @apply prose-ol:my-3 prose-ul:my-6;
     @apply prose-li:text-lg prose-li:tracking-tight prose-li:text-gray-new-30 dark:prose-li:text-gray-new-85;
 
+    & li > p {
+      @apply my-2!;
+    }
+
     > h2:first-child,
     > h3:first-child,
     > h4:first-child {


### PR DESCRIPTION
Numbered and bulleted lists on docs pages render with excessive spacing between items. Root cause: lists with blank lines between items (required when items contain images, admonitions, or code blocks) are parsed as "loose" by remark, wrapping every item's content in a `<p>` tag. The `prose-p:mb-6` rule then applies 1.5rem of margin to those paragraphs, including simple single-line steps.

Fix: one CSS rule inside `.prose-doc` that caps paragraph margins when `<p>` is a direct child of `<li>`. Uses `my-2` rather than `my-0` to preserve spacing for list items that genuinely contain multiple paragraphs.

Fixes #4841.