### PR TITLE
chore: update topbar to promote 5x data transfer on paid plans

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'All paid plans now include 5x more data transfer: 500 GB per month, up from 100 GB. Read the details here.'
+text: 'All paid plans now include 5x more free data transfer: 500 GB per month, up from 100 GB. Read the details here.'
 link:
   url: 'https://neon.com/blog/more-data-transfer-on-paid-plans'
   target: '_blank'

--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: ' We''re launching Compute, Object Storage, and AI Gateway to run alongside Database and Auth. Learn more and register for early access here.'
+text: 'All paid plans now include 5x more data transfer: 500 GB per month, up from 100 GB. Read the details here.'
 link:
-  url: 'https://neon.com/blog/were-building-backends'
+  url: 'https://neon.com/blog/more-data-transfer-on-paid-plans'
   target: '_blank'


### PR DESCRIPTION
## What

Updates the site-wide topbar banner to promote the new post: [We're including 5x more data transfer in all paid plans](https://neon.com/blog/more-data-transfer-on-paid-plans).

New banner copy:

> All paid plans now include 5x more data transfer: 500 GB per month, up from 100 GB. Read the details here.

## Why

Announces the included monthly data transfer increase (100 GB → 500 GB) across all paid plans, replacing the previous "building backends" launch banner.