### PR TITLE
Fix code examples in the PostgreSQL Trigger with a When Condition docs

### DIFF
--- a/content/postgresql/triggers/trigger-when-condition.md
+++ b/content/postgresql/triggers/trigger-when-condition.md
@@ -30,7 +30,7 @@ Sometimes, you want the trigger to be activated only when a specific condition i
 ```sql
 CREATE TRIGGER trigger_name
 ON table_name
-WHEN condition
+WHEN (boolean_expression)
 EXECUTE FUNCTION function_name('optional', 'arguments');
 ```
 

--- a/content/postgresql/triggers/trigger-when-condition.md
+++ b/content/postgresql/triggers/trigger-when-condition.md
@@ -31,7 +31,7 @@ Sometimes, you want the trigger to be activated only when a specific condition i
 CREATE TRIGGER trigger_name
 ON table_name
 WHEN condition
-EXECUTE FUNCTION function_name(arguments);
+EXECUTE FUNCTION function_name();
 ```
 
 In this syntax, the `condition` is a boolean expression. If the `condition` is true, the trigger is fired; otherwise, the trigger will not be activated.
@@ -120,7 +120,7 @@ The `AFTER INSERT` trigger fires and insert rows into the `customer_stats` table
 Sixth, change the order statuses of customer id 1 and 2 to `completed`:
 
 ```sql
-UPDATE order
+UPDATE orders
 SET status = 'completed'
 WHERE customer_id IN (1,2);
 ```

--- a/content/postgresql/triggers/trigger-when-condition.md
+++ b/content/postgresql/triggers/trigger-when-condition.md
@@ -31,7 +31,7 @@ Sometimes, you want the trigger to be activated only when a specific condition i
 CREATE TRIGGER trigger_name
 ON table_name
 WHEN condition
-EXECUTE FUNCTION function_name();
+EXECUTE FUNCTION function_name('optional', 'arguments');
 ```
 
 In this syntax, the `condition` is a boolean expression. If the `condition` is true, the trigger is fired; otherwise, the trigger will not be activated.


### PR DESCRIPTION
### Detail
- Removed `arguments`, since trigger functions do not take any arguments
- Fixed the table name in the code examples