### PR TITLE
Update topbar to no-add-on-fees message

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'Team accounts with unlimited members now available to everyone! Invite your teammates and ship faster together, even on the Free Plan.'
+text: "Put an end to add-on fees. Neon includes SOC2, HIPAA, PrivateLink, Log Exports, PITR, SLAs on the Scale plan. 100% usage-based. No fixed fees."
 link:
-  url: 'https://neon.com/docs/changelog/2026-03-13'
+  url: 'https://neon.com/blog/why-we-no-longer-lock-premium-features'
   target: '_blank'


### PR DESCRIPTION
## Summary

- Replaces the team-accounts topbar message with a no-add-on-fees pitch linked to the [Why we no longer lock premium features](https://neon.com/blog/why-we-no-longer-lock-premium-features) blog post.

## Test plan

- [x] Verify the new banner renders correctly on the Vercel preview.
- [x] Confirm the link opens the blog post in a new tab.