### PR TITLE
Add twitter:site metadata

### DIFF
--- a/src/utils/get-metadata.js
+++ b/src/utils/get-metadata.js
@@ -77,6 +77,7 @@ export default function getMetadata({
     category,
     twitter: {
       card: 'summary_large_image',
+      site: '@neondatabase',
     },
   };
 }


### PR DESCRIPTION
This is kind of an opinionated change so feel free to reject — adds `twitter:site` (`@neondatabase`) to the site-wide Twitter card metadata.