### PR TITLE
docs(mcp): prompt for Neon API key interactively in add-mcp example

### DIFF
--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -39,7 +39,7 @@ This command adds the required configuration to your editor's MCP config files; 
 - **API key authentication (remote agents):** For remote agents or when OAuth isn't available:
 
   ```bash
-  npx add-mcp https://mcp.neon.tech/mcp --header "Authorization: Bearer $NEON_API_KEY"
+  npx add-mcp https://mcp.neon.tech/mcp --header 'Authorization: Bearer ${NEON_API_KEY}'
   ```
 
 - **Manual configuration:** See [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon) for step-by-step instructions for any editor, including Windsurf, ChatGPT, Zed, and others.


### PR DESCRIPTION
## Summary

- Update the API key authentication example on `/docs/ai/neon-mcp-server` so the `--header` argument uses single quotes around a literal `${NEON_API_KEY}` placeholder instead of double quotes around `$NEON_API_KEY`.
- With double quotes, the shell expands `$NEON_API_KEY` before `add-mcp` ever sees it, which silently sends an empty bearer token if the env var isn't set. With single quotes, `add-mcp` receives the literal `\${NEON_API_KEY}` placeholder and prompts the user for their Neon API key in interactive mode.

## Test plan

- [ ] Render the docs page locally and confirm the code block shows the new single-quoted form.
- [ ] Run the documented command in a fresh shell and confirm `add-mcp` prompts for the Neon API key rather than sending an empty bearer.