### PR TITLE
docs: document Next.js server logging, cookies, and network errors

### DIFF
--- a/content/docs/auth/reference/nextjs-server.md
+++ b/content/docs/auth/reference/nextjs-server.md
@@ -8,7 +8,7 @@ summary: >-
   management and middleware creation.
 enableTableOfContents: true
 layout: wide
-updatedOn: '2026-05-17T19:42:11.654Z'
+updatedOn: '2026-05-17T20:19:55.872Z'
 ---
 
 Reference documentation for the Neon Auth Next.js server SDK (`@neondatabase/auth/next/server`). This package provides server-side authentication for Next.js applications using React Server Components, API routes, middleware, and server actions.
@@ -849,7 +849,7 @@ When the SDK cannot reach your Neon Auth server (wrong `baseUrl`, DNS, TLS, time
 
 Client-visible messages are generic (for example, “Could not resolve authentication server hostname”). Check server logs (set `logLevel: 'debug'`) for `detail` and the raw error.
 
-**Non-transport failures** (unexpected exceptions while handling a response) are **re-thrown** so Next.js error boundaries behave as before. HTTP **4xx** upstream responses are logged at **`info`**; **5xx** at **`warn`**.
+**Non-transport failures** (unexpected exceptions while handling a response) are **re-thrown** so Next.js error boundaries still receive the original error. HTTP **4xx** upstream responses are logged at **`info`**; **5xx** at **`warn`**.
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
@@ -932,7 +932,7 @@ Complete configuration options for `createNeonAuth()`:
 - **cookies.secret**: Secret for HMAC-SHA256 signing (32+ characters)
 - **cookies.sessionDataTtl**: Cache TTL in seconds for the signed `session_data` cookie
 - **cookies.domain**: For cross-subdomain sessions (for example, ".example.com")
-- **cookies.sameSite**: `strict` (default), `lax`, or `none`. Use `lax` or `none` if you embed the app in a third-party iframe or need the previous Lax behavior
+- **cookies.sameSite**: `strict` (default), `lax`, or `none`. Use `lax` or `none` if you embed the app in a third-party iframe or need cookies on cross-site navigations
 - **logLevel**: `silent`, `error`, `warn`, `info`, or `debug` — see [Server logging](#server-logging)
 - **logger**: Optional custom logger; see [Server logging](#server-logging)
 

--- a/content/docs/auth/reference/nextjs-server.md
+++ b/content/docs/auth/reference/nextjs-server.md
@@ -8,7 +8,7 @@ summary: >-
   management and middleware creation.
 enableTableOfContents: true
 layout: wide
-updatedOn: '2026-03-23T12:18:17.915Z'
+updatedOn: '2026-05-17T19:42:11.654Z'
 ---
 
 Reference documentation for the Neon Auth Next.js server SDK (`@neondatabase/auth/next/server`). This package provides server-side authentication for Next.js applications using React Server Components, API routes, middleware, and server actions.
@@ -70,12 +70,17 @@ Returns an `auth` object with:
 
 ### Parameters
 
-| Parameter                       | Type   | Required | Default |
-| ------------------------------- | ------ | -------- | ------- |
-| <tt>baseUrl</tt>                | string | ✓        | -       |
-| <tt>cookies.secret</tt>         | string | ✓        | -       |
-| <tt>cookies.sessionDataTtl</tt> | number |          | 300     |
-| <tt>cookies.domain</tt>         | string |          | -       |
+| Parameter                       | Type   | Required | Default               |
+| ------------------------------- | ------ | -------- | --------------------- |
+| <tt>baseUrl</tt>                | string | ✓        | -                     |
+| <tt>cookies.secret</tt>         | string | ✓        | -                     |
+| <tt>cookies.sessionDataTtl</tt> | number |          | 300                   |
+| <tt>cookies.domain</tt>         | string |          | -                     |
+| <tt>cookies.sameSite</tt>       | string |          | `strict`              |
+| <tt>logLevel</tt>               | string |          | `warn`                |
+| <tt>logger</tt>                 | object |          | `console` (per level) |
+
+See [Server logging](#server-logging) and [Upstream fetch errors](#upstream-fetch-errors).
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
@@ -89,8 +94,49 @@ export const auth = createNeonAuth({
   cookies: {
     secret: process.env.NEON_AUTH_COOKIE_SECRET!,
   },
+  // logLevel: 'silent',
 });
 ```
+
+</TwoColumnLayout.Block>
+</TwoColumnLayout.Item>
+
+<TwoColumnLayout.Item title="Server logging" id="server-logging">
+<TwoColumnLayout.Block>
+
+Neon Auth server surfaces (API proxy, middleware, and Better Auth server `fetch`) emit structured logs for upstream failures and session issues.
+
+**Defaults (opt-out):** `logLevel: 'warn'` writes **`error`** and **`warn`** to **`console`**. Set **`logLevel: 'silent'`** to disable all Neon Auth `console` output (`'silent'` ignores any custom **`logger`**). Use **`info`** or **`debug`** for more detail during local troubleshooting.
+
+**Custom sink:** Pass a partial **`logger`** object with `error`, `warn`, `info`, and/or `debug` methods. Omitted methods still use `console`. Metadata may include `err` and `detail` for observability tools.
+
+`auth.middleware()` inherits the same resolved logging configuration from `createNeonAuth` (no per-request reconfiguration).
+
+</TwoColumnLayout.Block>
+<TwoColumnLayout.Block>
+
+```typescript
+import { createNeonAuth } from '@neondatabase/auth/next/server';
+
+export const auth = createNeonAuth({
+  baseUrl: process.env.NEON_AUTH_BASE_URL!,
+  cookies: { secret: process.env.NEON_AUTH_COOKIE_SECRET! },
+  logLevel: 'debug',
+  logger: {
+    warn(message, meta) {
+      myLogger.warn({ message, ...meta });
+    },
+  },
+});
+```
+
+| <tt>logLevel</tt> | Console output  |
+| ----------------- | --------------- |
+| `silent`          | None            |
+| `error`           | `error` only    |
+| `warn` (default)  | `error`, `warn` |
+| `info`            | through `info`  |
+| `debug`           | all levels      |
 
 </TwoColumnLayout.Block>
 </TwoColumnLayout.Item>
@@ -786,6 +832,52 @@ const { data, error } = await auth.admin.setRole({
 </TwoColumnLayout.Block>
 </TwoColumnLayout.Item>
 
+<TwoColumnLayout.Item title="Upstream fetch errors" id="upstream-fetch-errors">
+<TwoColumnLayout.Block>
+
+When the SDK cannot reach your Neon Auth server (wrong `baseUrl`, DNS, TLS, timeout), the API proxy returns a synthetic **502** JSON body with a stable **`code`**. Server methods such as `auth.signIn.email()` surface the same codes on **`error.code`** when the failure is transport-related.
+
+| Code              | Typical cause             |
+| ----------------- | ------------------------- |
+| `NETWORK_DNS`     | Hostname does not resolve |
+| `NETWORK_REFUSED` | Connection refused        |
+| `NETWORK_TIMEOUT` | Request timed out         |
+| `NETWORK_TLS`     | TLS / certificate error   |
+| `NETWORK_RESET`   | Connection reset          |
+| `NETWORK_ABORT`   | Request aborted           |
+| `NETWORK_ERROR`   | Other transport failure   |
+
+Client-visible messages are generic (for example, “Could not resolve authentication server hostname”). Check server logs (set `logLevel: 'debug'`) for `detail` and the raw error.
+
+**Non-transport failures** (unexpected exceptions while handling a response) are **re-thrown** so Next.js error boundaries behave as before. HTTP **4xx** upstream responses are logged at **`info`**; **5xx** at **`warn`**.
+
+</TwoColumnLayout.Block>
+<TwoColumnLayout.Block>
+
+```typescript
+'use server';
+
+import { auth } from '@/lib/auth/server';
+
+export async function signIn(formData: FormData) {
+  const { error } = await auth.signIn.email({
+    email: formData.get('email') as string,
+    password: formData.get('password') as string,
+  });
+
+  if (error?.code === 'NETWORK_DNS') {
+    return { error: 'Check NEON_AUTH_BASE_URL in .env.local' };
+  }
+
+  if (error) {
+    return { error: error.message };
+  }
+}
+```
+
+</TwoColumnLayout.Block>
+</TwoColumnLayout.Item>
+
 <TwoColumnLayout.Item title="Performance features" id="performance-features">
 <TwoColumnLayout.Block>
 
@@ -832,11 +924,17 @@ Complete configuration options for `createNeonAuth()`:
 | `cookies.secret`         | string | Yes      | -         |
 | `cookies.sessionDataTtl` | number | No       | 300       |
 | `cookies.domain`         | string | No       | undefined |
+| `cookies.sameSite`       | string | No       | `strict`  |
+| `logLevel`               | string | No       | `warn`    |
+| `logger`                 | object | No       | `console` |
 
 - **baseUrl**: Your Neon Auth server URL from the Neon Console
 - **cookies.secret**: Secret for HMAC-SHA256 signing (32+ characters)
-- **cookies.sessionDataTtl**: Cache TTL in seconds
+- **cookies.sessionDataTtl**: Cache TTL in seconds for the signed `session_data` cookie
 - **cookies.domain**: For cross-subdomain sessions (for example, ".example.com")
+- **cookies.sameSite**: `strict` (default), `lax`, or `none`. Use `lax` or `none` if you embed the app in a third-party iframe or need the previous Lax behavior
+- **logLevel**: `silent`, `error`, `warn`, `info`, or `debug` — see [Server logging](#server-logging)
+- **logger**: Optional custom logger; see [Server logging](#server-logging)
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
@@ -865,7 +963,7 @@ Recommended file structure for Next.js with Neon Auth:
 - `app/dashboard/page.tsx` - Protected pages
 - `lib/auth/server.ts` - Server auth instance
 - `lib/auth/client.ts` - Client auth instance
-- `middleware.ts` - Next.js middleware
+- `proxy.ts` (Next.js 16+) or `middleware.ts` (earlier versions) - Route protection
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
@@ -889,7 +987,7 @@ lib/
     ├── server.ts
     └── client.ts
 
-middleware.ts
+proxy.ts          # or middleware.ts on Next.js < 16
 .env.local
 ```
 

--- a/content/docs/auth/reference/nextjs-server.md
+++ b/content/docs/auth/reference/nextjs-server.md
@@ -8,7 +8,7 @@ summary: >-
   management and middleware creation.
 enableTableOfContents: true
 layout: wide
-updatedOn: '2026-05-17T20:19:55.872Z'
+updatedOn: '2026-05-18T21:06:51.697Z'
 ---
 
 Reference documentation for the Neon Auth Next.js server SDK (`@neondatabase/auth/next/server`). This package provides server-side authentication for Next.js applications using React Server Components, API routes, middleware, and server actions.
@@ -104,9 +104,9 @@ export const auth = createNeonAuth({
 <TwoColumnLayout.Item title="Server logging" id="server-logging">
 <TwoColumnLayout.Block>
 
-Neon Auth server surfaces (API proxy, middleware, and Better Auth server `fetch`) emit structured logs for upstream failures and session issues.
+Neon Auth emits structured logs from the API proxy, middleware, and Better Auth server `fetch` for upstream failures and session issues.
 
-**Defaults (opt-out):** `logLevel: 'warn'` writes **`error`** and **`warn`** to **`console`**. Set **`logLevel: 'silent'`** to disable all Neon Auth `console` output (`'silent'` ignores any custom **`logger`**). Use **`info`** or **`debug`** for more detail during local troubleshooting.
+**Defaults:** `logLevel: 'warn'` writes **`error`** and **`warn`** to **`console`**. Set **`logLevel: 'silent'`** to disable all Neon Auth `console` output (`'silent'` ignores any custom **`logger`**). Use **`info`** or **`debug`** for more detail during local troubleshooting.
 
 **Custom sink:** Pass a partial **`logger`** object with `error`, `warn`, `info`, and/or `debug` methods. Omitted methods still use `console`. Metadata may include `err` and `detail` for observability tools.
 
@@ -130,13 +130,13 @@ export const auth = createNeonAuth({
 });
 ```
 
-| <tt>logLevel</tt> | Console output  |
-| ----------------- | --------------- |
-| `silent`          | None            |
-| `error`           | `error` only    |
-| `warn` (default)  | `error`, `warn` |
-| `info`            | through `info`  |
-| `debug`           | all levels      |
+| <tt>logLevel</tt> | Console output          |
+| ----------------- | ----------------------- |
+| `silent`          | None                    |
+| `error`           | `error` only            |
+| `warn` (default)  | `error`, `warn`         |
+| `info`            | `error`, `warn`, `info` |
+| `debug`           | all levels              |
 
 </TwoColumnLayout.Block>
 </TwoColumnLayout.Item>
@@ -194,11 +194,12 @@ The middleware automatically:
 
 </details>
 
+<NextjsProxyNote/>
+
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
 
-```typescript
-// middleware.ts
+```typescript filename="proxy.ts"
 import { auth } from '@/lib/auth/server';
 
 export default auth.middleware({
@@ -964,6 +965,8 @@ Recommended file structure for Next.js with Neon Auth:
 - `lib/auth/server.ts` - Server auth instance
 - `lib/auth/client.ts` - Client auth instance
 - `proxy.ts` (Next.js 16+) or `middleware.ts` (earlier versions) - Route protection
+
+<NextjsProxyNote/>
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>

--- a/content/docs/auth/troubleshooting.md
+++ b/content/docs/auth/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   OAuth redirect URIs, trusted domains, environment configuration, adapter
   setup, CSS imports, and framework-specific requirements.
 enableTableOfContents: true
-updatedOn: '2026-05-15T14:48:25.606Z'
+updatedOn: '2026-05-17T19:42:11.654Z'
 ---
 
 This page covers common issues when integrating [Neon Auth](/docs/auth/overview) with `@neondatabase/auth` (Next.js) or `@neondatabase/neon-js` (React SPAs).
@@ -35,6 +35,50 @@ export default async function Page() {
 ```
 
 This is required because `getSession()` reads cookies, which are only available at request time. See [getSession](/docs/auth/reference/nextjs-server#get-session) in the Next.js Server SDK reference.
+
+## Neon Auth server logging in the terminal
+
+After upgrading `@neondatabase/auth`, you may see structured **`warn`** or **`error`** lines in the Next.js server console when the auth proxy cannot reach Neon Auth or when session cookies fail validation. This is expected: the SDK defaults to **`logLevel: 'warn'`** (opt-out).
+
+To mute Neon Auth console output:
+
+```typescript
+export const auth = createNeonAuth({
+  baseUrl: process.env.NEON_AUTH_BASE_URL!,
+  cookies: { secret: process.env.NEON_AUTH_COOKIE_SECRET! },
+  logLevel: 'silent',
+});
+```
+
+To investigate further, use **`logLevel: 'debug'`** or a custom **`logger`**. See [Server logging](/docs/auth/reference/nextjs-server#server-logging).
+
+## Upstream NETWORK\_\* errors
+
+Server actions or API routes may return errors with **`code`** values such as **`NETWORK_DNS`**, **`NETWORK_REFUSED`**, or **`NETWORK_TIMEOUT`**. These mean your app could not reach the Auth server at **`NEON_AUTH_BASE_URL`** (typo, wrong branch URL, offline network, or TLS issue).
+
+1. Confirm **`NEON_AUTH_BASE_URL`** in `.env.local` matches the Auth URL in the Neon Console (Project → Branch → Auth → Configuration).
+2. Restart the dev server after changing env vars.
+3. Enable **`logLevel: 'debug'`** and retry; logs include a safe **`detail`** field.
+
+See [Upstream fetch errors](/docs/auth/reference/nextjs-server#upstream-fetch-errors) for the full code list.
+
+## Cookies blocked in iframe or cross-site embeds
+
+Neon Auth cookies default to **`SameSite=Strict`**. If your app runs inside another site's **iframe**, or you relied on the previous Lax behavior, sessions may not persist.
+
+Set an explicit SameSite mode when creating the auth instance:
+
+```typescript
+export const auth = createNeonAuth({
+  baseUrl: process.env.NEON_AUTH_BASE_URL!,
+  cookies: {
+    secret: process.env.NEON_AUTH_COOKIE_SECRET!,
+    sameSite: 'lax', // or 'none' for third-party iframe contexts (requires HTTPS)
+  },
+});
+```
+
+See [Configuration reference](/docs/auth/reference/nextjs-server#configuration-reference) and the [Next.js quick start](/docs/auth/quick-start/nextjs-api-only).
 
 ## Using v0.1 API patterns
 

--- a/content/docs/auth/troubleshooting.md
+++ b/content/docs/auth/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   OAuth redirect URIs, trusted domains, environment configuration, adapter
   setup, CSS imports, and framework-specific requirements.
 enableTableOfContents: true
-updatedOn: '2026-05-17T19:42:11.654Z'
+updatedOn: '2026-05-17T20:19:55.872Z'
 ---
 
 This page covers common issues when integrating [Neon Auth](/docs/auth/overview) with `@neondatabase/auth` (Next.js) or `@neondatabase/neon-js` (React SPAs).
@@ -38,7 +38,7 @@ This is required because `getSession()` reads cookies, which are only available 
 
 ## Neon Auth server logging in the terminal
 
-After upgrading `@neondatabase/auth`, you may see structured **`warn`** or **`error`** lines in the Next.js server console when the auth proxy cannot reach Neon Auth or when session cookies fail validation. This is expected: the SDK defaults to **`logLevel: 'warn'`** (opt-out).
+You may see structured **`warn`** or **`error`** lines in the Next.js server console when the auth proxy cannot reach Neon Auth or when session cookies fail validation. This is expected: the SDK defaults to **`logLevel: 'warn'`** (opt-out).
 
 To mute Neon Auth console output:
 
@@ -64,7 +64,7 @@ See [Upstream fetch errors](/docs/auth/reference/nextjs-server#upstream-fetch-er
 
 ## Cookies blocked in iframe or cross-site embeds
 
-Neon Auth cookies default to **`SameSite=Strict`**. If your app runs inside another site's **iframe**, or you relied on the previous Lax behavior, sessions may not persist.
+Neon Auth cookies default to **`SameSite=Strict`**. If your app runs inside another site's **iframe**, or needs cookies on top-level cross-site navigations, sessions may not persist.
 
 Set an explicit SameSite mode when creating the auth instance:
 


### PR DESCRIPTION
## Summary

Stacks on #4931. Extends the Next.js Server SDK reference and auth troubleshooting for SDK changes merged in neondatabase/neon-js#134:

- **Server logging** — `logLevel`, `logger`, opt-out `warn` default, `silent` / `debug`
- **Cookies** — `cookies.sameSite` (`strict` default, `lax` / `none` for iframe embeds)
- **Upstream errors** — `NETWORK_*` codes on proxy 502 and `error.code` in server actions

## Test plan

- [ ] Preview [nextjs-server reference](https://neon.com/docs/auth/reference/nextjs-server) — new sections render
- [ ] Preview [troubleshooting](https://neon.com/docs/auth/troubleshooting) — new headings and anchors
- [ ] Quick start cross-links from #4931 resolve (`#server-logging`, `#neon-auth-server-logging-in-the-terminal`)

## Merge order

Merge **#4931** first, then rebase this PR onto `main` (or merge with GitHub’s stacked flow).