### PR TITLE
feat: docs-fact-conflicts workflow (cross-page fact conflict checker)

### DIFF
--- a/.claude/commands/fact-check.md
+++ b/.claude/commands/fact-check.md
@@ -25,27 +25,56 @@ current `main` first. Let the user decide whether to proceed or update.
 
 ## Pick the engine (auto-detect)
 
+**First, resolve the target to an ABSOLUTE path** inside the worktree you mean to check
+(e.g. `/abs/path/<worktree>/content/docs/introduction/plans.md`). Both engines otherwise search
+`content/docs` relative to the session's cwd — silently checking whatever checkout the session sits
+in, which is the wrong tree when you mean to vet a different branch. Confirm which branch that
+worktree is on (warn if it is stale vs `main`), then pass absolute paths so the corpus root is
+unambiguous.
+
 Check whether the **`Workflow` tool** is available this session (e.g. `ToolSearch` for `Workflow`).
 
-- **Workflow available + single-page** → run the headless engine:
+- **Workflow available + single-page** → run the headless engine, passing the ABSOLUTE target so it
+  roots its search at the right worktree (the script derives `docsRoot` from an absolute target, or
+  pass `docsRoot` explicitly):
   ```
-  Workflow({ scriptPath: ".claude/workflows/docs-fact-conflicts.js", args: "<page path>" })
+  Workflow({ scriptPath: "<abs>/.claude/workflows/docs-fact-conflicts.js",
+             args: { path: "<abs>/content/docs/.../page.md" } })
   ```
-  (Add `{ path, semantic: true }` for higher recall — see the script header.)
+  Never invoke it with a bare relative path unless the session cwd IS the target worktree — it
+  checks the wrong tree silently otherwise. (Add `semantic: true` for higher recall.)
 - **Workflow unavailable, OR full-corpus scope** → run the agent runbook
   `.claude/workflows/docs-fact-conflicts.agents.md`. Follow it stage by stage: extract → search →
-  judge (dispatched **by fact id**) → coverage gate → verify → `synth.mjs`.
+  judge (dispatched **by fact id**) → coverage gate → verify → `synth.mjs`. Give every agent the
+  absolute docs root too (same reason).
 
   > Note: the Workflow engine (`docs-fact-conflicts.js`) is single-page only, so **full-corpus
   > always uses the agent runbook** until a full-corpus workflow script exists. Both engines share
   > `lib/synth.mjs`, so the report shape is identical.
 
-## Report
+## Report and resolve
 
-Summarize what `report.json` / the engine returns: facts checked, candidates, **confirmed**
-conflicts (each as `file:line` on both sides, with the suggested correction), and **low-confidence
-/ unverified** ones listed separately as "needs human confirmation" (a single-verifier dissent may
-be a deliberate exception, not a bug).
+Lead with the honest scope: **this checks consistency, not correctness** — a clean result means the
+docs agree with each other, not that they are right. Say so up front so a green run isn't
+over-trusted.
 
-**Do not apply edits.** Findings are leads — open each cited `file:line` pair and confirm by hand.
-Offer to apply a specific suggested edit only if the user asks, one page at a time.
+Summarize what the engine returns: facts checked, **confirmed** conflicts (each as `file:line` on
+both sides), and **low-confidence / unverified** ones flagged separately as "needs human
+confirmation" (a single-verifier dissent may be a deliberate exception, not a bug).
+
+Then resolve each confirmed conflict with the human in the loop. Never auto-decide which side is
+right, and never mass-edit:
+
+1. **Show both sides; ask which is canonical.** The tool cannot know which value is correct.
+   Present both (`file:line` + value) and ask the user to choose the canonical one — ideally
+   confirmed against the real source (control plane / pricing / product), not just "looks right."
+2. **Propose aligning edits as reviewable diffs, one page at a time.** The user approves each
+   before it is applied. Never edit silently; never touch legacy or out-of-scope pages.
+3. **Flag scope.** Conflicting pages are often NOT in the user's PR. State which are in-PR vs not,
+   and ask whether to fix the others here (this broadens the PR) or flag them for a separate change.
+4. **Record the canonical value (only if a canonical-values config is in use).** Offer to record
+   the user-confirmed value there as its own reviewable change — it gates CI for everyone, so it
+   gets its own review, never a silent in-chat write.
+
+Truth flows one direction: the human (or the real system) asserts the canonical value, and the tool
+propagates it into the docs. Never infer the canonical value from the docs themselves.

--- a/.claude/commands/fact-check.md
+++ b/.claude/commands/fact-check.md
@@ -1,0 +1,51 @@
+---
+description: 'Check docs for facts that contradict the rest of content/docs — one page or the whole corpus. Auto-detects the Workflow engine, falls back to agents. Report only.'
+---
+
+Find factual contradictions inside the Neon docs: one page against the rest, or every page
+against each other. Extracts cross-referenceable facts (plan limits, prices, defaults, units,
+product-name casing), finds where pages disagree, adversarially verifies each disagreement, and
+reports confirmed conflicts. It does **not** modify any docs.
+
+**Arguments:**
+
+- A repo-relative page path (e.g. `content/docs/introduction/plans.md`) → **single-page** scope.
+- `--all` or a directory → **full-corpus** scope (heavier).
+- No argument → ask the user whether they mean a specific page or `--all`.
+
+**Freshness guard (run first):** the check is only meaningful against current docs — a stale tree
+surfaces already-fixed "findings."
+
+```bash
+git fetch -q origin main && echo "behind origin/main by $(git rev-list --count HEAD..origin/main)"
+```
+
+If behind, warn that any findings may already be fixed upstream and suggest checking against
+current `main` first. Let the user decide whether to proceed or update.
+
+## Pick the engine (auto-detect)
+
+Check whether the **`Workflow` tool** is available this session (e.g. `ToolSearch` for `Workflow`).
+
+- **Workflow available + single-page** → run the headless engine:
+  ```
+  Workflow({ scriptPath: ".claude/workflows/docs-fact-conflicts.js", args: "<page path>" })
+  ```
+  (Add `{ path, semantic: true }` for higher recall — see the script header.)
+- **Workflow unavailable, OR full-corpus scope** → run the agent runbook
+  `.claude/workflows/docs-fact-conflicts.agents.md`. Follow it stage by stage: extract → search →
+  judge (dispatched **by fact id**) → coverage gate → verify → `synth.mjs`.
+
+  > Note: the Workflow engine (`docs-fact-conflicts.js`) is single-page only, so **full-corpus
+  > always uses the agent runbook** until a full-corpus workflow script exists. Both engines share
+  > `lib/synth.mjs`, so the report shape is identical.
+
+## Report
+
+Summarize what `report.json` / the engine returns: facts checked, candidates, **confirmed**
+conflicts (each as `file:line` on both sides, with the suggested correction), and **low-confidence
+/ unverified** ones listed separately as "needs human confirmation" (a single-verifier dissent may
+be a deliberate exception, not a bug).
+
+**Do not apply edits.** Findings are leads — open each cited `file:line` pair and confirm by hand.
+Offer to apply a specific suggested edit only if the user asks, one page at a time.

--- a/.claude/workflows/docs-fact-conflicts.agents.md
+++ b/.claude/workflows/docs-fact-conflicts.agents.md
@@ -63,8 +63,11 @@ large JSON back into the main thread. Files:
 
 ### 1. Setup
 
-Create the scratch dir and write `meta.json` (`{target, mode, scope}`). For full-corpus, list the
-target pages (`content/docs/**/*.md`, minus anything intentionally divergent like `legacy-*`).
+Resolve an ABSOLUTE docs root from the target worktree (e.g. `/abs/<worktree>/content/docs`) and
+pass absolute paths to every agent — they otherwise grep a cwd-relative `content/docs` and can
+silently check the wrong checkout. Create the scratch dir and write `meta.json`
+(`{target, mode, scope}`). For full-corpus, list the target pages (`content/docs/**/*.md`, minus
+anything intentionally divergent like `legacy-*`).
 
 ### 2. Extract — one agent per page
 
@@ -121,8 +124,10 @@ clean, for each flagged conflict spawn a skeptical verify agent:
 ### 6. Report
 
 Re-run `synth.mjs` to fold in verdicts. It writes `report.json` and prints the summary
-(confirmed / unverified / refuted). **Report only — never edit docs.** Treat findings as leads:
-open each cited `file:line` pair before acting. A clean result only means something on a fresh
+(confirmed / unverified / refuted). **The sweep stage is report-only.** Resolving a conflict
+(confirm which value is canonical → propose aligning edits one page at a time, each reviewed) is a
+separate human-in-the-loop step — see "Report and resolve" in `fact-check.md`. Never auto-edit, and
+remember this checks consistency, not correctness. A clean result only means something on a fresh
 tree, so run against current `origin/main`.
 
 ## Full-corpus — known gaps (TODO for a dedicated engine)

--- a/.claude/workflows/docs-fact-conflicts.agents.md
+++ b/.claude/workflows/docs-fact-conflicts.agents.md
@@ -1,0 +1,138 @@
+# docs-fact-conflicts — agent-orchestrated runbook (no-Workflow fallback)
+
+This is the **fallback** for `docs-fact-conflicts.js` for when the Claude Code **Workflow tool is
+unavailable**. It runs the same pipeline — extract → search → judge → verify → synth — but the
+orchestration is performed by the main Claude session calling the `Agent` tool, instead of a
+headless Workflow script.
+
+The `/fact-check` command auto-detects: it uses the Workflow engine when available and falls back
+to this runbook when not. You can also follow this runbook directly: "run the docs-fact-conflicts
+agent runbook on `content/docs/introduction/plans.md`".
+
+Same findings either way (the prompts below are lifted from `docs-fact-conflicts.js`); the agent
+path just has no schema enforcement or built-in dispatcher, so it adds the **Guardrails** below.
+
+## Scopes
+
+- **Single-page** (default): does one page contradict the rest of `content/docs`? Cheap; good for
+  a page you just edited. `args`: one repo-relative page path.
+- **Full-corpus**: do any pages disagree with each other across the whole set? Heavier. `args`:
+  `--all` (or a directory). Extract runs once per page; the corpus of facts is then clustered by
+  subject and judged across pages.
+
+## Modes (what counts as a conflict)
+
+- **cross-page** (default): a fact on one page vs the same fact on *other* pages.
+- **intra-page**: a page contradicting *itself*. REQUIRED to catch bugs like a page saying
+  "0.5 GB per branch" in one line and "per project" in three others. To enable it, **do not
+  exclude the target file** from the search, and make extract emit *each* conflicting same-page
+  variant as its own fact (do not normalize to the majority value).
+
+## Scratch protocol
+
+All stages hand off via JSON files in a scratch dir (default `/tmp/docs-fact-conflicts/<run>/`).
+Subagents WRITE their structured output to a file and return only a short summary — never paste
+large JSON back into the main thread. Files:
+
+| File | Written by | Shape |
+| --- | --- | --- |
+| `meta.json` | orchestrator | `{ target, mode, scope }` |
+| `facts.json` | extract | `{ facts: [ {id, subject, qualifier, claim, source_file?, source_line} ] }` |
+| `candidates.json` | search | `{ results: [ {fact_id, candidates:[{file,line,snippet}]} ] }` |
+| `judge-<group>.json` | judge | `{ judged: [ {fact_id, subject, qualifier, claim, source_file?, source_line, conflict, conflicting_locations:[{file,line,value}], explanation, confidence} ] }` |
+| `verify-<group>.json` | verify | `{ verdicts: [ {fact_id, still_conflict, reason} ] }` |
+| `report.json` | `synth.mjs` | final result |
+
+## Guardrails
+
+1. **Dispatch judge/verify work BY FACT ID, never by array-index range** (index dispatch can
+   silently drop facts). Give each judge agent an explicit list of fact ids.
+2. **Run the coverage check every time.**
+   - Single-page: `synth.mjs` exits non-zero and lists any fact ids never judged — dispatch a
+     judge for exactly those ids and re-run.
+   - Full-corpus: the per-fact gate does NOT apply (judges emit conflicts, not a verdict per
+     fact); run `synth.mjs` with corpus scope and instead confirm every extracted fact was either
+     routed to a bucket or reviewed as single-source.
+   Never report a run that failed its coverage check.
+3. **Prefix every agent prompt with "This message is your task; do not invoke any skill."** A
+   skill-reminder injection can otherwise hijack an agent into doing nothing.
+4. **Verify must reuse the judge's anchor `fact_id`** (do not invent a new id), so `synth.mjs`
+   links each verdict to its finding.
+
+## Steps
+
+### 1. Setup
+
+Create the scratch dir and write `meta.json` (`{target, mode, scope}`). For full-corpus, list the
+target pages (`content/docs/**/*.md`, minus anything intentionally divergent like `legacy-*`).
+
+### 2. Extract — one agent per page
+
+Prompt (per page):
+
+> This message is your task; do not invoke any skill. Read the docs page at `<PAGE>` (use the Read tool). Extract ONLY facts worth cross-referencing
+> against other documentation pages — facts that, if stated differently elsewhere, would be a
+> contradiction: quantitative limits, prices and included allowances, plan/tier values
+> (Free/Launch/Scale), defaults, version numbers, product-name capitalization / unit terminology
+> (e.g. "CU" vs "CPU"). DO NOT extract prose, marketing, or anything self-scoped to this page.
+> For each fact set `qualifier` to the scope that MUST match for a real conflict (which plan,
+> per-branch vs per-project, legacy vs current, the unit). Give 2-5 ripgrep-friendly
+> `search_terms`. **For intra-page mode: if the page states the same subject two different ways,
+> emit BOTH as separate facts — do not normalize to the majority value.** Write strict JSON
+> `{ facts: [...] }` to `<scratch>/facts.json` (full-corpus: append with a `source_file` on each
+> fact). Return only the count + a 5-subject sample.
+
+### 3. Search — one batched agent
+
+> For EVERY fact in `<scratch>/facts.json`, find other places in `content/docs` that state the
+> same thing (ripgrep, case-insensitive, on `search_terms` and numeric variants of the claim).
+> cross-page mode: EXCLUDE the source file. intra-page mode: INCLUDE it. Cap ~15 candidates per
+> fact. Write strict JSON `{ results: [...] }` to `<scratch>/candidates.json` (repo-relative file
+> paths). Return total candidates + the 5 highest-candidate fact ids.
+> _(Optional higher recall: refresh and query the local semantic index in `lib/` — see
+> `docs-fact-conflicts.js` SEMANTIC SEARCH notes.)_
+
+### 4. Judge — parallel agents, dispatched BY ID
+
+Split the fact ids into N groups (≈12 per group). For each group, in one message, spawn a judge
+agent with its **explicit list of fact ids**:
+
+> This message is your task; do not invoke any skill. Decide whether any candidate CONTRADICTS each assigned fact. A real conflict = the SAME thing
+> under the SAME scope given a DIFFERENT value. NOT a conflict: a different plan/tier or product,
+> an explicitly legacy/deprecated page, a different unit or per-branch-vs-per-project basis, or
+> the same value worded differently. Use the fact's `qualifier`. If unsure, conflict=false. You
+> may Read a candidate's file around its line to confirm scope. Write strict JSON
+> `{ judged: [...] }` to `<scratch>/judge-<group>.json` (one entry per assigned fact id). Return
+> how many you flagged and their subjects.
+
+### 5. Coverage gate + verify
+
+Run `node .claude/workflows/lib/synth.mjs <scratch> --mode <mode>`. If it reports a COVERAGE GAP,
+dispatch a judge for the listed ids (BY ID) into `judge-extra.json` and re-run. Once coverage is
+clean, for each flagged conflict spawn a skeptical verify agent:
+
+> This message is your task; do not invoke any skill. Try to REFUTE this reported conflict. Open
+> the cited files/lines (Read) and check context. Default to still_conflict=FALSE if the scope
+> differs (plan/product/unit/basis), one side is a legacy page, the context reconciles them, or
+> the citation is inaccurate. Write strict JSON `{ verdicts: [{fact_id, still_conflict, reason}] }`
+> to `<scratch>/verify-<group>.json`. Use the SAME `fact_id` the judge anchored the conflict on so
+> the verdict links back.
+
+### 6. Report
+
+Re-run `synth.mjs` to fold in verdicts. It writes `report.json` and prints the summary
+(confirmed / unverified / refuted). **Report only — never edit docs.** Treat findings as leads:
+open each cited `file:line` pair before acting. A clean result only means something on a fresh
+tree, so run against current `origin/main`.
+
+## Full-corpus — known gaps (TODO for a dedicated engine)
+
+Limitations of the full-corpus path to harden in a dedicated engine:
+
+- **Clustering**: the bucket step uses coarse keyword routing, which over-routes (very large
+  buckets strain a single judge) and can miss a fact whose wording matches no bucket. Move to a
+  controlled `subject_key` vocabulary or semantic clustering, and always review the unrouted set.
+- **Page selection**: pick pages by fact *presence* (any page stating ≥1 cross-referenceable
+  fact), not by hit-count density — a page with one critical fact ranks low but still matters.
+- **Disagreement = must-verify**: when overlapping buckets give contradictory verdicts on the same
+  subject, always send it to verify; that is how a borderline scope call gets resolved.

--- a/.claude/workflows/docs-fact-conflicts.js
+++ b/.claude/workflows/docs-fact-conflicts.js
@@ -11,42 +11,60 @@
  *   each flagged conflict before it is reported, which is what keeps false positives near zero.
  *
  * HOW TO RUN
- *   This is a dynamic (scriptPath) workflow, not a registered named one. Run it with:
+ *   This is a dynamic (scriptPath) workflow, not a registered named one.
+ *   Grep-only (default, no deps):
  *     Workflow({ scriptPath: ".claude/workflows/docs-fact-conflicts.js",
  *                args: "content/docs/introduction/plans.md" })
- *   `args` is the target page path, relative to the repo root. Pass exactly one page.
+ *   Grep + local semantic search (higher recall, see SEMANTIC SEARCH below):
+ *     Workflow({ scriptPath: ".claude/workflows/docs-fact-conflicts.js",
+ *                args: { path: "content/docs/introduction/plans.md", semantic: true } })
+ *   `args` is the target page path (string) or { path, semantic }. Pass exactly one page.
  *   Agents inherit the repo working directory, so relative content/docs paths resolve directly.
  *
  * OUTPUT
  *   Returns { target, counts:{facts,searched,flagged,confirmed,refuted}, confirmed:[...], refuted:[...] }.
  *   Each confirmed item has the source file:line, the claim, and the conflicting file:line(s).
- *   Treat `confidence: "medium"` findings as leads, not verdicts — always open the cited
- *   file:line pairs and confirm by hand before editing docs (a real bug was found this way:
- *   plans.md said 5,000 branches/project max while ai-agent-integration.md said 1,000).
+ *   Treat findings as LEADS, not verdicts — always open the cited file:line pairs and confirm by
+ *   hand before editing docs. Real bugs found this way: plans.md "5,000 branches/project max" vs
+ *   ai-agent-integration.md "1,000"; plans.md HIPAA "additional charge" vs hipaa.md "no additional
+ *   cost". NOTE: the Extract stage is non-deterministic — different runs surface different facts,
+ *   so re-running can find new conflicts. Run a few times for fuller coverage.
  *
- * COST / SCALE (measured on plans.md, ~550 lines)
- *   ~52 facts extracted -> ~107 subagents, ~3.4M subagent tokens, ~5 min wall-clock.
- *   Cost scales with the NUMBER OF FACTS on the target page, not corpus size — the per-fact
- *   Search agents (one ripgrep+read pass each) dominate. To cut cost 3-5x on a big page:
- *     - run the Extract and Search stages on a cheaper model (e.g. {model:'haiku'} on those agents);
- *     - or batch ~5 facts per Search agent instead of one-each.
- *   The Search stage is the only exhaustive part and it is bounded per-fact (~40 candidates).
+ * COST / SCALE (measured on plans.md, ~550 lines, grep-only)
+ *   ~52 facts extracted. The Search stage is now ONE batched agent (was ~52 per-fact agents),
+ *   so total agents ≈ 1 extract + 1 search + ~52 judge + a few verify ≈ ~55 (down from ~107).
+ *   Cost still scales with NUMBER OF FACTS, dominated by the per-fact Judge agents. To cut further:
+ *     - run Extract/Search/Judge on a cheaper model (e.g. {model:'haiku'} on those agent calls);
+ *     - batch the Judge stage too (groups of facts per agent) — trades some reasoning quality.
+ *   Semantic mode adds one incremental index refresh (seconds if docs unchanged) + per-fact vector
+ *   queries inside the single search agent; negligible token cost, small wall-clock add.
  *
- * KNOWN LIMITATIONS (both inherent to single-page mode — verified, not bugs)
- *   1. Intra-page contradictions are invisible: the candidate search EXCLUDES the target file,
- *      so a page that contradicts itself (e.g. "per branch" on one line, "per project" on
- *      another) is not caught. To catch these, stop excluding the target file in the Search
- *      stage and let the judge compare same-page lines.
+ * SEMANTIC SEARCH (opt-in, args.semantic = true)
+ *   Grep is lexical: it misses conflicting facts phrased with no shared keywords. The semantic
+ *   path adds a local vector search to raise recall. It is fully LOCAL — no API keys:
+ *     - lib/build-index.mjs embeds every content/docs chunk with Xenova/all-MiniLM-L6-v2
+ *       (384-d, runs offline in Node) into a SQLite + sqlite-vec database at lib/.cache/.
+ *     - lib/query-index.mjs embeds a query and runs a KNN lookup, returning file:line hits.
+ *   The build is INCREMENTAL (sha1 per file), so refreshing before a run is cheap and also picks
+ *   up edits to the page you are checking (fixes the staleness trap). Deps live in lib/package.json,
+ *   isolated from the website build; lib/node_modules and lib/.cache are gitignored. First build
+ *   downloads the ~90MB model once. Semantic is best as a COMPLEMENT to grep: grep nails exact
+ *   numbers/units, vectors find paraphrases; the search agent merges both, deduped by file:line.
+ *
+ * KNOWN LIMITATIONS (inherent to single-page mode — verified, not bugs)
+ *   1. Intra-page contradictions are invisible: the search EXCLUDES the target file, so a page
+ *      that contradicts itself (e.g. "per branch" vs "per project") is not caught. To catch these,
+ *      stop excluding the target file in the Search stage and let the judge compare same-page lines.
  *   2. It only finds conflicts that INVOLVE the target page. A mismatch between two OTHER pages
  *      (e.g. "2 CPUs" vs "2 CUs" in two get-started pages) is unreachable from a single target.
- *      Catching those requires the full-corpus sweep (extract all -> fact index -> all-pairs),
- *      which is a separate, much pricier mode not implemented here.
+ *      Catching those requires a full-corpus sweep (extract all -> fact index -> all-pairs), a
+ *      separate, pricier mode not implemented here.
  *
  * ARCHITECTURE NOTE
- *   Workflow scripts have NO filesystem/shell access, so the "deterministic ripgrep" step runs
- *   inside a lightweight Search agent (which has Grep/Bash) rather than in the script body.
- *   Stages 2-4 are pipelined per fact (no barriers): a fact's judge+verify runs as soon as its
- *   own search completes, so wall-clock is the slowest single fact's chain, not the sum.
+ *   Workflow scripts have NO filesystem/shell access, so all file I/O (grep AND the node-based
+ *   index build/query) runs inside agents (which have Grep/Bash), not the script body. The script
+ *   only orchestrates. Stage 2 is a single batched search agent; stages 3-4 (judge -> verify) are
+ *   pipelined per fact (no barriers), so a fact's judge+verify runs as soon as it is ready.
  */
 export const meta = {
   name: 'docs-fact-conflicts',
@@ -55,16 +73,37 @@ export const meta = {
     'Verify a docs page you just edited does not contradict facts (plan limits, prices, defaults, units, product-name casing) stated elsewhere in content/docs. Pass the target page path as args.',
   phases: [
     { title: 'Extract', detail: 'pull cross-referenceable facts from the target page' },
-    { title: 'Search', detail: 'ripgrep the corpus for each fact (one retriever per fact)' },
+    { title: 'Search', detail: 'one batched agent greps (and optionally vector-searches) the corpus for every fact' },
     { title: 'Judge', detail: 'scope-aware conflict decision per fact' },
     { title: 'Verify', detail: 'adversarially refute each flagged conflict' },
   ],
 }
 
-// ---- target page -----------------------------------------------------------
-const TARGET = typeof args === 'string' ? args.trim() : (args && args.path)
+// ---- args ------------------------------------------------------------------
+// args may be:
+//   - a plain page path string: "content/docs/..."
+//   - an object: { path: "content/docs/...", semantic: true }
+//   - a JSON STRING of that object (some callers stringify args), which we parse here.
+// semantic=true adds a local sqlite-vec vector search alongside grep (see lib/).
+let parsedArgs = args
+if (typeof args === 'string') {
+  const s = args.trim()
+  if (s.startsWith('{')) {
+    try {
+      parsedArgs = JSON.parse(s)
+    } catch {
+      parsedArgs = { path: s }
+    }
+  } else {
+    parsedArgs = { path: s }
+  }
+}
+const TARGET = parsedArgs && typeof parsedArgs === 'object' ? parsedArgs.path : undefined
+const SEMANTIC = !!(parsedArgs && parsedArgs.semantic)
 if (!TARGET) {
-  throw new Error('Pass the target page path as args, e.g. "content/docs/introduction/plans.md"')
+  throw new Error(
+    'Pass the target page path as args, e.g. "content/docs/introduction/plans.md" or { path, semantic: true }'
+  )
 }
 
 // ---- schemas ---------------------------------------------------------------
@@ -98,19 +137,30 @@ const FACTS_SCHEMA = {
   },
 }
 
-const CANDIDATES_SCHEMA = {
+// One batched search agent returns candidates for every fact at once.
+const BATCH_SEARCH_SCHEMA = {
   type: 'object',
-  required: ['candidates'],
+  required: ['results'],
   properties: {
-    candidates: {
+    results: {
       type: 'array',
       items: {
         type: 'object',
-        required: ['file', 'line', 'snippet'],
+        required: ['fact_id', 'candidates'],
         properties: {
-          file: { type: 'string' },
-          line: { type: 'integer' },
-          snippet: { type: 'string', description: 'the matching line plus a little context' },
+          fact_id: { type: 'string' },
+          candidates: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['file', 'line', 'snippet'],
+              properties: {
+                file: { type: 'string' },
+                line: { type: 'integer' },
+                snippet: { type: 'string' },
+              },
+            },
+          },
         },
       },
     },
@@ -176,24 +226,54 @@ const facts = (extracted && extracted.facts) || []
 log(`Extracted ${facts.length} cross-referenceable facts from ${TARGET}`)
 if (!facts.length) return { target: TARGET, counts: { facts: 0 }, confirmed: [] }
 
-// ---- stages 2-4: pipeline per fact ----------------------------------------
+// ---- stage 2: ONE batched search agent ------------------------------------
+// Collapsing the former per-fact search agents into a single agent that loops
+// over all facts is the big cost win: ~N search agents -> 1. The mechanical
+// grep work does not benefit from per-fact LLM parallelism; the reasoning
+// (judge) still runs per fact below.
+phase('Search')
+const semanticInstructions = SEMANTIC
+  ? `
+
+SEMANTIC SEARCH (enabled): the corpus also has a local vector index under
+\`.claude/workflows/lib\`. Use it to catch conflicting facts that share no keywords with grep.
+  1. First refresh the index (incremental — only re-embeds changed files, so it also picks up
+     edits to the target page):
+       node .claude/workflows/lib/build-index.mjs --root "$(pwd)"
+  2. For EACH fact, in addition to grep, run a vector query and merge the hits:
+       node .claude/workflows/lib/query-index.mjs "<subject>. <claim>" --exclude "${TARGET}" --k 8
+     (run it from the repo root; it prints JSON {results:[{file,line,distance,preview}]}).
+  Merge semantic hits with the grep hits, de-duplicating by file:line. Keep a semantic hit only
+  if its preview looks topically related to the fact.`
+  : ''
+
+const batch = await agent(
+  `You are the retrieval step of a docs conflict checker. For EVERY fact below, find other
+places in \`content/docs\` that state the same thing, so a later step can check for conflicts.
+
+Facts (JSON array):
+${JSON.stringify(facts)}
+
+For each fact: run ripgrep over \`content/docs\` (case-insensitive, use Grep/Bash) for its
+search_terms and for numeric variants of its claim. EXCLUDE the source file \`${TARGET}\`.
+Collect plausibly-related lines as candidates (file, 1-based line, the matching line plus a
+little context). Do NOT judge conflicts here — just retrieve. Cap each fact at ~15 of its most
+relevant candidates.${semanticInstructions}
+
+Return one results entry per fact (use the fact's \`id\` as \`fact_id\`), even if its candidates
+array is empty.`,
+  { label: 'search:all-facts', phase: 'Search', schema: BATCH_SEARCH_SCHEMA }
+)
+
+const byId = new Map(((batch && batch.results) || []).map((r) => [r.fact_id, r.candidates || []]))
+const searched = facts.map((fact) => ({ fact, candidates: byId.get(fact.id) || [] }))
+log(
+  `Searched ${searched.length} facts -> ${searched.reduce((n, s) => n + s.candidates.length, 0)} candidate lines${SEMANTIC ? ' (grep + semantic)' : ' (grep)'}`
+)
+
+// ---- stages 3-4: pipeline per fact (judge -> verify) ----------------------
 const results = await pipeline(
-  facts,
-
-  // stage 2: retrieve candidate mentions from OTHER files
-  (fact) =>
-    agent(
-      `Search the Neon docs corpus for other mentions of this fact so we can check for conflicts.
-
-Fact: ${JSON.stringify(fact)}
-
-Run ripgrep over \`content/docs\` (case-insensitive) for each of the search_terms and for
-numeric variants of the claim. Use Grep/Bash. EXCLUDE the source file \`${TARGET}\` itself.
-Return every plausibly-related line as a candidate with its file, 1-based line number, and the
-matching line plus one line of surrounding context. Cast a wide net — do NOT judge conflicts
-here, just retrieve. Cap at ~40 candidates; if more, keep the most relevant.`,
-      { label: `search:${fact.id}`, phase: 'Search', schema: CANDIDATES_SCHEMA },
-    ).then((r) => ({ fact, candidates: (r && r.candidates) || [] })),
+  searched,
 
   // stage 3: scope-aware judge (skip if nothing to compare)
   (sc) => {

--- a/.claude/workflows/docs-fact-conflicts.js
+++ b/.claude/workflows/docs-fact-conflicts.js
@@ -105,6 +105,14 @@ if (!TARGET) {
     'Pass the target page path as args, e.g. "content/docs/introduction/plans.md" or { path, semantic: true }'
   )
 }
+// Corpus root the search/index step works against. Without this, agents grep a cwd-relative
+// "content/docs", which silently checks whatever checkout the session happens to sit in — the
+// wrong tree when the target lives in another worktree, and it fails without any error. Resolve it
+// explicitly: an ABSOLUTE target derives its own root, or pass { path, docsRoot } to override.
+// To check a specific branch/worktree, pass an absolute target path.
+const rootMatch = typeof TARGET === 'string' ? TARGET.match(/^(.*\/content\/docs)(?:\/|$)/) : null
+const DOCS_ROOT = (parsedArgs && parsedArgs.docsRoot) || (rootMatch ? rootMatch[1] : 'content/docs')
+const REPO_ROOT = DOCS_ROOT === 'content/docs' ? '.' : DOCS_ROOT.replace(/\/content\/docs$/, '')
 
 // ---- schemas ---------------------------------------------------------------
 const FACTS_SCHEMA = {
@@ -239,7 +247,7 @@ SEMANTIC SEARCH (enabled): the corpus also has a local vector index under
 \`.claude/workflows/lib\`. Use it to catch conflicting facts that share no keywords with grep.
   1. First refresh the index (incremental — only re-embeds changed files, so it also picks up
      edits to the target page):
-       node .claude/workflows/lib/build-index.mjs --root "$(pwd)"
+       node .claude/workflows/lib/build-index.mjs --root "${REPO_ROOT}"
   2. For EACH fact, in addition to grep, run a vector query and merge the hits:
        node .claude/workflows/lib/query-index.mjs "<subject>. <claim>" --exclude "${TARGET}" --k 8
      (run it from the repo root; it prints JSON {results:[{file,line,distance,preview}]}).
@@ -249,12 +257,12 @@ SEMANTIC SEARCH (enabled): the corpus also has a local vector index under
 
 const batch = await agent(
   `You are the retrieval step of a docs conflict checker. For EVERY fact below, find other
-places in \`content/docs\` that state the same thing, so a later step can check for conflicts.
+places in \`${DOCS_ROOT}\` that state the same thing, so a later step can check for conflicts.
 
 Facts (JSON array):
 ${JSON.stringify(facts)}
 
-For each fact: run ripgrep over \`content/docs\` (case-insensitive, use Grep/Bash) for its
+For each fact: run ripgrep over \`${DOCS_ROOT}\` (case-insensitive, use Grep/Bash) for its
 search_terms and for numeric variants of its claim. EXCLUDE the source file \`${TARGET}\`.
 Collect plausibly-related lines as candidates (file, 1-based line, the matching line plus a
 little context). Do NOT judge conflicts here — just retrieve. Cap each fact at ~15 of its most

--- a/.claude/workflows/docs-fact-conflicts.js
+++ b/.claude/workflows/docs-fact-conflicts.js
@@ -1,0 +1,274 @@
+/**
+ * docs-fact-conflicts — find facts on ONE docs page that contradict the rest of content/docs.
+ *
+ * WHAT IT DOES
+ *   Given a target page, it extracts the cross-referenceable facts on that page (plan limits,
+ *   prices, defaults, units, version numbers, product-name casing), searches the rest of
+ *   content/docs for other statements of the same fact, and reports only the ones that
+ *   genuinely conflict. The judge is SCOPE-AWARE: a different plan/tier, a different product
+ *   (e.g. agent plan), an explicitly legacy page, a different unit, or an included-allowance
+ *   vs hard-maximum distinction is NOT a conflict. A final adversarial pass tries to refute
+ *   each flagged conflict before it is reported, which is what keeps false positives near zero.
+ *
+ * HOW TO RUN
+ *   This is a dynamic (scriptPath) workflow, not a registered named one. Run it with:
+ *     Workflow({ scriptPath: ".claude/workflows/docs-fact-conflicts.js",
+ *                args: "content/docs/introduction/plans.md" })
+ *   `args` is the target page path, relative to the repo root. Pass exactly one page.
+ *   Agents inherit the repo working directory, so relative content/docs paths resolve directly.
+ *
+ * OUTPUT
+ *   Returns { target, counts:{facts,searched,flagged,confirmed,refuted}, confirmed:[...], refuted:[...] }.
+ *   Each confirmed item has the source file:line, the claim, and the conflicting file:line(s).
+ *   Treat `confidence: "medium"` findings as leads, not verdicts — always open the cited
+ *   file:line pairs and confirm by hand before editing docs (a real bug was found this way:
+ *   plans.md said 5,000 branches/project max while ai-agent-integration.md said 1,000).
+ *
+ * COST / SCALE (measured on plans.md, ~550 lines)
+ *   ~52 facts extracted -> ~107 subagents, ~3.4M subagent tokens, ~5 min wall-clock.
+ *   Cost scales with the NUMBER OF FACTS on the target page, not corpus size — the per-fact
+ *   Search agents (one ripgrep+read pass each) dominate. To cut cost 3-5x on a big page:
+ *     - run the Extract and Search stages on a cheaper model (e.g. {model:'haiku'} on those agents);
+ *     - or batch ~5 facts per Search agent instead of one-each.
+ *   The Search stage is the only exhaustive part and it is bounded per-fact (~40 candidates).
+ *
+ * KNOWN LIMITATIONS (both inherent to single-page mode — verified, not bugs)
+ *   1. Intra-page contradictions are invisible: the candidate search EXCLUDES the target file,
+ *      so a page that contradicts itself (e.g. "per branch" on one line, "per project" on
+ *      another) is not caught. To catch these, stop excluding the target file in the Search
+ *      stage and let the judge compare same-page lines.
+ *   2. It only finds conflicts that INVOLVE the target page. A mismatch between two OTHER pages
+ *      (e.g. "2 CPUs" vs "2 CUs" in two get-started pages) is unreachable from a single target.
+ *      Catching those requires the full-corpus sweep (extract all -> fact index -> all-pairs),
+ *      which is a separate, much pricier mode not implemented here.
+ *
+ * ARCHITECTURE NOTE
+ *   Workflow scripts have NO filesystem/shell access, so the "deterministic ripgrep" step runs
+ *   inside a lightweight Search agent (which has Grep/Bash) rather than in the script body.
+ *   Stages 2-4 are pipelined per fact (no barriers): a fact's judge+verify runs as soon as its
+ *   own search completes, so wall-clock is the slowest single fact's chain, not the sum.
+ */
+export const meta = {
+  name: 'docs-fact-conflicts',
+  description: 'Check one docs page for facts that conflict with the rest of content/docs',
+  whenToUse:
+    'Verify a docs page you just edited does not contradict facts (plan limits, prices, defaults, units, product-name casing) stated elsewhere in content/docs. Pass the target page path as args.',
+  phases: [
+    { title: 'Extract', detail: 'pull cross-referenceable facts from the target page' },
+    { title: 'Search', detail: 'ripgrep the corpus for each fact (one retriever per fact)' },
+    { title: 'Judge', detail: 'scope-aware conflict decision per fact' },
+    { title: 'Verify', detail: 'adversarially refute each flagged conflict' },
+  ],
+}
+
+// ---- target page -----------------------------------------------------------
+const TARGET = typeof args === 'string' ? args.trim() : (args && args.path)
+if (!TARGET) {
+  throw new Error('Pass the target page path as args, e.g. "content/docs/introduction/plans.md"')
+}
+
+// ---- schemas ---------------------------------------------------------------
+const FACTS_SCHEMA = {
+  type: 'object',
+  required: ['facts'],
+  properties: {
+    facts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'subject', 'qualifier', 'claim', 'search_terms', 'source_line'],
+        properties: {
+          id: { type: 'string', description: 'short kebab id, unique within this page' },
+          subject: { type: 'string', description: 'what the fact is about, e.g. "Free plan project limit"' },
+          qualifier: {
+            type: 'string',
+            description:
+              'scope that must match for a real conflict: plan name (Free/Launch/Scale), per-branch vs per-project, legacy?, unit, etc. Empty string if globally true.',
+          },
+          claim: { type: 'string', description: 'the asserted value, e.g. "100 projects"' },
+          search_terms: {
+            type: 'array',
+            items: { type: 'string' },
+            description: '2-5 ripgrep-friendly terms/regexes to find OTHER mentions of this subject',
+          },
+          source_line: { type: 'integer', description: 'line number in the target page' },
+        },
+      },
+    },
+  },
+}
+
+const CANDIDATES_SCHEMA = {
+  type: 'object',
+  required: ['candidates'],
+  properties: {
+    candidates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['file', 'line', 'snippet'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          snippet: { type: 'string', description: 'the matching line plus a little context' },
+        },
+      },
+    },
+  },
+}
+
+const JUDGE_SCHEMA = {
+  type: 'object',
+  required: ['conflict', 'conflicting_locations', 'explanation', 'confidence'],
+  properties: {
+    conflict: { type: 'boolean' },
+    conflicting_locations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['file', 'line', 'value'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          value: { type: 'string', description: 'the conflicting value found there' },
+        },
+      },
+    },
+    explanation: { type: 'string' },
+    confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['still_conflict', 'reason'],
+  properties: {
+    still_conflict: { type: 'boolean' },
+    reason: { type: 'string' },
+  },
+}
+
+// ---- stage 1: extract ------------------------------------------------------
+phase('Extract')
+const extracted = await agent(
+  `Read the docs page at \`${TARGET}\` (use the Read tool).
+
+Extract ONLY facts that are worth cross-referencing against other documentation pages —
+facts that, if stated differently elsewhere, would be a contradiction. These are:
+- quantitative limits (project/branch counts, storage, CU-hours, retention windows)
+- prices and included allowances
+- plan features and tier values (Free/Launch/Scale)
+- defaults and configuration values
+- version numbers
+- product-name capitalization / unit terminology (e.g. "CU" vs "CPU", "Postgres" vs "PostgreSQL")
+
+DO NOT extract: prose, marketing language, worked examples, or anything self-scoped to this
+page (e.g. "in this guide we use X").
+
+For each fact set \`qualifier\` to the scope that MUST match for a real conflict to exist
+(which plan, per-branch vs per-project, legacy vs current, the unit). This is critical — it
+lets a later step avoid false positives. Give 2-5 \`search_terms\` that would find OTHER
+mentions of the same subject via ripgrep.`,
+  { label: `extract:${TARGET.split('/').pop()}`, phase: 'Extract', schema: FACTS_SCHEMA },
+)
+
+const facts = (extracted && extracted.facts) || []
+log(`Extracted ${facts.length} cross-referenceable facts from ${TARGET}`)
+if (!facts.length) return { target: TARGET, counts: { facts: 0 }, confirmed: [] }
+
+// ---- stages 2-4: pipeline per fact ----------------------------------------
+const results = await pipeline(
+  facts,
+
+  // stage 2: retrieve candidate mentions from OTHER files
+  (fact) =>
+    agent(
+      `Search the Neon docs corpus for other mentions of this fact so we can check for conflicts.
+
+Fact: ${JSON.stringify(fact)}
+
+Run ripgrep over \`content/docs\` (case-insensitive) for each of the search_terms and for
+numeric variants of the claim. Use Grep/Bash. EXCLUDE the source file \`${TARGET}\` itself.
+Return every plausibly-related line as a candidate with its file, 1-based line number, and the
+matching line plus one line of surrounding context. Cast a wide net — do NOT judge conflicts
+here, just retrieve. Cap at ~40 candidates; if more, keep the most relevant.`,
+      { label: `search:${fact.id}`, phase: 'Search', schema: CANDIDATES_SCHEMA },
+    ).then((r) => ({ fact, candidates: (r && r.candidates) || [] })),
+
+  // stage 3: scope-aware judge (skip if nothing to compare)
+  (sc) => {
+    if (!sc.candidates.length) return { ...sc, judged: { conflict: false, conflicting_locations: [], explanation: 'no candidates', confidence: 'high' } }
+    return agent(
+      `Decide whether any candidate CONTRADICTS this fact.
+
+Fact (from ${TARGET}, line ${sc.fact.source_line}): ${JSON.stringify(sc.fact)}
+
+Candidates from other pages:
+${sc.candidates.map((c) => `- ${c.file}:${c.line}  ${c.snippet}`).join('\n')}
+
+A real conflict means the SAME thing under the SAME scope is given a DIFFERENT value.
+NOT a conflict (be strict about this):
+- a different plan/tier (Free vs Launch vs Scale), or a different product (e.g. agent plan)
+- a page that is explicitly LEGACY/deprecated (e.g. legacy-plans.md) stating old values
+- a different unit or a different per-branch vs per-project basis than the fact's qualifier
+- the same value worded differently
+Use the fact's \`qualifier\` to decide whether scope matches. Only report conflicting_locations
+that genuinely clash. If unsure, set conflict=false.`,
+      { label: `judge:${sc.fact.id}`, phase: 'Judge', schema: JUDGE_SCHEMA },
+    ).then((judged) => ({ ...sc, judged }))
+  },
+
+  // stage 4: adversarial verify (only for flagged conflicts)
+  (jr) => {
+    if (!jr.judged || !jr.judged.conflict || !jr.judged.conflicting_locations.length) return jr
+    return agent(
+      `You are a skeptical reviewer. Try to REFUTE this reported documentation conflict.
+
+Reported fact (${TARGET}:${jr.fact.source_line}): ${JSON.stringify(jr.fact)}
+Reported conflicting locations: ${JSON.stringify(jr.judged.conflicting_locations)}
+Judge's explanation: ${jr.judged.explanation}
+
+Open the cited files/lines (Read tool) and check the surrounding context. Default to
+still_conflict=FALSE if: the scope differs (different plan/product/unit/basis), one side is a
+legacy/deprecated page, the context makes the two statements compatible, or the citation is
+inaccurate. Only return still_conflict=TRUE if the same fact under the same scope truly has two
+different values in current docs.`,
+      { label: `verify:${jr.fact.id}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+    ).then((v) => ({ ...jr, verdict: v }))
+  },
+)
+
+// ---- stage 5: synthesize ---------------------------------------------------
+const clean = results.filter(Boolean)
+const flagged = clean.filter((r) => r.judged && r.judged.conflict && r.judged.conflicting_locations.length)
+const confirmed = flagged
+  .filter((r) => r.verdict && r.verdict.still_conflict)
+  .map((r) => ({
+    fact_id: r.fact.id,
+    subject: r.fact.subject,
+    qualifier: r.fact.qualifier,
+    source: `${TARGET}:${r.fact.source_line}`,
+    claim: r.fact.claim,
+    conflicts_with: r.judged.conflicting_locations,
+    explanation: r.judged.explanation,
+    confidence: r.judged.confidence,
+  }))
+
+const refuted = flagged
+  .filter((r) => r.verdict && !r.verdict.still_conflict)
+  .map((r) => ({ fact_id: r.fact.id, subject: r.fact.subject, reason: r.verdict.reason }))
+
+log(`Confirmed ${confirmed.length} conflict(s); ${refuted.length} flagged-then-refuted`)
+
+return {
+  target: TARGET,
+  counts: {
+    facts: facts.length,
+    searched: clean.length,
+    flagged: flagged.length,
+    confirmed: confirmed.length,
+    refuted: refuted.length,
+  },
+  confirmed,
+  refuted,
+}

--- a/.claude/workflows/lib/.gitignore
+++ b/.claude/workflows/lib/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.cache/

--- a/.claude/workflows/lib/build-index.mjs
+++ b/.claude/workflows/lib/build-index.mjs
@@ -1,0 +1,131 @@
+// Build a local-only semantic index of content/docs into a SQLite + sqlite-vec database.
+//
+// Usage:
+//   node build-index.mjs [--rebuild] [--root <repoRoot>] [--db <path>]
+//
+// - Embeddings: Xenova/all-MiniLM-L6-v2 (384-d), runs fully offline in Node (no API key).
+//   The model (~90MB) downloads once to the transformers.js cache, then is reused.
+// - Storage: node:sqlite + sqlite-vec extension. One row per heading-delimited chunk.
+// - Incremental: skips files whose sha1 is unchanged since the last build (unless --rebuild).
+//
+// This file lives under .claude/workflows/ and is intentionally NOT wired into the website
+// build. Its deps live in ./package.json here, isolated from the repo root.
+
+import { createHash } from 'node:crypto'
+import { readdirSync, readFileSync, statSync, mkdirSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DatabaseSync } from 'node:sqlite'
+import * as sqliteVec from 'sqlite-vec'
+import { pipeline } from '@xenova/transformers'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const argv = process.argv.slice(2)
+const flag = (name) => argv.includes(`--${name}`)
+const opt = (name, def) => {
+  const i = argv.indexOf(`--${name}`)
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def
+}
+
+const REPO_ROOT = resolve(opt('root', resolve(HERE, '../../..')))
+const DOCS_DIR = join(REPO_ROOT, 'content', 'docs')
+const DB_PATH = resolve(opt('db', join(HERE, '.cache', 'docs-index.db')))
+const REBUILD = flag('rebuild')
+const DIM = 384
+
+mkdirSync(dirname(DB_PATH), { recursive: true })
+
+// ---- collect markdown files ------------------------------------------------
+function walk(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name)
+    if (entry.isDirectory()) walk(p, acc)
+    else if (entry.isFile() && entry.name.endsWith('.md')) acc.push(p)
+  }
+  return acc
+}
+
+// ---- chunk a file by heading ----------------------------------------------
+// Each ## / ### (and the leading preamble) becomes one chunk, tagged with its
+// 1-based start line. Long sections are truncated for embedding only (the line
+// pointer still lands the reader at the section start).
+function chunkFile(absPath) {
+  const text = readFileSync(absPath, 'utf8')
+  const lines = text.split('\n')
+  const chunks = []
+  let buf = []
+  let startLine = 1
+  const flush = (endIdx) => {
+    const body = buf.join('\n').trim()
+    if (body) chunks.push({ line: startLine, text: body.slice(0, 2000) })
+    buf = []
+    startLine = endIdx + 2 // next line, 1-based
+  }
+  lines.forEach((ln, idx) => {
+    if (/^#{1,4}\s/.test(ln) && buf.length) flush(idx - 1)
+    if (/^#{1,4}\s/.test(ln) && !buf.length) startLine = idx + 1
+    buf.push(ln)
+  })
+  flush(lines.length - 1)
+  return chunks
+}
+
+// ---- db setup --------------------------------------------------------------
+const db = new DatabaseSync(DB_PATH, { allowExtension: true })
+db.loadExtension(sqliteVec.getLoadablePath())
+db.exec(`
+  CREATE TABLE IF NOT EXISTS files (file TEXT PRIMARY KEY, hash TEXT);
+  CREATE TABLE IF NOT EXISTS chunks (id INTEGER PRIMARY KEY, file TEXT, line INTEGER, text TEXT);
+  CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(embedding float[${DIM}]);
+`)
+if (REBUILD) {
+  db.exec('DELETE FROM files; DELETE FROM chunks; DELETE FROM vec_chunks;')
+}
+
+// ---- embedder --------------------------------------------------------------
+process.stderr.write('loading embedding model (first run downloads ~90MB)...\n')
+const extractor = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2')
+const embed = async (s) => {
+  const out = await extractor(s, { pooling: 'mean', normalize: true })
+  return Float32Array.from(out.data)
+}
+const toBlob = (f32) => new Uint8Array(f32.buffer, f32.byteOffset, f32.byteLength)
+
+// ---- index -----------------------------------------------------------------
+const files = walk(DOCS_DIR)
+const getHash = db.prepare('SELECT hash FROM files WHERE file = ?')
+const delChunks = db.prepare('DELETE FROM chunks WHERE file = ?')
+const delVec = db.prepare(
+  'DELETE FROM vec_chunks WHERE rowid IN (SELECT id FROM chunks WHERE file = ?)'
+)
+const upFile = db.prepare('INSERT INTO files(file, hash) VALUES(?, ?) ON CONFLICT(file) DO UPDATE SET hash=excluded.hash')
+const insChunk = db.prepare('INSERT INTO chunks(file, line, text) VALUES(?, ?, ?)')
+const insVec = db.prepare('INSERT INTO vec_chunks(rowid, embedding) VALUES(?, ?)')
+
+let changed = 0
+let chunkCount = 0
+for (const abs of files) {
+  const rel = relative(REPO_ROOT, abs)
+  const raw = readFileSync(abs)
+  const hash = createHash('sha1').update(raw).digest('hex')
+  const prev = getHash.get(rel)
+  if (prev && prev.hash === hash && !REBUILD) continue
+
+  delVec.run(rel)
+  delChunks.run(rel)
+  for (const c of chunkFile(abs)) {
+    const vec = await embed(c.text)
+    const info = insChunk.run(rel, c.line, c.text)
+    insVec.run(BigInt(info.lastInsertRowid), toBlob(vec)) // vec0 rowid must bind as BigInt
+    chunkCount++
+  }
+  upFile.run(rel, hash)
+  changed++
+  if (changed % 25 === 0) process.stderr.write(`  ${changed} files indexed...\n`)
+}
+
+const total = db.prepare('SELECT COUNT(*) n FROM chunks').get().n
+console.log(
+  JSON.stringify({ db: DB_PATH, filesScanned: files.length, filesChanged: changed, chunksWritten: chunkCount, chunksTotal: total })
+)
+db.close()

--- a/.claude/workflows/lib/package.json
+++ b/.claude/workflows/lib/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "docs-fact-conflicts-lib",
+  "private": true,
+  "type": "module",
+  "description": "Isolated deps for the semantic search index. NOT part of the website build.",
+  "dependencies": {
+    "@xenova/transformers": "^2.17.2",
+    "sqlite-vec": "^0.1.9"
+  }
+}

--- a/.claude/workflows/lib/query-index.mjs
+++ b/.claude/workflows/lib/query-index.mjs
@@ -1,0 +1,58 @@
+// Query the local semantic docs index. Prints JSON results to stdout.
+//
+// Usage:
+//   node query-index.mjs "the query text" [--k 8] [--exclude content/docs/introduction/plans.md] [--db <path>]
+//
+// Emits: { query, results: [{ file, line, distance, preview }] }
+
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DatabaseSync } from 'node:sqlite'
+import * as sqliteVec from 'sqlite-vec'
+import { pipeline } from '@xenova/transformers'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const argv = process.argv.slice(2)
+const opt = (name, def) => {
+  const i = argv.indexOf(`--${name}`)
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def
+}
+const query = argv.find((a) => !a.startsWith('--') && argv[argv.indexOf(a) - 1] !== '--k' && argv[argv.indexOf(a) - 1] !== '--exclude' && argv[argv.indexOf(a) - 1] !== '--db')
+const K = parseInt(opt('k', '8'), 10)
+const EXCLUDE = opt('exclude', '')
+const DB_PATH = resolve(opt('db', join(HERE, '.cache', 'docs-index.db')))
+
+if (!query) {
+  console.error('Provide a query string')
+  process.exit(1)
+}
+
+const db = new DatabaseSync(DB_PATH, { allowExtension: true })
+db.loadExtension(sqliteVec.getLoadablePath())
+
+const extractor = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2')
+const out = await extractor(query, { pooling: 'mean', normalize: true })
+const qvec = Float32Array.from(out.data)
+const blob = new Uint8Array(qvec.buffer, qvec.byteOffset, qvec.byteLength)
+
+// over-fetch so we can drop excluded-file rows and still return K
+const rows = db
+  .prepare(
+    `SELECT c.file AS file, c.line AS line, c.text AS text, v.distance AS distance
+     FROM vec_chunks v JOIN chunks c ON c.id = v.rowid
+     WHERE v.embedding MATCH ? AND k = ? ORDER BY v.distance`
+  )
+  .all(blob, K * 3)
+
+const results = rows
+  .filter((r) => r.file !== EXCLUDE)
+  .slice(0, K)
+  .map((r) => ({
+    file: r.file,
+    line: r.line,
+    distance: Number(r.distance.toFixed(4)),
+    preview: r.text.replace(/\s+/g, ' ').slice(0, 200),
+  }))
+
+console.log(JSON.stringify({ query, results }))
+db.close()

--- a/.claude/workflows/lib/synth.mjs
+++ b/.claude/workflows/lib/synth.mjs
@@ -198,6 +198,8 @@ if (jsonOnly) {
   if (!confirmed.length && !unverified.length && coverageOk) {
     L.push(`No conflicts found. (A clean result only means something on a fresh tree — run against current \`main\`.)`)
   }
+  L.push(``)
+  L.push(`_Consistency check, not correctness: a finding means two pages disagree, not which side is right — a human picks the canonical value._`)
   console.log(L.join('\n'))
 }
 

--- a/.claude/workflows/lib/synth.mjs
+++ b/.claude/workflows/lib/synth.mjs
@@ -1,0 +1,204 @@
+// synth.mjs — deterministic synthesis + coverage gate for docs-fact-conflicts.
+//
+// WHY THIS EXISTS
+//   The check has two front-ends: the Workflow script (docs-fact-conflicts.js) and the
+//   agent-orchestrated runbook (docs-fact-conflicts.agents.md, the fallback when the Workflow
+//   tool is unavailable). Both stages hand their per-fact results off as JSON files;
+//   this script does the final merge for EITHER front-end. Keeping it as one shared, runnable
+//   script means the synthesis is identical whichever engine ran, and — critically — it is
+//   DETERMINISTIC, not eyeballed.
+//
+//   It also enforces the COVERAGE GATE: every extracted fact must have been judged. Dispatch
+//   judge work BY FACT ID (not by array-index range, which can silently drop facts), then run
+//   this script to confirm every fact was covered before trusting the result.
+//
+// SCOPE-AGNOSTIC
+//   Works for single-page (one target) and full-corpus (facts from many pages) runs. Facts and
+//   judgements may carry a per-item `source_file`; if absent, the `target` meta/flag is used.
+//
+// USAGE
+//   node synth.mjs <scratchDir> [--target <repo-relative-path>] [--mode intra|cross] [--json-only]
+//
+// READS (in <scratchDir>)
+//   facts.json     { facts: [ { id, subject, qualifier, claim, source_file?, source_line } ... ] }
+//   judge-*.json   { judged: [ { fact_id, subject, qualifier, claim, source_file?, source_line,
+//                                conflict, conflicting_locations: [ {file,line,value} ],
+//                                explanation, confidence } ... ] }
+//   verify-*.json  (optional) { verdicts: [ { fact_id, still_conflict, reason } ... ] }
+//   meta.json      (optional) { target, mode, scope } — flags override these.
+//
+// WRITES
+//   <scratchDir>/report.json   — structured result.
+//   stdout                     — markdown summary (unless --json-only).
+//
+// EXIT CODES
+//   0  coverage complete, report written.
+//   2  COVERAGE GAP — some facts were never judged (listed). Dispatch a judge for exactly those
+//      ids (BY ID) and re-run. report.json is still written for inspection.
+//   1  usage / IO error.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const argv = process.argv.slice(2)
+const scratchDir = argv.find((a) => !a.startsWith('--'))
+if (!scratchDir) {
+  console.error('usage: node synth.mjs <scratchDir> [--target <path>] [--mode intra|cross] [--json-only]')
+  process.exit(1)
+}
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`)
+  return i >= 0 ? argv[i + 1] : undefined
+}
+const jsonOnly = argv.includes('--json-only')
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'))
+const tryReadJson = (path) => {
+  try {
+    return existsSync(path) ? readJson(path) : null
+  } catch (e) {
+    console.error(`! could not parse ${path}: ${e.message}`)
+    process.exit(1)
+  }
+}
+
+const meta = tryReadJson(join(scratchDir, 'meta.json')) || {}
+const target = flag('target') || meta.target || '(unknown target)'
+const mode = flag('mode') || meta.mode || 'cross'
+const scope = meta.scope || (target.includes(',') ? 'corpus' : 'page')
+
+const factsDoc = tryReadJson(join(scratchDir, 'facts.json'))
+const facts = (factsDoc && factsDoc.facts) || []
+
+let files
+try {
+  files = readdirSync(scratchDir)
+} catch (e) {
+  console.error(`! cannot read scratch dir ${scratchDir}: ${e.message}`)
+  process.exit(1)
+}
+
+const judged = []
+for (const f of files.filter((f) => /^judge-.*\.json$/.test(f)).sort()) {
+  const doc = tryReadJson(join(scratchDir, f))
+  if (doc && Array.isArray(doc.judged)) judged.push(...doc.judged)
+}
+const verdicts = new Map()
+for (const f of files.filter((f) => /^verify-.*\.json$/.test(f)).sort()) {
+  const doc = tryReadJson(join(scratchDir, f))
+  if (doc && Array.isArray(doc.verdicts)) {
+    for (const v of doc.verdicts) verdicts.set(v.fact_id, v)
+  }
+}
+
+// ---- coverage gate: every extracted fact judged exactly once ---------------
+const judgedIds = judged.map((j) => j.fact_id)
+const judgedSet = new Set(judgedIds)
+const factIds = facts.map((f) => f.id)
+const missing = factIds.filter((id) => !judgedSet.has(id))
+const dupes = [...new Set(judgedIds.filter((id, i) => judgedIds.indexOf(id) !== i))]
+// Full-corpus runs cluster-judge (judges emit conflicts, not a verdict per fact), so the per-fact
+// gate does not apply — coverage there is enforced at the clustering step (every fact routed to a
+// bucket or reviewed as single-source). Only gate single-page runs.
+const perFactGate = scope !== 'corpus'
+const coverageOk = !perFactGate || facts.length === 0 || missing.length === 0
+
+// ---- classify --------------------------------------------------------------
+const sourceOf = (j) => `${j.source_file || target}:${j.source_line ?? '?'}`
+const isFlagged = (j) => j.conflict === true && Array.isArray(j.conflicting_locations) && j.conflicting_locations.length > 0
+const flagged = judged.filter(isFlagged)
+
+const confirmed = []
+const refuted = []
+const unverified = []
+for (const j of flagged) {
+  const v = verdicts.get(j.fact_id)
+  const item = {
+    fact_id: j.fact_id,
+    subject: j.subject,
+    qualifier: j.qualifier,
+    source: sourceOf(j),
+    claim: j.claim,
+    conflicts_with: j.conflicting_locations,
+    explanation: j.explanation,
+    confidence: j.confidence,
+  }
+  if (!v) unverified.push(item)
+  else if (v.still_conflict) confirmed.push({ ...item, verify_reason: v.reason })
+  else refuted.push({ fact_id: j.fact_id, subject: j.subject, reason: v.reason })
+}
+
+const report = {
+  target,
+  mode,
+  scope,
+  counts: {
+    facts: facts.length,
+    judged: judgedSet.size,
+    flagged: flagged.length,
+    confirmed: confirmed.length,
+    refuted: refuted.length,
+    unverified: unverified.length,
+  },
+  coverage: { ok: coverageOk, missing, duplicates: dupes },
+  confirmed,
+  unverified,
+  refuted,
+}
+
+writeFileSync(join(scratchDir, 'report.json'), JSON.stringify(report, null, 2))
+
+// ---- output ----------------------------------------------------------------
+if (jsonOnly) {
+  console.log(JSON.stringify(report, null, 2))
+} else {
+  const L = []
+  L.push(`# docs-fact-conflicts — ${scope === 'corpus' ? 'full-corpus' : 'single-page'} run`)
+  L.push(``)
+  L.push(`- target: \`${target}\``)
+  L.push(`- mode: **${mode}**`)
+  L.push(`- facts: ${report.counts.facts}  judged: ${report.counts.judged}  flagged: ${report.counts.flagged}`)
+  L.push(`- confirmed: **${report.counts.confirmed}**  refuted: ${report.counts.refuted}  unverified: ${report.counts.unverified}`)
+  L.push(``)
+  if (scope === 'corpus') {
+    L.push(`_full-corpus run: per-fact coverage gate N/A — confirm at the clustering step that every fact was routed to a bucket or reviewed as single-source._`)
+    L.push(``)
+  }
+  if (!coverageOk) {
+    L.push(`## ⚠ COVERAGE GAP — do not trust this run yet`)
+    L.push(`${missing.length} fact(s) were never judged. Dispatch a judge for these ids (BY ID) and re-run synth:`)
+    L.push('```')
+    L.push(missing.join('\n'))
+    L.push('```')
+    L.push(``)
+  }
+  if (dupes.length) L.push(`_note: ${dupes.length} fact id(s) judged more than once: ${dupes.join(', ')}_\n`)
+  const fmtLocs = (locs) => locs.map((c) => `\`${c.file}:${c.line}\` → ${c.value}`).join('; ')
+  if (confirmed.length) {
+    L.push(`## Confirmed conflicts (${confirmed.length})`)
+    for (const c of confirmed) {
+      L.push(`- **${c.subject}** (${c.qualifier || 'global'}) — \`${c.source}\` says "${c.claim}"`)
+      L.push(`  - conflicts with: ${fmtLocs(c.conflicts_with)}`)
+      L.push(`  - ${c.explanation} _(confidence: ${c.confidence})_`)
+    }
+    L.push(``)
+  }
+  if (unverified.length) {
+    L.push(`## Flagged but NOT yet verified (${unverified.length}) — run the verify stage`)
+    for (const c of unverified) {
+      L.push(`- **${c.subject}** — \`${c.source}\` "${c.claim}" vs ${fmtLocs(c.conflicts_with)}`)
+    }
+    L.push(``)
+  }
+  if (refuted.length) {
+    L.push(`## Flagged then refuted (${refuted.length}) — not bugs`)
+    for (const r of refuted) L.push(`- ${r.subject}: ${r.reason}`)
+    L.push(``)
+  }
+  if (!confirmed.length && !unverified.length && coverageOk) {
+    L.push(`No conflicts found. (A clean result only means something on a fresh tree — run against current \`main\`.)`)
+  }
+  console.log(L.join('\n'))
+}
+
+process.exit(coverageOk ? 0 : 2)


### PR DESCRIPTION
## What

Adds a developer tool (not a site/runtime change) under `.claude/workflows/` that checks a single `content/docs` page for **facts that contradict the rest of the docs** — e.g. one page saying "5,000 branches/project" while another says "1,000".

It is a dynamic Claude Code workflow run via the `Workflow` tool with the target page as `args`. Nothing here is imported by the Next.js build.

## How it works

1. **Extract** — one agent pulls cross-referenceable facts (plan limits, prices, units, defaults, version numbers, product-name casing) from the target page, each tagged with a `qualifier` (which plan, per-branch vs per-project, legacy, unit).
2. **Search** — one batched agent finds other mentions of each fact across `content/docs` (grep, plus optional local semantic search).
3. **Judge** — per fact, a scope-aware agent decides whether a candidate genuinely conflicts (a different plan/tier, a legacy page, or a different unit is **not** a conflict).
4. **Verify** — an adversarial pass tries to refute each flagged conflict before it is reported, keeping false positives near zero.

## Two search modes

- **Default (grep-only, no deps):** `args: "content/docs/introduction/plans.md"`
- **Grep + local semantic search:** `args: { path: "...", semantic: true }` — a SQLite + `sqlite-vec` index of `content/docs`, embedded with `Xenova/all-MiniLM-L6-v2`, running **fully offline (no API key)**. Raises recall on paraphrased facts grep misses. Index build is incremental (sha1 per file), which also refreshes the page being checked.

Semantic deps live in `.claude/workflows/lib/package.json`, isolated from the website build; `lib/node_modules` and `lib/.cache` are gitignored.

## Validation

Run against `content/docs/introduction/plans.md`:

- Batched search cut subagents ~107 → ~50 and tokens ~3.4M → ~1.4M, same wall-clock.
- Semantic index: 577 files / 6,950 chunks; build + query verified running cleanly inside the workflow.
- Surfaced real, hand-confirmed conflicts, including `plans.md` "5,000 branches/project max" vs `ai-agent-integration.md` "1,000", and `plans.md` HIPAA "additional charge" vs `hipaa.md` "no additional cost".

## Notes / limitations (documented in the script header)

- The extract stage is non-deterministic — different runs surface different facts, so re-running improves coverage.
- Single-page mode does not catch intra-page self-contradictions or conflicts between two pages that both exclude the target; a full-corpus sweep would, and is left as a follow-up.
- Findings are leads to confirm by hand, not auto-verdicts.