### PR TITLE
docs: add auth references

### DIFF
--- a/content/docs/auth/guides/manage-auth-api.md
+++ b/content/docs/auth/guides/manage-auth-api.md
@@ -8,12 +8,12 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/neon-auth/api
   - /docs/guides/neon-auth-api
-updatedOn: '2026-05-13T12:43:58.316Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
 
-You can manage Neon Auth programmatically using the [Neon API](https://api-docs.neon.tech/reference/getting-started).
+You can manage Neon Auth programmatically using the [Neon API](https://api-docs.neon.tech/reference/getting-started). You can also enable and configure Neon Auth from an AI editor using the [Neon MCP server](/docs/ai/neon-mcp-server#supported-actions-tools) (`provision_neon_auth`, `configure_neon_auth`, `get_neon_auth_config`). See [Set up with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor).
 
 <Admonition type="note">
 Neon Auth operates at the **branch level**. Each branch can have its own independent auth configuration, which means preview and development branches can have separate auth state from your production branch.

--- a/content/docs/auth/overview.md
+++ b/content/docs/auth/overview.md
@@ -6,7 +6,7 @@ summary: >-
   integrates with your Neon database, allowing for branch-aware authentication
   and seamless testing of authentication workflows in isolated environments.
 enableTableOfContents: true
-updatedOn: '2026-05-12T23:02:23.681Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 redirectFrom:
   - /docs/neon-auth/quick-start/nextjs
   - /docs/auth/migrate/from-stack-auth
@@ -40,14 +40,9 @@ Choose your framework to get started:
 
 </TechCards>
 
-<Admonition type="tip" title="Using an AI coding tool?">
-Run [`neonctl init`](/docs/reference/cli-init) to configure your editor with the Neon MCP server and agent skills, including Neon Auth setup guidance:
+## Set up with your AI editor
 
-```bash
-npx neonctl@latest init
-```
-
-</Admonition>
+<AuthAISetup />
 
 ## Why Neon Auth?
 
@@ -86,7 +81,7 @@ As Neon Auth evolves, more Better Auth integrations and features will be added. 
 
 ## Basic usage
 
-Enable Auth in your Neon project, then add authentication to your app.
+Enable Auth in the Neon Console or [with your AI editor](#set-up-with-your-ai-editor), then add authentication to your app.
 
 **For Next.js (server-side):**
 

--- a/content/docs/auth/quick-start/nextjs-api-only.md
+++ b/content/docs/auth/quick-start/nextjs-api-only.md
@@ -6,7 +6,7 @@ summary: >-
   enabling authentication, installing the Neon SDK, and setting up environment
   variables.
 enableTableOfContents: true
-updatedOn: '2026-05-06T12:48:49.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 layout: wide
 redirectFrom:
   - /docs/auth/quick-start/nextjs
@@ -15,14 +15,7 @@ redirectFrom:
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
 
-<Admonition type="tip" title="Using an AI coding tool?">
-Run [`neonctl init`](/docs/reference/cli-init) to configure your editor with the Neon MCP server and agent skills, including Neon Auth setup guidance:
-
-```bash
-npx neonctl@latest init
-```
-
-</Admonition>
+<AuthAISetupTip />
 
 This guide shows you how to integrate Neon Auth into a [Next.js](https://nextjs.org) (App Router) project using SDK methods directly. For pre-built UI components, see the [UI components reference](/docs/auth/reference/ui-components) and the [neon-js examples](https://github.com/neondatabase/neon-js/tree/main/examples). Upgrading from v0.1? See the [migration guide](/docs/auth/migrate/from-auth-v0.1).
 

--- a/content/docs/auth/quick-start/react.md
+++ b/content/docs/auth/quick-start/react.md
@@ -6,7 +6,7 @@ summary: >-
   covering project setup, SDK installation, environment variable configuration,
   and client setup for authentication methods.
 enableTableOfContents: true
-updatedOn: '2026-03-23T15:16:28.133Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 layout: wide
 redirectFrom:
   - /docs/auth/quick-start/react-router-components
@@ -15,14 +15,7 @@ redirectFrom:
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
 
-<Admonition type="tip" title="Using an AI coding tool?">
-Run [`neonctl init`](/docs/reference/cli-init) to configure your editor with the Neon MCP server and agent skills, including Neon Auth setup guidance:
-
-```bash
-npx neonctl@latest init
-```
-
-</Admonition>
+<AuthAISetupTip />
 
 <TwoColumnLayout>
 

--- a/content/docs/auth/quick-start/tanstack-router.md
+++ b/content/docs/auth/quick-start/tanstack-router.md
@@ -6,20 +6,13 @@ summary: >-
   project creation, SDK installation, environment variable configuration, and
   style integration.
 enableTableOfContents: true
-updatedOn: '2026-05-06T12:48:49.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 layout: wide
 ---
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
 
-<Admonition type="tip" title="Using an AI coding tool?">
-Run [`neonctl init`](/docs/reference/cli-init) to configure your editor with the Neon MCP server and agent skills, including Neon Auth setup guidance:
-
-```bash
-npx neonctl@latest init
-```
-
-</Admonition>
+<AuthAISetupTip />
 
 <TwoColumnLayout>
 

--- a/content/docs/auth/roadmap.md
+++ b/content/docs/auth/roadmap.md
@@ -6,7 +6,7 @@ summary: >-
   frameworks, authentication methods, Better Auth plugins, platform features,
   SDK references, and migration guides.
 enableTableOfContents: true
-updatedOn: '2026-05-12T23:02:23.681Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
@@ -65,11 +65,12 @@ See [Set up OAuth](/docs/auth/guides/setup-oauth) for Neon-specific OAuth config
 
 These capabilities are documented in Neon Auth guides but are not Better Auth plugins you enable through the SDK.
 
-| Capability                           | Status    | Documentation                                                    |
-| ------------------------------------ | --------- | ---------------------------------------------------------------- |
-| Trusted domains (redirect allowlist) | Supported | [Configure trusted domains](/docs/auth/guides/configure-domains) |
-| Webhooks (auth events)               | Supported | [Webhooks](/docs/auth/guides/webhooks)                           |
-| Manage Auth via Neon API             | Supported | [Manage Auth in the Neon API](/docs/auth/guides/manage-auth-api) |
+| Capability                           | Status    | Documentation                                                                |
+| ------------------------------------ | --------- | ---------------------------------------------------------------------------- |
+| Trusted domains (redirect allowlist) | Supported | [Configure trusted domains](/docs/auth/guides/configure-domains)             |
+| Webhooks (auth events)               | Supported | [Webhooks](/docs/auth/guides/webhooks)                                       |
+| Manage Auth via Neon API             | Supported | [Manage Auth in the Neon API](/docs/auth/guides/manage-auth-api)             |
+| Manage Auth via Neon MCP (AI editor) | Supported | [Set up with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor) |
 
 Branch-aware auth (separate auth state per Neon branch) is supported; see [Branching authentication](/docs/auth/branching-authentication) and [Authentication flow](/docs/auth/authentication-flow).
 

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   Row-Level Security (RLS), and execute your first query, including optional
   authentication and schema access configurations.
 enableTableOfContents: true
-updatedOn: '2026-04-18T12:16:58.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 This guide walks you through enabling the Data API, creating a table with RLS, and running your first query.
@@ -489,6 +489,7 @@ For the complete list of methods and detailed examples, see the [Neon TypeScript
 
 ## Next steps
 
+- [Set up Neon Auth](/docs/auth/overview): Managed authentication with JWTs that work natively with the Data API and Row Level Security
 - [Build a note-taking app](/docs/data-api/demo): Hands-on tutorial with Data API queries
 - [Neon TypeScript SDK](/docs/reference/javascript-sdk): All database methods: select, insert, update, delete, filters, and more
 - [Generate TypeScript types](/docs/data-api/generate-types): Get autocomplete for table names and columns

--- a/content/docs/get-started/connect-neon.md
+++ b/content/docs/get-started/connect-neon.md
@@ -8,7 +8,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/get-started-with-neon/connect-neon
-updatedOn: '2026-02-06T22:07:32.886Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 Connecting to Neon works like any Postgres database. You use a standard connection string with your language or framework of choice. This guide shows you the essentials to get connected quickly.
@@ -239,6 +239,8 @@ This covers the basics. For more connection options and detailed guidance:
 <a href="/docs/get-started/languages" description="Connection examples for JavaScript, Python, Go, Rust, and other languages" icon="code">Language guides</a>
 
 <a href="/docs/serverless/serverless-driver" description="Connect from serverless and edge environments using HTTP or WebSockets" icon="audio-jack">Serverless driver</a>
+
+<a href="/docs/auth/overview" description="Managed authentication that branches with your database" icon="lock-landscape">Set up Neon Auth</a>
 
 </DetailIconCards>
 

--- a/content/docs/get-started/frameworks.md
+++ b/content/docs/get-started/frameworks.md
@@ -8,14 +8,16 @@ summary: >-
 enableTableOfContents: false
 redirectFrom:
   - /docs/get-started-with-neon/frameworks
-updatedOn: '2026-02-06T22:07:32.888Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
+
+Several frameworks support [Neon Auth](/docs/auth/overview), managed authentication stored in your database that **branches with your data**. Quick starts are available for [Next.js](/docs/auth/quick-start/nextjs-api-only), [React](/docs/auth/quick-start/react), and [TanStack Router](/docs/auth/quick-start/tanstack-router).
 
 <TechCards>
 
 <a href="/docs/guides/node" title="Node.js" description="Connect a Node.js application to Neon" icon="node-js"></a>
 
-<a href="/docs/guides/nextjs" title="Next.js" description="Connect a Next.js application to Neon" icon="next-js"></a>
+<a href="/docs/guides/nextjs" title="Next.js" description="Connect a Next.js application to Neon. Neon Auth supported." icon="next-js"></a>
 
 <a href="/docs/guides/nestjs" title="NestJS" description="Connect a NestJS application to Neon" icon="nest-js"></a>
 
@@ -65,7 +67,7 @@ updatedOn: '2026-02-06T22:07:32.888Z'
 
 <a href="/docs/guides/sveltekit" title="Sveltekit" description="Connect a Sveltekit application to Neon" icon="svelte"></a>
 
-<a href="/docs/guides/tanstack-start" title="TanStack Start" description="Connect a TanStack Start application to Neon" icon="tanstack"></a>
+<a href="/docs/guides/tanstack-start" title="TanStack Start" description="Connect a TanStack Start application to Neon. Neon Auth supported." icon="tanstack"></a>
 
 <a href="/docs/guides/vue" title="Vue" description="Connect a Vue.js application to Neon" icon="vue"></a>
 

--- a/content/docs/get-started/signing-up.md
+++ b/content/docs/get-started/signing-up.md
@@ -11,7 +11,7 @@ redirectFrom:
   - /docs/cloud/getting-started/
   - /docs/cloud/getting_started/
   - /docs/get-started-with-neon/signing-up
-updatedOn: '2026-04-06T14:16:24.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 <InfoBlock>
@@ -378,5 +378,9 @@ Make sure that your development team is always working from the latest schema an
 - **Working with sensitive data?** Neon supports [schema-only branching](/docs/guides/branching-schema-only) to create branches with just the database structure, without copying production data.
 - **Need automatic cleanup?** Set branches to automatically [expire and be deleted](/docs/guides/branch-expiration) after a specified time period, perfect for temporary test branches or time-limited preview environments.
 </Admonition>
+
+## What's next
+
+Building an app with users? [Set up Neon Auth](/docs/auth/overview) for managed sign-up, sessions, and OAuth. Identity lives in Postgres and branches with your data, so you can test full login flows on preview branches without touching production.
 
 <NeedHelp/>

--- a/content/docs/get-started/workflow-primer.md
+++ b/content/docs/get-started/workflow-primer.md
@@ -9,7 +9,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/get-started-with-neon/workflow-primer
-updatedOn: '2026-04-18T12:27:58.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 With Neon, you can work with your data just like you work with your code. The key is Neon's database [branching](/docs/guides/branching-intro) feature, which lets you instantly create branches of your data that you can include in your workflow, as many branches as you need.
@@ -155,8 +155,7 @@ dev/alice             dev/new-onboarding
 
 Whenever you create a pull request, you can create a Neon branch for your preview deployment. This allows you to test your code changes and SQL migrations against production-like data.
 
-<Admonition type="tip">
-We recommend following this naming convention to identify these branches easily:
+We recommend following this naming convention to identify preview branches easily:
 
 ```bash
 preview/pr-<pull_request_number>-<git_branch_name>
@@ -168,6 +167,8 @@ Example:
 preview/pr-123-feat/new-login-screen
 ```
 
+<Admonition type="tip" title="Using Neon Auth?">
+[Neon Auth](/docs/auth/overview) is provisioned on preview branches when enabled on production. Each preview gets isolated users, sessions, and auth configuration that branches with the database. Vercel integrations set `NEON_AUTH_BASE_URL` and `VITE_NEON_AUTH_URL` automatically. See [Branching authentication](/docs/auth/branching-authentication) and [Neon-managed Vercel integration](/docs/guides/neon-managed-vercel-integration).
 </Admonition>
 
 You can also automate branch creation for every preview. These example applications show how to create Neon branches with GitHub Actions for every preview environment.

--- a/content/docs/guides/auth-auth0.md
+++ b/content/docs/guides/auth-auth0.md
@@ -7,11 +7,11 @@ summary: >-
   application using a Neon Postgres database, including setup, schema
   definition, and user data management.
 enableTableOfContents: true
-updatedOn: '2026-05-09T15:15:10.215Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
-<Admonition type="note">
-Neon also provides [Neon Auth](/docs/auth/overview), a managed authentication service built on Better Auth that stores users, sessions, and auth configuration directly in your Neon database. Neon Auth branches with your database, letting you test authentication workflows in preview environments.
+<Admonition type="tip" title="Building on Neon?">
+Neon provides [Neon Auth](/docs/auth/overview), a managed authentication service built on Better Auth that stores users, sessions, and auth configuration directly in your Neon database. Auth state **branches with your data**, so preview and CI environments get isolated users and sessions.
 </Admonition>
 
 User authentication is an essential part of most web applications. Modern apps often require features like social login, multi-factor authentication, and secure user data management that complies with privacy regulations.

--- a/content/docs/guides/auth-authjs.md
+++ b/content/docs/guides/auth-authjs.md
@@ -7,15 +7,11 @@ summary: >-
   application using Auth.js with Neon Postgres as the database backend and
   Resend for sending magic link emails.
 enableTableOfContents: true
-updatedOn: '2026-02-15T20:51:54.119Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
-<Admonition type="note">
-Neon also provides [Neon Auth](/docs/auth/overview), a managed authentication service built on Better Auth that stores users, sessions, and auth configuration directly in your Neon database. Neon Auth branches with your database, letting you test authentication workflows in preview environments.
-</Admonition>
-
-<Admonition type="tip" title="Did you know?">
-We recently introduced an Auth.js adapter for Neon, making it easier to store user and session data in Neon. For installation and setup instructions, see [Neon Adapter](https://authjs.dev/getting-started/adapters/neon).
+<Admonition type="tip" title="Authentication on Neon">
+This guide uses the [Neon Adapter](https://authjs.dev/getting-started/adapters/neon) for Auth.js to store users and sessions in your database. If you prefer a managed option with no separate auth infrastructure, see [Neon Auth](/docs/auth/overview). Auth state branches with your database for preview and CI environments.
 </Admonition>
 
 [Auth.js](https://authjs.dev/) (formerly NextAuth.js) is a popular authentication solution that supports a wide range of authentication methods, including social logins (for example, Google, Facebook), traditional email/password, and passwordless options like magic links. For simple authentication flows, such as social logins, Auth.js can operate using only in-memory session storage (in a browser cookie). However, if you want to implement custom login flows, or persist the signed-in users' information in your database, you need to specify a database backend.

--- a/content/docs/guides/auth-clerk.md
+++ b/content/docs/guides/auth-clerk.md
@@ -7,11 +7,11 @@ summary: >-
   application using a Neon Postgres database, covering project setup, database
   connection, schema definition, and user data management.
 enableTableOfContents: true
-updatedOn: '2026-02-06T22:07:32.918Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
-<Admonition type="note">
-Neon also provides [Neon Auth](/docs/auth/overview), a managed authentication service built on Better Auth that stores users, sessions, and auth configuration directly in your Neon database. Neon Auth branches with your database, letting you test authentication workflows in preview environments.
+<Admonition type="tip" title="Building on Neon?">
+Neon provides [Neon Auth](/docs/auth/overview), a managed authentication service built on Better Auth that stores users, sessions, and auth configuration directly in your Neon database. Auth state **branches with your data**, so preview and CI environments get isolated users and sessions.
 </Admonition>
 
 User authentication is a critical requirement for web applications. Modern applications require advanced features like social login and multi-factor authentication besides the regular login flow. Additionally, managing personally identifiable information (PII) requires a secure solution compliant with data protection regulations.

--- a/content/docs/guides/auth-okta.md
+++ b/content/docs/guides/auth-okta.md
@@ -7,11 +7,11 @@ summary: >-
   application using Okta, including project setup, database connection, schema
   definition, and user data management.
 enableTableOfContents: true
-updatedOn: '2026-05-09T15:15:10.215Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
-<Admonition type="note">
-Neon also provides [Neon Auth](/docs/auth/overview), a managed authentication service built on Better Auth that stores users, sessions, and auth configuration directly in your Neon database. Neon Auth branches with your database, letting you test authentication workflows in preview environments.
+<Admonition type="tip" title="Building on Neon?">
+Neon provides [Neon Auth](/docs/auth/overview), a managed authentication service built on Better Auth that stores users, sessions, and auth configuration directly in your Neon database. Auth state **branches with your data**, so preview and CI environments get isolated users and sessions.
 </Admonition>
 
 User authentication is critical for web applications, especially for apps internal to an organization. [Okta Workforce Identity Cloud](https://www.okta.com/workforce-identity/) is an identity and access management platform for organizations, that provides authentication, authorization, and user management capabilities.

--- a/content/docs/guides/branching-intro.md
+++ b/content/docs/guides/branching-intro.md
@@ -6,7 +6,7 @@ summary: >-
   workflows, including automation with APIs, CLI, and CI/CD tools for efficient
   branch management and preview deployments.
 enableTableOfContents: true
-updatedOn: '2026-05-12T14:01:17.544Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 Find detailed information and instructions about Neon's branching feature and how you can integrate branching with your development workflows.
@@ -24,6 +24,8 @@ Learn about branching and how you can apply it in your development workflows.
 <a href="/docs/guides/branch-archiving" description="Learn how Neon automatically archives inactive branches to cost-effective storage" icon="split-branch">Branch archiving</a>
 
 <a href="/docs/guides/branching-schema-only" description="Learn how you can protect sensitive data with schema-only branches" icon="split-branch">Schema-only branches</a>
+
+<a href="/docs/auth/branching-authentication" description="Test sign-in, OAuth, and permissions in isolated branches without touching production" icon="lock-landscape">Branching authentication</a>
 
 </DetailIconCards>
 

--- a/content/docs/guides/drizzle.md
+++ b/content/docs/guides/drizzle.md
@@ -6,7 +6,7 @@ summary: >-
   using Drizzle ORM, including configuration for migrations and driver
   connections.
 enableTableOfContents: true
-updatedOn: '2026-04-19T23:49:49.000Z'
+updatedOn: '2026-05-17T10:23:09.592Z'
 ---
 
 <CopyPrompt src="/prompts/drizzle-prompt.md" 
@@ -21,6 +21,7 @@ description="Pre-built prompt for connecting Node/TypeScript applications to Neo
 <DocsList title="Related resources" theme="docs">
   <a href="https://orm.drizzle.team/docs/tutorials/drizzle-with-neon">Drizzle with Neon Postgres (Drizzle Docs)</a>
   <a href="/docs/guides/drizzle-migrations">Schema migration with Drizzle ORM</a>
+  <a href="/docs/guides/nextjs#video-walkthrough">Getting started with Neon (Next.js and Drizzle video)</a>
 </DocsList>
 
 </InfoBlock>

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -9,13 +9,19 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
   - /docs/integrations/vercel
-updatedOn: '2026-05-17T10:06:14.681Z'
+updatedOn: '2026-05-17T10:23:09.592Z'
 ---
 
 <CopyPrompt src="/prompts/nextjs-prompt.md"
 description="Pre-built prompt for connecting Next.js applications to Neon"/>
 
 Next.js by Vercel is an open-source web development framework that enables React-based web applications. This topic describes how to create a Neon project and access it from a Next.js application.
+
+## Video walkthrough
+
+Watch **Getting started with Neon** for an end-to-end setup with Next.js and Drizzle.
+
+<YoutubeIframe embedId="XtMiMnX0hDg" />
 
 To create a Neon project and access it from a Next.js application:
 

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -9,7 +9,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
   - /docs/integrations/vercel
-updatedOn: '2026-04-18T12:27:58.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 <CopyPrompt src="/prompts/nextjs-prompt.md"
@@ -427,5 +427,9 @@ PostgreSQL 17.7 on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14+
 ### Where to upload and serve files?
 
 Neon does not provide a built-in file storage service. For managing binary file data (blobs), we recommend using dedicated, specialized storage services. Follow our guide on [File Storage](/docs/guides/file-storage) to learn more about how to store files in external object storage and file management services and track metadata in Neon.
+
+## Next steps
+
+- [Set up Neon Auth](/docs/auth/quick-start/nextjs-api-only): Add managed authentication that branches with your database
 
 <NeedHelp/>

--- a/content/docs/guides/react-router.md
+++ b/content/docs/guides/react-router.md
@@ -6,7 +6,7 @@ summary: >-
   project, including project creation, dependency installation, and
   configuration of the Postgres client using a server-side `loader` function.
 enableTableOfContents: true
-updatedOn: '2026-02-06T22:07:33.036Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 [React Router](https://reactrouter.com/home) is a powerful routing library for React that also includes modern, full-stack framework features. This guide explains how to connect a React Router application to Neon using a server-side `loader` function.
@@ -181,5 +181,9 @@ PostgreSQL 17.5 (6bc9ef8) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 
 ```
 
 </Steps>
+
+## Next steps
+
+- [Set up Neon Auth](/docs/auth/quick-start/react): Add managed authentication that branches with your database
 
 <NeedHelp/>

--- a/content/docs/guides/react.md
+++ b/content/docs/guides/react.md
@@ -6,7 +6,7 @@ summary: >-
   database using various React meta-frameworks, ensuring proper server-side
   access.
 enableTableOfContents: true
-updatedOn: '2026-02-06T22:07:33.036Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 React by Facebook is an open-source front-end JavaScript library for building user interfaces based on components.
@@ -28,5 +28,19 @@ Find detailed instructions for connecting to Neon from various React meta-framew
 <a href="/docs/guides/sveltekit" title="Sveltekit" description="Connect a Sveltekit application to Neon" icon="svelte"></a>
 
 </TechCards>
+
+## Neon Auth
+
+After you connect your database, add managed authentication with [Neon Auth](/docs/auth/overview). Quick starts are available for supported React meta-frameworks:
+
+<TechCards>
+
+<a href="/docs/auth/quick-start/nextjs-api-only" title="Next.js" description="Set up Neon Auth with Next.js" icon="next-js"></a>
+
+<a href="/docs/auth/quick-start/tanstack-router" title="TanStack Router" description="Set up Neon Auth with TanStack Router" icon="tanstack"></a>
+
+</TechCards>
+
+For React Router, follow the [React Auth quick start](/docs/auth/quick-start/react).
 
 <NeedHelp/>

--- a/content/docs/guides/tanstack-start.md
+++ b/content/docs/guides/tanstack-start.md
@@ -9,7 +9,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/tanstack-start
   - /docs/integrations/tanstack-start
-updatedOn: '2026-04-18T12:27:58.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 <CopyPrompt src="/prompts/tanstack-start-prompt.md"
@@ -267,5 +267,9 @@ You can find the source code for the applications described in this guide on Git
 
 <a href="https://github.com/neondatabase/examples/tree/main/with-tanstack-start-static-server-functions" description="Get started with TanStack Start Static Server Functions and Neon" icon="github">Get started with TanStack Start Static Server Functions and Neon</a>
 </DetailIconCards>
+
+## Next steps
+
+- [Set up Neon Auth](/docs/auth/quick-start/tanstack-router): Add managed authentication that branches with your database
 
 <NeedHelp/>

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -9,7 +9,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-05-04T10:00:54.000Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 Neon is serverless Postgres designed to help you build faster. **Autoscaling**, **branching**, **instant restore**, and more. Get started with our [Free plan](https://console.neon.tech)
@@ -35,77 +35,77 @@ Neon is serverless Postgres designed to help you build faster. **Autoscaling**, 
 
 </DetailIconCards>
 
-## Quickstart prompts
+## Quickstarts
 
-Copy a setup prompt, or browse our [framework](/docs/get-started/frameworks), [language](/docs/get-started/languages), and [ORM](/docs/get-started/orms) guides.
+Step-by-step guides for frameworks, languages, and ORMs to connect your application to Neon. Using Next.js, React, or TanStack Router? Add [Neon Auth](/docs/auth/overview) after you connect.
 
-<PromptCards withToggler>
+<TechCards withToggler>
 
-<a title="Next.js" icon="next-js" promptSrc="/prompts/nextjs-prompt.md"></a>
+<a href="/docs/guides/nextjs" title="Next.js" description="Connect a Next.js application to Neon" icon="next-js"></a>
 
-<a title="Django" icon="django" promptSrc="/prompts/django-prompt.md"></a>
+<a href="/docs/guides/django" title="Django" description="Connect a Django application to Neon" icon="django"></a>
 
-<a title="Drizzle" icon="drizzle" promptSrc="/prompts/drizzle-prompt.md"></a>
+<a href="/docs/guides/drizzle" title="Drizzle" description="Learn how to use Drizzle ORM with your Neon Postgres database" icon="drizzle"></a>
 
-<a title="React Router" icon="react" promptSrc="/prompts/react-router-prompt.md"></a>
+<a href="/docs/guides/react-router" title="React Router" description="Connect a React Router application to Neon" icon="react"></a>
 
-<a title="TanStack Start" icon="tanstack" promptSrc="/prompts/tanstack-start-prompt.md"></a>
+<a href="/docs/guides/tanstack-start" title="TanStack Start" description="Connect a TanStack Start application to Neon" icon="tanstack"></a>
 
-<a title="Express" icon="express" promptSrc="/prompts/express-prompt.md"></a>
+<a href="/docs/guides/express" title="Express" description="Connect an Express application to Neon" icon="express"></a>
 
-<a title="NestJS" icon="nest-js" promptSrc="/prompts/nestjs-prompt.md"></a>
+<a href="/docs/guides/nestjs" title="NestJS" description="Connect a NestJS application to Neon" icon="nest-js"></a>
 
-<a title="Astro" icon="astro" promptSrc="/prompts/astro-serverless-prompt.md"></a>
+<a href="/docs/guides/astro" title="Astro" description="Connect an Astro site or app to Neon" icon="astro"></a>
 
-<a title="SvelteKit" icon="svelte" promptSrc="/prompts/sveltekit-prompt.md"></a>
+<a href="/docs/guides/sveltekit" title="SvelteKit" description="Connect a Sveltekit application to Neon" icon="svelte"></a>
 
-<a title="Nuxt" icon="nuxt" promptSrc="/prompts/nuxt-neon-prompt.md"></a>
+<a href="/docs/guides/nuxt" title="Nuxt" description="Connect a Nuxt application to Neon" icon="nuxt"></a>
 
-<a title="Laravel" icon="laravel" promptSrc="/prompts/laravel-prompt.md"></a>
+<a href="/docs/guides/laravel" title="Laravel" description="Connect a Laravel application to Neon" icon="laravel"></a>
 
-<a title="Rails" icon="rails" promptSrc="/prompts/ruby-on-rails-prompt.md"></a>
+<a href="/docs/guides/ruby-on-rails" title="Rails" description="Connect a Ruby on Rails application to Neon" icon="rails"></a>
 
-<a title="Python" icon="python" promptSrc="/prompts/python-prompt.md"></a>
+<a href="/docs/guides/python" title="Python" description="Connect a Python application to Neon" icon="python"></a>
 
-<a title="Go" icon="go" promptSrc="/prompts/golang-prompt.md"></a>
+<a href="/docs/guides/go" title="Go" description="Connect a Go application to Neon" icon="go"></a>
 
-<a title="Java" icon="java" promptSrc="/prompts/java-prompt.md"></a>
+<a href="/docs/guides/java" title="Java" description="Connect a Java application to Neon" icon="java"></a>
 
-<a title="Rust" icon="rust" promptSrc="/prompts/rust-prompt.md"></a>
+<a href="/docs/guides/rust" title="Rust" description="Connect a Rust application to Neon" icon="rust"></a>
 
-<a title=".NET" icon="dotnet" promptSrc="/prompts/dotnet-prompt.md"></a>
+<a href="/docs/guides/dotnet-npgsql" title=".NET" description="Connect a .NET (C#) application to Neon" icon="dotnet"></a>
 
-<a title="Elixir" icon="elixir" promptSrc="/prompts/elixir-prompt.md"></a>
+<a href="/docs/guides/elixir" title="Elixir" description="Connect an Elixir application to Neon" icon="elixir"></a>
 
-<a title="Phoenix" icon="phoenix" promptSrc="/prompts/phoenix-prompt.md"></a>
+<a href="/docs/guides/phoenix" title="Phoenix" description="Connect a Phoenix site or app to Neon" icon="phoenix"></a>
 
-<a title="Prisma" icon="prisma" promptSrc="/prompts/prisma-prompt.md"></a>
+<a href="/docs/guides/prisma" title="Prisma" description="Learn how to connect from Prisma ORM to your Neon Postgres database" icon="prisma"></a>
 
-<a title="Kysely" icon="kysely" promptSrc="/prompts/kysely-prompt.md"></a>
+<a href="/docs/guides/kysely" title="Kysely" description="Learn how to connect from Kysely to your Neon Postgres database" icon="kysely"></a>
 
-<a title="Tortoise ORM" icon="tortoise-orm" promptSrc="/prompts/tortoise-orm-prompt.md"></a>
+<a href="/docs/guides/tortoise-orm" title="Tortoise ORM" description="Connect a Tortoise ORM application to Neon" icon="tortoise-orm"></a>
 
-<a title="TypeORM" icon="typeorm" promptSrc="/prompts/typeorm-prompt.md"></a>
+<a href="/docs/guides/typeorm" title="TypeORM" description="Connect a TypeORM application to Neon" icon="typeorm"></a>
 
-<a title="SQLAlchemy" icon="sqlalchemy" promptSrc="/prompts/sqlalchemy-prompt.md"></a>
+<a href="/docs/guides/sqlalchemy" title="SQLAlchemy" description="Connect a SQLAlchemy application to Neon" icon="sqlalchemy"></a>
 
-<a title="Hono" icon="hono" promptSrc="/prompts/hono-prompt.md"></a>
+<a href="/docs/guides/hono" title="Hono" description="Connect a Hono application to Neon" icon="hono"></a>
 
-<a title="SolidStart" icon="solidstart" promptSrc="/prompts/solidstart-prompt.md"></a>
+<a href="/docs/guides/solid-start" title="SolidStart" description="Connect a SolidStart site or app to Neon" icon="solidstart"></a>
 
-<a title="Reflex" icon="reflex" promptSrc="/prompts/reflex-prompt.md"></a>
+<a href="/docs/guides/reflex" title="Reflex" description="Build Python Apps with Reflex and Neon" icon="reflex"></a>
 
-<a title="JavaScript" icon="javascript" promptSrc="/prompts/javascript-prompt.md"></a>
+<a href="/docs/guides/javascript" title="JavaScript" description="Connect a JavaScript application to Neon" icon="javascript"></a>
 
-<a title="Symfony" icon="symfony" promptSrc="/prompts/symfony-prompt.md"></a>
+<a href="/docs/guides/symfony" title="Symfony" description="Connect from Symfony with Doctrine to Neon" icon="symfony"></a>
 
-<a title="Quarkus" icon="quarkus" promptSrc="/prompts/quarkus-jdbc-prompt.md"></a>
+<a href="/docs/guides/quarkus-jdbc" title="Quarkus" description="Connect Quarkus (JDBC) to Neon" icon="quarkus"></a>
 
-<a title="Micronaut" icon="micronaut" promptSrc="/prompts/micronaut-kotlin-prompt.md"></a>
+<a href="/docs/guides/micronaut-kotlin" title="Micronaut" description="Connect a Micronaut Kotlin application to Neon" icon="micronaut"></a>
 
-<a title="Redwood" icon="redwoodsdk" promptSrc="/prompts/redwood-sdk-prompt.md"></a>
+<a href="/docs/guides/redwoodsdk" title="Redwood" description="Connect a RedwoodSDK application to Neon" icon="redwoodsdk"></a>
 
-</PromptCards>
+</TechCards>
 
 ## Explore the docs
 
@@ -116,6 +116,8 @@ Copy a setup prompt, or browse our [framework](/docs/get-started/frameworks), [l
 <a href="/docs/import/import-intro" description="Migrate your data to Neon" icon="import">Import data</a>
 
 <a href="/docs/ai/ai-intro" description="Build AI apps with pgvector" icon="openai">AI & embeddings</a>
+
+<a href="/docs/auth/overview" description="Managed authentication that branches with your database" icon="lock-landscape">Neon Auth</a>
 
 <a href="/docs/guides/branching-intro" description="Optimize development workflows" icon="split-branch">Branching</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -9,7 +9,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-05-17T10:06:14.681Z'
+updatedOn: '2026-05-17T10:13:12.126Z'
 ---
 
 Neon is serverless Postgres designed to help you build faster. **Autoscaling**, **branching**, **instant restore**, and more. Get started with our [Free plan](https://console.neon.tech)
@@ -18,6 +18,7 @@ Neon is serverless Postgres designed to help you build faster. **Autoscaling**, 
   title="Set up Neon in one command"
   description="Run this command to launch AI-guided setup. <a href='https://neon.com/blog/one-command-to-bridge-cursor-and-neon'>Learn more<svg width='16' height='12' viewBox='0 0 16 12' fill='none' xmlns='http://www.w3.org/2000/svg' style='display:inline-block;vertical-align:middle;margin-left:8px' aria-hidden='true'><path d='M11.1084 10.9211L14.9999 7.02965L11.1084 3.13816' stroke='currentColor' stroke-width='1.4' stroke-linecap='square'/><path d='M0.938093 7.03198L13.666 7.03198' stroke='currentColor' stroke-width='1.4' stroke-linecap='square'/></svg></a>"
   command="npx neonctl@latest init"
+  buttonText="Sign up"
   trackingLabel="Copy neonctl init - docs intro"
 />
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -9,7 +9,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-05-17T10:13:12.126Z'
+updatedOn: '2026-05-17T10:17:43.045Z'
 ---
 
 Neon is serverless Postgres designed to help you build faster. **Autoscaling**, **branching**, **instant restore**, and more. Get started with our [Free plan](https://console.neon.tech)
@@ -114,15 +114,17 @@ Step-by-step guides for frameworks, languages, and ORMs to connect your applicat
 
 <a href="/docs/connect/connect-intro" description="Connect from any application" icon="audio-jack">Connect</a>
 
-<a href="/docs/import/import-intro" description="Migrate your data to Neon" icon="import">Import data</a>
-
-<a href="/docs/ai/ai-intro" description="Build AI apps with pgvector" icon="openai">AI & embeddings</a>
-
-<a href="/docs/auth/overview" description="Managed authentication that branches with your database" icon="lock-landscape">Neon Auth</a>
+<a href="/docs/manage/platform" description="Manage projects, branches, and endpoints in the console" icon="gear">Manage</a>
 
 <a href="/docs/guides/branching-intro" description="Optimize development workflows" icon="split-branch">Branching</a>
 
+<a href="/docs/import/import-intro" description="Migrate your data to Neon" icon="import">Import data</a>
+
 <a href="/docs/extensions/pg-extensions" description="Extend Postgres capabilities" icon="app-store">Extensions</a>
+
+<a href="/docs/auth/overview" description="Managed authentication that branches with your database" icon="lock-landscape">Neon Auth</a>
+
+<a href="/docs/ai/ai-intro" description="Build AI apps with pgvector" icon="openai">AI & embeddings</a>
 
 <a href="/docs/reference/neon-cli" description="Manage from the terminal" icon="transactions">Neon CLI</a>
 

--- a/content/docs/introduction/branching.md
+++ b/content/docs/introduction/branching.md
@@ -11,7 +11,7 @@ redirectFrom:
   - /docs/conceptual-guides/branching
   - /docs/concepts/branching
   - /docs/introduction/point-in-time-restore
-updatedOn: '2026-05-12T14:01:17.544Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 With Neon, you can quickly branch your data for development, testing, and various other purposes, enabling you to improve developer productivity and optimize continuous integration and delivery (CI/CD) pipelines.
@@ -31,6 +31,10 @@ A branch is isolated from its originating data, so you are free to play around w
 Creating a branch does not increase load on the parent branch or affect it in any way, which means you can create a branch without impacting the performance of your production database.
 
 Each Neon project is created with a [root branch](/docs/reference/glossary#root-branch) called `main`. The first branch that you create is branched from the project's root branch. Subsequent branches can be branched from the root branch or from a previously created branch.
+
+<Admonition type="tip" title="Using Neon Auth?">
+Users, sessions, and auth configuration in the `neon_auth` schema branch with your data, so preview and test environments get isolated authentication state. See [Neon Auth](/docs/auth/overview) and [Branching authentication](/docs/auth/branching-authentication).
+</Admonition>
 
 ## Branching workflows
 

--- a/content/docs/shared-content/auth-ai-setup-tip.md
+++ b/content/docs/shared-content/auth-ai-setup-tip.md
@@ -1,0 +1,7 @@
+---
+updatedOn: '2026-05-17T10:06:14.681Z'
+---
+
+<Admonition type="tip" title="Using an AI coding tool?">
+Run `npx neonctl@latest init` to connect the [Neon MCP server](/docs/ai/neon-mcp-server) and [Agent Skills](/docs/ai/agent-skills) for Neon Auth. See [Set up with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor) for MCP tools, example prompts, and how skills help wire auth into your app.
+</Admonition>

--- a/content/docs/shared-content/auth-ai-setup.md
+++ b/content/docs/shared-content/auth-ai-setup.md
@@ -1,0 +1,29 @@
+---
+updatedOn: '2026-05-17T10:06:14.681Z'
+---
+
+The fastest way to connect your editor to Neon Auth is to run `npx neonctl@latest init` from your project root:
+
+```bash
+npx neonctl@latest init
+```
+
+This command configures the [Neon MCP server](/docs/ai/neon-mcp-server) and installs **[Agent Skills](/docs/ai/agent-skills)** (`neon-postgres`) in your project. Together they help you set up Neon Auth in two ways:
+
+1. **Configure Neon Auth on your branch (MCP).** After `init`, ask your assistant to enable and configure auth in natural language. The MCP server exposes:
+   - `provision_neon_auth`: Enable Neon Auth on a branch
+   - `configure_neon_auth`: Set OAuth providers, email, sign-in methods, trusted domains, and more
+   - `get_neon_auth_config`: Read the current configuration
+
+   See [Neon MCP Server: Neon Auth tools](/docs/ai/neon-mcp-server#supported-actions-tools) for details.
+
+2. **Add Neon Auth to your application (Agent Skills).** Skills teach your assistant how to install the SDK, environment variables, and routes for your framework. Use the quick start guides on this page, or ask your assistant directly.
+
+**Example prompt:**
+
+```text
+Set up Neon Auth for my project. Enable Google OAuth and email/password sign-in,
+and set the application name to "My App".
+```
+
+You can also enable Neon Auth in the [Neon Console](https://console.neon.tech) (Project → Branch → Auth) and configure settings manually.

--- a/content/docs/shared-content/index.js
+++ b/content/docs/shared-content/index.js
@@ -18,6 +18,8 @@ const sharedMdxComponents = {
   PrivatePreviewEnquire: 'shared-content/private-preview-enquire',
   EarlyAccessProps: 'shared-content/early-access-props',
   AgentSkillsTip: 'shared-content/agent-skills-tip',
+  AuthAISetup: 'shared-content/auth-ai-setup',
+  AuthAISetupTip: 'shared-content/auth-ai-setup-tip',
   AzureRegionsDeprecation: 'shared-content/azure-regions-deprecation',
   ConsumptionAccountApiDeprecation: 'shared-content/consumption-account-api-deprecation',
   NextjsProxyNote: 'shared-content/nextjs-proxy-note',

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-05-13T12:49:16.911Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 ## Supported actions (tools)
@@ -45,6 +45,8 @@ The Neon MCP Server provides the following actions, which are exposed as "tools"
 - `complete_query_tuning`: Finalizes query tuning by either applying optimizations to the main branch or discarding them. Cleans up the temporary tuning branch.
 
 **Neon Auth:**
+
+To set up Neon Auth in your application code, use [Agent Skills](/docs/ai/agent-skills) after running `npx neonctl@latest init`. See [Set up Neon Auth with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor).
 
 - `provision_neon_auth`: Provisions [Neon Auth](/docs/auth/overview) for a project's branch so you can add authentication to your app without standing up a separate auth service. If Neon Auth is already provisioned, this returns the existing configuration instead of erroring.
 - `get_neon_auth_config`: Returns the Neon Auth configuration for a branch, including the auth `base_url`, `jwks_url`, trusted origins, allowed auth methods (for example email and password), configured OAuth providers, and email provider settings. Secrets such as OAuth client secrets and SMTP passwords are redacted.

--- a/content/docs/shared-content/next-steps.md
+++ b/content/docs/shared-content/next-steps.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-03-05T04:12:51.014Z'
+updatedOn: '2026-05-17T10:06:14.681Z'
 ---
 
 ## Next steps
@@ -7,4 +7,4 @@ updatedOn: '2026-03-05T04:12:51.014Z'
 - [Import data into your database](/docs/import/migrate-intro)
 - [Integrate database branching into your dev workflow](/docs/get-started/workflow-primer)
 - [Secure your app with the Neon Data API](/docs/data-api/get-started)
-- [Setup Neon Auth for your app](/docs/guides/neon-auth)
+- [Set up Neon Auth for your app](/docs/auth/overview)

--- a/src/scripts/process-md-for-llms.js
+++ b/src/scripts/process-md-for-llms.js
@@ -71,6 +71,8 @@ const SHARED_CONTENT_COMPONENTS = {
   AzureRegionsDeprecation: 'azure-regions-deprecation',
   ConsumptionAccountApiDeprecation: 'consumption-account-api-deprecation',
   NextjsProxyNote: 'nextjs-proxy-note',
+  AuthAISetup: 'auth-ai-setup',
+  AuthAISetupTip: 'auth-ai-setup-tip',
 };
 
 /**


### PR DESCRIPTION
Summary

- Rework the docs intro Quickstarts section: link framework/language/ORM cards to connection guides instead of copy-prompt modals, and rename the section to Quickstarts.
- Promote Neon Auth on high-traffic paths: new Set up with your AI editor section on the [Auth overview](https://neon.com/docs/auth/overview) (neonctl init, MCP tools, Agent Skills), plus cross-links on connect, signup, branching, workflow primer, frameworks hub, and Data API get started.
- Add Next steps → Neon Auth on Next.js, React Router, and TanStack Start guides.
- Shared AuthAISetup / AuthAISetupTip snippets for Auth quick