### PR TITLE
docs: add admonition to pg_session_jwt page warning against manual installation

### DIFF
--- a/content/docs/extensions/pg_session_jwt.md
+++ b/content/docs/extensions/pg_session_jwt.md
@@ -6,7 +6,7 @@ summary: >-
   authenticated sessions using JSON Web Tokens (JWTs), including JWK validation
   and PostgREST compatibility for secure user identity handling.
 enableTableOfContents: true
-updatedOn: '2026-03-05T04:12:51.007Z'
+updatedOn: '2026-05-15T10:22:57.192Z'
 ---
 
 <InfoBlock>
@@ -22,6 +22,10 @@ updatedOn: '2026-03-05T04:12:51.007Z'
 </DocsList>
 
 </InfoBlock>
+
+<Admonition type="important">
+The `pg_session_jwt` extension is automatically installed when you enable the [Neon Data API](/docs/data-api/overview) for a branch. Do not install this extension manually.
+</Admonition>
 
 The `pg_session_jwt` extension is a Postgres extension designed to handle authenticated sessions through JSON Web Tokens (JWTs). When configured with a JWK (JSON Web Key), it verifies JWT authenticity. When operating without a JWK, it falls back to using PostgREST-compatible JWT claims.
 


### PR DESCRIPTION
## Summary

- Adds an `important`-type admonition at the top of the `pg_session_jwt` extension page
- The note clarifies that the extension is auto-installed when the Neon Data API is enabled and should not be installed manually

## Motivation

Users were manually installing `pg_session_jwt`, which conflicts with the auto-installation performed when enabling the Neon Data API. This change surfaces the warning prominently before any other page content.

Closes LKB-12876

This pull request and its description were written by Isaac.

## NEON PREVIEW

- https://neon-next-git-lkb-12876-pg-session-jwt-admonition-neondatabase.vercel.app/docs/extensions/pg_session_jwt