### PR TITLE
feat: render RequestForm in blog posts

### DIFF
--- a/src/components/pages/blog-post/blog-post-page/blog-post-page.jsx
+++ b/src/components/pages/blog-post/blog-post-page/blog-post-page.jsx
@@ -18,6 +18,7 @@ import BlogQuote from 'components/shared/blog-quote';
 import ChangelogForm from 'components/shared/changelog-form';
 import EmbedTweet from 'components/shared/embed-tweet';
 import ImageZoom from 'components/shared/image-zoom';
+import RequestForm from 'components/shared/request-form';
 import { DEFAULT_BLOG_ROUTE_CONFIG } from 'constants/blog';
 import getFormattedDate from 'utils/get-formatted-date';
 import getMarkdownTableOfContents from 'utils/get-markdown-table-of-contents';
@@ -61,6 +62,7 @@ const mdxComponents = {
   CodeTabs,
   CTA,
   EmbedTweet,
+  RequestForm,
   YoutubeIframe,
 };
 


### PR DESCRIPTION
## Summary

- Registers the shared `RequestForm` component in the blog MDX component map so posts can embed `<RequestForm type="..." />` the same way docs already can.

## Test plan

- [ ] Embed `<RequestForm type="backend-platform" />` (or another existing type) in a blog post draft and confirm it renders.
- [ ] Confirm existing blog posts are unaffected.

This pull request and its description were written by Isaac.