### PR TITLE
docs: increase included egress to 500 GB on paid plans

### DIFF
--- a/content/docs/guides/datadog.md
+++ b/content/docs/guides/datadog.md
@@ -6,7 +6,7 @@ summary: >-
   metrics and Postgres logs to monitor database performance and resource
   utilization directly within Datadog's observability platform.
 enableTableOfContents: true
-updatedOn: '2026-02-06T22:07:32.945Z'
+updatedOn: '2026-05-29T00:27:59.360Z'
 ---
 
 <InfoBlock>
@@ -687,7 +687,7 @@ You can export your Postgres logs from your Neon compute to your Datadog account
 Enabling this feature may result in:
 
 - An increase in compute resource usage for log processing
-- Additional network egress for log transmission, which is billed after 100 GB on paid plans
+- Additional network egress for log transmission, which is billed after 500 GB on paid plans
 - Associated costs based on log volume in Datadog
 
 ## Feedback and future improvements

--- a/content/docs/guides/grafana-cloud.md
+++ b/content/docs/guides/grafana-cloud.md
@@ -6,7 +6,7 @@ summary: >-
   configuration for log forwarding and the transmission of metrics related to
   database performance and resource utilization.
 enableTableOfContents: true
-updatedOn: '2026-02-15T20:51:54.161Z'
+updatedOn: '2026-05-29T00:27:59.360Z'
 ---
 
 <InfoBlock>
@@ -698,7 +698,7 @@ You can export your Postgres logs from your Neon compute to your Grafana Cloud s
 Enabling this feature may result in:
 
 - An increase in compute resource usage for log processing
-- Additional network egress for log transmission, which is billed after 100 GB on paid plans
+- Additional network egress for log transmission, which is billed after 500 GB on paid plans
 - Associated costs based on log volume in Grafana Cloud
 
 ### Querying logs in Grafana Cloud

--- a/content/docs/introduction/cost-optimization.md
+++ b/content/docs/introduction/cost-optimization.md
@@ -6,7 +6,7 @@ summary: >-
   usage, including right-sizing, effective autoscaling, enabling scale to zero,
   and managing persistent connections.
 enableTableOfContents: true
-updatedOn: '2026-05-12T14:01:17.544Z'
+updatedOn: '2026-05-29T00:27:59.360Z'
 ---
 
 Managing your Neon costs effectively requires understanding how each billing factor works and implementing strategies to control usage. This guide provides actionable recommendations for optimizing costs across all billing metrics.
@@ -165,7 +165,7 @@ Extra branches beyond your plan's allowance are billed at $1.50/branch-month, pr
 
 ## Public data transfer
 
-Public network transfer (egress) is the data sent from your databases over the public internet. Free plans include 5 GB/month. On paid plans, the first 100 GB/month is included, then $0.10/GB. You see no data transfer cost until you exceed that allowance, so the charge might show up unexpectedly if you're not monitoring data transfer. For a deeper look at what causes high network transfer and how to monitor it, see [Network transfer](/docs/introduction/network-transfer).
+Public network transfer (egress) is the data sent from your databases over the public internet. Free plans include 5 GB/month. On paid plans, the first 500 GB/month is included, then $0.10/GB. You see no data transfer cost until you exceed that allowance, so the charge might show up unexpectedly if you're not monitoring data transfer. For a deeper look at what causes high network transfer and how to monitor it, see [Network transfer](/docs/introduction/network-transfer).
 
 **Optimization strategies:**
 

--- a/content/docs/introduction/network-transfer.md
+++ b/content/docs/introduction/network-transfer.md
@@ -7,7 +7,7 @@ summary: >-
   Neon, including the egress optimizer agent skill, public and private transfer
   types, common causes of high usage, Console and API monitoring, and strategies
   to reduce transfer.
-updatedOn: '2026-03-16T10:19:48.546Z'
+updatedOn: '2026-05-29T00:27:59.360Z'
 ---
 
 Network transfer is one of the usage metrics that affects your Neon bill. This guide explains what network transfer is, what causes it to increase, how to monitor it, and how to reduce it. For broader cost guidance, see [Cost optimization](/docs/introduction/cost-optimization). For plan allowances and pricing, see [Plans](/docs/introduction/plans).
@@ -20,7 +20,7 @@ There are two types of network transfer:
 
 - **Public network transfer**: Data sent over the public internet. [Logical replication](/docs/guides/logical-replication-neon) to any destination counts as public network transfer.
   - **Free plan**: 5 GB/month included. Exceeding this suspends your compute until the next billing cycle or you upgrade.
-  - **Launch / Scale plans**: 100 GB/month included, then $0.10/GB.
+  - **Launch / Scale plans**: 500 GB/month included, then $0.10/GB.
 - **Private network transfer**: Traffic routed over AWS PrivateLink. Available on the Scale plan only. Billed at $0.01/GB, bi-directional. Unlike public network transfer, which only counts outbound data, private network transfer counts traffic in both directions: data sent from your database to clients and data sent from clients to your database.
 
 In the Console, these appear as **Public network transfer** and **Private network transfer**. In the Consumption API, the fields are `public_network_transfer_bytes` and `private_network_transfer_bytes`. In project and branch detail API responses, the combined field is `data_transfer_bytes`.

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -19,7 +19,7 @@ redirectFrom:
   - /docs/reference/billing-sample
   - /docs/introduction/legacy-plans
   - /docs/introduction/extra-usage
-updatedOn: '2026-05-20T14:13:43.586Z'
+updatedOn: '2026-05-29T00:27:59.360Z'
 ---
 
 Neon offers plans to support you at every stage, from your first prototype to production at scale.
@@ -47,7 +47,7 @@ For AI agent platforms that provision thousands of databases, Neon offers an **A
 | [Autoscaling](#autoscaling)                           | Up to 2 CU (8 GB RAM)                      | Up to 16 CU (64 GB RAM)              | Up to 16 CU autoscaling, or fixed sizes up to 56 CU (224 GB RAM)                                  |
 | [Scale to zero](#scale-to-zero)                       | After 5 min                                | After 5 min, can be disabled         | Configurable (1 minute to always on)                                                              |
 | [Storage](#storage)                                   | 0.5 GB/project                             | $0.35/GB-month                       | $0.35/GB-month                                                                                    |
-| [Public network transfer](#public-network-transfer)   | 5 GB included                              | 100 GB included, then $0.10/GB       | 100 GB included, then $0.10/GB                                                                    |
+| [Public network transfer](#public-network-transfer)   | 5 GB included                              | 500 GB included, then $0.10/GB       | 500 GB included, then $0.10/GB                                                                    |
 | [Monitoring](#monitoring)                             | 1 day                                      | 3 days                               | 14 days                                                                                           |
 | [Metrics/logs export](#metricslogs-export)            | —                                          | —                                    | ✅                                                                                                |
 | [Instant restore](#instant-restore)                   | —                                          | $0.20/GB-month                       | $0.20/GB-month                                                                                    |
@@ -238,8 +238,8 @@ Public network transfer (egress) is the total volume of data sent from your data
 Allowances per plan:
 
 - **Free**: 5 GB/month
-- **Launch**: 100 GB/month, then $0.10/GB
-- **Scale**: 100 GB/month, then $0.10/GB
+- **Launch**: 500 GB/month, then $0.10/GB
+- **Scale**: 500 GB/month, then $0.10/GB
 
 ### Monitoring
 
@@ -511,7 +511,7 @@ How are read replicas billed?
 : Each read replica is its own compute and contributes to CU-hours.
 
 Do public network transfer limits reset each month?
-: Yes. Free plan includes 5 GB/month, Launch and Scale include 100 GB/month. Beyond that, it's $0.10/GB.
+: Yes. Free plan includes 5 GB/month, Launch and Scale include 500 GB/month. Beyond that, it's $0.10/GB.
 
 How is private network transfer billed?
 : Only available on Scale: $0.01/GB, bidirectional, between Neon and private network services.

--- a/content/docs/introduction/usage-calculations.md
+++ b/content/docs/introduction/usage-calculations.md
@@ -6,7 +6,7 @@ summary: >-
   byte-hours and CU-seconds into human-readable billing units, and calculate
   costs using plan rates and allowances.
 enableTableOfContents: true
-updatedOn: '2026-05-29T00:27:59.360Z'
+updatedOn: '2026-05-29T16:16:59.299Z'
 ---
 
 This guide helps you use the Neon API to fetch your consumption data, convert raw metrics into human-readable numbers, and understand how your bill is calculated. To monitor usage in the Neon Console instead, see [Monitor billing and usage](/docs/introduction/monitor-usage).
@@ -75,7 +75,7 @@ Sum each metric's cost to get the total. Rates differ by plan (see [Plans](/docs
 | Child storage    | GB-months x rate                  | $0.35/GB-mo  | $0.35/GB-mo  |
 | Instant restore  | GB-months x rate                  | $0.20/GB-mo  | $0.20/GB-mo  |
 | Snapshots        | GB-months x rate                  | $0.09/GB-mo  | $0.09/GB-mo  |
-| Public transfer  | max(0, org_total_GB - 100) x rate | $0.10/GB     | $0.10/GB     |
+| Public transfer  | max(0, org_total_GB - 500) x rate | $0.10/GB     | $0.10/GB     |
 | Private transfer | GB x rate                         | n/a          | $0.01/GB     |
 | Extra branches   | branch-months x rate              | $1.50/mo     | $1.50/mo     |
 

--- a/content/docs/introduction/usage-calculations.md
+++ b/content/docs/introduction/usage-calculations.md
@@ -6,7 +6,7 @@ summary: >-
   byte-hours and CU-seconds into human-readable billing units, and calculate
   costs using plan rates and allowances.
 enableTableOfContents: true
-updatedOn: '2026-05-22T09:50:49.895Z'
+updatedOn: '2026-05-29T00:27:59.360Z'
 ---
 
 This guide helps you use the Neon API to fetch your consumption data, convert raw metrics into human-readable numbers, and understand how your bill is calculated. To monitor usage in the Neon Console instead, see [Monitor billing and usage](/docs/introduction/monitor-usage).
@@ -129,10 +129,10 @@ Repeat for each day in the billing period and sum the billable branch-hours acro
 
 ### Public transfer allowance
 
-On paid plans, the 100 GB free allowance applies **org-wide**, not per project. Sum public transfer across all projects before subtracting the allowance:
+On paid plans, the 500 GB free allowance applies **org-wide**, not per project. Sum public transfer across all projects before subtracting the allowance:
 
 ```
-billable GB = max(0, total_org_GB - 100)
+billable GB = max(0, total_org_GB - 500)
 cost = billable_GB x $0.10
 ```
 
@@ -157,7 +157,7 @@ To reconcile the numbers yourself:
 1. Fetch consumption history for the billing month (`from` = month start, `to` = month end or current date).
 2. Sum each metric across all projects.
 3. Convert to billing units using the formulas above.
-4. Apply allowances (100 GB public transfer, branch allowance per project).
+4. Apply allowances (500 GB public transfer, branch allowance per project).
 5. Multiply by your plan's rates.
 
 The result should closely match the costs in your weekly email. Small differences can occur due to:

--- a/content/docs/reference/metrics-logs.md
+++ b/content/docs/reference/metrics-logs.md
@@ -6,7 +6,7 @@ summary: >-
   observability platforms, detailing available metrics, their labels, and
   integration specifics with tools like Datadog and Grafana Cloud.
 enableTableOfContents: true
-updatedOn: '2026-05-09T15:15:10.215Z'
+updatedOn: '2026-05-29T00:27:59.360Z'
 ---
 
 This page provides a comprehensive reference for all metrics and log fields that Neon exports to observability platforms through integrations like [Datadog](/docs/guides/datadog), [Grafana Cloud](/docs/guides/grafana-cloud), and [OpenTelemetry](/docs/guides/opentelemetry).
@@ -99,7 +99,7 @@ During the beta phase, you may see some Neon-specific system logs included. Thes
 Enabling log export may result in:
 
 - An increase in compute resource usage for log processing
-- Additional network egress for log transmission, billed on paid plans for usage over 100 GB
+- Additional network egress for log transmission, billed on paid plans for usage over 500 GB
 - Associated costs based on log volume in your observability platform
 
 <Admonition type="note">

--- a/content/faqs/affordable-managed-postgres-options-startups.md
+++ b/content/faqs/affordable-managed-postgres-options-startups.md
@@ -28,7 +28,7 @@ When you outgrow Free, the [Launch plan](/docs/introduction/plans) is pay-as-you
 
 - Compute: $0.106/CU-hour
 - Storage: $0.35/GB-month
-- 100 GB of public network transfer included, then $0.10/GB
+- 500 GB of public network transfer included, then $0.10/GB
 
 A worked example from the [Launch plan usage examples](/docs/introduction/plans#launch-plan): 120 CU-hours of compute (about 20 billable days at 0.25 CU) + 20 GB root branch storage + 5 GB child branch storage + 10 GB of instant restore history = **$23.47/month**.
 

--- a/content/faqs/best-free-low-cost-managed-postgres-services.md
+++ b/content/faqs/best-free-low-cost-managed-postgres-services.md
@@ -39,7 +39,7 @@ If you blow past 100 CU-hours, run out of storage, or want to disable scale-to-z
 
 - Compute: $0.106/CU-hour
 - Storage: $0.35/GB-month
-- 100 GB egress included
+- 500 GB egress included
 
 There's no monthly minimum. A light project running 10 CU-hours/month with 2 GB of storage works out to about $2 a month on Launch (see the [usage examples](/docs/introduction/plans#launch-plan)).
 

--- a/content/faqs/postgres-providers-multiple-apps-separate-databases-under-10.md
+++ b/content/faqs/postgres-providers-multiple-apps-separate-databases-under-10.md
@@ -27,7 +27,7 @@ If one app starts getting steady traffic, move that project to the Launch plan. 
 
 - **$0.106 per CU-hour** of compute
 - **$0.35 per GB-month** of storage
-- $0 for the first 100 GB of egress, then $0.10/GB
+- $0 for the first 500 GB of egress, then $0.10/GB
 
 A back-of-envelope estimate for a small always-on app running at 0.25 CU for 30 hours per month with 1 GB of data:
 

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -35,7 +35,7 @@ Invoices under $0.50 are not collected.
 | History window                   | 6 hours (1 GB limit)                       | Up to 7 days                         | Up to 30 days                                                    |
 | Snapshots (manual)               | 1                                          | 10                                   | 10                                                               |
 | Snapshots (scheduled)            | -                                          | Yes                                  | Yes                                                              |
-| Public network transfer (egress) | 5 GB included                              | 100 GB included, then $0.10/GB       | 100 GB included, then $0.10/GB                                   |
+| Public network transfer (egress) | 5 GB included                              | 500 GB included, then $0.10/GB       | 500 GB included, then $0.10/GB                                   |
 | Private network transfer         | -                                          | -                                    | $0.01/GB                                                         |
 | Auth (MAU)                       | Up to 60k MAU                              | Up to 1M MAU                         | Up to 1M MAU                                                     |
 | Monitoring retention             | 1 day                                      | 3 days                               | 14 days                                                          |

--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -203,8 +203,8 @@ export default {
         subtitle: 'Egress',
       },
       free: '5 GB included',
-      launch: '100 GB included<span>then $0.10 per GB</span>',
-      scale: '100 GB included<span>then $0.10 per GB</span>',
+      launch: '500 GB included<span>then $0.10 per GB</span>',
+      scale: '500 GB included<span>then $0.10 per GB</span>',
     },
     {
       rows: '2',


### PR DESCRIPTION
## Summary

The included public network transfer (egress) allowance on the Launch and Scale plans has increased from **100 GB to 500 GB**. This PR updates the website to reflect the new allowance everywhere it's documented.

The Free plan allowance (5 GB) and the overage rate ($0.10/GB) are unchanged.

## Changes

**Docs**
- `content/docs/introduction/plans.md` — comparison table, allowances list (Launch + Scale), and the FAQ entry
- `content/docs/introduction/usage-calculations.md` — allowance description, the `billable GB = max(0, total_org_GB - 500)` formula, and the calculation-steps note
- `content/docs/introduction/cost-optimization.md` — paid-plan egress description
- `content/docs/introduction/network-transfer.md` — Launch/Scale allowance
- `content/docs/guides/datadog.md`, `content/docs/guides/grafana-cloud.md`, `content/docs/reference/metrics-logs.md` — log-export egress billing note

**FAQs**
- `content/faqs/affordable-managed-postgres-options-startups.md`
- `content/faqs/best-free-low-cost-managed-postgres-services.md`
- `content/faqs/postgres-providers-multiple-apps-separate-databases-under-10.md`

**Pricing page data**
- `src/components/pages/pricing/plans/data/plans.js` — Launch and Scale egress cells in the pricing comparison table

## Notes

- Blog posts and changelog entries were intentionally left unchanged, since they are dated historical records.
- Remaining `100 GB` references in docs are storage-related (e.g. the `$0.35/GB-month` storage example, copy-on-write branching examples) and were not touched.