### PR TITLE
docs: add Get started CTA to Neon Twin intro

### DIFF
--- a/content/docs/guides/neon-twin-intro.md
+++ b/content/docs/guides/neon-twin-intro.md
@@ -8,7 +8,7 @@ summary: >-
   workflows.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-03-14T03:21:15.121Z'
+updatedOn: '2026-05-27T13:00:42.095Z'
 ---
 
 <CTA title="Explore our dev/test use case" description="Move development and testing to Neon; keep production right where it is.<br/><br/>Read more about our dev/test use case <a href='/use-cases/dev-test'>here</a>."></CTA>
@@ -32,3 +32,15 @@ The workflows in this section enable automatic synchronization between your prod
 With a Neon Twin created, [branches](/docs/introduction/branching) can be quickly spun up or torn down, enabling developers to build new features or debug issues, all within their own isolated environments with a dedicated compute resource.
 
 Branches can be created and managed through the [Neon console](https://console.neon.tech/) or programmatically via the [API](/docs/reference/api-reference).
+
+## Get started
+
+Pick the workflow that fits your needs. A full Twin mirrors your entire production database; a partial Twin clones only the schema and selected tables, which is faster and useful when you don't need every row of production data.
+
+<DetailIconCards>
+
+<a href="/docs/guides/neon-twin-full-pg-dump-restore" description="Clone your entire production database to Neon using pg_dump and pg_restore in a GitHub Actions workflow." icon="database">Create a full Twin</a>
+
+<a href="/docs/guides/neon-twin-partial-pg-dump-restore" description="Clone only the schema and selected tables from production using pg_dump, pg_restore, and psql." icon="split-branch">Create a partial Twin</a>
+
+</DetailIconCards>


### PR DESCRIPTION
## Summary
- Adds a Get started section to `content/docs/guides/neon-twin-intro.md` with a `DetailIconCards` block that routes readers to the full Twin and partial Twin workflow guides.
- One-line framing explains when to pick a full vs partial Twin so readers can self-select.

## Test plan
- [ ] Preview `/docs/guides/neon-twin-intro` and confirm the cards render with database and split-branch icons
- [ ] Click each card and confirm they route to the full and partial pg_dump/pg_restore pages