### PR TITLE
docs: add PostgreSQL 19 Beta 1 callout to PG19 pages

### DIFF
--- a/content/postgresql/postgresql-19-new-features.md
+++ b/content/postgresql/postgresql-19-new-features.md
@@ -3,12 +3,16 @@ title: 'PostgreSQL 19 New Features'
 page_title: "PostgreSQL 19 New Features: What's New and Why It Matters"
 page_description: 'Explore PostgreSQL 19 new features including SQL/PGQ property graph queries, ON CONFLICT DO SELECT, temporal data operations, pg_plan_advice, REPACK, parallel autovacuum, and more.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 nextLink:
   title: 'PostgreSQL 19 SQL/PGQ Graph Queries'
   slug: 'postgresql-19/sql-pgq-graph-queries'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can test the features in this guide for yourself ahead of the final release expected later in 2026. Beta 1 includes SQL/PGQ property graph queries, `ON CONFLICT DO SELECT`, the new `REPACK` command, parallel autovacuum, and native JSON output for `COPY TO`.
+</Admonition>
 
 **Summary**: PostgreSQL 19 is a landmark release that brings SQL/PGQ property graph queries, atomic get-or-create with `ON CONFLICT DO SELECT`, temporal data operations, query plan hints, online table repacking, parallel autovacuum, native JSON export, and logical replication improvements. This overview covers the highlights with links to detailed guides.
 

--- a/content/postgresql/postgresql-19/breaking-changes.md
+++ b/content/postgresql/postgresql-19/breaking-changes.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 Breaking Changes and Upgrade Notes'
 page_title: 'PostgreSQL 19 Breaking Changes - What to Check Before Upgrading'
 page_description: 'Review PostgreSQL 19 breaking changes including JIT disabled by default, LZ4 TOAST compression, RADIUS removal, and string handling changes before upgrading your database.'
 ogImage: ''
-updatedOn: '2026-05-01T20:19:36.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 Monitoring and Operations'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 New Features'
   slug: 'postgresql-19-new-features'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can test how these changes affect your applications ahead of the final release expected later in 2026. Beta 1 disables JIT by default, switches default TOAST compression to `lz4`, issues a warning after MD5 password authentication, and forces `standard_conforming_strings` on.
+</Admonition>
 
 **Summary**: PostgreSQL 19 includes several breaking changes that may affect your applications and configuration. JIT compilation is now off by default, TOAST compression defaults to LZ4, MD5-hashed passwords are being deprecated and string handling is stricter. Review these changes before upgrading.
 

--- a/content/postgresql/postgresql-19/json-copy-to.md
+++ b/content/postgresql/postgresql-19/json-copy-to.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 JSON Format for COPY TO'
 page_title: 'PostgreSQL 19 JSON COPY TO - Native JSON Data Export'
 page_description: 'Learn how to use PostgreSQL 19 COPY TO with FORMAT JSON to export data as NDJSON or JSON arrays, replacing workarounds with native streaming JSON output.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 Logical Replication Improvements'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 Query Improvements'
   slug: 'postgresql-19/query-improvements'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try native JSON export for yourself ahead of the final release expected later in 2026. Beta 1 lets `COPY TO` output JSON, including the option to emit results as a single JSON array.
+</Admonition>
 
 **Summary**: PostgreSQL 19 adds native JSON output support to the `COPY TO` command. You can export table data as NDJSON (one JSON object per line) or as a JSON array, with streaming output that handles large datasets without loading everything into memory.
 

--- a/content/postgresql/postgresql-19/logical-replication-improvements.md
+++ b/content/postgresql/postgresql-19/logical-replication-improvements.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 Logical Replication Improvements'
 page_title: 'PostgreSQL 19 Logical Replication - Sequence Sync, EXCEPT TABLE, and More'
 page_description: 'Learn about PostgreSQL 19 logical replication improvements including sequence synchronization, EXCEPT TABLE for publications, and dynamic WAL level configuration.'
 ogImage: ''
-updatedOn: '2026-05-01T20:19:36.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 REPACK Command'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 JSON COPY TO'
   slug: 'postgresql-19/json-copy-to'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the logical replication improvements for yourself ahead of the final release expected later in 2026. Beta 1 adds sequence value synchronization, an `EXCEPT` clause to exclude tables from publications, and automatic enablement of logical replication when `wal_level` is `replica`.
+</Admonition>
 
 **Summary**: PostgreSQL 19 brings several improvements to logical replication, including sequence synchronization between publisher and subscriber, the ability to exclude specific tables from `FOR ALL TABLES` publications, and dynamic WAL level adjustment.
 

--- a/content/postgresql/postgresql-19/monitoring-operations.md
+++ b/content/postgresql/postgresql-19/monitoring-operations.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 Monitoring and Operations'
 page_title: 'PostgreSQL 19 Monitoring and Operations Improvements'
 page_description: 'Learn about PostgreSQL 19 monitoring and operational improvements including online data checksums, WAL statistics, vacuum progress tracking, per-process logging, psql enhancements, and 64-bit MultiXactOffset.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 Schema Management'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 Parallel Autovacuum'
   slug: 'postgresql-19/parallel-autovacuum'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the new operational features for yourself ahead of the final release expected later in 2026. Beta 1 adds online enabling and disabling of data checksums, a `WAIT FOR` command for read-your-writes on standbys, per-process-type log levels, and 64-bit MultiXact offsets that remove the MultiXact wraparound risk.
+</Admonition>
 
 **Summary**: PostgreSQL 19 adds online data checksum management, WAL full-page image tracking, vacuum progress details, per-process-type log levels, psql prompt improvements, the new `WAIT FOR LSN` command for read-your-writes on async replicas, dynamic WAL level, and eliminates the MultiXact wraparound risk with a 64-bit offset. These changes give DBAs better visibility into database operations and remove long-standing operational hazards.
 

--- a/content/postgresql/postgresql-19/on-conflict-do-select.md
+++ b/content/postgresql/postgresql-19/on-conflict-do-select.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 ON CONFLICT DO SELECT'
 page_title: 'PostgreSQL 19 ON CONFLICT DO SELECT - Atomic Get-or-Create'
 page_description: 'Learn how to use PostgreSQL 19 ON CONFLICT DO SELECT for atomic get-or-create operations without dead rows, extra queries, or CTE workarounds.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 SQL/PGQ Graph Queries'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 Temporal Data Operations'
   slug: 'postgresql-19/temporal-data-operations'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try `ON CONFLICT DO SELECT` for yourself ahead of the final release expected later in 2026. Beta 1 adds `INSERT ... ON CONFLICT DO SELECT ... RETURNING`, which returns conflicting rows (optionally locked with `FOR UPDATE`/`SHARE`) for atomic get-or-create.
+</Admonition>
 
 **Summary**: PostgreSQL 19 adds `ON CONFLICT DO SELECT` to the `INSERT` statement, giving you an atomic get-or-create operation that returns existing rows on conflict without generating dead tuples or requiring CTE workarounds.
 

--- a/content/postgresql/postgresql-19/parallel-autovacuum.md
+++ b/content/postgresql/postgresql-19/parallel-autovacuum.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 Parallel Autovacuum'
 page_title: 'PostgreSQL 19 Parallel Autovacuum - Faster Index Cleanup'
 page_description: 'Learn how to configure PostgreSQL 19 parallel autovacuum to speed up index vacuuming on large tables with multiple indexes.'
 ogImage: ''
-updatedOn: '2026-05-01T20:19:36.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 Monitoring and Operations'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 Breaking Changes'
   slug: 'postgresql-19/breaking-changes'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try parallel autovacuum for yourself ahead of the final release expected later in 2026. Beta 1 lets autovacuum use parallel workers for index vacuuming, configured with the new `autovacuum_max_parallel_workers` setting and per-table `autovacuum_parallel_workers`.
+</Admonition>
 
 **Summary**: PostgreSQL 19 lets autovacuum use parallel workers for index vacuuming and cleanup. On tables with multiple large indexes, this can cut vacuum time significantly by processing indexes in parallel instead of one at a time.
 

--- a/content/postgresql/postgresql-19/pg-plan-advice.md
+++ b/content/postgresql/postgresql-19/pg-plan-advice.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 pg_plan_advice'
 page_title: 'PostgreSQL 19 pg_plan_advice - Query Plan Hints for PostgreSQL'
 page_description: 'Learn how to use PostgreSQL 19 pg_plan_advice to stabilize query plans, override planner decisions, and diagnose performance issues with plan hints.'
 ogImage: ''
-updatedOn: '2026-05-01T20:19:36.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 Temporal Data Operations'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 REPACK Command'
   slug: 'postgresql-19/repack-command'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try `pg_plan_advice` for yourself ahead of the final release expected later in 2026. Beta 1 adds the `pg_plan_advice` module to stabilize and control planner decisions, generated and applied through an `EXPLAIN` workflow rather than inline SQL hints.
+</Admonition>
 
 **Summary**: PostgreSQL 19 introduces `pg_plan_advice`, a contrib module that brings query plan hints to PostgreSQL. Unlike Oracle or MySQL hints embedded in SQL comments, pg_plan_advice uses a GUC setting and an `EXPLAIN (PLAN_ADVICE)` workflow to generate, apply, and validate plan advice externally from query text.
 

--- a/content/postgresql/postgresql-19/query-improvements.md
+++ b/content/postgresql/postgresql-19/query-improvements.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 Query Writing Improvements'
 page_title: 'PostgreSQL 19 Query Improvements - GROUP BY ALL, IGNORE NULLS, and Memoize Estimates'
 page_description: 'Learn about PostgreSQL 19 query writing improvements including GROUP BY ALL for automatic grouping, IGNORE NULLS for window functions, and Memoize plan estimates in EXPLAIN.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 JSON COPY TO'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 Schema Management'
   slug: 'postgresql-19/schema-management'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the new query features for yourself ahead of the final release expected later in 2026. Beta 1 adds `GROUP BY ALL`, `IGNORE NULLS`/`RESPECT NULLS` for window functions, and Memoize cache estimates in `EXPLAIN` output.
+</Admonition>
 
 **Summary**: PostgreSQL 19 adds `GROUP BY ALL` for automatic grouping, `IGNORE NULLS` and `RESPECT NULLS` options for window functions, and Memoize cost estimates in EXPLAIN output. These features reduce boilerplate, improve time-series queries, and make query plan analysis easier.
 

--- a/content/postgresql/postgresql-19/repack-command.md
+++ b/content/postgresql/postgresql-19/repack-command.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 REPACK Command'
 page_title: 'PostgreSQL 19 REPACK Command - Online Table Maintenance'
 page_description: 'Learn how to use PostgreSQL 19 REPACK command to reclaim space and reorder tables, replacing VACUUM FULL and CLUSTER with optional online (CONCURRENTLY) mode.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 pg_plan_advice'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 Logical Replication Improvements'
   slug: 'postgresql-19/logical-replication-improvements'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the new `REPACK` command for yourself ahead of the final release expected later in 2026. Beta 1 adds `REPACK`, which replaces `VACUUM FULL` and `CLUSTER`, and its `CONCURRENTLY` option rebuilds tables online without an access-exclusive lock.
+</Admonition>
 
 **Summary**: PostgreSQL 19 introduces the `REPACK` command, which absorbs the functionality of both `VACUUM FULL` and `CLUSTER` into a single command. With the `CONCURRENTLY` option, you can repack tables online while they remain readable and writable.
 

--- a/content/postgresql/postgresql-19/schema-management.md
+++ b/content/postgresql/postgresql-19/schema-management.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 Schema Management and Backup'
 page_title: 'PostgreSQL 19 pg_get_*_ddl() Functions and pg_dumpall Improvements'
 page_description: 'Learn how to use PostgreSQL 19 pg_get_database_ddl, pg_get_role_ddl, pg_get_tablespace_ddl functions and pg_dumpall non-text output formats for better schema management and backup workflows.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 Query Improvements'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 Monitoring and Operations'
   slug: 'postgresql-19/monitoring-operations'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the new schema tooling for yourself ahead of the final release expected later in 2026. Beta 1 adds `pg_get_database_ddl()`, `pg_get_role_ddl()`, and `pg_get_tablespace_ddl()` for DDL extraction, and lets `pg_dumpall` produce custom, directory, and tar output formats.
+</Admonition>
 
 **Summary**: PostgreSQL 19 adds `pg_get_database_ddl()`, `pg_get_role_ddl()`, and `pg_get_tablespace_ddl()` functions for programmatic DDL extraction, and extends `pg_dumpall` to support custom, directory, and tar output formats. Together, these features give you better tools for schema management, auditing, and backup workflows.
 

--- a/content/postgresql/postgresql-19/sql-pgq-graph-queries.md
+++ b/content/postgresql/postgresql-19/sql-pgq-graph-queries.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 SQL/PGQ Property Graph Queries'
 page_title: 'PostgreSQL 19 SQL/PGQ - Graph Queries on Existing Tables'
 page_description: 'Learn how to use PostgreSQL 19 SQL/PGQ to define property graphs over existing tables and query relationships with graph pattern matching, no migration or extensions required.'
 ogImage: ''
-updatedOn: '2026-05-07T18:15:13.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 New Features'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 ON CONFLICT DO SELECT'
   slug: 'postgresql-19/on-conflict-do-select'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try SQL/PGQ property graph queries for yourself ahead of the final release expected later in 2026. Beta 1 adds support for property graph queries using SQL standard syntax over your existing relational tables, with no new storage engine or extensions.
+</Admonition>
 
 **Summary**: PostgreSQL 19 adds SQL/PGQ (Property Graph Queries) based on the SQL:2023 standard. You can define graph structures over your existing relational tables and query them with pattern matching syntax - no new storage engine, no extensions, no data migration.
 

--- a/content/postgresql/postgresql-19/temporal-data-operations.md
+++ b/content/postgresql/postgresql-19/temporal-data-operations.md
@@ -3,7 +3,7 @@ title: 'PostgreSQL 19 Temporal Data Operations'
 page_title: 'PostgreSQL 19 UPDATE/DELETE FOR PORTION OF - Temporal Data Operations'
 page_description: 'Learn how to use PostgreSQL 19 UPDATE and DELETE FOR PORTION OF to modify temporal data, automatically splitting rows to preserve history outside the targeted time range.'
 ogImage: ''
-updatedOn: '2026-05-01T20:19:36.000Z'
+updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL 19 ON CONFLICT DO SELECT'
@@ -12,6 +12,10 @@ nextLink:
   title: 'PostgreSQL 19 pg_plan_advice'
   slug: 'postgresql-19/pg-plan-advice'
 ---
+
+<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the new temporal operations for yourself ahead of the final release expected later in 2026. Beta 1 adds a `FOR PORTION OF` clause to `UPDATE` and `DELETE`, so you can modify temporal data within a specific range while preserving the untouched portions.
+</Admonition>
 
 **Summary**: PostgreSQL 19 adds `UPDATE ... FOR PORTION OF` and `DELETE ... FOR PORTION OF` to modify temporal data within a specific time range, automatically splitting rows to preserve the untouched portions. This completes the SQL:2011 temporal feature set that began with `WITHOUT OVERLAPS` in PostgreSQL 18.
 


### PR DESCRIPTION
## What

Adds a celebratory admonition to all 13 PostgreSQL 19 pages announcing the **PostgreSQL 19 Beta 1** release (June 4, 2026), linking to the [postgresql.org news post](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/).

Each callout is tailored to the feature its page covers (rather than a generic blurb), and the GA timing ("expected later in 2026") is included.

## Pages updated

- `postgresql-19-new-features.md` (index)
- 12 feature pages under `postgresql-19/`: sql-pgq-graph-queries, on-conflict-do-select, temporal-data-operations, pg-plan-advice, repack-command, parallel-autovacuum, json-copy-to, logical-replication-improvements, query-improvements, schema-management, monitoring-operations, breaking-changes

## Accuracy

Every feature named in a callout was verified against the PostgreSQL 19 release notes. The announcement-only "up to 2x faster FK inserts" figure was intentionally left out of the per-page callouts since it isn't in the release notes and doesn't map to any of these pages.