### PR TITLE
fix: redirect /cookie-policy to Databricks cookie notice

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -184,6 +184,11 @@ const defaultConfig = {
 
     return [
       {
+        source: '/cookie-policy',
+        destination: 'https://www.databricks.com/legal/cookienotice',
+        permanent: true,
+      },
+      {
         source: '/docs/use-cases/:path*',
         destination: '/use-cases',
         permanent: true,


### PR DESCRIPTION
## What

Adds a permanent (308) redirect from `/cookie-policy` to `https://www.databricks.com/legal/cookienotice`.

## Why

Neon's cookie policy is now hosted on the Databricks legal site. The on-site `/cookie-policy` path (referenced from the footer via `src/constants/links.js`) should send visitors to the canonical Databricks cookie notice.

## Notes

- No page route existed at `/cookie-policy`; it was only referenced through `links.js`. The footer link is left pointing at the canonical on-site path, which now redirects externally.
- Implemented in the `redirects()` array in `next.config.js`.