### PR TITLE
feat: classify curl user-agent as an AI agent

### DIFF
--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -31,6 +31,7 @@ export function isAIAgentRequest(request) {
     'llm-agent',
     'axios', // Used by Claude Code
     'got', // Used by Cursor
+    'curl', // Common CLI HTTP client used to fetch docs as markdown
   ];
 
   const hasAIAgentUserAgent = aiAgentPatterns.some((pattern) =>

--- a/src/utils/ai-agent-detection.test.js
+++ b/src/utils/ai-agent-detection.test.js
@@ -26,6 +26,7 @@ describe('isAIAgentRequest', () => {
       'llm-agent',
       'axios',
       'got',
+      'curl',
     ];
 
     aiAgentPatterns.forEach((pattern) => {


### PR DESCRIPTION
## What

Adds `curl` to the AI-agent User-Agent patterns in `src/utils/ai-agent-detection.js`, so requests from the `curl` CLI are served markdown instead of HTML.

This matches the existing handling for other CLI HTTP clients already on the list (`axios`, `got`). Detection is a case-insensitive substring match, and curl's default User-Agent (`curl/8.x.x`) contains `curl`.

## Changes

- `src/utils/ai-agent-detection.js` — add `'curl'` to `aiAgentPatterns`
- `src/utils/ai-agent-detection.test.js` — add `curl` to the covered patterns

## Testing

`npx vitest run src/utils/ai-agent-detection.test.js src/middleware.test.js` — 134 tests pass.