### PR TITLE
feat: clean up mcp server configurator

### DIFF
--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { Suspense, use, useDeferredValue, useEffect, useMemo, useState } from 'react';
 
 import CodeBlockWrapper from 'components/shared/code-block-wrapper';
-import InfoIcon from 'components/shared/info-icon';
 import highlight from 'lib/shiki';
 
 import {
@@ -97,7 +96,7 @@ SegmentedControl.propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-const Toggle = ({ checked, onChange, label, description, tooltip, tooltipId }) => (
+const Toggle = ({ checked, onChange, label, description }) => (
   <button
     type="button"
     role="switch"
@@ -122,12 +121,7 @@ const Toggle = ({ checked, onChange, label, description, tooltip, tooltipId }) =
       />
     </span>
     <span className="min-w-0 flex-1">
-      <span className="flex items-center gap-1.5 text-sm font-medium text-gray-new-10 dark:text-white">
-        {label}
-        {tooltip && tooltipId && (
-          <InfoIcon tooltip={tooltip} tooltipId={tooltipId} tooltipPlace="top" />
-        )}
-      </span>
+      <span className="block text-sm font-medium text-gray-new-10 dark:text-white">{label}</span>
       {description && (
         <span className={clsx('mt-0.5 block', HELPER_TEXT_CLASS)}>{description}</span>
       )}
@@ -140,8 +134,6 @@ Toggle.propTypes = {
   onChange: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   description: PropTypes.string,
-  tooltip: PropTypes.string,
-  tooltipId: PropTypes.string,
 };
 
 const HighlightedCode = ({ code, language }) => {
@@ -305,7 +297,6 @@ const McpSetupConfigurator = () => {
   const [apiKey, setApiKey] = useState('');
   const [readOnly, setReadOnly] = useState(false);
   const [projectId, setProjectId] = useState('');
-  const [gitignore, setGitignore] = useState(false);
   const [selectedScopes, setSelectedScopes] = useState(SCOPE_IDS);
   const [toolsReloadNonce, setToolsReloadNonce] = useState(0);
 
@@ -360,11 +351,8 @@ const McpSetupConfigurator = () => {
         `--header "Authorization: ${generatedHeaders.Authorization || 'Bearer <NEON_API_KEY>'}"`
       );
     }
-    if (gitignore) {
-      commandParts.push('--gitignore');
-    }
     return commandParts.join(' \\\n  ');
-  }, [authMode, generatedHeaders.Authorization, generatedServerUrl, gitignore, queryString]);
+  }, [authMode, generatedHeaders.Authorization, generatedServerUrl, queryString]);
 
   const filteredToolsUrl = useMemo(
     () => appendParams(getListToolsBaseUrl(), queryParams),
@@ -404,7 +392,7 @@ const McpSetupConfigurator = () => {
                   onChange={(event) => setApiKey(event.target.value)}
                 />
                 <span className={clsx('mt-2 block', HELPER_TEXT_CLASS)}>
-                  Do not commit API keys. Prefer OAuth for project-scoped MCP config files.
+                  Do not commit API keys to a shared repo.
                 </span>
               </label>
             )}
@@ -528,37 +516,19 @@ const McpSetupConfigurator = () => {
             >
               <HighlightedCode code={addMcpCommand} language="bash" />
             </CodeBlockWrapper>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={gitignore}
-              className="-mt-2 flex w-fit items-center gap-2 text-left"
-              onClick={() => setGitignore(!gitignore)}
-            >
-              <span
-                className={clsx(
-                  'inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full border transition-colors',
-                  gitignore
-                    ? 'border-secondary-8 bg-secondary-8 dark:border-primary-1 dark:bg-primary-1'
-                    : 'border-gray-new-80 bg-gray-new-90 dark:border-gray-new-30 dark:bg-gray-new-20'
-                )}
-              >
-                <span
-                  className={clsx(
-                    'inline-block h-4 w-4 translate-x-0.5 transform rounded-full bg-white shadow-sm transition-transform',
-                    gitignore && 'translate-x-[18px]'
-                  )}
-                />
-              </span>
-              <span className="flex items-center gap-1.5 text-sm font-medium text-gray-new-10 dark:text-white">
-                Add config to .gitignore
-                <InfoIcon
-                  tooltip="Tells add-mcp to gitignore the generated config file so credentials aren't committed."
-                  tooltipId="mcp-gitignore"
-                  tooltipPlace="top"
-                />
-              </span>
-            </button>
+            <p className={clsx('mt-2', HELPER_TEXT_CLASS)}>
+              {authMode === 'apiKey' ? (
+                <>
+                  Add{' '}
+                  <code className="rounded bg-gray-new-94 px-1 py-0.5 text-[12px] dark:bg-gray-new-15">
+                    -g
+                  </code>{' '}
+                  to store the key in your global config, out of your repo.
+                </>
+              ) : (
+                <>OAuth has no static secret, so a project-level config is safe to commit.</>
+              )}
+            </p>
           </div>
 
           <div>

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -3,14 +3,23 @@
 import clsx from 'clsx';
 import parse from 'html-react-parser';
 import PropTypes from 'prop-types';
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, use, useDeferredValue, useEffect, useMemo, useState } from 'react';
 
 import CodeBlockWrapper from 'components/shared/code-block-wrapper';
+import InfoIcon from 'components/shared/info-icon';
 import highlight from 'lib/shiki';
 
-const SERVER_BASE = 'https://mcp.neon.tech';
-const MCP_PATH = '/mcp';
-const PROD_LIST_TOOLS_URL = `${SERVER_BASE}/api/list-tools`;
+import {
+  MCP_PATH,
+  MCP_SERVER_BASE,
+  appendParams,
+  buildQueryParams,
+  getHiddenTools,
+  getListToolsBaseUrl,
+  getTools,
+  getToolsPreviewErrorMessage,
+  getToolsPreviewResource,
+} from './utils';
 
 const AUTH_MODES = [
   {
@@ -40,50 +49,10 @@ const SCOPE_ID_SET = new Set(SCOPE_IDS);
 const CARD_CLASS =
   'rounded-xl border border-gray-new-90 bg-white/80 p-5 backdrop-blur-sm dark:border-gray-new-20 dark:bg-gray-new-10/50';
 const SECTION_LABEL_CLASS =
-  'mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-gray-new-40 dark:text-gray-new-60';
+  'mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-gray-new-40 dark:text-gray-new-60';
 const FIELD_LABEL_CLASS =
   'mb-1.5 block text-xs font-semibold uppercase tracking-wide text-gray-new-30 dark:text-gray-new-70';
 const HELPER_TEXT_CLASS = 'text-[13px] leading-relaxed text-gray-new-40 dark:text-gray-new-60';
-
-function getListToolsBaseUrl() {
-  if (process.env.NEXT_PUBLIC_MCP_API_URL) {
-    return process.env.NEXT_PUBLIC_MCP_API_URL;
-  }
-  return PROD_LIST_TOOLS_URL;
-}
-
-function buildQueryParams({ readOnly, projectId, selectedScopes }) {
-  const params = new URLSearchParams();
-  if (readOnly) {
-    params.set('readonly', 'true');
-  }
-  const trimmedProjectId = projectId.trim();
-  if (trimmedProjectId) {
-    params.set('projectId', trimmedProjectId);
-  }
-  const validScopes = selectedScopes.filter((id) => SCOPE_ID_SET.has(id));
-  if (validScopes.length > 0 && validScopes.length < SCOPE_IDS.length) {
-    params.set('category', validScopes.join(','));
-  }
-  return params;
-}
-
-function appendParams(baseUrl, params) {
-  const qs = params.toString();
-  return qs ? `${baseUrl}?${qs}` : baseUrl;
-}
-
-async function fetchTools({ url, timeoutMs = 12000 }) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  const response = await fetch(url, { signal: controller.signal }).finally(() =>
-    clearTimeout(timeout)
-  );
-  if (!response.ok) {
-    throw new Error(`Failed to fetch tools preview: ${response.status}`);
-  }
-  return response.json();
-}
 
 const SegmentedControl = ({ name, options, value, onChange }) => (
   <div
@@ -128,17 +97,18 @@ SegmentedControl.propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-const Toggle = ({ checked, onChange, label, description }) => (
+const Toggle = ({ checked, onChange, label, description, tooltip, tooltipId }) => (
   <button
     type="button"
     role="switch"
     aria-checked={checked}
-    className="flex w-full items-start gap-3 text-left"
+    className={clsx('flex w-full gap-3 text-left', description ? 'items-start' : 'items-center')}
     onClick={() => onChange(!checked)}
   >
     <span
       className={clsx(
-        'mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full border transition-colors',
+        'inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full border transition-colors',
+        description && 'mt-0.5',
         checked
           ? 'border-secondary-8 bg-secondary-8 dark:border-primary-1 dark:bg-primary-1'
           : 'border-gray-new-80 bg-gray-new-90 dark:border-gray-new-30 dark:bg-gray-new-20'
@@ -152,7 +122,12 @@ const Toggle = ({ checked, onChange, label, description }) => (
       />
     </span>
     <span className="min-w-0 flex-1">
-      <span className="block text-sm font-medium text-gray-new-10 dark:text-white">{label}</span>
+      <span className="flex items-center gap-1.5 text-sm font-medium text-gray-new-10 dark:text-white">
+        {label}
+        {tooltip && tooltipId && (
+          <InfoIcon tooltip={tooltip} tooltipId={tooltipId} tooltipPlace="top" />
+        )}
+      </span>
       {description && (
         <span className={clsx('mt-0.5 block', HELPER_TEXT_CLASS)}>{description}</span>
       )}
@@ -165,6 +140,8 @@ Toggle.propTypes = {
   onChange: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   description: PropTypes.string,
+  tooltip: PropTypes.string,
+  tooltipId: PropTypes.string,
 };
 
 const HighlightedCode = ({ code, language }) => {
@@ -199,28 +176,153 @@ HighlightedCode.propTypes = {
   language: PropTypes.string.isRequired,
 };
 
+const ToolsPreviewContent = ({ filteredUrl, isPending, reloadNonce, onRetry }) => {
+  const { allPayload, error, filteredPayload } = use(
+    getToolsPreviewResource({ filteredUrl, reloadNonce })
+  );
+
+  const selectedTools = getTools(filteredPayload);
+  const hiddenTools = getHiddenTools({
+    allTools: filteredPayload ? getTools(allPayload) : [],
+    selectedTools,
+  });
+
+  return (
+    <>
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <span className="text-[11px] font-semibold tracking-[0.08em] text-gray-new-40 uppercase dark:text-gray-new-60">
+          Tools preview
+        </span>
+        <span className="text-xs text-gray-new-40 dark:text-gray-new-60">
+          {selectedTools.length} enabled · {hiddenTools.length} hidden
+        </span>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-secondary-1/40 bg-secondary-1/5 px-3 py-2.5 text-secondary-1 dark:border-secondary-1/30 dark:bg-secondary-1/10 dark:text-secondary-4">
+          <p className="m-0 text-[13px]">
+            Could not refresh selected tools. {getToolsPreviewErrorMessage(error)}
+          </p>
+          <div className="mt-2 flex items-center gap-3">
+            <button
+              type="button"
+              className="cursor-pointer text-xs font-medium text-secondary-8 underline underline-offset-2 hover:no-underline dark:text-primary-1"
+              onClick={onRetry}
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
+
+      {filteredPayload && (
+        <div className={clsx('transition-opacity duration-150', isPending && 'opacity-50')}>
+          <div className="flex flex-wrap gap-1.5">
+            {selectedTools.map((tool) => (
+              <span
+                key={tool.name}
+                className="inline-flex items-center rounded-md border border-secondary-8/30 bg-secondary-8/5 px-2 py-1 font-mono text-[11px] leading-tight text-secondary-8 dark:border-primary-1/30 dark:bg-primary-1/10 dark:text-primary-1"
+              >
+                {tool.title || tool.name}
+              </span>
+            ))}
+            {selectedTools.length === 0 && (
+              <span className="text-[13px] text-gray-new-40 dark:text-gray-new-60">
+                No tools match the current configuration.
+              </span>
+            )}
+          </div>
+          {hiddenTools.length > 0 && (
+            <>
+              <div className="my-3 flex items-center gap-2">
+                <span className="h-px flex-1 bg-gray-new-90 dark:bg-gray-new-20" />
+                <span className="text-[10px] font-semibold tracking-wider text-gray-new-40 uppercase dark:text-gray-new-60">
+                  Hidden
+                </span>
+                <span className="h-px flex-1 bg-gray-new-90 dark:bg-gray-new-20" />
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {hiddenTools.map((tool) => (
+                  <span
+                    key={tool.name}
+                    className="inline-flex items-center rounded-md border border-gray-new-90 bg-gray-new-98 px-2 py-1 font-mono text-[11px] leading-tight text-gray-new-40 line-through dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-60"
+                  >
+                    {tool.title || tool.name}
+                  </span>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+ToolsPreviewContent.propTypes = {
+  filteredUrl: PropTypes.string.isRequired,
+  isPending: PropTypes.bool.isRequired,
+  reloadNonce: PropTypes.number.isRequired,
+  onRetry: PropTypes.func.isRequired,
+};
+
+const ToolsPreviewCard = ({ filteredUrl, reloadNonce, onRetry }) => {
+  const deferredFilteredUrl = useDeferredValue(filteredUrl);
+  const deferredReloadNonce = useDeferredValue(reloadNonce);
+  const isPending = deferredFilteredUrl !== filteredUrl || deferredReloadNonce !== reloadNonce;
+
+  return (
+    <div className="rounded-xl border border-gray-new-90 bg-white p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
+      <Suspense
+        fallback={
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="text-[11px] font-semibold tracking-[0.08em] text-gray-new-40 uppercase dark:text-gray-new-60">
+              Tools preview
+            </span>
+            <span className="text-xs text-gray-new-40 dark:text-gray-new-60">Loading tools...</span>
+          </div>
+        }
+      >
+        <ToolsPreviewContent
+          filteredUrl={deferredFilteredUrl}
+          isPending={isPending}
+          reloadNonce={deferredReloadNonce}
+          onRetry={onRetry}
+        />
+      </Suspense>
+    </div>
+  );
+};
+
+ToolsPreviewCard.propTypes = {
+  filteredUrl: PropTypes.string.isRequired,
+  reloadNonce: PropTypes.number.isRequired,
+  onRetry: PropTypes.func.isRequired,
+};
+
 const McpSetupConfigurator = () => {
   const [authMode, setAuthMode] = useState('oauth');
   const [apiKey, setApiKey] = useState('');
   const [readOnly, setReadOnly] = useState(false);
   const [projectId, setProjectId] = useState('');
+  const [gitignore, setGitignore] = useState(false);
   const [selectedScopes, setSelectedScopes] = useState(SCOPE_IDS);
-  const [toolsPreview, setToolsPreview] = useState(null);
-  const [allTools, setAllTools] = useState(null);
-  const [toolsPreviewLoading, setToolsPreviewLoading] = useState(false);
-  const [toolsPreviewError, setToolsPreviewError] = useState(false);
-  const [toolsPreviewErrorMessage, setToolsPreviewErrorMessage] = useState('');
-  const [lastSuccessfulToolsPreview, setLastSuccessfulToolsPreview] = useState(null);
-  const [lastSuccessfulAllTools, setLastSuccessfulAllTools] = useState(null);
   const [toolsReloadNonce, setToolsReloadNonce] = useState(0);
 
   const queryParams = useMemo(
-    () => buildQueryParams({ readOnly, projectId, selectedScopes }),
+    () =>
+      buildQueryParams({
+        projectId,
+        readOnly,
+        scopeIds: SCOPE_IDS,
+        scopeIdSet: SCOPE_ID_SET,
+        selectedScopes,
+      }),
     [readOnly, projectId, selectedScopes]
   );
   const queryString = queryParams.toString();
 
-  const baseServerUrl = `${SERVER_BASE}${MCP_PATH}`;
+  const baseServerUrl = `${MCP_SERVER_BASE}${MCP_PATH}`;
   const generatedServerUrl = useMemo(
     () => appendParams(baseServerUrl, queryParams),
     [baseServerUrl, queryParams]
@@ -258,71 +360,16 @@ const McpSetupConfigurator = () => {
         `--header "Authorization: ${generatedHeaders.Authorization || 'Bearer <NEON_API_KEY>'}"`
       );
     }
-    return commandParts.join(' \\\n  ');
-  }, [authMode, generatedHeaders.Authorization, generatedServerUrl, queryString]);
-
-  const effectiveToolsPreview = useMemo(() => {
-    if (toolsPreviewError && lastSuccessfulToolsPreview) return lastSuccessfulToolsPreview;
-    return toolsPreview;
-  }, [lastSuccessfulToolsPreview, toolsPreview, toolsPreviewError]);
-
-  const effectiveAllTools = useMemo(() => {
-    if (toolsPreviewError && lastSuccessfulAllTools) return lastSuccessfulAllTools;
-    return allTools;
-  }, [allTools, lastSuccessfulAllTools, toolsPreviewError]);
-
-  const selectedTools = useMemo(() => {
-    if (!Array.isArray(effectiveToolsPreview?.tools)) return [];
-    return effectiveToolsPreview.tools;
-  }, [effectiveToolsPreview]);
-
-  const notIncludedTools = useMemo(() => {
-    if (!Array.isArray(effectiveAllTools?.tools) || !Array.isArray(effectiveToolsPreview?.tools)) {
-      return [];
+    if (gitignore) {
+      commandParts.push('--gitignore');
     }
-    const selectedNames = new Set(effectiveToolsPreview.tools.map((tool) => tool.name));
-    return effectiveAllTools.tools.filter((tool) => !selectedNames.has(tool.name));
-  }, [effectiveAllTools, effectiveToolsPreview]);
+    return commandParts.join(' \\\n  ');
+  }, [authMode, generatedHeaders.Authorization, generatedServerUrl, gitignore, queryString]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const listToolsBase = getListToolsBaseUrl();
-    const filteredUrl = appendParams(listToolsBase, queryParams);
-
-    setToolsPreviewLoading(true);
-    setToolsPreviewError(false);
-    setToolsPreviewErrorMessage('');
-
-    Promise.all([fetchTools({ url: filteredUrl }), fetchTools({ url: listToolsBase })])
-      .then(([filteredPayload, allPayload]) => {
-        if (!cancelled) {
-          setToolsPreview(filteredPayload);
-          setAllTools(allPayload);
-          setLastSuccessfulToolsPreview(filteredPayload);
-          setLastSuccessfulAllTools(allPayload);
-          setToolsPreviewLoading(false);
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setToolsPreviewError(true);
-          if (error instanceof Error) {
-            const message =
-              error.name === 'AbortError'
-                ? 'Request timed out while loading tools.'
-                : error.message;
-            setToolsPreviewErrorMessage(message);
-          } else {
-            setToolsPreviewErrorMessage('Unable to load tools.');
-          }
-          setToolsPreviewLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [queryParams, toolsReloadNonce]);
+  const filteredToolsUrl = useMemo(
+    () => appendParams(getListToolsBaseUrl(), queryParams),
+    [queryParams]
+  );
 
   const toggleScope = (scopeId) => {
     setSelectedScopes((prev) =>
@@ -334,17 +381,8 @@ const McpSetupConfigurator = () => {
 
   return (
     <div className="my-6 overflow-hidden rounded-2xl border border-gray-new-90 bg-white shadow-sm dark:border-gray-new-20 dark:bg-gray-new-8">
-      <div className="border-b border-gray-new-90 bg-gradient-to-br from-gray-new-98 via-white to-gray-new-98 px-6 py-5 dark:border-gray-new-20 dark:from-gray-new-10 dark:via-gray-new-8 dark:to-gray-new-10">
-        <h3 className="mt-0 mb-1 text-lg font-semibold text-gray-new-10 dark:text-white">
-          MCP Server Config Generator
-        </h3>
-        <p className="mt-0 mb-0 text-sm text-gray-new-40 dark:text-gray-new-60">
-          Generate a ready-to-use config for Neon&apos;s hosted MCP server.
-        </p>
-      </div>
-
       <div className="grid grid-cols-1">
-        <div className="space-y-5 bg-gray-new-98/60 p-6 dark:bg-gray-new-10/30">
+        <div className="space-y-5 p-6">
           <h4 className="sr-only">Configuration</h4>
 
           <div className={CARD_CLASS}>
@@ -472,115 +510,61 @@ const McpSetupConfigurator = () => {
 
         <div className="space-y-5 p-6">
           <div>
-            <p className={SECTION_LABEL_CLASS}>
-              <span className="bg-green-500 inline-block h-1 w-4 rounded-full" />
-              Result
-            </p>
+            <p className={SECTION_LABEL_CLASS}>Result</p>
           </div>
 
-          <div className="rounded-xl border border-gray-new-90 bg-white p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
-            <div className="mb-3 flex items-baseline justify-between gap-3">
-              <span className="text-[11px] font-semibold tracking-[0.08em] text-gray-new-40 uppercase dark:text-gray-new-60">
-                Tools preview
-              </span>
-              <span className="text-xs text-gray-new-40 dark:text-gray-new-60">
-                {selectedTools.length} enabled · {notIncludedTools.length} hidden
-              </span>
-            </div>
-
-            {toolsPreviewLoading && (
-              <div className="animate-pulse">
-                <div className="mb-2 flex flex-wrap gap-1.5">
-                  {Array.from({ length: 12 }).map((_, idx) => (
-                    <span
-                      key={`tool-skeleton-${idx}`}
-                      className="inline-block h-6 w-24 rounded-md bg-gray-new-94 dark:bg-gray-new-15"
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {toolsPreviewError && (
-              <div className="rounded-lg border border-secondary-1/40 bg-secondary-1/5 px-3 py-2.5 text-secondary-1 dark:border-secondary-1/30 dark:bg-secondary-1/10 dark:text-secondary-4">
-                <p className="m-0 text-[13px]">
-                  Could not refresh selected tools.
-                  {toolsPreviewErrorMessage ? ` ${toolsPreviewErrorMessage}` : ''}
-                </p>
-                <div className="mt-2 flex items-center gap-3">
-                  <button
-                    type="button"
-                    className="cursor-pointer text-xs font-medium text-secondary-8 underline underline-offset-2 hover:no-underline dark:text-primary-1"
-                    onClick={() => setToolsReloadNonce((prev) => prev + 1)}
-                  >
-                    Retry
-                  </button>
-                  {lastSuccessfulToolsPreview && (
-                    <span className="text-xs text-gray-new-40 dark:text-gray-new-60">
-                      Showing last successful results.
-                    </span>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {!toolsPreviewLoading && !toolsPreviewError && (
-              <>
-                <div className="flex flex-wrap gap-1.5">
-                  {selectedTools.map((tool) => (
-                    <span
-                      key={tool.name}
-                      className="inline-flex items-center rounded-md border border-secondary-8/30 bg-secondary-8/5 px-2 py-1 font-mono text-[11px] leading-tight text-secondary-8 dark:border-primary-1/30 dark:bg-primary-1/10 dark:text-primary-1"
-                    >
-                      {tool.title || tool.name}
-                    </span>
-                  ))}
-                  {selectedTools.length === 0 && (
-                    <span className="text-[13px] text-gray-new-40 dark:text-gray-new-60">
-                      No tools match the current configuration.
-                    </span>
-                  )}
-                </div>
-                {notIncludedTools.length > 0 && (
-                  <>
-                    <div className="my-3 flex items-center gap-2">
-                      <span className="h-px flex-1 bg-gray-new-90 dark:bg-gray-new-20" />
-                      <span className="text-[10px] font-semibold tracking-wider text-gray-new-40 uppercase dark:text-gray-new-60">
-                        Hidden
-                      </span>
-                      <span className="h-px flex-1 bg-gray-new-90 dark:bg-gray-new-20" />
-                    </div>
-                    <div className="flex flex-wrap gap-1.5">
-                      {notIncludedTools.map((tool) => (
-                        <span
-                          key={tool.name}
-                          className="inline-flex items-center rounded-md border border-gray-new-90 bg-gray-new-98 px-2 py-1 font-mono text-[11px] leading-tight text-gray-new-40 line-through decoration-gray-new-70/60 dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-60 dark:decoration-gray-new-30/60"
-                        >
-                          {tool.title || tool.name}
-                        </span>
-                      ))}
-                    </div>
-                  </>
-                )}
-              </>
-            )}
-          </div>
+          <ToolsPreviewCard
+            filteredUrl={filteredToolsUrl}
+            reloadNonce={toolsReloadNonce}
+            onRetry={() => setToolsReloadNonce((prev) => prev + 1)}
+          />
 
           <div>
             <span className={FIELD_LABEL_CLASS}>add-mcp command</span>
             <CodeBlockWrapper
-              className="rounded-xl border border-gray-new-90 dark:border-gray-new-20 [&>pre]:my-0 [&>pre]:!bg-gray-new-98 [&>pre]:dark:!bg-gray-new-10"
+              className="!my-0 overflow-hidden rounded-xl border border-gray-new-90 dark:border-gray-new-20 [&>pre]:my-0 [&>pre]:!bg-gray-new-98 [&>pre]:!pt-2 [&>pre]:!pb-3 [&>pre]:dark:!bg-gray-new-10"
               as="div"
               copyCode={addMcpCommand}
             >
               <HighlightedCode code={addMcpCommand} language="bash" />
             </CodeBlockWrapper>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={gitignore}
+              className="-mt-2 flex w-fit items-center gap-2 text-left"
+              onClick={() => setGitignore(!gitignore)}
+            >
+              <span
+                className={clsx(
+                  'inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full border transition-colors',
+                  gitignore
+                    ? 'border-secondary-8 bg-secondary-8 dark:border-primary-1 dark:bg-primary-1'
+                    : 'border-gray-new-80 bg-gray-new-90 dark:border-gray-new-30 dark:bg-gray-new-20'
+                )}
+              >
+                <span
+                  className={clsx(
+                    'inline-block h-4 w-4 translate-x-0.5 transform rounded-full bg-white shadow-sm transition-transform',
+                    gitignore && 'translate-x-[18px]'
+                  )}
+                />
+              </span>
+              <span className="flex items-center gap-1.5 text-sm font-medium text-gray-new-10 dark:text-white">
+                Add config to .gitignore
+                <InfoIcon
+                  tooltip="Tells add-mcp to gitignore the generated config file so credentials aren't committed."
+                  tooltipId="mcp-gitignore"
+                  tooltipPlace="top"
+                />
+              </span>
+            </button>
           </div>
 
           <div>
             <span className={FIELD_LABEL_CLASS}>MCP JSON config</span>
             <CodeBlockWrapper
-              className="rounded-xl border border-gray-new-90 dark:border-gray-new-20 [&>pre]:my-0 [&>pre]:!bg-gray-new-98 [&>pre]:dark:!bg-gray-new-10"
+              className="overflow-hidden rounded-xl border border-gray-new-90 dark:border-gray-new-20 [&>pre]:my-0 [&>pre]:!bg-gray-new-98 [&>pre]:dark:!bg-gray-new-10"
               as="div"
               copyCode={generatedConfig}
             >

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -391,11 +391,21 @@ const McpSetupConfigurator = () => {
                   className="w-full rounded-lg border border-gray-new-90 bg-white px-3 py-2 font-mono text-sm text-gray-new-20 transition-colors outline-none focus:border-secondary-8 focus:ring-2 focus:ring-secondary-8/20 dark:border-gray-new-20 dark:bg-gray-new-10 dark:text-gray-new-90 dark:focus:border-primary-1 dark:focus:ring-primary-1/20"
                   onChange={(event) => setApiKey(event.target.value)}
                 />
-                <span className={clsx('mt-2 block', HELPER_TEXT_CLASS)}>
-                  Do not commit API keys to a shared repo.
-                </span>
               </label>
             )}
+            <span className={clsx('mt-3 block', HELPER_TEXT_CLASS)}>
+              {authMode === 'apiKey' ? (
+                <>
+                  Keep API keys out of your repo. Add{' '}
+                  <code className="rounded bg-gray-new-94 px-1 py-0.5 text-[12px] dark:bg-gray-new-15">
+                    -g
+                  </code>{' '}
+                  to store the key in your global config instead of a project file.
+                </>
+              ) : (
+                <>OAuth has no static secret, so a project-level config is safe to commit.</>
+              )}
+            </span>
           </div>
 
           <div className={CARD_CLASS}>
@@ -516,19 +526,6 @@ const McpSetupConfigurator = () => {
             >
               <HighlightedCode code={addMcpCommand} language="bash" />
             </CodeBlockWrapper>
-            <p className={clsx('mt-2', HELPER_TEXT_CLASS)}>
-              {authMode === 'apiKey' ? (
-                <>
-                  Add{' '}
-                  <code className="rounded bg-gray-new-94 px-1 py-0.5 text-[12px] dark:bg-gray-new-15">
-                    -g
-                  </code>{' '}
-                  to store the key in your global config, out of your repo.
-                </>
-              ) : (
-                <>OAuth has no static secret, so a project-level config is safe to commit.</>
-              )}
-            </p>
           </div>
 
           <div>

--- a/src/components/pages/doc/mcp-setup-configurator/utils.js
+++ b/src/components/pages/doc/mcp-setup-configurator/utils.js
@@ -1,0 +1,89 @@
+const SERVER_BASE = 'https://mcp.neon.tech';
+const PROD_LIST_TOOLS_URL = `${SERVER_BASE}/api/list-tools`;
+
+const toolsPreviewCache = new Map();
+
+export const MCP_PATH = '/mcp';
+export const MCP_SERVER_BASE = SERVER_BASE;
+
+export function getListToolsBaseUrl() {
+  if (process.env.NEXT_PUBLIC_MCP_API_URL) {
+    return process.env.NEXT_PUBLIC_MCP_API_URL;
+  }
+  return PROD_LIST_TOOLS_URL;
+}
+
+export function buildQueryParams({ readOnly, projectId, selectedScopes, scopeIdSet, scopeIds }) {
+  const params = new URLSearchParams();
+  if (readOnly) {
+    params.set('readonly', 'true');
+  }
+  const trimmedProjectId = projectId.trim();
+  if (trimmedProjectId) {
+    params.set('projectId', trimmedProjectId);
+  }
+  const validScopes = selectedScopes.filter((id) => scopeIdSet.has(id));
+  if (validScopes.length > 0 && validScopes.length < scopeIds.length) {
+    params.set('category', validScopes.join(','));
+  }
+  return params;
+}
+
+export function appendParams(baseUrl, params) {
+  const qs = params.toString();
+  return qs ? `${baseUrl}?${qs}` : baseUrl;
+}
+
+export function getTools(payload) {
+  return Array.isArray(payload?.tools) ? payload.tools : [];
+}
+
+export function getHiddenTools({ allTools, selectedTools }) {
+  const selectedToolNames = new Set(selectedTools.map((tool) => tool.name));
+  return allTools.filter((tool) => !selectedToolNames.has(tool.name));
+}
+
+export function getToolsPreviewErrorMessage(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'Unable to load tools.';
+}
+
+async function fetchTools({ url, timeoutMs = 12000 }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const response = await fetch(url, { signal: controller.signal }).finally(() =>
+    clearTimeout(timeout)
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tools preview: ${response.status}`);
+  }
+  return response.json();
+}
+
+export function getToolsPreviewResource({ filteredUrl, reloadNonce }) {
+  const cacheKey = `${reloadNonce}:${filteredUrl}`;
+
+  if (!toolsPreviewCache.has(cacheKey)) {
+    const listToolsBaseUrl = getListToolsBaseUrl();
+    const promise = Promise.allSettled([
+      fetchTools({ url: filteredUrl }),
+      fetchTools({ url: listToolsBaseUrl }),
+    ]).then(([filteredResult, allResult]) => {
+      const filteredPayload = filteredResult.status === 'fulfilled' ? filteredResult.value : null;
+      const allPayload = allResult.status === 'fulfilled' ? allResult.value : null;
+      const error = filteredResult.status === 'rejected' ? filteredResult.reason : null;
+
+      return {
+        allPayload,
+        error,
+        filteredPayload,
+      };
+    });
+
+    toolsPreviewCache.set(cacheKey, promise);
+  }
+
+  return toolsPreviewCache.get(cacheKey);
+}


### PR DESCRIPTION
Stacked on #4599.

Adds an **Add config to .gitignore** toggle to the MCP config generator. When enabled, it appends `--gitignore` to the generated `add-mcp` command so the written config file (which can hold a bearer token) is kept out of version control. Flag confirmed in the [add-mcp README](https://github.com/neon-solutions/add-mcp#readme).

Also refactors the tools-preview fetch into a Suspense resource in `utils.js`, and applies UI polish: drops the redundant header, tightens the command/toggle spacing, fixes the hidden-tool strikethrough color, and clips the code-block rounded corners.

## Preview:

https://github.com/user-attachments/assets/66208ccf-573b-46fb-8e13-dcee352abfb8