### PR TITLE
fix: links hover

### DIFF
--- a/src/styles/blog-content.css
+++ b/src/styles/blog-content.css
@@ -2,7 +2,7 @@
   .prose-blog {
     @apply max-w-none leading-normal text-gray-new-90 prose-strong:text-gray-new-90;
     @apply prose-headings:leading-tight prose-headings:font-medium prose-headings:tracking-tighter prose-headings:text-white;
-    @apply prose-a:rounded-sm prose-a:font-normal prose-a:text-white prose-a:underline prose-a:decoration-white/40 prose-a:decoration-dashed prose-a:underline-offset-4 prose-a:transition-colors prose-a:duration-200 prose-a:ease-in-out hover:prose-a:decoration-white sm:prose-a:break-words;
+    @apply prose-a:rounded-sm prose-a:font-normal prose-a:text-white prose-a:underline prose-a:decoration-white/40 prose-a:decoration-dashed prose-a:underline-offset-4 prose-a:transition-colors prose-a:duration-200 prose-a:ease-in-out prose-a:hover:decoration-white sm:prose-a:break-words;
     @apply prose-figure:my-10 prose-img:my-10 prose-img:border prose-img:border-gray-new-90 dark:prose-img:border-gray-new-20 md:prose-figure:my-8 md:prose-img:my-8 sm:prose-figure:my-6 sm:prose-img:my-6;
     @apply prose-figcaption:mt-2.5 prose-figcaption:text-base prose-figcaption:leading-snug prose-figcaption:tracking-tight prose-figcaption:text-gray-new-50;
     @apply prose-pre:my-0 prose-pre:px-2;

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -9,7 +9,7 @@
     @apply text-base leading-normal font-normal tracking-tight dark:text-gray-new-85;
 
     a {
-      @apply text-black-pure underline decoration-black-pure/40 decoration-dashed decoration-1 underline-offset-[3px] hover:decoration-black-pure dark:text-white dark:decoration-white/40 hover:dark:decoration-white/100 sm:break-words;
+      @apply text-black-pure underline decoration-black-pure/40 decoration-dashed decoration-1 underline-offset-[3px] hover:decoration-black-pure dark:text-white dark:decoration-white/40 dark:hover:decoration-white sm:break-words;
     }
     p:first-child {
       @apply mt-0;
@@ -71,7 +71,7 @@
   .prose-doc {
     @apply max-w-none text-lg leading-normal tracking-extra-tight text-gray-new-8 dark:text-gray-new-90;
     @apply prose-headings:font-sans prose-headings:leading-tight prose-headings:font-medium prose-headings:tracking-tighter prose-headings:text-black-pure dark:prose-headings:text-white prose-p:my-3 prose-p:leading-normal;
-    @apply prose-a:rounded-sm prose-a:font-normal prose-a:text-gray-new-20 prose-a:underline prose-a:decoration-[rgba(0,0,0,0.40)] prose-a:decoration-dashed prose-a:decoration-1 prose-a:underline-offset-4 prose-a:transition-all prose-a:duration-200 prose-a:ease-in-out hover:prose-a:decoration-[rgba(0,0,0,0.70)] dark:prose-a:text-white dark:prose-a:decoration-[rgba(255,255,255,0.40)] dark:hover:prose-a:decoration-[rgba(255,255,255,0.70)] prose-a:sm:break-words;
+    @apply prose-a:rounded-sm prose-a:font-normal prose-a:text-gray-new-20 prose-a:underline prose-a:decoration-[rgba(0,0,0,0.40)] prose-a:decoration-dashed prose-a:decoration-1 prose-a:underline-offset-4 prose-a:transition-all prose-a:duration-200 prose-a:ease-in-out prose-a:hover:decoration-[rgba(0,0,0,0.70)] dark:prose-a:text-white dark:prose-a:decoration-[rgba(255,255,255,0.40)] dark:prose-a:hover:decoration-[rgba(255,255,255,0.70)] prose-a:sm:break-words;
     @apply prose-pre:px-0;
 
     > * {


### PR DESCRIPTION
## Summary
- Restrict link hover styling so it only applies when hovering the link itself.

## Steps to check
- open [blog post](https://neon-next-git-fix-links-hover-pixelpoint.vercel.app/blog/introducing-organization-spending-limits) and [docs](https://neon-next-git-fix-links-hover-pixelpoint.vercel.app/docs/get-started/dev-experience) preview
- make sure that everything looks and works as expected
