### PR TITLE
docs: fix typos and errors across PostgreSQL tutorial

### DIFF
--- a/content/postgresql/18/oauth-authentication.md
+++ b/content/postgresql/18/oauth-authentication.md
@@ -6,7 +6,7 @@ page_description: >-
   token-based database connections with your existing identity providers like
   Google, Auth0, or enterprise SSO systems.
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL 18 Logical Replication Improvements
@@ -45,7 +45,7 @@ PostgreSQL validates tokens but doesn't issue them, that's handled by your OAuth
 
 OAuth support must be enabled when PostgreSQL is compiled.
 
-As of the latest beta, most distributions do not include this by default, but if you're building from source, you can `--with-libcurl` to enable OAuth client features.
+As of the latest beta, most distributions do not include this by default, but if you're building from source, you can pass `--with-libcurl` to enable OAuth client features.
 
 Note that you will also need a compatible PostgreSQL client which supports OAuth connections, in the case of `psql`, this is available in PostgreSQL 18 and later.
 

--- a/content/postgresql/administration/alter-database.md
+++ b/content/postgresql/administration/alter-database.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-alter-database/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL CREATE DATABASE
@@ -35,7 +35,7 @@ The `ALTER DATABASE` statement allows you to carry the following action on the d
 
 ### 1\) Changing attributes of a database
 
-To change the attributes of a database, you use the following form of the `ALTER TABLE` statement:
+To change the attributes of a database, you use the following form of the `ALTER DATABASE` statement:
 
 ```sql
 ALTER DATABASE name WITH option;

--- a/content/postgresql/administration/alter-role.md
+++ b/content/postgresql/administration/alter-role.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-alter-role/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL CURRENT_USER
@@ -27,7 +27,7 @@ The ALTER ROLE statement works the same way across every PostgreSQL deployment, 
 
 To change attributes of a [role](postgresql-roles), you use the following form of `ALTER ROLE` statement.
 
-Here’s the basic syntax of the
+Here’s the basic syntax of the `ALTER ROLE` statement:
 
 ```sql
 ALTER ROLE role_name [WITH] option;

--- a/content/postgresql/administration/create-tablespace.md
+++ b/content/postgresql/administration/create-tablespace.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-create-tablespace/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: How to Change the Password of a PostgreSQL User
@@ -55,7 +55,7 @@ The name of the tablespace should not start with `pg_` since these names are res
 
 By default, the user who executes the `CREATE TABLESPACE` become the owner of the tablespace. To assign ownership to another user, you specify it after the `OWNER` keyword.
 
-The `directory_path` is the absolute path to an empty directory used for the tablespace. PostgreSQL system users must have onwership of this directory to read from and write data into it.
+The `directory_path` is the absolute path to an empty directory used for the tablespace. PostgreSQL system users must have ownership of this directory to read from and write data into it.
 
 After creating a new table space, you can specify it in the [`CREATE DATABASE`](postgresql-create-database), [`CREATE TABLE`](../postgresql-tutorial/postgresql-create-table) and [`CREATE INDEX`](../postgresql-indexes/postgresql-create-index) statements to store data files of the objects in the tablespace.
 

--- a/content/postgresql/administration/current_user.md
+++ b/content/postgresql/administration/current_user.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-current_user/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL SET ROLE Statement
@@ -92,7 +92,7 @@ It returns `bob` instead:
 (1 row)
 ```
 
-Six, use the `SESSION_USER` function to retrieve the original user who connected to the session:
+Sixth, use the `SESSION_USER` function to retrieve the original user who connected to the session:
 
 ```sql
 SELECT SESSION_USER;

--- a/content/postgresql/administration/drop-tablespace.md
+++ b/content/postgresql/administration/drop-tablespace.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-drop-tablespace/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL ALTER TABLESPACE
@@ -134,7 +134,7 @@ Seventh, connect to the `postgres` database:
 \c postgres
 ```
 
-Eight, drop the `demodb` database:
+Eighth, drop the `demodb` database:
 
 ```sql
 DROP DATABASE demodb;

--- a/content/postgresql/administration/restart-ubuntu.md
+++ b/content/postgresql/administration/restart-ubuntu.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-restart-ubuntu/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: How to Check PostgreSQL Version
@@ -21,7 +21,7 @@ nextLink:
 Restarting PostgreSQL on Ubuntu works the same way across any self-managed install, whether you reach for systemctl, service, or pg_ctl. If you'd rather skip the server babysitting altogether, [Lakebase](https://www.databricks.com/product/lakebase) delivers enterprise-grade managed Postgres for the AI era, tightly integrated with the Lakehouse and built for performance and security at scale. [Neon](https://neon.com) is the AI-native backend platform for apps and agents: Postgres Database, Auth, Storage, Functions and AI Gateway.
 </Admonition>
 
-**Summary**: in this tutorial, you will how to restart PostgreSQL on Ubuntu using `systemctl`, `service` command, and `pg_ctrl` command.
+**Summary**: in this tutorial, you will learn how to restart PostgreSQL on Ubuntu using `systemctl`, `service` command, and `pg_ctrl` command.
 
 We assume that you have sufficient permissions to restart the PostgreSQL service or can use `sudo` to execute the commands with root privileges.
 

--- a/content/postgresql/administration/restore-database.md
+++ b/content/postgresql/administration/restore-database.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-restore-database/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Backup
@@ -97,7 +97,7 @@ Sixth, exit the psql:
 exit
 ```
 
-Seven, restore the dvdrental database from the backup file using the pg_restore tool:
+Seventh, restore the dvdrental database from the backup file using the pg_restore tool:
 
 ```bash
 pg_restore -U postgres -d dvdrental D:/backup/dvdrental.tar

--- a/content/postgresql/administration/set-role.md
+++ b/content/postgresql/administration/set-role.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-administration/postgresql-set-role/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Role Membership
@@ -46,7 +46,7 @@ We’ll take an example of using the `SET ROLE` statement.
 First, [connect](../postgresql-getting-started/connect-to-postgresql-database) to the `dvdrental` database using `psql`:
 
 ```bash
-psql -U postres -d dvdrental
+psql -U postgres -d dvdrental
 ```
 
 Second, [create a group role](postgresql-role-membership) called `marketing`:
@@ -90,7 +90,7 @@ Output:
 (1 row)
 ```
 
-Eight, switch the current role to `marketing`:
+Eighth, switch the current role to `marketing`:
 
 ```sql
 SET ROLE marketing;

--- a/content/postgresql/aggregate-functions/min-function.md
+++ b/content/postgresql/aggregate-functions/min-function.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-aggregate-functions/postgresql-min-function/
 ogImage: /postgresqltutorial/film-film_category-category-tables.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL MAX Function
@@ -99,7 +99,7 @@ Output:
 
 How it works.
 
-- First, the [subquery](../postgresql-tutorial/postgresql-subquery) to select the lowest rental rate.
+- First, the [subquery](../postgresql-tutorial/postgresql-subquery) selects the lowest rental rate.
 - Then, the outer query selects films with rental rates equal to the lowest rental rate returned by the subquery.
 
 ### 3\) Using PostgreSQL MIN() function with GROUP BY clause example

--- a/content/postgresql/aggregate-functions/sum-function.md
+++ b/content/postgresql/aggregate-functions/sum-function.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-aggregate-functions/postgresql-sum-function/
 ogImage: /postgresqltutorial/payment-table.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL MIN() Function
@@ -89,7 +89,7 @@ Output:
 (1 row)
 ```
 
-In this example, the `SUM()` function returns a `NULL` because the `payment` the table has no row with the `customer_id` 2000\.
+In this example, the `SUM()` function returns a `NULL` because the `payment` table has no row with the `customer_id` 2000\.
 
 ### 3\) Using the SUM() function with COALESCE() function example
 

--- a/content/postgresql/csharp/csharp-delete.md
+++ b/content/postgresql/csharp/csharp-delete.md
@@ -6,7 +6,7 @@ page_description: >-
   PostgreSQL database from a C# program.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-csharp/postgresql-csharp-delete/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL C#: Updating Data'
@@ -100,7 +100,7 @@ catch (NpgsqlException ex)
 
 How it works.
 
-First, construct an `DELETE` statement that deletes a row specified by an id from the `students` table:
+First, construct a `DELETE` statement that deletes a row specified by an id from the `students` table:
 
 ```cs
 var sql = @"DELETE FROM students WHERE id = @id";
@@ -173,4 +173,4 @@ The output indicates that the program has successfully deleted the row id 1\.
 
 ## Summary
 
-- Use the `NpgsqlCommand` object to execute an `DELETE` statement that deletes a row from a table.
+- Use the `NpgsqlCommand` object to execute a `DELETE` statement that deletes a row from a table.

--- a/content/postgresql/csharp/csharp-import-csv-file.md
+++ b/content/postgresql/csharp/csharp-import-csv-file.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-csharp/postgresql-csharp-import-csv-file/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL C#: Inserting data'
@@ -23,7 +23,7 @@ Importing CSV data into PostgreSQL with C# and Npgsql works the same against any
 
 **Summary**: in this tutorial, you will learn how to import data from a CSV file into a table in PostgreSQL using C\#.
 
-This tutorial begins where the [Inserting data into a table in PostgreSQL tutoria](postgresql-csharp-insert)l left off.
+This tutorial begins where the [Inserting data into a table in PostgreSQL tutorial](postgresql-csharp-insert) left off.
 
 ## How to import a CSV file into the PostgreSQL database using C\#
 

--- a/content/postgresql/date-functions.md
+++ b/content/postgresql/date-functions.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: 'https://www.postgresqltutorial.com/postgresql-date-functions/'
 ogImage: >-
   https://www.postgresqltutorial.com//postgresqltutorial/postgresql-date-functions.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL BOOL_OR() Function
@@ -25,7 +25,7 @@ The following page shows the most commonly used PostgreSQL date functions that a
 
 ## Section 1\. Getting the current date and time
 
-This section shows you various functions for getting the current date, current date and time, current timestamp, without or without timezone.
+This section shows you various functions for getting the current date, current date and time, current timestamp, with or without timezone.
 
 - [CURRENT_DATE](postgresql-date-functions/postgresql-current_date) – Return the current date.
 - [CURRENT_TIME](postgresql-date-functions/postgresql-current_time) – Return the current time without date parts.

--- a/content/postgresql/date-functions/date_trunc.md
+++ b/content/postgresql/date-functions/date_trunc.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-date_trunc/
 ogImage: /postgresqltutorial/rental-table.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL AT TIME ZONE Operator
@@ -41,7 +41,7 @@ In this syntax:
 
 ### field
 
-`field` specifies the to which precision to truncate the `source`.
+`field` specifies the precision to which to truncate the `source`.
 
 Here are the valid values for the `field`:
 

--- a/content/postgresql/date-functions/justify_interval.md
+++ b/content/postgresql/date-functions/justify_interval.md
@@ -5,7 +5,7 @@ page_description: "How to use the PostgreSQL JUSTIFY_INTERVAL() to normalize an 
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-justify_interval/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL JUSTIFY_HOURS() Function
@@ -82,7 +82,7 @@ justify_interval
 
 ### 2\) Using the JUSTIFY_INTERVAL() function with negative intervals
 
-The following example uses the `JUSTIFY_INTERVAL()` function to convert a negative interval into hours days and hours:
+The following example uses the `JUSTIFY_INTERVAL()` function to convert a negative interval into days and hours:
 
 ```sql
 SELECT JUSTIFY_INTERVAL('-2 days 5 hours');

--- a/content/postgresql/date-functions/localtime.md
+++ b/content/postgresql/date-functions/localtime.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-localtime/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL NOW() Function
@@ -43,7 +43,7 @@ If you omit the `precision` argument, it defaults to 6\.
 
 The `LOCALTIME` function returns a [`TIME`](../postgresql-tutorial/postgresql-time) value that represents the time at which the current transaction starts.
 
-Note that the `LOCATIME` function returns a `TIME` without time zone whereas the [`CURRENT_TIME`](postgresql-current_time) function returns a `TIME` with the timezone.
+Note that the `LOCALTIME` function returns a `TIME` without time zone whereas the [`CURRENT_TIME`](postgresql-current_time) function returns a `TIME` with the timezone.
 
 ## PostgreSQL LOCALTIME function examples
 

--- a/content/postgresql/date-functions/now.md
+++ b/content/postgresql/date-functions/now.md
@@ -6,7 +6,7 @@ page_description: >-
   current date and time with the timezone.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-now/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL STATEMENT_TIMESTAMP() Function
@@ -208,7 +208,7 @@ COMMIT
 
 In this example, we called the `NOW()` function within a transaction and its return values do not change through the transaction.
 
-Note that the `pg_sleep()` function pauses the current session’s process sleep for a specified of seconds.
+Note that the `pg_sleep()` function pauses the current session’s process sleep for a specified number of seconds.
 
 If you want to get the current date and time that does advance during the transaction, you can use the `TIMEOFDAY()` function. Consider the following example:
 

--- a/content/postgresql/date-functions/pg_sleep.md
+++ b/content/postgresql/date-functions/pg_sleep.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-pg_sleep/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL TIMEOFDAY() Function
@@ -90,7 +90,7 @@ pg_sleep |
 now      | 2024-03-21 02:26:37.710939-07
 ```
 
-The output indicates that the result of the `NOW()` function does not change within the same statement even though we use pause the execution between the calls of the `NOW()` functions for 3 seconds.
+The output indicates that the result of the `NOW()` function does not change within the same statement even though we pause the execution between the calls of the `NOW()` functions for 3 seconds.
 
 ### 4\) Using the PG_SLEEP() function with CLOCK_TIMESTAMP() function
 

--- a/content/postgresql/getting-started.md
+++ b/content/postgresql/getting-started.md
@@ -6,7 +6,7 @@ page_description: >-
   install PostgreSQL on Windows, Linux, and macOS.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-getting-started/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: ''
@@ -29,7 +29,7 @@ This section helps you get started with PostgreSQL by showing you how to install
 
 ## PostgreSQL on Windows
 
-If you’re using windows, you can follow these tutorials to install PostgreSQL, connect to it, and load the sample database into the PostgreSQL database server:
+If you’re using Windows, you can follow these tutorials to install PostgreSQL, connect to it, and load the sample database into the PostgreSQL database server:
 
 - [Install PostgreSQL on Windows](postgresql-getting-started/install-postgresql 'Install PostgreSQL') – walk you through the steps of how to install PostgreSQL on Windows.
 - [Connect to PostgreSQL database server](postgresql-getting-started/connect-to-postgresql-database 'Connect to PostgreSQL Database') – show you how to connect to the PostgreSQL using psql tool and pgAdmin 4 GUI tool.

--- a/content/postgresql/getting-started/install-postgresql-linux.md
+++ b/content/postgresql/getting-started/install-postgresql-linux.md
@@ -8,7 +8,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql-linux/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: Install PostgreSQL macOS
@@ -181,7 +181,7 @@ Seventh, access the PostgreSQL database server again using `psql`:
 psql
 ```
 
-Eighth, switch to the `dvdental` database:
+Eighth, switch to the `dvdrental` database:
 
 ```
 \c dvdrental

--- a/content/postgresql/getting-started/install-postgresql-macos.md
+++ b/content/postgresql/getting-started/install-postgresql-macos.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql-macos/
 ogImage: /postgresqltutorial/Install-PostgreSQL-macOS-step-1.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: Load PostgreSQL Sample Database
@@ -62,7 +62,7 @@ Eighth, review the installation information. If everything looks correct, click 
 Ninth, click the Next button to start installing the PostgreSQL database server on your computer:
 
 ![](/postgresqltutorial/Install-PostgreSQL-macOS-step-9.png)
-It will take few mintues to complete the installation.
+It will take a few minutes to complete the installation.
 
 ![](/postgresqltutorial/Install-PostgreSQL-step-10.png)
 Finally, click the Finish button once the installation is completed:

--- a/content/postgresql/getting-started/install-postgresql.md
+++ b/content/postgresql/getting-started/install-postgresql.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql/
 ogImage: /postgresqltutorial/Install-PostgreSQL-Windows-Step-1.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Sample Database
@@ -91,7 +91,7 @@ Step 10\. Click the **Finish** button to complete the PostgreSQL installation.
 
 ## 3\) Adding bin directory to the PATH environment variable
 
-By adding the bin directory of the PostgreSQL to the `PATH` environment variable, you enable the execution of common PostgreSQL tools, such as `plsql` and `pg_restore`, from any directory without the need to navigate the bin directory first.
+By adding the bin directory of the PostgreSQL to the `PATH` environment variable, you enable the execution of common PostgreSQL tools, such as `psql` and `pg_restore`, from any directory without the need to navigate the bin directory first.
 
 First, find the path of the `bin` directory of the PostgreSQL installation directory. Typically, it is set to the following:
 
@@ -108,7 +108,7 @@ C:\Program Files\PostgreSQL\16\bin
 Second, open the environment variables:
 
 - Press `Win + R` to open the Run dialog
-- Type `sysdm.cpl` an press Enter. The System Properties dialog will display.
+- Type `sysdm.cpl` and press Enter. The System Properties dialog will display.
 - Select the Advanced tab and click the `Environment Variables...` button.
 
 You’ll see two sections in the `Environment Variables` window:

--- a/content/postgresql/jdbc/connecting-to-postgresql-database.md
+++ b/content/postgresql/jdbc/connecting-to-postgresql-database.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-jdbc/connecting-to-postgresql-database/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL JDBC
@@ -59,7 +59,7 @@ You can download the latest version of the driver on the [jdbc.postgresql.org do
 
 ## Creating a new project
 
-First, launch the IntellJ IDE.
+First, launch the IntelliJ IDE.
 
 Next, create a new project called `sales`.
 

--- a/content/postgresql/json-functions/jsonb_each_text.md
+++ b/content/postgresql/json-functions/jsonb_each_text.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-json-functions/postgresql-jsonb_each_text/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL jsonb_each() Function
@@ -39,7 +39,7 @@ In this syntax:
 
 The function returns a set of records where each record consists of two fields key and value, both have the type `text`.
 
-If the `json_object` is null, the function returns an empty set. in case the `json_object` is not a JSON object, the function will issue an error.
+If the `json_object` is null, the function returns an empty set. In case the `json_object` is not a JSON object, the function will issue an error.
 
 ## PostgreSQL jsonb_each_text() function examples
 

--- a/content/postgresql/json-functions/jsonb_path_query.md
+++ b/content/postgresql/json-functions/jsonb_path_query.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-json-functions/postgresql-jsonb_path_query/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL JSON Path
@@ -48,7 +48,7 @@ Let’s take some examples of using the `jsonb_path_query()` function.
 
 ### Setting up a sample table
 
-First, [create a table](../postgresql-tutorial/postgresql-create-table) named `products`with a JSONB column names `attributes` to store product attributes:
+First, [create a table](../postgresql-tutorial/postgresql-create-table) named `products` with a JSONB column names `attributes` to store product attributes:
 
 ```sql
 CREATE TABLE products (

--- a/content/postgresql/json-functions/jsonb_populate_recordset.md
+++ b/content/postgresql/json-functions/jsonb_populate_recordset.md
@@ -2,12 +2,12 @@
 title: PostgreSQL jsonb_populate_recordset() Function
 page_title: PostgreSQL jsonb_populate_recordset() Function
 page_description: >-
-  How to se the PostgreSQL jsonb_popuplate_recordset() function to populate the
+  How to use the PostgreSQL jsonb_populate_recordset() function to populate the
   fields of a record type from a JSON object.
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-json-functions/postgresql-jsonb_populate_recordset/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL jsonb_populate_record() Function
@@ -23,11 +23,11 @@ The jsonb_populate_recordset() function works the same across any PostgreSQL dep
 
 **Summary**: in this tutorial, you will learn how to use the PostgreSQL `jsonb_populate_recordset()` function to populate the fields of a record type from a JSON array of objects.
 
-## Introduction to the PostgreSQL jsonb_popuplate_recordset() function
+## Introduction to the PostgreSQL jsonb_populate_recordset() function
 
 The `jsonb_populate_recordset()` function allows you to populate the fields of a record type from a JSON array of objects.
 
-In other words, the `jsonb_popuplate_recordset()` function converts a JSON array of objects with the JSONB type into a set of records of a specified type.
+In other words, the `jsonb_populate_recordset()` function converts a JSON array of objects with the JSONB type into a set of records of a specified type.
 
 Here’s the syntax of the `jsonb_populate_recordset()` function:
 
@@ -45,7 +45,7 @@ In this syntax:
 
 The `jsonb_populate_recordset()` function returns a set of records of a specified type, with each record’s fields populated using the corresponding key\-value pairs from the JSONB objects in the array.
 
-## PostgreSQL jsonb_popuplate_recordset() function examples
+## PostgreSQL jsonb_populate_recordset() function examples
 
 Let’s explore some examples of using the `jsonb_populate_recordset()` function.
 
@@ -131,4 +131,4 @@ Output:
 
 ## Summary
 
-- Use the `jsonb_popuplate_recordset()` function to populate the fields of a record type or a custom composite type from a JSON object.
+- Use the `jsonb_populate_recordset()` function to populate the fields of a record type or a custom composite type from a JSON object.

--- a/content/postgresql/math-functions.md
+++ b/content/postgresql/math-functions.md
@@ -2,11 +2,11 @@
 title: PostgreSQL Math Functions
 page_title: PostgreSQL Math Functions
 page_description: >-
-  Provide the most commonly used PostgreSQL Match functions that help you
+  Provide the most commonly used PostgreSQL Math functions that help you
   perform various math operations quickly and effectively.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-math-functions/'
 ogImage: 'https://www.postgresqltutorial.com//postgresqltutorial/math-functions.png'
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL TO_NUMBER() Function

--- a/content/postgresql/math-functions/ln.md
+++ b/content/postgresql/math-functions/ln.md
@@ -6,7 +6,7 @@ page_description: >-
   calculate the natural logarithm of a number.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-math-functions/postgresql-ln/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL LCM() Function
@@ -26,7 +26,7 @@ The LN() function works the same way in any PostgreSQL database, so everything h
 
 The natural logarithm is a function that represents the logarithm to base e, where e is Euler’s number, which is approximately equal to `2.71828`.
 
-In Math, the natural logarithm of a x is denoted as ln(x).
+In Math, the natural logarithm of x is denoted as ln(x).
 
 If ln(x) \= y, then ey \= x.
 

--- a/content/postgresql/math-functions/log.md
+++ b/content/postgresql/math-functions/log.md
@@ -6,7 +6,7 @@ page_description: >-
   calculate the logarithm of a number
 prev_url: 'https://www.postgresqltutorial.com/postgresql-math-functions/postgresql-log/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL LN() Function
@@ -120,7 +120,7 @@ Output:
 (1 row)
 ```
 
-In this example, the `LOG()` function converts the text `'64'` into a number and calculate the base\-2 logarithm of 64\.
+In this example, the `LOG()` function converts the text `'64'` into a number and calculates the base\-2 logarithm of 64\.
 
 The following example raises an error because the `LOG()` function cannot convert the string `'64x'` into a number for calculation:
 

--- a/content/postgresql/math-functions/scale.md
+++ b/content/postgresql/math-functions/scale.md
@@ -6,7 +6,7 @@ page_description: >-
   retrieve the scale of a number.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-math-functions/postgresql-scale/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL SQRT() Function
@@ -59,7 +59,7 @@ Output:
 
 It returns 15 indicating that there are 15 digits after the decimal point.
 
-### 2\) Using the SCALE() table to examine table data
+### 2\) Using the SCALE() function to examine table data
 
 First, [create a table](../postgresql-tutorial/postgresql-create-table) called `product_prices` to store product prices with various scales:
 

--- a/content/postgresql/php/connect.md
+++ b/content/postgresql/php/connect.md
@@ -6,7 +6,7 @@ page_description: >-
   connect to the PostgreSQL database using PHP PDO API.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-php/connect/'
 ogImage: /postgresqltutorial/PostgreSQL-PHP-Connect.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL PHP
@@ -190,7 +190,7 @@ use PostgreSQLTutorial\Connection as Connection;
 
 try {
     Connection::get()->connect();
-    echo 'A connection to the PostgreSQL database sever has been established successfully.';
+    echo 'A connection to the PostgreSQL database server has been established successfully.';
 } catch (\PDOException $e) {
     echo $e->getMessage();
 }
@@ -213,7 +213,7 @@ Generating optimized autoload files
 Finally, launch the `index.php` file from the web browser to test it.
 
 ```
-A connection to the PostgreSQL database sever has been established successfully.
+A connection to the PostgreSQL database server has been established successfully.
 ```
 
 If you want to see the exception that may occur, you can change the parameters in the `database.ini` file to an invalid one and test it.

--- a/content/postgresql/php/query.md
+++ b/content/postgresql/php/query.md
@@ -1,12 +1,12 @@
 ---
 title: 'PostgreSQL PHP: Querying Data'
-page_title: 'PostgreSQL PHP: Queying Data From PostgreSQL Tables'
+page_title: 'PostgreSQL PHP: Querying Data From PostgreSQL Tables'
 page_description: >-
   In this tutorial, you will step by step learn how to query data from the
   tables in the PostgreSQL database using PHP PDO.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-php/query/'
 ogImage: /postgresqltutorial/PostgreSQL-PHP-Query-Example.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL PHP: Updating Data In a Table'

--- a/content/postgresql/plpgsql/create-function.md
+++ b/content/postgresql/plpgsql/create-function.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-plpgsql/postgresql-create-function/
 ogImage: /postgresqltutorial/film.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Exception
@@ -55,7 +55,7 @@ In this syntax:
 
 We’ll use the `film` table from the [sample database](../postgresql-getting-started/postgresql-sample-database).
 
-![](/postgresqltutorial/film.png)The following statement creates a function that returns the number films whose length between the `len_from` and `len_to` parameters:
+![](/postgresqltutorial/film.png)The following statement creates a function that returns the number of films whose length between the `len_from` and `len_to` parameters:
 
 ```plsql
 create function get_film_count(len_from int, len_to int)

--- a/content/postgresql/plpgsql/pl-pgsql-while-loop.md
+++ b/content/postgresql/plpgsql/pl-pgsql-while-loop.md
@@ -6,7 +6,7 @@ page_description: >-
   to execute a block of code as long as a condition is true.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-plpgsql/pl-pgsql-while-loop/'
 ogImage: /postgresqltutorial/plpgsql-WHILE-loop.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PL/pgSQL Loop Statements
@@ -39,7 +39,7 @@ In this syntax, PostgreSQL evaluates the `condition` before executing the `state
 
 If the condition is true, it executes the `statements`. After each iteration, the `while` loop evaluates the `condition` again.
 
-Inside the body of the `while` loop, you need to change the some [variables](plpgsql-variables) to make the `condition` `false` or `null` at some points. Otherwise, you will have an indefinite loop.
+Inside the body of the `while` loop, you need to change some [variables](plpgsql-variables) to make the `condition` `false` or `null` at some points. Otherwise, you will have an indefinite loop.
 
 Because the `while` loop tests the `condition` before executing the `statements`, it is often referred to as a **pretest loop**.
 

--- a/content/postgresql/plpgsql/plpgsql-case-statement.md
+++ b/content/postgresql/plpgsql/plpgsql-case-statement.md
@@ -6,7 +6,7 @@ page_description: >-
   executes a command based on a certain condition.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-plpgsql/plpgsql-case-statement/'
 ogImage: /postgresqltutorial/plpgsql-simple-case-statement.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PL/pgSQL IF Statement
@@ -22,7 +22,7 @@ The PL/pgSQL CASE statement works the same way on any PostgreSQL deployment, so 
 
 **Summary**: in this tutorial, you will learn about the PL/pgSQL `case` that executes statements based on a certain condition.
 
-## Introduction to PL/pgSQL CASE Statment
+## Introduction to PL/pgSQL CASE Statement
 
 Besides the [if statement](plpgsql-if-else-statements), PostgreSQL provides the `case` statements that allow you to execute a block of code based on conditions.
 

--- a/content/postgresql/plpgsql/plpgsql-record-types.md
+++ b/content/postgresql/plpgsql/plpgsql-record-types.md
@@ -3,10 +3,10 @@ title: PL/pgSQL Record Types
 page_title: PL/pgSQL Record Types Explained Clearly By Examples
 page_description: >-
   You will learn about the PL/pgSQL record types that allow you to define
-  variables that can hold a sinle row of a result set.
+  variables that can hold a single row of a result set.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-plpgsql/plpgsql-record-types/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PL/pgSQL Row Types

--- a/content/postgresql/python/connect.md
+++ b/content/postgresql/python/connect.md
@@ -6,7 +6,7 @@ page_description: >-
   server from Python using the psycopg2 package.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-python/connect/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Python
@@ -127,7 +127,7 @@ The `config.py` module uses the built\-in `configparser` module to read data fro
 
 By using the `database.ini`, you can change the PostgreSQL connection parameters when moving the code to different environments such as testing or production.
 
-Notice that if you git source control, you need to add the `database.ini` to the `.gitignore` file to avoid committing sensitive information to a public repository like GitHub:
+Notice that if you use git source control, you need to add the `database.ini` to the `.gitignore` file to avoid committing sensitive information to a public repository like GitHub:
 
 ```
 database.ini

--- a/content/postgresql/python/insert.md
+++ b/content/postgresql/python/insert.md
@@ -1,12 +1,12 @@
 ---
 title: 'PostgreSQL Python: Insert Data Into a Table'
-page_title: 'PostgresSQL Python: Insert Data Into a Table'
+page_title: 'PostgreSQL Python: Insert Data Into a Table'
 page_description: >-
   This tutorial shows you the step by step how to insert one or more rows into a
   PostgreSQL table in Python.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-python/insert/'
 ogImage: /postgresqltutorial/vendors_table.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL Python: Create Tables'

--- a/content/postgresql/python/transaction.md
+++ b/content/postgresql/python/transaction.md
@@ -6,7 +6,7 @@ page_description: >-
   commit() and rollback() methods of the connection object.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-python/transaction/'
 ogImage: /postgresqltutorial/parts_vendors_tables.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: 'PostgreSQL Python: Querying Data'
@@ -30,7 +30,7 @@ In the `psycopg2` package, the `connection` class is responsible for managing tr
 
 When you send the first SQL statement to the PostgreSQL database using a `cursor` object, `psycopg2` initiates a new [transaction](../postgresql-tutorial/postgresql-transaction).
 
-Subsequentially, all the following statements are executed within the same transaction. If any statement encounters an error, `psycopg2` will abort the entire transaction.
+Subsequently, all the following statements are executed within the same transaction. If any statement encounters an error, `psycopg2` will abort the entire transaction.
 
 The `connection` class has two methods for concluding a transaction:
 

--- a/content/postgresql/string-functions/repeat.md
+++ b/content/postgresql/string-functions/repeat.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-string-functions/postgresql-repeat/
 ogImage: 'https://www.mysqltutorial.org//postgresqltutorial/products.svg'
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL REGEXP_REPLACE() Function
@@ -50,7 +50,7 @@ Let’s explore some examples of using the `REPEAT()` function.
 
 ### 1\) Basic REPEAT() function example
 
-The following example uses the `REPEAT()` function to repeat the letter “A” there times:
+The following example uses the `REPEAT()` function to repeat the letter “A” three times:
 
 ```sql
 SELECT REPEAT('A',3);

--- a/content/postgresql/string-functions/reverse.md
+++ b/content/postgresql/string-functions/reverse.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-string-functions/postgresql-reverse/
 ogImage: /postgresqltutorial/customer.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL REPEAT() Function
@@ -41,7 +41,7 @@ The `REVERSE()` function returns a string with the order of all the characters r
 
 The `REVERSE()` function returns `NULL` if the `text` is `NULL`.
 
-## MySQL REVERSE() function examples
+## PostgreSQL REVERSE() function examples
 
 Let’s explore some examples of using the `REVERSE()` function.
 

--- a/content/postgresql/triggers/after-delete-trigger.md
+++ b/content/postgresql/triggers/after-delete-trigger.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-triggers/postgresql-after-delete-trigger/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL BEFORE DELETE Trigger
@@ -153,7 +153,7 @@ Output:
 (1 row)
 ```
 
-The `AFTER INSERT` trigger will be activated that calls the `archive_deleted_employee()` function to insert the deleted row into the `employee_archives` table.
+The `AFTER DELETE` trigger will be activated that calls the `archive_deleted_employee()` function to insert the deleted row into the `employee_archives` table.
 
 Seventh, retrieve data from the `employee_archives` table:
 

--- a/content/postgresql/triggers/after-update-trigger.md
+++ b/content/postgresql/triggers/after-update-trigger.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-triggers/postgresql-after-update-trigger/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL BEFORE UPDATE Trigger
@@ -42,7 +42,7 @@ Additionally, you can access the following variables:
 - `TG_OP`: Represent the operation that activates the trigger, which is `UPDATE` for the `AFTER` `UPDATE` trigger.
 - `TG_WHEN`: Represent the trigger timing, which is `AFTER` for the `AFTER UPDATE` trigger.
 
-To create a `AFTER UPDATE` trigger, you use the following steps:
+To create an `AFTER UPDATE` trigger, you use the following steps:
 
 First, [define a trigger function](../postgresql-plpgsql/postgresql-create-function) that will execute when the `AFTER UPDATE` trigger fires:
 

--- a/content/postgresql/triggers/before-truncate-trigger.md
+++ b/content/postgresql/triggers/before-truncate-trigger.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-triggers/postgresql-before-truncate-trigger/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL INSTEAD OF Triggers
@@ -25,7 +25,7 @@ The `BEFORE TRUNCATE` trigger is a standard PostgreSQL feature, so everything he
 
 ## Introduction to the PostgreSQL BEFORE TRUNCATE trigger
 
-A [`TRUNCATE TABLE`](../postgresql-tutorial/postgresql-truncate-table) statement removes all from a table without creating any logs, making it faster than a [`DELETE`](../postgresql-tutorial/postgresql-delete) operation.
+A [`TRUNCATE TABLE`](../postgresql-tutorial/postgresql-truncate-table) statement removes all rows from a table without creating any logs, making it faster than a [`DELETE`](../postgresql-tutorial/postgresql-delete) operation.
 
 PostgreSQL allows you to [create a trigger](creating-first-trigger-postgresql) that fires before a `TRUNCATE` event occurs.
 

--- a/content/postgresql/tutorial/any.md
+++ b/content/postgresql/tutorial/any.md
@@ -6,7 +6,7 @@ page_description: >-
   value to a set of values returned by a subquery.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-any/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Correlated Subquery
@@ -26,7 +26,7 @@ The ANY operator works the same across every PostgreSQL deployment, so everythin
 
 The PostgreSQL `ANY` operator compares a value with a set of values returned by a [subquery](postgresql-subquery). It is commonly used in combination with comparison operators such as \=, \<, \>, \<\=, \>\=, and \<\>.
 
-Here’s the basic syntax of  the `ANY` operator:
+Here’s the basic syntax of the `ANY` operator:
 
 ```sql
 expression operator ANY(subquery)

--- a/content/postgresql/tutorial/case.md
+++ b/content/postgresql/tutorial/case.md
@@ -6,7 +6,7 @@ page_description: >-
   form conditional queries.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-case/'
 ogImage: /postgresqltutorial/film.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Composite Types
@@ -151,7 +151,7 @@ The `CASE` first evaluates the `expression` and compares the result with each va
 
 Once the result of the `expression` equals a value (value1, value2, etc.) in a `WHEN` clause, the `CASE` returns the corresponding result in the `THEN` clause.
 
-If `CASE` does not find any matches, it returns the `else_result` in that follows the `ELSE`, or `NULL` value if the `ELSE` is not available.
+If `CASE` does not find any matches, it returns the `else_result` that follows the `ELSE`, or `NULL` value if the `ELSE` is not available.
 
 ### 1\) Simple PostgreSQL CASE expression example
 

--- a/content/postgresql/tutorial/cast.md
+++ b/content/postgresql/tutorial/cast.md
@@ -6,7 +6,7 @@ page_description: >-
   (::) to cast a value of one type to another.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-cast/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL NULLIF
@@ -387,7 +387,7 @@ Output:
 
 In this example:
 
-- `rating ~ E'^\\d+$'`: This expression matches the values in the rating column with a regular expression `E'^\\d+$'`. The pattern checks if a value contains only digits (`\d+`) from the beginning (`^`) to the end (`$`). The letter `E` before the string indicates is an escape string.
+- `rating ~ E'^\\d+$'`: This expression matches the values in the rating column with a regular expression `E'^\\d+$'`. The pattern checks if a value contains only digits (`\d+`) from the beginning (`^`) to the end (`$`). The letter `E` before the string indicates it is an escape string.
 - If the value contains only digits, the `CAST()` function converts it to an integer. Otherwise, it returns zero.
 
 In this tutorial, you have learned how to use PostgreSQL `CAST` to convert a value of one type to another.

--- a/content/postgresql/tutorial/data-types.md
+++ b/content/postgresql/tutorial/data-types.md
@@ -6,7 +6,7 @@ page_description: >-
   Boolean, character, number, temporal, special types, and array.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-data-types/'
 ogImage: /postgresqltutorial/PostgreSQL-Data-Types-300x254.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: Export PostgreSQL Table to CSV File
@@ -22,7 +22,7 @@ PostgreSQL data types like Boolean, character, numeric, temporal, array, JSON, a
 
 **Summary**: in this tutorial, you will learn about **PostgreSQL data types** including Boolean, character, numeric, temporal, array, json, UUID, and special types.
 
-## PostgreSQL Data TypesOverview of PostgreSQL data types
+## Overview of PostgreSQL data types
 
 PostgreSQL supports the following data types:
 

--- a/content/postgresql/tutorial/except.md
+++ b/content/postgresql/tutorial/except.md
@@ -2,11 +2,11 @@
 title: PostgreSQL EXCEPT
 page_title: PostgreSQL EXCEPT
 page_description: >-
-  Show you how to the PostgreSQL EXCEPT operator to combine the result sets of
+  Show you how to use the PostgreSQL EXCEPT operator to combine the result sets of
   two queries.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-except/'
 ogImage: /postgresqltutorial/PostgreSQL-EXCEPT-300x202.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL INTERSECT Operator

--- a/content/postgresql/tutorial/exists.md
+++ b/content/postgresql/tutorial/exists.md
@@ -6,7 +6,7 @@ page_description: >-
   existence of rows in the subquery.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-exists/'
 ogImage: /postgresqltutorial/customer-and-payment-tables.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL ALL Operator
@@ -92,7 +92,7 @@ We will use the following `customer` and `payment` tables in the [sample databas
 
 ### 1\) Basic EXISTS operator example
 
-The following example uses the `EXISTS` operator to check if the payment value is zero exists in the `payment` table:
+The following example uses the `EXISTS` operator to check if a payment value of zero exists in the `payment` table:
 
 ```sql
 SELECT

--- a/content/postgresql/tutorial/full-outer-join.md
+++ b/content/postgresql/tutorial/full-outer-join.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-full-outer-join/
 ogImage: /postgresqltutorial/PostgreSQL-Join-Full-Outer-Join.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Self-Join
@@ -25,7 +25,7 @@ FULL OUTER JOIN is standard PostgreSQL and works the same on any Postgres deploy
 
 ## Introduction to the PostgreSQL FULL OUTER JOIN clause
 
-The `FULL OUTER JOIN` combine data from two tables and returns all rows from both tables, including matching and non\-matching rows from both sides.
+The `FULL OUTER JOIN` combines data from two tables and returns all rows from both tables, including matching and non\-matching rows from both sides.
 
 In other words, the `FULL OUTER JOIN` combines the results of both the [left join](postgresql-left-join) and the [right join](postgresql-right-join).
 

--- a/content/postgresql/tutorial/having.md
+++ b/content/postgresql/tutorial/having.md
@@ -6,7 +6,7 @@ page_description: >-
   filter groups of rows based on a specified condition.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-having/'
 ogImage: /postgresqltutorial/postgresql-having.svg
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL GROUP BY
@@ -96,7 +96,7 @@ Output:
 ...
 ```
 
-The following statement adds the `HAVING`clause to select the only customers who have been spending more than `200`:
+The following statement adds the `HAVING` clause to select only the customers who have been spending more than `200`:
 
 ```sql
 SELECT

--- a/content/postgresql/tutorial/how-to-delete-duplicate-rows-in-postgresql.md
+++ b/content/postgresql/tutorial/how-to-delete-duplicate-rows-in-postgresql.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-tutorial/how-to-delete-duplicate-rows-in-postgresql/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL DELETE CASCADE
@@ -77,7 +77,7 @@ The output indicates some duplicate rows such as 2 apples and 3 oranges in the `
 
 If the table has few rows, you can easily see which ones are duplicates immediately. However, this is not the case with a table that has lots of rows.
 
-The find the duplicate rows, you use the following statement:
+To find the duplicate rows, you use the following statement:
 
 ```sql
 SELECT

--- a/content/postgresql/tutorial/rename-table.md
+++ b/content/postgresql/tutorial/rename-table.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-rename-table/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL ALTER TABLE
@@ -104,7 +104,7 @@ Indexes:
 
 Notice that the name of the table changed but the [sequence](postgresql-sequences) (`vendors_id_seq`) remains intact.
 
-### 1\) Renaming a table that has dependent objects
+### 2\) Renaming a table that has dependent objects
 
 First, create new tables called `customers` and `groups`:
 

--- a/content/postgresql/tutorial/rollup.md
+++ b/content/postgresql/tutorial/rollup.md
@@ -6,7 +6,7 @@ page_description: >-
   multiple grouping sets.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-rollup/'
 ogImage: /postgresqltutorial/PostgreSQL-ROLLUP-example.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL CUBE
@@ -171,7 +171,7 @@ ORDER BY
 See the following `rental` table from the [sample database](../postgresql-getting-started/postgresql-sample-database).
 
 ![Rental Table](/postgresqltutorial/rental.png)
-The following statement finds the number of rental per day, month, and year by using the `ROLLUP`:
+The following statement finds the number of rentals per day, month, and year by using the `ROLLUP`:
 
 ```sql
 SELECT

--- a/content/postgresql/tutorial/temporary-table.md
+++ b/content/postgresql/tutorial/temporary-table.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-temporary-table/
 ogImage: /postgresqltutorial/PostgreSQL-Temporary-Table-300x254.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL TRUNCATE TABLE
@@ -182,5 +182,5 @@ DROP TABLE customers;
 ## Summary
 
 - A temporary table is a short\-lived table that exists during a database session or a transaction.
-- Use `the CREATE TEMP TABLE` statement to create a temporary table.
+- Use the `CREATE TEMP TABLE` statement to create a temporary table.
 - Use the `DROP TABLE` statement to drop a temporary table.

--- a/content/postgresql/tutorial/update.md
+++ b/content/postgresql/tutorial/update.md
@@ -6,7 +6,7 @@ page_description: >-
   data of one or more columns of a table.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-update/'
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL INSERT Multiple Rows
@@ -143,7 +143,7 @@ Output:
 
 ### 2\) Updating a row and returning the updated row
 
-The following statement uses the `UPDATE` statement update `published_date` of the course id 2 to `2020-07-01` and returns the updated course.
+The following statement uses the `UPDATE` statement to update `published_date` of the course id 2 to `2020-07-01` and returns the updated course.
 
 ```sql
 UPDATE courses

--- a/content/postgresql/tutorial/xml-data-type.md
+++ b/content/postgresql/tutorial/xml-data-type.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: >-
   https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-xml-data-type/
 ogImage: ''
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL enum
@@ -126,7 +126,7 @@ Output:
 
 Each row in the result set is an array of XML values representing person names. Since each person has one name, the result array has only one element.
 
-Fourth, retrieve person names as text from the XML documents using `xpath()` function:
+Fifth, retrieve person names as text from the XML documents using `xpath()` function:
 
 ```sql
 SELECT (xpath('/person/name/text()', info))[1]::text AS name
@@ -151,7 +151,7 @@ How it works.
 - Second, the `[1]` subscript returns the first element of the array.
 - Third, the `::text` casts the XML value to the text.
 
-Fifth, retrieve the ages of persons:
+Sixth, retrieve the ages of persons:
 
 ```sql
 SELECT (xpath('/person/age/text()', info))[1]::text::integer AS age
@@ -179,7 +179,7 @@ In this query:
 
 In this example, we cast an XML value to text and text to an integer because we cannot cast an XML value directly to an integer.
 
-Sixth, retrieve the name, age, and city from the XML document:
+Seventh, retrieve the name, age, and city from the XML document:
 
 ```sql
 SELECT
@@ -202,7 +202,7 @@ Output:
 (4 rows)
 ```
 
-Seventh, find the person with the name “Jane Doe”:
+Eighth, find the person with the name “Jane Doe”:
 
 ```sql
 SELECT *
@@ -263,7 +263,7 @@ Third, call the `generate_persons` to insert 1000 rows into the `person` table:
 SELECT generate_persons();
 ```
 
-Fifth, find a person with the name `Jane Doe`:
+Fourth, find a person with the name `Jane Doe`:
 
 ```sql
 EXPLAIN ANALYZE

--- a/content/postgresql/views/managing-postgresql-views.md
+++ b/content/postgresql/views/managing-postgresql-views.md
@@ -1,12 +1,12 @@
 ---
 title: PostgreSQL CREATE VIEW
-page_title: PosgreSQL CREATE VIEW
+page_title: PostgreSQL CREATE VIEW
 page_description: >-
   This tutorial shows you how to use the CREATE VIEW statement to create a new
   view in your database.
 prev_url: 'https://www.postgresqltutorial.com/postgresql-views/managing-postgresql-views/'
 ogImage: /postgresqltutorial/customer.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL Views

--- a/content/postgresql/window-function/first_value-function.md
+++ b/content/postgresql/window-function/first_value-function.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: index.html
 ogImage: >-
   https://www.postgresqltutorial.com//postgresqltutorial/products_product_groups_tables.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL DENSE_RANK Function
@@ -55,7 +55,7 @@ The `expression` can be an expression, column, or subquery evaluated against the
 
 The `PARTITION BY` clause divides rows in a result set into partitions to which the `FIRST_VALUE()` function is applied.
 
-When you the `PARTITION BY` clause, the `FIRST_VALUE()` function treats the whole result set as a single partition.
+When you omit the `PARTITION BY` clause, the `FIRST_VALUE()` function treats the whole result set as a single partition.
 
 ### ORDER BY clause
 

--- a/content/postgresql/window-function/lead-function.md
+++ b/content/postgresql/window-function/lead-function.md
@@ -6,7 +6,7 @@ page_description: >-
   access a row that follows the current row, at a specific physical offset.
 prev_url: index.html
 ogImage: /postgresqltutorial/Sales-sample-table.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL LAST_VALUE Function
@@ -24,7 +24,7 @@ The LEAD() function is standard PostgreSQL and works the same on any Postgres de
 
 ## Introduction to PostgreSQL LEAD() function
 
-PostgreSQL `LEAD()` function provide access to a row that follows the current row at a specified physical offset.
+PostgreSQL `LEAD()` function provides access to a row that follows the current row at a specified physical offset.
 
 It means that from the current row, the `LEAD()` function can access data of the next row, the row after the next row, and so on.
 

--- a/content/postgresql/window-function/nth_value-function.md
+++ b/content/postgresql/window-function/nth_value-function.md
@@ -7,7 +7,7 @@ page_description: >-
 prev_url: index.html
 ogImage: >-
   https://www.postgresqltutorial.com//postgresqltutorial/products-table-sample-data.png
-updatedOn: '2026-06-03T13:01:21.685Z'
+updatedOn: '2026-06-04T15:04:42.682Z'
 enableTableOfContents: true
 previousLink:
   title: PostgreSQL NTILE Function
@@ -130,4 +130,4 @@ In this example,
 - The frame clause defined the whole partition as a frame.
 - And the `NTH_VALUE()` function returns the product name of the 2nd row of each product group.
 
-Now, you should how to use the PostgreSQL `NTH_VALUE()` function to get a value from the nth row of a result set.
+Now, you should know how to use the PostgreSQL `NTH_VALUE()` function to get a value from the nth row of a result set.


### PR DESCRIPTION
## Summary

Swept all 431 markdown files in `content/postgresql/` for typos, broken sentences, and minor errors. 63 files changed, 74 fixes. No rewrites, no structural changes, no code block edits.

## Notable fixes

| File | Error | Fix |
|------|-------|-----|
| `administration/set-role.md` | `psql -U postres` | `psql -U postgres` |
| `triggers/after-delete-trigger.md` | "AFTER INSERT trigger" label | "AFTER DELETE trigger" |
| `string-functions/reverse.md` | "MySQL REVERSE() function examples" heading | "PostgreSQL REVERSE() function examples" |
| `getting-started/install-postgresql.md` | `plsql` (wrong tool name) | `psql` |
| `getting-started/install-postgresql-linux.md` | `dvdental` database name | `dvdrental` |
| `json-functions/jsonb_populate_recordset.md` | `jsonb_popuplate_recordset` (×5) | `jsonb_populate_recordset` |
| `administration/alter-database.md` | "ALTER TABLE statement" in ALTER DATABASE doc | "ALTER DATABASE statement" |
| Various `administration/` files | Six/Seven/Eight in numbered steps | Sixth/Seventh/Eighth |

## Test plan

- [ ] Spot-check changed files in Vercel preview
- [ ] No code blocks, SQL, or frontmatter structure was modified

This pull request and its description were written by Isaac.