### PR TITLE
chore: feature the latest changelog in the topbar banner

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'All paid plans now include 5x more free data transfer: 500 GB per month, up from 100 GB. Read the details here.'
+text: 'New in Neon: a backend for apps and agents, Postgres 18 by default, and more. Read the latest changelog.'
 link:
-  url: 'https://neon.com/blog/more-data-transfer-on-paid-plans'
-  target: '_blank'
+  url: '/docs/changelog/2026-06-05'
+  target: '_self'


### PR DESCRIPTION
## What

Updates the topbar announcement banner (`content/config/topbar.yaml`) to feature the **2026-06-05 changelog** instead of the standalone "500 GB data transfer" blog post.

The data transfer change is now just one item within that changelog (alongside the backend-for-apps-and-agents preview, Postgres 18 as the default for new projects, faster Text-to-SQL, CLI v2.22.2, and more), so pointing the banner at the changelog surfaces all of it.

## Change

```yaml
text: 'New in Neon: a backend for apps and agents, Postgres 18 by default, and more. Read the latest changelog.'
link:
  url: '/docs/changelog/2026-06-05'
  target: '_self'
```

Uses a relative internal URL with `_self` (the banner links to an on-site changelog page rather than an external blog).