### PR TITLE
feat: add github field to open source form

### DIFF
--- a/src/components/shared/program-form/data.js
+++ b/src/components/shared/program-form/data.js
@@ -22,8 +22,6 @@ const OPENSOURCE = {
   buttonText: 'Apply',
   eventName: 'Open Source Program Application Submitted',
   showGithubUrl: true,
-  githubUrlLabel: 'GitHub Project Link: *',
-  githubUrlPlaceholder: 'https://github.com/your-org/your-project',
 };
 
 const CREATOR = {

--- a/src/components/shared/program-form/data.js
+++ b/src/components/shared/program-form/data.js
@@ -21,6 +21,9 @@ const OPENSOURCE = {
   placeholder: 'Project URL',
   buttonText: 'Apply',
   eventName: 'Open Source Program Application Submitted',
+  showGithubUrl: true,
+  githubUrlLabel: 'GitHub Project Link: *',
+  githubUrlPlaceholder: 'https://github.com/your-org/your-project',
 };
 
 const CREATOR = {

--- a/src/components/shared/program-form/program-form.jsx
+++ b/src/components/shared/program-form/program-form.jsx
@@ -113,7 +113,7 @@ const ProgramForm = ({ type }) => {
                 name="githubUrl"
                 label="GitHub Project Link *"
                 type="url"
-                placeholder="https://github.com/your-org/your-project"
+                placeholder="Enter a link to your GitHub project"
                 error={errors.githubUrl?.message}
                 isDisabled={formState === FORM_STATES.LOADING}
                 {...register('githubUrl')}

--- a/src/components/shared/program-form/program-form.jsx
+++ b/src/components/shared/program-form/program-form.jsx
@@ -16,9 +16,15 @@ import sendGtagEvent from 'utils/send-gtag-event';
 import DATA from './data';
 
 // Schema for validation
-const createSchema = () =>
+const createSchema = ({ showGithubUrl } = {}) =>
   yup.object({
     url: yup.string().required('This field is required'),
+    ...(showGithubUrl && {
+      githubUrl: yup
+        .string()
+        .url('Please enter a valid URL')
+        .required('This field is required'),
+    }),
     email: yup
       .string()
       .email('Please enter a valid email address')
@@ -33,7 +39,15 @@ const fieldProps = {
 };
 
 const ProgramForm = ({ type }) => {
-  const { title, description, placeholder, buttonText } = DATA[type];
+  const {
+    title,
+    description,
+    placeholder,
+    buttonText,
+    showGithubUrl,
+    githubUrlLabel,
+    githubUrlPlaceholder,
+  } = DATA[type];
   const [formState, setFormState] = useState(FORM_STATES.DEFAULT);
 
   const {
@@ -41,13 +55,13 @@ const ProgramForm = ({ type }) => {
     handleSubmit,
     formState: { errors },
   } = useForm({
-    resolver: yupResolver(createSchema()),
+    resolver: yupResolver(createSchema({ showGithubUrl })),
     mode: 'onSubmit',
   });
 
   const onSubmit = async (data, e) => {
     e.preventDefault();
-    const { url, email } = data;
+    const { url, email, githubUrl } = data;
     const loadingAnimationStartedTime = Date.now();
 
     setFormState(FORM_STATES.LOADING);
@@ -58,7 +72,11 @@ const ProgramForm = ({ type }) => {
 
         // Send identify event with user provided email
         await sendGtagEvent('identify', { email });
-        await sendGtagEvent(eventName, { email, url });
+        await sendGtagEvent(eventName, {
+          email,
+          url,
+          ...(showGithubUrl && { githubUrl }),
+        });
       }
 
       doNowOrAfterSomeTime(() => {
@@ -96,6 +114,19 @@ const ProgramForm = ({ type }) => {
               isDisabled={formState === FORM_STATES.LOADING}
               {...register('url')}
             />
+
+            {showGithubUrl && (
+              <Field
+                {...fieldProps}
+                name="githubUrl"
+                label={githubUrlLabel}
+                type="url"
+                placeholder={githubUrlPlaceholder}
+                error={errors.githubUrl?.message}
+                isDisabled={formState === FORM_STATES.LOADING}
+                {...register('githubUrl')}
+              />
+            )}
 
             <Field
               {...fieldProps}

--- a/src/components/shared/program-form/program-form.jsx
+++ b/src/components/shared/program-form/program-form.jsx
@@ -39,15 +39,7 @@ const fieldProps = {
 };
 
 const ProgramForm = ({ type }) => {
-  const {
-    title,
-    description,
-    placeholder,
-    buttonText,
-    showGithubUrl,
-    githubUrlLabel,
-    githubUrlPlaceholder,
-  } = DATA[type];
+  const { title, description, placeholder, buttonText, showGithubUrl } = DATA[type];
   const [formState, setFormState] = useState(FORM_STATES.DEFAULT);
 
   const {
@@ -119,9 +111,9 @@ const ProgramForm = ({ type }) => {
               <Field
                 {...fieldProps}
                 name="githubUrl"
-                label={githubUrlLabel}
+                label="GitHub Project Link *"
                 type="url"
-                placeholder={githubUrlPlaceholder}
+                placeholder="https://github.com/your-org/your-project"
                 error={errors.githubUrl?.message}
                 isDisabled={formState === FORM_STATES.LOADING}
                 {...register('githubUrl')}


### PR DESCRIPTION
## Summary
Adds a required GitHub Project Link field to the Open Source application form on `/programs/open-source`. The field appears between the existing Project URL and Contact Email inputs and is validated as a required, well-formed URL.

The `ProgramForm` component is shared across four program pages (Agents, Startup, Creator, Open Source), so the new field is gated by a per-program `showGithubUrl` flag in `data.js` — only the Open Source form renders it. The GitHub URL is also forwarded to the `zaraz` / gtag analytics event payload when present.

## Test plan
Tested locally
<img width="1580" height="1520" alt="github_open_source_form" src="https://github.com/user-attachments/assets/ab7d97bd-f6df-4dcf-a510-765b12e4f4d9" />