### PR TITLE
docs: tighten API reference CopyPrompt and update neon-api-prompt

### DIFF
--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -8,11 +8,11 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/reference/about
   - /docs/api/about
-updatedOn: '2026-05-15T17:36:12.033Z'
+updatedOn: '2026-05-15T17:51:14.030Z'
 ---
 
 <CopyPrompt src="/prompts/neon-api-prompt.md" title="AI prompt: Get started with the Neon API"
-description="Copy into your AI coding assistant to get help creating an API key and making your first API call."/>
+description="Copy into your AI assistant to get an API key and make your first API call."/>
 
 The Neon API allows you to manage your Neon projects programmatically. You can create and manage projects, branches, databases, roles, compute endpoints, and more. Everything you can do in the Neon Console, you can do with the API.
 

--- a/content/docs/reference/api-reference.md
+++ b/content/docs/reference/api-reference.md
@@ -8,11 +8,11 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/reference/about
   - /docs/api/about
-updatedOn: '2026-04-14T20:58:35.000Z'
+updatedOn: '2026-05-15T17:36:12.033Z'
 ---
 
 <CopyPrompt src="/prompts/neon-api-prompt.md" title="AI prompt: Get started with the Neon API"
-description="Copy this prompt into your AI coding assistant (Cursor, Copilot, etc.) to get help creating your first API key and making your first successful API call (using curl, the TypeScript SDK, or the Python SDK)."/>
+description="Copy into your AI coding assistant to get help creating an API key and making your first API call."/>
 
 The Neon API allows you to manage your Neon projects programmatically. You can create and manage projects, branches, databases, roles, compute endpoints, and more. Everything you can do in the Neon Console, you can do with the API.
 

--- a/public/prompts/neon-api-prompt.md
+++ b/public/prompts/neon-api-prompt.md
@@ -4,13 +4,6 @@
 
 **Purpose:** To guide the user through getting an API key and making their first successful API call.
 
-**When to use this prompt:** Copy and paste this into your AI assistant when you want to:
-- Get set up with a Neon API key for the first time
-- Make your first API call to verify everything works
-- Understand the basics of Neon API authentication
-
----
-
 ## Step 1: Get Your Neon API Key
 
 Before you can use the Neon API, you need an API key. Here's how to create one:
@@ -112,47 +105,11 @@ All three options return your projects:
 
 ---
 
-## Next Steps
-
-Once your first API call works, here are common operations:
-
-### Create a Branch
-
-Use the `project_id` from the list projects response:
-
-**curl:**
-```bash
-curl -X POST 'https://console.neon.tech/api/v2/projects/{project_id}/branches' \
-  -H "Authorization: Bearer $NEON_API_KEY" \
-  -H 'Content-Type: application/json' \
-  -d '{"branch": {"name": "dev-branch"}}'
-```
-
-**TypeScript SDK:**
-```typescript
-const response = await apiClient.createProjectBranch('project-id-here', {
-  branch: { name: 'dev-branch' },
-});
-console.log(response.data.branch);
-```
-
-**Python SDK:**
-```python
-branch = neon.branch_create(
-    project_id="project-id-here",
-    branch={"name": "dev-branch"}
-)
-print(branch)
-```
-
----
-
 ## Key Resources
 
 - **Interactive API Reference:** https://api-docs.neon.tech/reference/getting-started-with-neon-api (try endpoints directly)
-- **Full API Documentation:** https://neon.tech/docs/reference/api-reference
-- **SDKs:** https://neon.tech/docs/reference/sdk
-- **Comprehensive AI Rules:** https://neon.tech/docs/ai/ai-rules-neon-api (for deeper AI integration)
+- **Full API Documentation:** https://neon.com/docs/reference/api-reference
+- **SDKs:** https://neon.com/docs/reference/sdk
 
 ---
 


### PR DESCRIPTION
## Summary

- Shortened the `CopyPrompt` description on the API reference page from a long parenthetical list to a single concise sentence
- Updated `neon-api-prompt.md`: removed the "When to use this prompt" meta-section, removed the "Next Steps: Create a Branch" section (out of scope for a getting-started prompt), fixed `neon.tech/docs` links to `neon.com/docs`, and removed a broken link to a non-existent `ai-rules-neon-api` page

## Test plan

- [ ] Verify the CopyPrompt CTA on `/docs/reference/api-reference` renders correctly
- [ ] Confirm the copied prompt text is accurate and concise
- [ ] Check that the Key Resources links in the prompt resolve correctly

## NEON PREVIEW

- https://neon-next-git-doc-api-cta-neondatabase.vercel.app/docs/reference/api-reference