### PR TITLE
docs: remove beta label from Snapshots

### DIFF
--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -11,8 +11,8 @@ enableTableOfContents: true
 updatedOn: '2026-05-20T14:13:43.586Z'
 ---
 
-<Admonition type="note" title="Beta">
-Snapshots are available in Beta. Please give us [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://discord.gg/92vNTzKDGp).
+<Admonition type="note">
+Please give us [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://discord.gg/92vNTzKDGp).
 
 **Limits and pricing:** The Free plan includes 1 manual snapshot, and paid plans (including the [Agent plan](https://neon.com/use-cases/ai-agents)) include 100 manual snapshots. On paid plans, snapshots created by backup schedules do not count toward this limit. Snapshot storage is billed at $0.09/GB-month. If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
 </Admonition>

--- a/content/docs/guides/backup-restore.md
+++ b/content/docs/guides/backup-restore.md
@@ -10,8 +10,8 @@ enableTableOfContents: true
 updatedOn: '2026-05-20T14:13:43.586Z'
 ---
 
-<Admonition type="note" title="Snapshots in Beta">
-The **Snapshots** feature is in Beta and available to all users. Manual snapshot limits: 1 on the Free plan and 100 on paid plans. On paid plans, snapshots created by backup schedules do not count toward this limit. Automated backup schedules are available on paid plans except for the Agent plan. If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
+<Admonition type="note" title="Snapshots">
+The **Snapshots** feature is available to all users. Manual snapshot limits: 1 on the Free plan and 100 on paid plans. On paid plans, snapshots created by backup schedules do not count toward this limit. Automated backup schedules are available on paid plans except for the Agent plan. If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
 
 **Pricing:** Snapshot storage is billed at $0.09/GB-month.
 

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -143,7 +143,7 @@ We're accelerating work on improving and scaling the core database on Neon as we
 - **Neon on Azure GA**: We've announced our general availability release on Azure with deeper Azure integration. [Read the announcement](/blog/azure-native-integration-ga).
 - **Import Data Assistant**: The [Import Data Assistant](/docs/import/import-data-assistant) makes data import easier and faster.
 - **Neon serverless driver GA**: Our JavaScript/TypeScript serverless driver has reached version 1.0.0, bringing stronger SQL injection safeguards and better performance for serverless environments.
-- **Neon snapshots (Beta)**: Create and manage point-in-time snapshots of your database with our new unified Backup & Restore experience.
+- **Neon snapshots**: Create and manage point-in-time snapshots of your database with our new unified Backup & Restore experience.
 - **Inbound logical replication GA**: Neon now fully supports Postgres logical replication for inbound data (replicating data to Neon).
 - **Postgres logs in Datadog (Beta)**: Stream and analyze your Postgres logs directly in your Datadog dashboard for better observability.
 - **GitHub Secret Scanning**: Neon joined GitHub's Secret Scanning Partner Program to automatically detect and protect against exposed database credentials in public repositories.


### PR DESCRIPTION
## What did you change, and why?

Snapshots billing is now enabled and the feature is GA. This removes all beta labels from evergreen documentation.

**Files updated:**
- `content/docs/guides/backup-restore.md` — removed "in Beta" from the admonition title and body
- `content/docs/introduction/roadmap.md` — removed "(Beta)" from the Neon snapshots entry
- `content/docs/ai/ai-database-versioning.md` — removed beta admonition title and "available in Beta" sentence

Changelog entries (`2025-09-19`, `2025-10-31`) are intentionally left unchanged as they are historical records.

<!-- SCREENSHOT PLACEHOLDER: attach screenshot showing the Backup & Restore UI with no beta label -->