### PR TITLE
fix: copy correct SVG source from navbar logo context menu

### DIFF
--- a/src/components/shared/logo/logo.jsx
+++ b/src/components/shared/logo/logo.jsx
@@ -22,7 +22,7 @@ const copySvgToClipboard = async () => {
     const isDarkMode = document.documentElement.classList.contains('dark');
     const logoToUse = isDarkMode ? logoDarkSvg : logoLightSvg;
 
-    const response = await fetch(logoToUse);
+    const response = await fetch(logoToUse.src);
     const svgContent = await response.text();
     copyToClipboard(svgContent);
   } catch (error) {

--- a/src/components/shared/logo/logo.jsx
+++ b/src/components/shared/logo/logo.jsx
@@ -23,10 +23,20 @@ const copySvgToClipboard = async () => {
     const logoToUse = isDarkMode ? logoDarkSvg : logoLightSvg;
 
     const response = await fetch(logoToUse.src);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch logo SVG: ${response.status} ${response.statusText}`);
+    }
+
     const svgContent = await response.text();
-    copyToClipboard(svgContent);
+    const copied = copyToClipboard(svgContent);
+    if (!copied) {
+      throw new Error('Failed to copy SVG content to clipboard');
+    }
+
+    return true;
   } catch (error) {
     console.error('Failed to copy SVG content: ', error);
+    return false;
   }
 };
 
@@ -53,9 +63,11 @@ const Logo = ({ className = null, width, height, isHeader = false }) => {
     setClicked(true);
   };
 
-  const handleCopySvg = () => {
-    copySvgToClipboard();
-    setOpen(true);
+  const handleCopySvg = async () => {
+    const copied = await copySvgToClipboard();
+    if (copied) {
+      setOpen(true);
+    }
   };
 
   return (


### PR DESCRIPTION
Static `.svg` imports resolve to a `StaticImageData` object, not a URL string, so the logo context-menu "Copy logo as SVG" action now fetches `logoToUse.src` instead of the object.

If you right click the logo on the landing page today and copy the svg it copies something completely unrelated hence this fix!