### PR TITLE
docs: add Lakebase Search access request form

### DIFF
--- a/content/docs/ai/lakebase-search.md
+++ b/content/docs/ai/lakebase-search.md
@@ -9,13 +9,13 @@ summary: >-
   learn what each extension provides, and navigate to the extension reference
   pages.
 enableTableOfContents: true
-updatedOn: '2026-06-09T19:58:30.808Z'
+updatedOn: '2026-06-09T20:13:02.957Z'
 ---
 
 <RequestForm type="lakebase-search" />
 
 <Callout title="About Lakebase">
-Lakebase Search is developed by Databricks. Neon joined Databricks in 2025, and these extensions are part of the shared technology foundation between Neon and the Databricks Lakebase platform.
+Lakebase Search is developed by Databricks. These extensions are part of the shared technology foundation between Neon and the Databricks Lakebase platform.
 </Callout>
 
 Lakebase Search is two Postgres extensions, `lakebase_vector` and `lakebase_text`, that bring scalable vector and BM25 full-text search to Neon, designed for backends that need both semantic and keyword search in a single database.

--- a/content/docs/ai/lakebase-search.md
+++ b/content/docs/ai/lakebase-search.md
@@ -9,10 +9,10 @@ summary: >-
   learn what each extension provides, and navigate to the extension reference
   pages.
 enableTableOfContents: true
-updatedOn: '2026-06-09T18:14:35.596Z'
+updatedOn: '2026-06-09T19:58:30.808Z'
 ---
 
-<EarlyAccessProps feature_name="Lakebase Search" />
+<RequestForm type="lakebase-search" />
 
 <Callout title="About Lakebase">
 Lakebase Search is developed by Databricks. Neon joined Databricks in 2025, and these extensions are part of the shared technology foundation between Neon and the Databricks Lakebase platform.

--- a/content/docs/extensions/lakebase-text.md
+++ b/content/docs/extensions/lakebase-text.md
@@ -10,14 +10,14 @@ summary: >-
   and prefilter GUCs, set fallback parameters at the index level, and reference
   all types, operators, functions, and index parameters.
 enableTableOfContents: true
-updatedOn: '2026-06-09T17:17:42.901Z'
+updatedOn: '2026-06-09T20:13:02.957Z'
 ---
 
 <EarlyAccessProps feature_name="lakebase_text" />
 
 The `lakebase_text` extension adds a `lakebase_bm25` index type to Postgres for [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) full-text search. It is a native upgrade to PostgreSQL's built-in full-text search: standard `tsvector` types and query operators work unchanged; only the index type changes.
 
-For an overview of Lakebase Search and its architecture advantages, see [Lakebase Search](/docs/ai/lakebase-search).
+Lakebase Search is in private preview. To request access or learn about its architecture advantages, see [Lakebase Search](/docs/ai/lakebase-search).
 
 ## Why lakebase_text?
 

--- a/content/docs/extensions/lakebase-vector.md
+++ b/content/docs/extensions/lakebase-vector.md
@@ -10,14 +10,14 @@ summary: >-
   search with the lakebase_ann.probes GUC, and reference all operator classes and
   index options.
 enableTableOfContents: true
-updatedOn: '2026-06-09T17:17:42.901Z'
+updatedOn: '2026-06-09T20:13:02.957Z'
 ---
 
 <EarlyAccessProps feature_name="lakebase_vector" />
 
 The `lakebase_vector` extension adds the `lakebase_ann` index type to Postgres for approximate nearest-neighbor (ANN) vector search. It is a drop-in companion to `pgvector`: the same `vector` types, distance operators, and query syntax work unchanged; only the index type changes.
 
-For an overview of Lakebase Search and its architecture advantages, see [Lakebase Search](/docs/ai/lakebase-search).
+Lakebase Search is in private preview. To request access or learn about its architecture advantages, see [Lakebase Search](/docs/ai/lakebase-search).
 
 ## Why lakebase_vector?
 

--- a/src/components/shared/request-form/data.js
+++ b/src/components/shared/request-form/data.js
@@ -174,10 +174,20 @@ const BACKEND_PLATFORM = {
   eventName: 'Backend Platform Access Requested',
 };
 
+const LAKEBASE_SEARCH = {
+  title: 'Request access to Lakebase Search',
+  description:
+    "Lakebase Search is in private preview. Drop your email and we'll reach out when we can get you access.",
+  buttonText: 'Request access',
+  confirmation: "You're on the list. We'll be in touch soon.",
+  eventName: 'Lakebase Search Access Requested',
+};
+
 const DATA = {
   region: REGIONS,
   extension: EXTENSIONS,
   'backend-platform': BACKEND_PLATFORM,
+  'lakebase-search': LAKEBASE_SEARCH,
 };
 
 export default DATA;

--- a/src/components/shared/request-form/data.js
+++ b/src/components/shared/request-form/data.js
@@ -177,7 +177,7 @@ const BACKEND_PLATFORM = {
 const LAKEBASE_SEARCH = {
   title: 'Request access to Lakebase Search',
   description:
-    "Lakebase Search is in private preview. Drop your email and we'll reach out when we can get you access.",
+    "Lakebase Search is in private preview. Submit your email and we'll enable it for you.",
   buttonText: 'Request access',
   confirmation: "You're on the list. We'll be in touch soon.",
   eventName: 'Lakebase Search Access Requested',


### PR DESCRIPTION
PREVIEW:
https://neon-next-git-lkb-13645-lakebase-search-eap-form-neondatabase.vercel.app/docs/ai/lakebase-search


## Summary

- Adds a new `lakebase-search` type to the `RequestForm` component (`src/components/shared/request-form/data.js`) with title, description, button text, and a distinct Zaraz event name: `Lakebase Search Access Requested`
- Replaces the `<EarlyAccessProps>` banner on the Lakebase Search overview page with `<RequestForm type="lakebase-search" />`, giving users a direct way to request access during private preview
- The `<EarlyAccessProps>` banners on the three sub-pages (get-started, lakebase-vector, lakebase-text) are left as informational notices for users who already have access

## Action needed (outside this PR)

A Zaraz routing rule needs to be added for the `Lakebase Search Access Requested` event so form submissions flow to HubSpot (same destination as other `RequestForm` event types). This is a marketing/ops step.

## Test plan

- [ ] Visit `/docs/ai/lakebase-search` and confirm the request form renders in place of the early access banner
- [ ] Submit the form with a valid email and confirm the success state appears
- [ ] Confirm the `Lakebase Search Access Requested` event fires in Zaraz (check browser devtools or Zaraz dashboard)

This pull request and its description were written by Isaac.