### PR TITLE
Fix a few minor mistakes in the PL/pgSQL Block Structure docs

### DIFF
--- a/content/postgresql/plpgsql/plpgsql-block-structure.md
+++ b/content/postgresql/plpgsql/plpgsql-block-structure.md
@@ -177,7 +177,7 @@ begin
 	   raise notice 'x=% y=%', x, y;
    end inner;
 end outer;
-$$
+$$;
 ```
 
 Output:
@@ -196,12 +196,12 @@ In the outer block:
 
 In the inner block (subblock or nested block):
 
-- Declare a variable y and initialize its value to zero.
+- Declare a variable y and initialize its value to two.
 - Increase the value of y by x.
 - Display the values of the variables x and y using the raise notice.
 
 ## Summary
 
-- PL/pgSQL is a blocked\-structure language that organizes a program into blocks.
+- PL/pgSQL is a block-structured language that organizes a program into blocks.
 - A block contains two parts: declaration and body. The declaration part is optional whereas the body part is mandatory.
 - Blocks can be nested. A nested block is a block placed inside the body of another block.


### PR DESCRIPTION
### Detail

- Add missing semicolon in a code example.
- Fix a few other minor typos. 