### PR TITLE
docs: update Neon positioning to AI-native backend platform across guides

### DIFF
--- a/content/guides/agentstack-neon.md
+++ b/content/guides/agentstack-neon.md
@@ -4,12 +4,12 @@ subtitle: Build a Web scraper AI Agent in minutes with AgentStack, Neon, and Fir
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-04T00:00:00.000Z'
-updatedOn: '2025-05-30T16:53:05.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 The rapid evolution of AI agents has created a key challenge: how to build and deploy agents quickly and efficiently. Imagine creating intelligent agents that can not only perform complex tasks but also interact easily with your data infrastructure, without adding unnecessary complexity to the code.
 
-This guide introduces [**AgentStack**](https://docs.agentstack.sh/introduction), a rapid development framework, and Neon, the serverless Postgres database, and shows how they can be used together to build powerful AI agents with database integration. We'll walk through building a **Web Scraper AI Agent** using AgentStack's CLI and tool integrations.
+This guide introduces [**AgentStack**](https://docs.agentstack.sh/introduction), a rapid development framework, and Neon, the AI-native backend platform for apps and agents (Postgres Database, Auth, Storage, Functions, and AI Gateway), and shows how they can be used together to build powerful AI agents with database integration. We'll walk through building a **Web Scraper AI Agent** using AgentStack's CLI and tool integrations.
 
 With AgentStack and Neon, you can generate complete agent workflows, create new agents and tasks with simple commands, and integrate them directly with your data layer. Let's get started.
 

--- a/content/guides/azure-ai-agent-service.md
+++ b/content/guides/azure-ai-agent-service.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to build an AI Agent for Postgres using Azure AI Agent Serv
 author: boburmirzo
 enableTableOfContents: true
 createdAt: '2025-04-07T00:00:00.000Z'
-updatedOn: '2026-05-09T19:22:21.118Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 AI agents are getting a lot of attention lately, but getting started can be confusing. You may have heard about tools like [LangChain/LangGraph](https://python.langchain.com/v0.1/docs/modules/agents/), [Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/overview/), [AutoGen](https://microsoft.github.io/autogen/), or [LlamaIndex](https://docs.llamaindex.ai/en/stable/use_cases/agents/). They are powerful, but sometimes all you need is something simple that works.
@@ -27,7 +27,7 @@ For example, when a user asks questions about their invoice, the AI can query Ne
 
 We’ll build an AI agent that connects to your Postgres database and uses a simple Python function to fetch and analyze the data.
 
-We’ll use [**Neon Serverless Postgres**](/) as our database. It’s a fully managed, cloud-native Postgres that’s free to start, scales automatically, and works great for [AI agents](/use-cases/ai-agents) that need to query data on demand without managing infrastructure.
+We’ll use [**Neon Postgres**](/) for our database. Neon is the AI-native backend platform for apps and agents, spanning a Postgres Database, Auth, Storage, Functions, and an AI Gateway. It’s free to start, scales automatically, and works great for [AI agents](/use-cases/ai-agents) that need to query data on demand without managing infrastructure.
 
 ### Prerequisites
 

--- a/content/guides/azure-logic-apps.md
+++ b/content/guides/azure-logic-apps.md
@@ -4,12 +4,12 @@ subtitle: Learn how to automate database operations and processes by connecting 
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2025-01-26T00:00:00.000Z'
-updatedOn: '2025-03-02T17:52:17.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 Azure Logic Apps provides a way to build automated workflows that integrate apps, data, services, and systems.
 
-When you combine it with Neon's serverless Postgres, you can create automation solutions that handle database operations based on various triggers and events.
+When you combine it with Neon, the AI-native backend platform for apps and agents that spans a Postgres Database, Auth, Storage, Functions, and an AI Gateway, you can create automation solutions that handle database operations based on various triggers and events.
 
 In this guide, you'll learn how to create Logic Apps workflows that interact with Neon Postgres to automate common processes and database operations.
 

--- a/content/guides/content-moderation-laravel-openai.md
+++ b/content/guides/content-moderation-laravel-openai.md
@@ -4,12 +4,12 @@ subtitle: Build an automated content moderation system for your application usin
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2025-03-22T00:00:00.000Z'
-updatedOn: '2026-04-24T22:05:15.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 Content moderation is essential for maintaining healthy online communities and platforms. In this guide, we'll create a content moderation system that uses OpenAI's moderation API to automatically analyze and flag potentially problematic content before it reaches your users.
 
-We will use Laravel, OpenAI's moderation API, and Neon's serverless Postgres database and build a system that can handle content moderation for comments, forum posts, product reviews, or any user-generated content.
+We will use Laravel, OpenAI's moderation API, and Neon, the AI-native backend platform for apps and agents that spans a Postgres Database, Auth, Storage, Functions, and an AI Gateway, and build a system that can handle content moderation for comments, forum posts, product reviews, or any user-generated content.
 
 ## What You'll Build
 

--- a/content/guides/dotnet-neon-entity-framework.md
+++ b/content/guides/dotnet-neon-entity-framework.md
@@ -4,10 +4,10 @@ subtitle: Learn how to build a .NET application with Neon's serverless Postgres 
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2024-11-02T00:00:00.000Z'
-updatedOn: '2025-06-26T22:22:29.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
-When building .NET applications, choosing the right database solution is an important step to good performance and scalability. Neon's serverless Postgres is a great choice for .NET developers, thanks to features like automatic scaling, branching, and connection pooling that integrate well with .NET's ecosystem.
+When building .NET applications, choosing the right database solution is an important step to good performance and scalability. Neon is the AI-native backend platform for apps and agents, spanning a Postgres Database, Auth, Storage, Functions, and an AI Gateway. It's a great choice for .NET developers, thanks to features like automatic scaling, branching, and connection pooling that integrate well with .NET's ecosystem.
 
 In this guide, we'll walk through setting up a Neon database with a .NET application and explore best practices for connecting and interacting with Neon Postgres and structuring your application using Entity Framework Core.
 

--- a/content/guides/golang-jwt.md
+++ b/content/guides/golang-jwt.md
@@ -4,7 +4,7 @@ subtitle: Learn how to build a secure authentication system using Go, JWT tokens
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2025-03-29T00:00:00.000Z'
-updatedOn: '2026-02-03T11:18:45.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 Authentication is the foundation of web applications, it ensures that users are who they claim to be. In this guide, you'll learn how to create a secure authentication system using Go, JSON Web Tokens (JWT), and Neon Postgres.
@@ -1296,7 +1296,7 @@ You can use tools like [Postman](https://www.postman.com/) or [Insomnia](https:/
 
 In this guide, you built a secure authentication system using Go, JWT, and Neon Postgres. The system includes secure password hashing, token-based authentication, refresh token support, middleware-protected routes, and basic rate limiting to prevent brute-force attacks. Security headers were also added to protect against common web vulnerabilities.
 
-By using Neon Postgres as the database, you gain the scalability and performance of a serverless Postgres platform, without sacrificing the reliability and flexibility developers expect from PostgreSQL. It's an ideal foundation for authentication systems that need to scale securely and efficiently.
+By building on Neon, the AI-native backend platform for apps and agents that spans a Postgres Database, Auth, Storage, Functions, and an AI Gateway, you gain the scalability and performance you need without sacrificing the reliability and flexibility developers expect from PostgreSQL. It's an ideal foundation for authentication systems that need to scale securely and efficiently.
 
 ## Additional Resources
 

--- a/content/guides/hasura-dynamic-routing-with-neon.md
+++ b/content/guides/hasura-dynamic-routing-with-neon.md
@@ -4,10 +4,10 @@ subtitle: Leverage Neon's branching with Hasura's dynamic routing for powerful d
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-04-20T00:00:00.000Z'
-updatedOn: '2026-03-04T15:50:25.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
-Managing different database environments for development, testing, staging, and production can be complex. Traditional methods often involve provisioning separate database instances, managing complex data synchronization scripts, or dealing with slow snapshot restores. Neon's serverless Postgres brings efficient, Git-like branching to your database, while Hasura provides an instant GraphQL API layer.
+Managing different database environments for development, testing, staging, and production can be complex. Traditional methods often involve provisioning separate database instances, managing complex data synchronization scripts, or dealing with slow snapshot restores. Neon, the AI-native backend platform for apps and agents that spans a Postgres Database, Auth, Storage, Functions, and an AI Gateway, brings efficient, Git-like branching to your database, while Hasura provides an instant GraphQL API layer.
 
 This guide demonstrates how to combine the power of [Neon's database branching](/docs/introduction/branching) with [Hasura's Dynamic Database Routing](https://hasura.io/docs/2.0/databases/database-config/dynamic-db-connection/) feature. This combination allows you to create isolated database environments instantly using Neon branches and dynamically route GraphQL requests from Hasura to the appropriate branch based on request context (like HTTP headers or session variables), streamlining your development, testing, and preview workflows. By leveraging Neon's branching and Hasura's dynamic routing, you can effectively consolidate your infrastructure, serving multiple development, testing, or preview environments from only one Neon project and one Hasura instance.
 

--- a/content/guides/laravel-authorization.md
+++ b/content/guides/laravel-authorization.md
@@ -1,10 +1,10 @@
 ---
 title: Implementing Fine-Grained Authorization in Laravel with Neon Postgres
-subtitle: Learn how to set up and utilize Laravel's powerful authorization features to create a secure and flexible application using Neon's high-performance database.
+subtitle: Learn how to set up and utilize Laravel's powerful authorization features to create a secure and flexible application using Neon, the AI-native backend platform for apps and agents.
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2024-07-14T00:00:00.000Z'
-updatedOn: '2026-03-03T03:19:43.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 Laravel provides an authorization system that allows developers to implement fine-grained access control in their applications. While Laravel's built-in features are powerful, some projects require even more advanced role-based access control (RBAC). This is where third-party packages like Spatie's Laravel Permission come into play.

--- a/content/guides/laravel-overview.md
+++ b/content/guides/laravel-overview.md
@@ -4,10 +4,10 @@ subtitle: Learn how to integrate Laravel with Postgres on Neon, leveraging Larav
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2024-05-25T00:00:00.000Z'
-updatedOn: '2024-06-10T10:07:18.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
-When combining the robust features of [Laravel](https://laravel.com/), a highly expressive PHP framework, with the efficiency and scalability of Postgres on Neon, developers gain a powerful toolset for web development.
+When combining the robust features of [Laravel](https://laravel.com/), a highly expressive PHP framework, with Neon, the AI-native backend platform for apps and agents that spans a Postgres database, Auth, Storage, Functions, and an AI Gateway, developers gain a powerful toolset for web development.
 
 Laravel's native support for Postgres ensures a smooth integration process. When working with Neon Postgres, the transition is nearly seamless, thanks to Laravel's database agnostic [migrations](https://laravel.com/docs/11.x/migrations) and [Eloquent ORM](https://laravel.com/docs/11.x/eloquent), which effortlessly maps application objects to database tables.
 

--- a/content/guides/migrate-faunadb-to-neon.md
+++ b/content/guides/migrate-faunadb-to-neon.md
@@ -4,10 +4,10 @@ subtitle: 'Learn how to migrate your data and applications from FaunaDB to Neon 
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-03-23T00:00:00.000Z'
-updatedOn: '2026-02-15T11:43:50.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
-Neon, like Fauna, offers a **serverless architecture**, but it’s built on **Postgres**. That means you get the scalability of serverless along with the reliability and familiarity of a proven SQL database.
+Neon is the AI-native backend platform for apps and agents, spanning a Postgres Database, Auth, Storage, Functions, and an AI Gateway. Like Fauna, it offers a **serverless architecture**, but it’s built on **Postgres**. That means you get the scalability of serverless along with the reliability and familiarity of a proven SQL database.
 
 This guide is designed to help FaunaDB users understand how to transition to Neon Postgres.
 

--- a/content/guides/neondatabase-toolkit.md
+++ b/content/guides/neondatabase-toolkit.md
@@ -4,7 +4,7 @@ subtitle: Rapidly provision, manage, and interact with Neon Postgres databases i
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-01-29T00:00:00.000Z'
-updatedOn: '2025-05-30T16:53:05.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 The AI landscape is poised for its next "ChatGPT moment" - not with smarter chatbots, but with **autonomous AI agents** that complete real-world tasks. These next-gen assistants go beyond answering questions to independently booking flights, analyzing data trends, and even managing cloud infrastructure.
@@ -26,7 +26,7 @@ There is one thing that is certain: The agent revolution won't be built on legac
 
 ## Neon: The Perfect Database for AI Agents
 
-Neon's serverless Postgres databases are built to be the ideal partner for AI agents. They offer a powerful, scalable, and cost-effective way to manage data. Here are some key benefits of using Neon databases for AI agents:
+Neon is the AI-native backend platform for apps and agents, spanning a Postgres Database, Auth, Storage, Functions, and an AI Gateway. Its Postgres databases are built to be the ideal partner for AI agents, offering a powerful, scalable, and cost-effective way to manage data. Here are some key benefits of using Neon databases for AI agents:
 
 | Capability           | Agent Benefit                                                                                                                                                                |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/guides/nuxt-vercel-neon.md
+++ b/content/guides/nuxt-vercel-neon.md
@@ -4,12 +4,12 @@ subtitle: 'Automate database branching for every preview deployment using the na
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-07-14T00:00:00.000Z'
-updatedOn: '2025-08-07T07:17:35.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 [Nuxt.js](https://nuxt.com) is an open-source, progressive framework built on [Vue.js](https://vuejs.org/) that simplifies web development. It enhances Vue with versatile rendering options, including default [universal rendering (SSR)](https://nuxt.com/docs/guide/concepts/rendering#universal-rendering) for fast initial loads and strong SEO, and [client-side rendering](https://nuxt.com/docs/guide/concepts/rendering#client-side-rendering) for highly interactive applications. Nuxt also supports advanced strategies like [hybrid rendering](https://nuxt.com/docs/guide/concepts/rendering#hybrid-rendering) to mix modes per-route.
 
-As your Nuxt application grows, managing database changes for new features can be challenging. How do you test a feature that requires database schema changes without disrupting your live application? This is where the integration between [Vercel](https://vercel.com) and [Neon](https://neon.com) comes in. Vercel is a deployment platform, and Neon provides a serverless Postgres database. Together, they offer seamless [**database branching**](/branching).
+As your Nuxt application grows, managing database changes for new features can be challenging. How do you test a feature that requires database schema changes without disrupting your live application? This is where the integration between [Vercel](https://vercel.com) and [Neon](https://neon.com) comes in. Vercel is a deployment platform, and Neon is the AI-native backend platform for apps and agents, spanning a Postgres Database, Auth, Storage, Functions, and an AI Gateway. Together, they offer seamless [**database branching**](/branching).
 
 When you enable the integration, every time you push a new feature branch, Vercel automatically creates a preview deployment. Simultaneously, Neon creates an isolated copy of your database just for that branch. This gives you a safe, sandboxed environment to develop and test with realistic data, without any risk to your live application.
 

--- a/content/guides/optuna-hyperprameter-kubernetes.md
+++ b/content/guides/optuna-hyperprameter-kubernetes.md
@@ -4,12 +4,12 @@ subtitle: Use Neon Postgres to orchestrate multi-node hyperparameter tuning for 
 author: sam-harri
 enableTableOfContents: true
 createdAt: '2024-10-28T00:00:00.000Z'
-updatedOn: '2026-05-09T19:22:21.118Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 In this guide, you'll learn how to set up distributed hyperparameter tuning for machine learning models across multiple nodes using Kubernetes. You'll use Optuna, a bayesian optimization library, to fine-tune models built with popular libraries like scikit-learn, XGBoost, PyTorch, and TensorFlow/Keras.
 
-To orchestrate all the trials, you'll use Neon Postgres, a serverless postgres database. The combination of Neon Postgres, Kubernetes, and Docker allows for scalable, distributed hyperparameter tuning, simplifying the orchestration and management of complex machine learning workflows.
+To orchestrate all the trials, you'll use Neon, the AI-native backend platform for apps and agents that spans a Postgres Database, Auth, Storage, Functions, and an AI Gateway. The combination of Neon Postgres, Kubernetes, and Docker allows for scalable, distributed hyperparameter tuning, simplifying the orchestration and management of complex machine learning workflows.
 
 ## Prerequisites
 

--- a/content/guides/prisma-drizzle-typeorm-postgres.md
+++ b/content/guides/prisma-drizzle-typeorm-postgres.md
@@ -4,12 +4,12 @@ subtitle: Learn real-world differences in schema modeling, migrations, and devel
 author: rishi-raj-jain
 enableTableOfContents: true
 createdAt: '2026-04-21T00:00:00.000Z'
-updatedOn: '2026-04-24T22:05:15.000Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
 If you are choosing a data layer for a TypeScript or JavaScript service on Postgres, you will almost certainly run into these three names. They are not interchangeable implementations of the same idea. They reflect different opinions about where your schema should live, how close to SQL you want to stay day to day, and how much tooling you want wrapped around migrations and collaboration.
 
-Neon does not ship its own ORM. Neon is a serverless Postgres to which you connect with a standard connection string and driver, and you pick the library that fits your team and architecture. That separation is useful to keep in mind. The database is Postgres and the ORM is how your application _talks_ to Postgres. Comparing these tools is less about crowning a winner and more about matching strengths and constraints to the kind of system you are building.
+Neon does not ship its own ORM. Neon is the AI-native backend platform for apps and agents, spanning a Postgres Database, Auth, Storage, Functions, and an AI Gateway. You connect to its Postgres with a standard connection string and driver, and you pick the library that fits your team and architecture. That separation is useful to keep in mind. The database is Postgres and the ORM is how your application _talks_ to Postgres. Comparing these tools is less about crowning a winner and more about matching strengths and constraints to the kind of system you are building.
 
 This article compares [Prisma](https://www.prisma.io/), [Drizzle](https://orm.drizzle.team/), and [TypeORM](https://typeorm.io/) by examining their approach to schema modeling, query styles, and migrations. It concludes with situations where each tool is particularly well-suited, without claiming that any single option is the universal “best” choice.
 

--- a/content/guides/query-postgres-azure-functions.md
+++ b/content/guides/query-postgres-azure-functions.md
@@ -19,7 +19,7 @@ You will need:
 
 ## Why Neon?
 
-Neon stands out as a cloud-native Postgres solution with an innovative architecture that separates compute and storage, offering a truly serverless database. This means Neon automatically adjusts its resources based on your application’s needs, making it ideal for projects that require flexible scalability without directly managing the infrastructure. In other words, Neon allows you to accelerate project delivery by focusing solely on development, while having an infrastructure that scales on demand.
+Neon is the AI-native backend platform for apps and agents, spanning a Postgres Database, Auth, Storage, Functions, and an AI Gateway. Its Postgres database uses an innovative architecture that separates compute and storage, offering a truly serverless experience. This means Neon automatically adjusts its resources based on your application’s needs, making it ideal for projects that require flexible scalability without directly managing the infrastructure. In other words, Neon allows you to accelerate project delivery by focusing solely on development, while having an infrastructure that scales on demand.
 
 > Neon Database is cloud-native Serverless Postgres, meaning it has completely separated storage from compute. This means Neon automatically adjusts its resources based on your application’s needs, making it ideal for projects that require flexible scaling without directly managing the infrastructure. In other words, Neon Database is a fully managed database service that allows you to focus on building your application without worrying about the underlying infrastructure.
 

--- a/content/guides/self-hosting-umami-neon.md
+++ b/content/guides/self-hosting-umami-neon.md
@@ -4,10 +4,10 @@ subtitle: Self host your Umami analytics on Fly.io and powered by Neon Postgres
 author: rishi-raj-jain
 enableTableOfContents: true
 createdAt: '2024-06-05T00:00:00.000Z'
-updatedOn: '2026-05-09T19:22:21.118Z'
+updatedOn: '2026-06-03T18:28:10.050Z'
 ---
 
-In this guide, you will learn how to self host your Umami analytics instance on Fly.io and powered by Neon Postgres as the serverless database.
+In this guide, you will learn how to self host your Umami analytics instance on Fly.io and powered by Neon, the AI-native backend platform for apps and agents whose offering spans a Postgres Database, Auth, Storage, Functions, and an AI Gateway. Here you will use its Postgres Database as Umami's data store.
 
 ## Prerequisites
 

--- a/content/pages/use-cases/postgres-for-saas.md
+++ b/content/pages/use-cases/postgres-for-saas.md
@@ -121,7 +121,7 @@ author={{
 
 <DefinitionList bulletType="check">
 It's Just Postgres
-: Deploy Postgres 15, 16, and 17 on Neon. There is no lock-in and no proprietary syntax to learn.
+: Deploy Postgres 15, 16, 17, and 18 on Neon. There is no lock-in and no proprietary syntax to learn.
 
 Integrates with any language/framework
 : Anything that has a Postgres driver or integration works with Neon.


### PR DESCRIPTION
## What

Updates the Neon product positioning across 17 guide and use-case pages from "serverless Postgres" framing to the current "AI-native backend platform for apps and agents" (Postgres Database, Auth, Storage, Functions, and AI Gateway).

## Files changed

- 16 guides in `content/guides/`
- `content/pages/use-cases/postgres-for-saas.md`

Each change is a one-line intro/subtitle/conclusion edit; no structural or code changes. `updatedOn` timestamps were refreshed automatically by the pre-commit hook.