### PR TITLE
Fix example in the PostgreSQL CREATE TRIGGER Statement docs

### DIFF
--- a/content/postgresql/triggers/creating-first-trigger-postgresql.md
+++ b/content/postgresql/triggers/creating-first-trigger-postgresql.md
@@ -140,7 +140,7 @@ BEGIN
 
 	RETURN NEW;
 END;
-$$
+$$;
 ```
 
 The function inserts the old last name into the `employee_audits` table including employee id, last name, and the time of change if the last name of an employee changes.


### PR DESCRIPTION
### Detail

Add missing semicolon after `CREATE OR REPLACE FUNCTION` statement