### PR TITLE
docs: Neon Auth OAuth BYO credentials (redirect URIs, troubleshooting)

### DIFF
--- a/content/docs/auth/guides/configure-domains.md
+++ b/content/docs/auth/guides/configure-domains.md
@@ -2,11 +2,10 @@
 title: Configure trusted domains
 subtitle: Add your application domains to enable secure authentication redirects
 summary: >-
-  Covers the setup of application domains in Neon Auth's allowlist to enable
-  secure OAuth and email verification redirects, preventing unauthorized access
-  and ensuring proper functionality in production environments.
+  Covers trusted domains for Neon Auth: exact origins, wildcard preview domains,
+  and enabling secure OAuth and email verification redirects.
 enableTableOfContents: true
-updatedOn: '2026-02-06T22:07:32.738Z'
+updatedOn: '2026-05-15T15:00:29.570Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
@@ -47,8 +46,14 @@ Add all domains where users access your application:
 - `https://www.myapp.com` (if you support www subdomain)
 - `https://app.myapp.com` (if using a subdomain)
 
-<Admonition type="important">
-Add each subdomain explicitly. Wildcards like `*.myapp.com` are not supported.
+## Wildcard domains for previews
+
+For preview environments with dynamic hostnames (for example Vercel preview deployments), you can add a **wildcard trusted domain** such as `https://*.my-app-preview.vercel.app`. One entry can match every preview under that pattern instead of adding hosts one by one.
+
+Use the same rules as fixed domains: include `https://` (or `http://` where appropriate) and omit trailing slashes after the pattern.
+
+<Admonition type="note">
+Wildcard patterns apply to the hostname segment you replace with `*`. Production apex domains (for example `https://myapp.com`) are usually still added as exact entries unless your wildcard covers them.
 </Admonition>
 
 ## Common issues

--- a/content/docs/auth/guides/setup-oauth.md
+++ b/content/docs/auth/guides/setup-oauth.md
@@ -1,12 +1,12 @@
 ---
 title: Set up OAuth
-subtitle: Add Google or GitHub sign-in to your application
+subtitle: Add Google, GitHub, or Vercel sign-in to your application
 summary: >-
   Step-by-step guide for setting up OAuth sign-in with Google, GitHub, or Vercel
-  in your application using Neon Auth, including development and production
-  configurations.
+  in your application using Neon Auth, including Google Cloud redirect URIs,
+  trusted domains, and production configuration.
 enableTableOfContents: true
-updatedOn: '2026-03-23T15:16:28.128Z'
+updatedOn: '2026-05-15T14:48:25.606Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
@@ -18,14 +18,14 @@ OAuth lets users sign in with their Google, GitHub, or Vercel account. Neon Auth
 Google OAuth is enabled by default with shared credentials for development and testing. You can start using Google sign-in immediately without any configuration.
 
 <Admonition type="note">
-GitHub and Vercel OAuth require custom credentials and is not available with shared credentials. See [Production setup](#production-setup) to configure your own OAuth apps.
+GitHub and Vercel OAuth require custom credentials and are not available with shared credentials. See [Production setup](#production-setup) to configure your own OAuth apps.
 </Admonition>
 
-For production, configure your own OAuth app credentials for both providers. See [Production setup](#production-setup) below.
+For production, configure your own OAuth app credentials for each provider you use. See [Production setup](#production-setup) below.
 
 ## Sign in with OAuth
 
-Call `signIn.social()` with your provider (`"google"`, `"github"` or `"vercel"`). The SDK redirects the user to the provider's authorization page, then back to your `callbackURL`:
+Call `signIn.social()` with your provider (`"google"`, `"github"`, or `"vercel"`). The SDK sends the user to the provider's sign-in page. After the user authorizes, the provider redirects to Neon Auth's OAuth callback route (see [Production setup](#production-setup)), then Neon Auth redirects the browser to your **`callbackURL`** (must use a [trusted domain](/docs/auth/guides/configure-domains) in production).
 
 <CodeTabs labels={["Google","GitHub","Vercel"]}>
 
@@ -78,7 +78,7 @@ const handleVercelSignIn = async () => {
 
 ## Handle the callback
 
-After the provider redirects back to your app, check for a session:
+After the OAuth exchange completes, Neon Auth redirects the browser to your **`callbackURL`**. Then load or refresh session state in your client:
 
 ```jsx {4-9} filename="src/App.jsx"
 import { authClient } from './auth';
@@ -110,17 +110,71 @@ await authClient.signIn.social({
 
 For production, configure your own OAuth app credentials. GitHub and Vercel OAuth require custom credentials, while Google OAuth works with shared credentials for development but should use custom credentials in production.
 
+### 1. Register redirect URIs with each provider
+
+Neon Auth uses [Better Auth](https://www.better-auth.com/) callback routes. For each OAuth provider you enable, register a redirect URI with this shape:
+
+```text
+{NEON_AUTH_BASE_URL}/callback/{provider}
+```
+
+Use the **Auth base URL** from the Neon Console for that branch. In your app it is usually the `NEON_AUTH_BASE_URL` or `VITE_NEON_AUTH_URL` value, or the URL you pass to `createAuthClient`. Do not add a trailing slash before `/callback`.
+
+Replace `{provider}` with `google`, `github`, or `vercel`.
+
+Example authorized redirect URI for Google:
+
+```text
+https://ep-example.neonauth.us-east-2.aws.neon.tech/neondb/auth/callback/google
+```
+
+Whether you use the [Next.js auth proxy](/docs/auth/reference/nextjs-server#auth-handler) (`app/api/auth/[...path]/route.ts`) or call Neon Auth from the browser, the provider redirects to **`{NEON_AUTH_BASE_URL}/callback/{provider}`** for that branch.
+
+<Admonition type="important" title="Do not confuse two different URLs">
+The **`callbackURL`** argument in `signIn.social()` is where users land **after** Neon Auth finishes the flow. That URL must live on an origin you add under [trusted domains](/docs/auth/guides/configure-domains).
+
+The provider's **authorized redirect URI** is where Google (or GitHub, and so on) sends the browser **during** the OAuth handshake. It must be **`{NEON_AUTH_BASE_URL}/callback/{provider}`**, not your app's homepage or only the `callbackURL`.
+
+Using only your marketing site's URL in Google Cloud Console, or only the `callbackURL`, is a common cause of `redirect_uri_mismatch`.
+</Admonition>
+
+**Google Cloud Console**
+
+Create an OAuth client with application type **Web application**. Under **Authorized redirect URIs**, add **`{NEON_AUTH_BASE_URL}/callback/google`** for each branch or environment (production, local testing against a branch, previews). Under **Authorized JavaScript origins**, include origins where your UI runs (for example `http://localhost:5173`, `https://myapp.com`) when Google asks for them, and include your Neon Auth origin (the scheme and host of `NEON_AUTH_BASE_URL`) if required.
+
+**GitHub**
+
+Set **Authorization callback URL** to **`{NEON_AUTH_BASE_URL}/callback/github`**.
+
+**Vercel**
+
+Follow [Vercel's OAuth app docs](https://vercel.com/docs/sign-in-with-vercel/manage-from-dashboard#create-an-app) and register **`{NEON_AUTH_BASE_URL}/callback/vercel`**.
+
+### 2. Add trusted domains for your app
+
+Before testing production OAuth, add every origin you pass as **`callbackURL`** (and related URLs) to Neon Auth's allowlist. See [Configure trusted domains](/docs/auth/guides/configure-domains).
+
+### 3. Create OAuth apps and paste credentials into Neon
+
 1. Create OAuth apps with your providers:
    - [Google OAuth setup](https://developers.google.com/identity/protocols/oauth2/web-server) (see [Google OAuth branding](#google-oauth-branding) below before going live)
    - [GitHub OAuth setup](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
    - [Vercel OAuth setup](https://vercel.com/docs/sign-in-with-vercel/manage-from-dashboard#create-an-app)
-2. In your project's **Settings** → **Auth** page, configure your Client ID and Client Secret for each provider
+2. In the Neon Console, open your **project**, select the **branch**, open **Auth**, then enter the **Client ID** and **Client Secret** for each provider.
 
-Your app will automatically use your configured credentials
+Neon Auth will use your configured credentials for that branch.
+
+### Branches and preview deployments
+
+Each branch has its own **`NEON_AUTH_BASE_URL`**. Register **`{NEON_AUTH_BASE_URL}/callback/google`** (and other providers you use) for every branch you test against (for example preview databases).
+
+Trusted domains do **not** support wildcards (`*.vercel.app`). See [Branching authentication](/docs/auth/branching-authentication) for preview workflows and the API for [trusted domains](https://api-docs.neon.tech/reference/addbranchneonauthtrusteddomain).
 
 ## Google OAuth branding
 
-When using your own Google OAuth credentials, users will see a consent screen before signing in. Without branding configured, Google displays the `redirect_uri` domain (**"Continue to neon.tech"**) instead of your app's name. This happens even when your OAuth client ID and secret are correctly configured.
+When using your own Google OAuth credentials, users will see a consent screen before signing in. Google shows a **Continue to** label that uses the hostname from your OAuth redirect URI (see [Production setup](#production-setup)), typically the Neon-managed host from your **`NEON_AUTH_BASE_URL`**.
+
+Without completing the OAuth consent screen branding (app name, support email, and authorized domains in Google Cloud Console), the consent UI can look generic or confusing even when your Client ID and Client Secret are correct.
 
 To show your app's name on the consent screen:
 
@@ -133,7 +187,7 @@ To show your app's name on the consent screen:
 4. Save your changes
 
 <Admonition type="important" title="Verification required for public apps">
-Apps in **Testing** status will still show the redirect_uri domain ("neon.tech") to users outside your test user list, regardless of branding settings. To show your app's name to all users, you must publish the app and submit it for Google verification. Verification typically takes a few business days but can take several weeks depending on the OAuth scopes requested.
+Apps in **Testing** status only allow Google accounts you list as **test users**. Everyone else sees errors or a blocked consent flow regardless of branding. To show your production branding and allow all users, publish the OAuth consent screen and complete Google verification when required. Verification typically takes a few business days but can take longer depending on the scopes you request.
 </Admonition>
 
 <DetailIconCards>

--- a/content/docs/auth/guides/setup-oauth.md
+++ b/content/docs/auth/guides/setup-oauth.md
@@ -6,7 +6,7 @@ summary: >-
   in your application using Neon Auth, including Google Cloud redirect URIs,
   trusted domains, and production configuration.
 enableTableOfContents: true
-updatedOn: '2026-05-15T14:48:25.606Z'
+updatedOn: '2026-05-15T15:00:29.570Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
@@ -168,7 +168,7 @@ Neon Auth will use your configured credentials for that branch.
 
 Each branch has its own **`NEON_AUTH_BASE_URL`**. Register **`{NEON_AUTH_BASE_URL}/callback/google`** (and other providers you use) for every branch you test against (for example preview databases).
 
-Trusted domains do **not** support wildcards (`*.vercel.app`). See [Branching authentication](/docs/auth/branching-authentication) for preview workflows and the API for [trusted domains](https://api-docs.neon.tech/reference/addbranchneonauthtrusteddomain).
+For preview deployments, trusted domains support **wildcard patterns** (for example `https://*.my-app-preview.vercel.app`), so you can cover many preview hosts without listing each one. See [Configure trusted domains](/docs/auth/guides/configure-domains), [Branching authentication](/docs/auth/branching-authentication), and the API for [trusted domains](https://api-docs.neon.tech/reference/addbranchneonauthtrusteddomain).
 
 ## Google OAuth branding
 

--- a/content/docs/auth/reference/ui-components.md
+++ b/content/docs/auth/reference/ui-components.md
@@ -6,7 +6,7 @@ summary: >-
   `@neondatabase/neon-js`, including installation, provider setup, and
   configuration of common props for customization.
 enableTableOfContents: true
-updatedOn: '2026-05-12T20:18:01.470Z'
+updatedOn: '2026-05-15T14:48:25.606Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
@@ -82,7 +82,7 @@ function App() {
 }
 ```
 
-**Note:** Google OAuth works with shared credentials for development. GitHub OAuth requires custom credentials. The `social.providers` prop controls which provider buttons are displayed in the UI. For production, configure your own OAuth credentials in the Neon Console (Settings → Auth). See the [OAuth setup guide](/docs/auth/guides/setup-oauth) for details.
+**Note:** Google OAuth works with shared credentials for development. GitHub OAuth requires custom credentials. The `social.providers` prop controls which provider buttons are displayed in the UI. For production, configure OAuth credentials in the Neon Console (**branch → Auth**) and register provider redirect URIs (see [OAuth setup](/docs/auth/guides/setup-oauth#production-setup)).
 
 ### React Router Integration
 

--- a/content/docs/auth/troubleshooting.md
+++ b/content/docs/auth/troubleshooting.md
@@ -3,10 +3,10 @@ title: Auth troubleshooting
 subtitle: Common issues when implementing Neon Auth and how to fix them
 summary: >-
   Troubleshooting guide for common Neon Auth implementation issues, including
-  environment configuration, adapter setup, CSS imports, and framework-specific
-  requirements.
+  OAuth redirect URIs, trusted domains, environment configuration, adapter
+  setup, CSS imports, and framework-specific requirements.
 enableTableOfContents: true
-updatedOn: '2026-05-06T12:48:49.000Z'
+updatedOn: '2026-05-15T14:48:25.606Z'
 ---
 
 This page covers common issues when integrating [Neon Auth](/docs/auth/overview) with `@neondatabase/auth` (Next.js) or `@neondatabase/neon-js` (React SPAs).
@@ -97,5 +97,28 @@ createAuthClient();
 ```
 
 See the [Next.js quick start](/docs/auth/quick-start/nextjs-api-only) and the [React quick start](/docs/auth/quick-start/react) for complete client setup examples.
+
+## OAuth errors (`redirect_uri_mismatch`, blocked consent, redirect loops)
+
+**`redirect_uri_mismatch` from Google (or another provider)**
+
+The authorized redirect URI in the provider's dashboard must match Neon Auth's callback route exactly: **`{NEON_AUTH_BASE_URL}/callback/{provider}`** (for example `.../callback/google`). See [Production setup](/docs/auth/guides/setup-oauth#production-setup).
+
+Common mistakes:
+
+- Registering only your marketing site or only the `callbackURL` from `signIn.social()`, instead of **`{NEON_AUTH_BASE_URL}/callback/{provider}`**.
+- Using a branch's **`NEON_AUTH_BASE_URL`** in your app while Google still lists redirect URIs for a different branch's Auth base URL.
+
+**OAuth succeeds but the user never reaches your app**
+
+Neon Auth only redirects to [trusted domains](/docs/auth/guides/configure-domains). Add every origin you use in **`callbackURL`** (including `https://www.example.com` separately if you use www).
+
+**Google consent screen shows an unexpected hostname**
+
+That hostname comes from the OAuth redirect URI (your app vs Neon Auth). See [Google OAuth branding](/docs/auth/guides/setup-oauth#google-oauth-branding).
+
+**Google says the app is in Testing / users outside test accounts cannot sign in**
+
+Add testers in Google Cloud Console or publish the OAuth consent screen for production use. See [Google OAuth branding](/docs/auth/guides/setup-oauth#google-oauth-branding).
 
 <NeedHelp/>


### PR DESCRIPTION
## Summary

- Expand [Set up OAuth](https://neon.com/docs/auth/guides/setup-oauth) for production BYO Google/GitHub/Vercel: document **`{NEON_AUTH_BASE_URL}/callback/{provider}`** for provider dashboards, distinguish **`callbackURL`** vs authorized redirects, link trusted domains, branches/previews, and refresh Google consent-screen guidance (without implying Microsoft is supported in Neon Auth UI/docs).
- Add an **OAuth errors** section to [Auth troubleshooting](https://neon.com/docs/auth/troubleshooting).
- Point [UI components](https://neon.com/docs/auth/reference/ui-components) OAuth notes at production setup for redirect URIs.

## Test plan

- [x] Spot-check rendered MDX locally (`npm run dev`) for `/docs/auth/guides/setup-oauth`, `/docs/auth/troubleshooting`, `/docs/auth/reference/ui-components`.
- [x] Confirm Neon Auth engineering agrees **`{NEON_AUTH_BASE_URL}/callback/{provider}`** matches deployed Neon Auth behavior.