### PR TITLE
fix: always show email field in RequestForm

### DIFF
--- a/src/components/shared/request-form/data.js
+++ b/src/components/shared/request-form/data.js
@@ -168,9 +168,9 @@ const EXTENSIONS = {
 const BACKEND_PLATFORM = {
   title: 'Get early access to the Neon backend platform',
   description:
-    "We're expanding Neon into a complete backend platform. Drop your email and we'll reach out as new components become available.",
+    "We're expanding Neon into a complete backend platform. Drop your email and we'll reach out soon for early access.",
   buttonText: 'Get access',
-  confirmation: "You're on the list. We'll be in touch as new components become available.",
+  confirmation: "You're on the list. We'll be in touch soon.",
   eventName: 'Backend Platform Access Requested',
 };
 

--- a/src/components/shared/request-form/request-form.jsx
+++ b/src/components/shared/request-form/request-form.jsx
@@ -21,20 +21,12 @@ import sendGtagEvent from 'utils/send-gtag-event';
 
 import DATA from './data';
 
-function getCookie(name) {
-  if (typeof document === 'undefined') return null;
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop().split(';').shift();
-  return null;
-}
-
 const RequestForm = ({ type }) => {
   const { title, description, placeholder, buttonText, confirmation, options, extendedOptions } =
     DATA[type];
   const hasOptions = Array.isArray(options) && options.length > 0;
 
-  const isRecognized = !!getCookie('ajs_user_id');
+  const isRecognized = false;
   const [selected, setSelected] = useState('');
   const [email, setEmail] = useState('');
   const [query, setQuery] = useState('');


### PR DESCRIPTION
## Summary

- Disable the cookie-based recognized-user check that hid the email input on `RequestForm`. The form now always collects an email regardless of whether `ajs_user_id` is set.
- Remove the now-unused `getCookie` helper.

## Test plan

- [ ] Visit a page with a `<RequestForm />` while signed in to neon.com (so `ajs_user_id` is set) and confirm the email field still renders and submit requires a valid email.
- [ ] Submit the form and confirm the analytics `identify` and request events fire.

This pull request and its description were written by Isaac.