### PR TITLE
docs: note default server logging in Next.js auth quick start

### DIFF
--- a/content/docs/auth/quick-start/nextjs-api-only.md
+++ b/content/docs/auth/quick-start/nextjs-api-only.md
@@ -6,7 +6,7 @@ summary: >-
   enabling authentication, installing the Neon SDK, and setting up environment
   variables.
 enableTableOfContents: true
-updatedOn: '2026-05-17T10:06:14.681Z'
+updatedOn: '2026-05-17T19:41:33.521Z'
 layout: wide
 redirectFrom:
   - /docs/auth/quick-start/nextjs
@@ -88,7 +88,11 @@ Create a unified auth instance in `lib/auth/server.ts`. This single instance pro
 - `.middleware()` for route protection
 - `.getSession()` and all Better Auth server methods
 
-See the [Next.js Server SDK reference](/docs/auth/reference/nextjs-server) for complete API documentation.
+See the [Next.js Server SDK reference](/docs/auth/reference/nextjs-server) for complete API documentation (logging, cookies, upstream errors).
+
+<Admonition type="note" title="Server logging (opt-out)">
+The SDK logs structured **`error`** and **`warn`** messages to **`console`** by default (`logLevel: 'warn'`). This helps when the auth proxy or upstream Auth URL is misconfigured. Set **`logLevel: 'silent'`** to disable Neon Auth console output, or **`logLevel: 'debug'`** for more detail. See [Server logging](/docs/auth/reference/nextjs-server#server-logging) in the reference.
+</Admonition>
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
@@ -100,7 +104,10 @@ export const auth = createNeonAuth({
   baseUrl: process.env.NEON_AUTH_BASE_URL!,
   cookies: {
     secret: process.env.NEON_AUTH_COOKIE_SECRET!,
+    // sessionDataTtl: 300, // optional session_data cache TTL in seconds (default: 300)
   },
+  // logLevel: 'silent', // disable Neon Auth console output
+  // logLevel: 'debug',  // verbose proxy/upstream logging
 });
 ```
 
@@ -473,6 +480,8 @@ The `auth` instance also includes `.handler()` for API routes and `.middleware()
 
 ## Next steps
 
+- [Next.js Server SDK reference](/docs/auth/reference/nextjs-server) — logging, cookie options, and upstream error codes
+- [Auth troubleshooting](/docs/auth/troubleshooting#neon-auth-server-logging-in-the-terminal) — unexpected console output, `NETWORK_*` errors, iframe cookies
 - [Add email verification](/docs/auth/guides/email-verification)
 - [Branching authentication](/docs/auth/branching-authentication)
 - [More example apps](/docs/auth/overview#example-applications) in the **neon-js** `examples/` directory

--- a/content/docs/auth/quick-start/nextjs-api-only.md
+++ b/content/docs/auth/quick-start/nextjs-api-only.md
@@ -6,7 +6,7 @@ summary: >-
   enabling authentication, installing the Neon SDK, and setting up environment
   variables.
 enableTableOfContents: true
-updatedOn: '2026-05-17T19:41:33.521Z'
+updatedOn: '2026-05-17T20:37:50.454Z'
 layout: wide
 redirectFrom:
   - /docs/auth/quick-start/nextjs
@@ -90,8 +90,8 @@ Create a unified auth instance in `lib/auth/server.ts`. This single instance pro
 
 See the [Next.js Server SDK reference](/docs/auth/reference/nextjs-server) for complete API documentation (logging, cookies, upstream errors).
 
-<Admonition type="note" title="Server logging (opt-out)">
-The SDK logs structured **`error`** and **`warn`** messages to **`console`** by default (`logLevel: 'warn'`). This helps when the auth proxy or upstream Auth URL is misconfigured. Set **`logLevel: 'silent'`** to disable Neon Auth console output, or **`logLevel: 'debug'`** for more detail. See [Server logging](/docs/auth/reference/nextjs-server#server-logging) in the reference.
+<Admonition type="note" title="Server logging">
+The SDK logs structured **`error`** and **`warn`** messages to **`console`** by default (`logLevel: 'warn'`). This helps when the auth proxy or upstream Auth URL is misconfigured. Set **`logLevel: 'silent'`** to disable Neon Auth logging, or **`logLevel: 'debug'`** for more detail. See [Server logging](/docs/auth/reference/nextjs-server#server-logging) in the reference.
 </Admonition>
 
 </TwoColumnLayout.Block>
@@ -106,7 +106,7 @@ export const auth = createNeonAuth({
     secret: process.env.NEON_AUTH_COOKIE_SECRET!,
     // sessionDataTtl: 300, // optional session_data cache TTL in seconds (default: 300)
   },
-  // logLevel: 'silent', // disable Neon Auth console output
+  // logLevel: 'silent', // disable Neon Auth logging
   // logLevel: 'debug',  // verbose proxy/upstream logging
 });
 ```
@@ -481,7 +481,7 @@ The `auth` instance also includes `.handler()` for API routes and `.middleware()
 ## Next steps
 
 - [Next.js Server SDK reference](/docs/auth/reference/nextjs-server) — logging, cookie options, and upstream error codes
-- [Auth troubleshooting](/docs/auth/troubleshooting#neon-auth-server-logging-in-the-terminal) — unexpected console output, `NETWORK_*` errors, iframe cookies
+- [Auth troubleshooting](/docs/auth/troubleshooting#neon-auth-server-logging-in-the-terminal) — server logging, `NETWORK_*` errors, iframe cookies
 - [Add email verification](/docs/auth/guides/email-verification)
 - [Branching authentication](/docs/auth/branching-authentication)
 - [More example apps](/docs/auth/overview#example-applications) in the **neon-js** `examples/` directory


### PR DESCRIPTION
## Summary

Documents opt-out `warn` console logging on `createNeonAuth` in the Next.js API quick start, with commented `logLevel` examples in the setup snippet.

Links to server reference and troubleshooting anchors in stacked PR #4932.

## Test plan

- [ ] Preview quick start page — logging admonition and snippet render correctly
- [ ] Cross-links work after #4932 merges