### PR TITLE
docs: long-tail tagline and positioning sweep

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -502,7 +502,7 @@ Check the example for default data of CTA block
 To change text in CTA block, you can pass to the component props `title`, `description`, `buttonText`, `buttonUrl`:
 
 ```md
-<CTA title="Try it on Neon!" description="Neon is Serverless Postgres built for the cloud. Explore Postgres features and functions in our user-friendly SQL Editor. Sign up for a free account to get started." buttonText="Sign Up" buttonUrl="https://console.neon.tech/signup" />
+<CTA title="Try it on Neon!" description="Neon is the backend for apps and agents. Sign up for a free Neon account to start building." buttonText="Sign Up" buttonUrl="https://console.neon.tech/signup" />
 ```
 
 ## Steps

--- a/content/docs/ai/ai-agents-tools.md
+++ b/content/docs/ai/ai-agents-tools.md
@@ -9,7 +9,7 @@ enableTableOfContents: true
 updatedOn: '2026-03-20T18:23:32.435Z'
 ---
 
-Neon provides several ways to integrate with AI tools and agents, from natural language database control to autonomous agent frameworks. Choose the tools that fit your workflow.
+Neon is the backend for apps and agents. This page covers Neon's integrations with AI tools and agent frameworks, from natural language database control to autonomous agent platforms. Choose the tools that fit your workflow.
 
 ## Quick setup
 

--- a/content/docs/ai/ai-intro.md
+++ b/content/docs/ai/ai-intro.md
@@ -11,7 +11,7 @@ redirectFrom:
 updatedOn: '2026-02-06T22:07:32.721Z'
 ---
 
-This guide collects resources for building AI applications with Neon Postgres. You'll find core concepts, starter applications, framework integrations, and deployment guides. Use these resources to build applications like RAG chatbots, semantic search engines, or custom AI tools.
+Build AI applications and agents on Neon. This guide collects resources for AI workloads: core concepts, starter applications, framework integrations, and deployment guides. Use them to build applications like RAG chatbots, semantic search engines, or custom AI tools.
 
 <CTA title="Start building AI apps with Neon" description="Sign up for Neon Postgres and jumpstart your AI application with our starter apps and resources." buttonText="Sign Up" buttonUrl="https://console.neon.tech/signup" />
 

--- a/content/docs/auth/overview.md
+++ b/content/docs/auth/overview.md
@@ -24,7 +24,7 @@ redirectFrom:
 
 <FeatureBetaProps feature_name="Neon Auth with Better Auth" />
 
-Neon Auth is a managed authentication service that stores users, sessions, and auth configuration directly in your Neon database. When you branch your database, your entire auth state branches with it. This lets you test real authentication workflows in preview environments.
+Neon Auth is the managed authentication service in the Neon backend for apps and agents. It stores users, sessions, and auth configuration directly in your Neon database. When you branch your database, your entire auth state branches with it, so you can test real authentication workflows in preview environments.
 
 ## Quick start guides
 

--- a/content/docs/data-api/overview.md
+++ b/content/docs/data-api/overview.md
@@ -11,7 +11,7 @@ updatedOn: '2026-04-18T12:16:58.000Z'
 
 <FeatureBetaProps feature_name="Neon Data API" />
 
-The Neon Data API provides a secure, stateless HTTP interface to your database. It lets you access and manage your data directly from web browsers, serverless functions, and edge runtimes using standard HTTP methods. Key benefits include:
+The Neon Data API is the HTTP query service in the Neon backend for apps and agents. It provides a secure, stateless interface to your database, letting you access and manage your data directly from web browsers, serverless functions, and edge runtimes using standard HTTP methods. Key benefits include:
 
 - **Browser & edge compatibility**
 

--- a/content/docs/get-started/built-to-scale.md
+++ b/content/docs/get-started/built-to-scale.md
@@ -65,7 +65,7 @@ At this stage, teams need performance, reliability, isolation, and automation wi
 
 ### Fleet management for platforms and agents
 
-- Instant, API-driven database provisioning allows to deploy a full serverless Postgres backend as part of your [platform](https://neon.com/docs/guides/embedded-postgres) or [agent](https://neon.com/docs/guides/ai-agent-integration)
+- Instant, API-driven database provisioning lets you deploy a full Neon backend as part of your [platform](https://neon.com/docs/guides/embedded-postgres) or [agent](https://neon.com/docs/guides/ai-agent-integration)
 - The fully embedded database experience keeps Neon invisible to your end users, with no third-party logins or external configuration required as part of your product workflow
 - [Scale to zero](https://neon.com/docs/introduction/scale-to-zero) keeps unit costs low when large numbers of generated apps are never used or only accessed sporadically
 - A mature API exposes [fleet management and cost-control capabilities](https://neon.com/docs/guides/consumption-limits) including quotas, usage limits, and lifecycle operations

--- a/content/docs/get-started/production-readiness.md
+++ b/content/docs/get-started/production-readiness.md
@@ -64,7 +64,7 @@ At this stage, teams need performance, reliability, isolation, and automation wi
 
 ### Fleet management for platforms and agents
 
-- Instant, API-driven database provisioning allows to deploy a full serverless Postgres backend as part of your [platform](https://neon.com/docs/guides/embedded-postgres) or [agent](https://neon.com/docs/guides/ai-agent-integration)
+- Instant, API-driven database provisioning lets you deploy a full Neon backend as part of your [platform](https://neon.com/docs/guides/embedded-postgres) or [agent](https://neon.com/docs/guides/ai-agent-integration)
 - The fully embedded database experience keeps Neon invisible to your end users, with no third-party logins or external configuration required as part of your product workflow
 - [Scale to zero](https://neon.com/docs/introduction/scale-to-zero) keeps unit costs low when large numbers of generated apps are never used or only accessed sporadically
 - A mature API exposes [fleet management and cost-control capabilities](https://neon.com/docs/guides/consumption-limits) including quotas, usage limits, and lifecycle operations

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -15,7 +15,7 @@ updatedOn: '2026-04-18T11:47:20.000Z'
 
 ## Our mission
 
-**Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Designed to help developers build scalable, dependable applications faster than ever.**
+**Neon is the backend for apps and agents. Neon Postgres, Neon Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Designed to help developers build scalable, dependable applications faster than ever.**
 
 We aim to deliver Postgres as a cloud service that feels effortless, from your first side project to millions of users in production. We believe Postgres should be as universal and accessible as object storage, something every developer can rely on without thinking about infrastructure.
 

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -15,9 +15,7 @@ updatedOn: '2026-04-18T11:47:20.000Z'
 
 ## Our mission
 
-**Neon is the backend for apps and agents. Neon Postgres, Auth, Data API, Storage\*, Compute\*, and AI Gateway\* are all agent-ready: instant, branchable, and serverless. Designed to help developers build scalable, dependable applications faster than ever.**
-
-_\*Coming soon._
+**Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Designed to help developers build scalable, dependable applications faster than ever.**
 
 We aim to deliver Postgres as a cloud service that feels effortless, from your first side project to millions of users in production. We believe Postgres should be as universal and accessible as object storage, something every developer can rely on without thinking about infrastructure.
 

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -1,11 +1,10 @@
 ---
 title: Why Neon?
-subtitle: 'Serverless Postgres, by Databricks'
+subtitle: 'The backend for apps and agents, by Databricks'
 summary: >-
-  Covers the features and architecture of Neon, a fully managed, serverless
-  Postgres solution designed for scalable application development, emphasizing
-  its unique separation of storage and compute for enhanced performance and
-  reliability.
+  Covers the mission and features of Neon, the backend for apps and agents,
+  built on a fully managed serverless Postgres engine with managed authentication,
+  an HTTP Data API, and a foundational separation of storage and compute.
 enableTableOfContents: true
 redirectFrom:
   - /docs/cloud/about
@@ -16,7 +15,9 @@ updatedOn: '2026-04-18T11:47:20.000Z'
 
 ## Our mission
 
-**Neon is the Postgres layer for the internet: a fully managed, serverless, open-source Postgres designed to help developers build scalable, dependable applications faster than ever.**
+**Neon is the backend for apps and agents. Neon Postgres, Auth, Data API, Storage\*, Compute\*, and AI Gateway\* are all agent-ready: instant, branchable, and serverless. Designed to help developers build scalable, dependable applications faster than ever.**
+
+_\*Coming soon._
 
 We aim to deliver Postgres as a cloud service that feels effortless, from your first side project to millions of users in production. We believe Postgres should be as universal and accessible as object storage, something every developer can rely on without thinking about infrastructure.
 

--- a/content/docs/guides/django.md
+++ b/content/docs/guides/django.md
@@ -200,4 +200,8 @@ Learn how to use Django with Neon Postgres with this blog post and the accompany
 
 </details>
 
+## Next steps
+
+- [Set up Neon Auth](/docs/auth/overview): Add managed authentication that branches with your database.
+
 <NeedHelp/>

--- a/content/docs/guides/medusajs.md
+++ b/content/docs/guides/medusajs.md
@@ -11,7 +11,7 @@ updatedOn: '2026-02-15T20:51:54.172Z'
 
 [Medusa](https://medusajs.com/) is an open-source headless e-commerce platform that provides a flexible backend for building modern e-commerce applications. It uses Postgres as its primary database to store all product, order, and customer data.
 
-In this guide, you'll learn how to set up and self-host Medusa using [Neon](https://neon.com) as your Postgres database. Neon is a serverless Postgres database platform that offers features like serverless compute, and automated scaling, making it an excellent choice for hosting your Medusa backend.
+In this guide, you'll learn how to set up and self-host Medusa using [Neon](https://neon.com) as your Postgres database. Neon is the backend for apps and agents. Neon Postgres is serverless, with autoscaling and scale-to-zero, making it an excellent choice for hosting your Medusa backend.
 
 ## Prerequisites
 

--- a/content/docs/guides/ruby-on-rails.md
+++ b/content/docs/guides/ruby-on-rails.md
@@ -130,4 +130,8 @@ For schema migration with Ruby on Rails, see our guide:
 
 </DetailIconCards>
 
+## Next steps
+
+- [Set up Neon Auth](/docs/auth/overview): Add managed authentication that branches with your database.
+
 <NeedHelp/>

--- a/content/docs/introduction/architecture-overview.md
+++ b/content/docs/introduction/architecture-overview.md
@@ -1,10 +1,10 @@
 ---
 title: Neon's lakebase architecture
-subtitle: Serverless Postgres with decoupled compute and durable storage
+subtitle: 'Inside Neon Postgres: decoupled compute and durable storage'
 summary: >-
-  Covers the architecture of Neon, a serverless Postgres database that separates
-  compute and storage layers, enabling independent scaling and optimized
-  performance while ensuring data durability and history management.
+  Covers the architecture of Neon Postgres, the database service in the Neon
+  backend that separates compute and storage layers for autoscaling, durability,
+  and history management.
 redirectFrom:
   - /docs/storage-engine/architecture-overview
   - /docs/conceptual-guides/architecture-overview
@@ -163,7 +163,7 @@ This layering is what allows Neon to tolerate failures intrinsically:
 
 ## In short
 
-Neon is a serverless Postgres engine that treats:
+Neon Postgres, the database service in the Neon backend, is a serverless engine that treats:
 
 - compute as ephemeral and replaceable;
 - storage as durable, replicated, and shared;

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -12,7 +12,7 @@ redirectFrom:
 updatedOn: '2026-05-21T10:42:15.476Z'
 ---
 
-Our development teams are focused on helping you ship faster with Postgres. This roadmap describes committed features we're working on right now, what we delivered recently, and a peek at what's on the horizon.
+Neon is the backend for apps and agents, and we're building the platform incrementally. This roadmap describes committed features in flight, what we delivered recently, and a peek at what's on the horizon.
 
 ## What we're working on now 🛠️
 

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -12,7 +12,7 @@ redirectFrom:
 updatedOn: '2026-05-21T10:42:15.476Z'
 ---
 
-Neon is the backend for apps and agents. We're expanding the platform with a branchable stack of backend primitives: Neon Postgres, Auth, Data API, Storage, Compute, and AI Gateway. This roadmap describes what's in flight, what we delivered recently, and what's on the horizon.
+Neon is the backend for apps and agents. We're expanding the platform with a branchable stack of backend primitives: Neon Postgres, Neon Auth, Data API, Storage, Compute, and AI Gateway. This roadmap describes what's in flight, what we delivered recently, and what's on the horizon.
 
 ## What we're working on now 🛠️
 

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -12,7 +12,7 @@ redirectFrom:
 updatedOn: '2026-05-21T10:42:15.476Z'
 ---
 
-Neon is the backend for apps and agents, and we're building the platform incrementally. This roadmap describes committed features in flight, what we delivered recently, and a peek at what's on the horizon.
+Neon is the backend for apps and agents. We're expanding the platform with a branchable stack of backend primitives: Neon Postgres, Auth, Data API, Storage, Compute, and AI Gateway. This roadmap describes what's in flight, what we delivered recently, and what's on the horizon.
 
 ## What we're working on now 🛠️
 

--- a/content/docs/introduction/serverless.md
+++ b/content/docs/introduction/serverless.md
@@ -10,7 +10,7 @@ enableTableOfContents: true
 updatedOn: '2026-04-18T11:47:20.000Z'
 ---
 
-Neon takes the world's most loved database &#8212; Postgres &#8212; and delivers it as a serverless platform, enabling teams to ship reliable and scalable applications faster.
+Neon Postgres, the database service in the Neon backend, is serverless. This page covers what that means: instant provisioning, autoscaling, scale-to-zero, and usage-based pricing.
 
 Enabling serverless Postgres begins with Neon's [lakebase architecture](/docs/introduction/architecture-overview), which natively decouples storage and compute. By separating these components, Neon can dynamically scale up during periods of high activity and down to zero when idle. Developers can be hands-off instead of sizing infrastructure manually.
 

--- a/content/docs/introduction/serverless.md
+++ b/content/docs/introduction/serverless.md
@@ -10,7 +10,7 @@ enableTableOfContents: true
 updatedOn: '2026-04-18T11:47:20.000Z'
 ---
 
-Neon Postgres, the database service in the Neon backend, is serverless. This page covers what that means: instant provisioning, autoscaling, scale-to-zero, and usage-based pricing.
+Neon takes the world's most loved database, Postgres, and makes it serverless. As part of the Neon backend, Neon Postgres helps teams ship reliable and scalable applications faster.
 
 Enabling serverless Postgres begins with Neon's [lakebase architecture](/docs/introduction/architecture-overview), which natively decouples storage and compute. By separating these components, Neon can dynamically scale up during periods of high activity and down to zero when idle. Developers can be hands-off instead of sizing infrastructure manually.
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -333,7 +333,7 @@ An [Organizations](#organization) role in Neon with access to all projects withi
 
 ## Neon
 
-A serverless Postgres platform designed to help developers build reliable and scalable applications faster. We separate compute and storage to offer modern developer features such as autoscaling, branching, instant restore, and more. For more information, see [Why Neon?](/docs/introduction).
+The backend for apps and agents. Includes Neon Postgres, Auth, and Data API today, with Storage, Compute, and AI Gateway coming soon. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero. For more information, see [Why Neon?](/docs/introduction).
 
 ## Neon API
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -333,7 +333,7 @@ An [Organizations](#organization) role in Neon with access to all projects withi
 
 ## Neon
 
-The backend for apps and agents. Includes Neon Postgres, Auth, and Data API today, with Storage, Compute, and AI Gateway coming soon. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero. For more information, see [Why Neon?](/docs/introduction).
+The backend for apps and agents. Includes Neon Postgres, Neon Auth, and Data API today, with Storage, Compute, and AI Gateway coming soon. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero. For more information, see [Why Neon?](/docs/introduction).
 
 ## Neon API
 

--- a/content/docs/shared-content/sign-up.md
+++ b/content/docs/shared-content/sign-up.md
@@ -4,4 +4,4 @@ updatedOn: '2024-06-30T18:09:08.270Z'
 
 ## Try it on Neon!
 
-Neon is Serverless Postgres built for the cloud. Explore Postgres features and functions in our user-friendly SQL Editor. [Sign up](https://console.neon.tech/signup) for a free account and get started.
+Neon is the backend for apps and agents. [Sign up](https://console.neon.tech/signup) for a free Neon account to start building.

--- a/public/agentic-provisioning-llm-context.md
+++ b/public/agentic-provisioning-llm-context.md
@@ -66,7 +66,7 @@ curl -X POST 'https://console.neon.tech/api/v2/projects/{project_id}/branches' \
 
 ## Part 2: Neon documentation and features
 
-Neon is the backend for apps and agents. Neon Postgres is serverless (autoscaling, branching, instant restore, scale-to-zero). Use the API key from Part 1 for all Neon API and connection operations. The Neon docs are the source of truth; prefer fetching current docs over relying on training data.
+Neon is the backend for apps and agents. Use the API key from Part 1 for all Neon API and connection operations. The Neon docs are the source of truth; prefer fetching current docs over relying on training data.
 
 **Fetching docs as Markdown:** Append `.md` to the URL (e.g. https://neon.com/docs/introduction/branching.md) or send `Accept: text/markdown` on the standard URL.
 

--- a/public/agentic-provisioning-llm-context.md
+++ b/public/agentic-provisioning-llm-context.md
@@ -5,6 +5,8 @@ description: Context for agents using or developing the Agentic Provisioning Pro
 
 # Agentic provisioning with Neon
 
+Neon is the backend for apps and agents. The platform includes Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless.
+
 Context for LLMs and agents: use the **API key** from the APP account request to interact with Neon (projects, branches, connection strings, provisioning). Full documentation index: [neon.com/docs/llms.txt](https://neon.com/docs/llms.txt).
 
 ---
@@ -64,7 +66,7 @@ curl -X POST 'https://console.neon.tech/api/v2/projects/{project_id}/branches' \
 
 ## Part 2: Neon documentation and features
 
-Neon is a serverless Postgres platform (autoscaling, branching, instant restore, scale-to-zero). Use the API key from Part 1 for all Neon API and connection operations. The Neon docs are the source of truth; prefer fetching current docs over relying on training data.
+Neon is the backend for apps and agents. Neon Postgres is serverless (autoscaling, branching, instant restore, scale-to-zero). Use the API key from Part 1 for all Neon API and connection operations. The Neon docs are the source of truth; prefer fetching current docs over relying on training data.
 
 **Fetching docs as Markdown:** Append `.md` to the URL (e.g. https://neon.com/docs/introduction/branching.md) or send `Accept: text/markdown` on the standard URL.
 

--- a/public/agentic-provisioning-llm-context.md
+++ b/public/agentic-provisioning-llm-context.md
@@ -5,7 +5,7 @@ description: Context for agents using or developing the Agentic Provisioning Pro
 
 # Agentic provisioning with Neon
 
-Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless.
+Neon is the backend for apps and agents. Neon Postgres, Neon Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless.
 
 Context for LLMs and agents: use the **API key** from the APP account request to interact with Neon (projects, branches, connection strings, provisioning). Full documentation index: [neon.com/docs/llms.txt](https://neon.com/docs/llms.txt).
 

--- a/public/agentic-provisioning-llm-context.md
+++ b/public/agentic-provisioning-llm-context.md
@@ -5,7 +5,7 @@ description: Context for agents using or developing the Agentic Provisioning Pro
 
 # Agentic provisioning with Neon
 
-Neon is the backend for apps and agents. The platform includes Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless.
+Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless.
 
 Context for LLMs and agents: use the **API key** from the APP account request to interact with Neon (projects, branches, connection strings, provisioning). Full documentation index: [neon.com/docs/llms.txt](https://neon.com/docs/llms.txt).
 

--- a/public/docs/ai/skills/neon-postgres/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 
 Guide the user through any Neon-related task: setup, connections, branching, and advanced features. Deliver a working Neon connection, a completed feature configuration, or a specific answer from the official Neon docs.
 
-Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
+Neon is the backend for apps and agents. Neon Postgres, Neon Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
 
 ## Neon Documentation
 

--- a/public/docs/ai/skills/neon-postgres/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 
 Guide the user through any Neon-related task: setup, connections, branching, and advanced features. Deliver a working Neon connection, a completed feature configuration, or a specific answer from the official Neon docs.
 
-Neon is the backend for apps and agents. The platform includes Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
+Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
 
 ## Neon Documentation
 

--- a/public/docs/ai/skills/neon-postgres/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neon-postgres
 description: >-
-  Guides and best practices for working with Neon Serverless Postgres.
+  Guides and best practices for working with Neon, the backend for apps and agents.
   Covers setup, connection methods, branching, autoscaling, scale-to-zero,
   read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server,
   REST API, TypeScript SDK, and Python SDK.
@@ -12,11 +12,11 @@ description: >-
   "Neon connection pooling".
 ---
 
-# Neon Serverless Postgres
+# Neon: the backend for apps and agents
 
 Guide the user through any Neon-related task: setup, connections, branching, and advanced features. Deliver a working Neon connection, a completed feature configuration, or a specific answer from the official Neon docs.
 
-Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
+Neon is the backend for apps and agents. The platform includes Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
 
 ## Neon Documentation
 

--- a/public/docs/ai/skills/neon-postgres/references/neon-auth.md
+++ b/public/docs/ai/skills/neon-postgres/references/neon-auth.md
@@ -1,6 +1,6 @@
 # Neon Auth
 
-Neon Auth provides managed authentication that stores users, sessions, and auth configuration directly in your Neon database. When you branch your database, your entire auth state branches with it.
+Neon Auth is the managed authentication service in the Neon backend for apps and agents. It stores users, sessions, and auth configuration directly in your Neon database. When you branch your database, your entire auth state branches with it.
 
 See the [official Neon Auth docs](https://neon.com/docs/auth/overview.md) for complete details.
 

--- a/public/docs/ai/skills/neon-postgres/references/what-is-neon.md
+++ b/public/docs/ai/skills/neon-postgres/references/what-is-neon.md
@@ -1,6 +1,6 @@
 # What is Neon
 
-Neon is the backend for apps and agents. The platform includes Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
+Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
 
 See the [official introduction](https://neon.com/docs/introduction.md) for complete details.
 

--- a/public/docs/ai/skills/neon-postgres/references/what-is-neon.md
+++ b/public/docs/ai/skills/neon-postgres/references/what-is-neon.md
@@ -1,6 +1,6 @@
 # What is Neon
 
-Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero.
+Neon is the backend for apps and agents. The platform includes Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
 
 See the [official introduction](https://neon.com/docs/introduction.md) for complete details.
 

--- a/public/docs/ai/skills/neon-postgres/references/what-is-neon.md
+++ b/public/docs/ai/skills/neon-postgres/references/what-is-neon.md
@@ -1,6 +1,6 @@
 # What is Neon
 
-Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
+Neon is the backend for apps and agents. Neon Postgres, Neon Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres is serverless, with autoscaling, branching, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.
 
 See the [official introduction](https://neon.com/docs/introduction.md) for complete details.
 

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -17,7 +17,7 @@
 
 module.exports = {
   tagline:
-    "Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.",
+    "Neon is the backend for apps and agents. Neon Postgres, Neon Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.",
 
   intro: [
     'Neon docs are available as markdown.',

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -17,7 +17,7 @@
 
 module.exports = {
   tagline:
-    "Neon is the backend for apps and agents. Build with Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.",
+    "Neon is the backend for apps and agents. Neon Postgres, Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.",
 
   intro: [
     'Neon docs are available as markdown.',

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -17,7 +17,7 @@
 
 module.exports = {
   tagline:
-    "Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.",
+    "Neon is the backend for apps and agents. Build with Neon Postgres, Auth, Data API, Storage*, Compute*, and AI Gateway* (*coming soon). Every service is agent-ready: instant, branchable, and serverless. Neon Postgres includes autoscaling, instant restore, and scale-to-zero, and is fully compatible with any language, framework, or ORM that supports Postgres.",
 
   intro: [
     'Neon docs are available as markdown.',


### PR DESCRIPTION
Aligns docs surfaces with the "Neon is the backend for apps and agents" positioning. Companion to #4915.

Covers high-LLM-training surfaces (llms.txt header tagline, agent skill files, glossary, mission page, agentic provisioning context), product overview pages (Auth, Data API), the architecture and serverless concept pages, hub pages (AI starter kit, AI agents tools), shared sign-up CTA, and framework guide next-step bullets.

Scopes "serverless Postgres engine" claims to Neon Postgres specifically. Other services (Auth, Data API, Storage, Compute, AI Gateway) are each independently serverless but use different underlying technologies.

Jira: LKB-13275

Co-authored-by: Isaac

## Problem sentences for a follow-up pass

  ### `content/docs/get-started/why-neon.md`

  - Line 24: "Neon is built on a distributed, cloud-native architecture that separates storage and compute, giving Postgres the scale,
  reliability, and efficiency modern applications require."
  - Line 113: "At the highest level, Neon is built on a simple but powerful idea: Postgres on the object store."

  ### `content/docs/introduction/neon-and-lakebase.md` (Lakebase boundary)

  - Line 15: "Neon continues as a standalone serverless Postgres platform..."
  - Line 21: "...a managed serverless Postgres service built on the same architectural foundation as Neon..."
  - Line 54 (comparison table): "Standalone serverless Postgres platform"

  ### `content/docs/introduction/serverless.md` (page-level decisions)

  - Title: bare `Serverless` — consider expanding to `Serverless Postgres` for SEO
  - Subtitle: `Postgres with instant provisioning, no server management, and pay-per-usage billing` — still Postgres-led; consider
  shifting to Neon-backend-led
  - Bigger question: keep as concept-definition page, repurpose as "Why serverless?", or fold into architecture-overview?

  ### `content/docs/guides/metabase-neon.md`

  - Line 376: "Since Neon is built on Postgres, you can define RLS policies directly in your database and force Metabase to respect
  them."

  ### `content/docs/guides/benchmarking-latency.md`

  - Title (line 2): "Benchmarking latency in Neon's serverless Postgres"
  - Summary (line 6): "...benchmarking latency in Neon's serverless Postgres..."
  - Body (line 13): "Neon's serverless Postgres environment adds additional layers to this complexity..."
  - Closer (line 137): "Benchmarking Neon requires understanding the unique characteristics of serverless Postgres..."
  - Note: these are arguably legitimate technical vocabulary, not brand framing. Team may want to leave as-is.

  ### `content/docs/community/component-guide.md`

  - Lines 665, 673: CTA examples use "Start building with serverless Postgres today" — illustrative copy in MDX component reference.
