### PR TITLE
docs: add Neon Functions documentation

### DIFF
--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -63,7 +63,7 @@ esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=di
 zip -j function.zip dist/index.mjs
 ```
 
-The archive's entry file must be named `index.mjs`; the runtime imports it by that name.
+The archive's entry file must be named `index.mjs` or `index.js`; the runtime looks for those names.
 
 From Node.js, `buildFunctionBundle` from [`@neondatabase/config-runtime`](https://www.npmjs.com/package/@neondatabase/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -1,0 +1,176 @@
+---
+title: Deploy and manage functions
+subtitle: CLI and API reference for deploying and managing Neon Functions.
+summary: >-
+  Reference for deploying Neon Functions with neonctl functions deploy or the
+  Neon API, including flags, deployment states, and slug rules. Also covers
+  checking status, listing functions, and deleting them.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+## Deploy with the CLI
+
+```bash shouldWrap
+neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
+```
+
+The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags will error.
+
+| Flag              | Default       | Description                                                        |
+| ----------------- | ------------- | ------------------------------------------------------------------ |
+| `--path`          | `.`           | Directory containing the function source                           |
+| `--entry`         | `index.ts`    | Entry file relative to `--path`                                    |
+| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Baked into the deployment |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value               |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                   |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes               |
+
+**Examples:**
+
+```bash
+neonctl functions deploy hello --path . --entry functions/hello.ts
+```
+
+```bash
+neonctl functions deploy hello --path . --env OPENAI_API_KEY=sk-...
+```
+
+```bash
+neonctl functions deploy hello --path . --branch feat/my-feature
+```
+
+<Callout>
+If you use `neon.ts`, `neonctl deploy` applies your entire branch config (functions and all) in one step. See `neonctl deploy --help` for details.
+</Callout>
+
+## Deploy with the API
+
+Bundle with esbuild, zip the output, then POST to the deploy endpoint.
+
+**1. Bundle:**
+
+```bash
+esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=dist/index.js
+```
+
+**2. Zip:**
+
+```bash
+zip -j function.zip dist/index.js
+```
+
+From Node.js, `buildFunctionBundle` from [`@neondatabase/config-runtime`](https://www.npmjs.com/package/@neondatabase/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
+
+```ts
+import { buildFunctionBundle } from "@neondatabase/config-runtime/v1";
+
+const zip = await buildFunctionBundle({
+  slug: "hello",
+  name: "My first function",
+  source: "./functions/hello.ts",
+  env: {},
+  runtime: "nodejs24",
+});
+```
+
+**3. Deploy:**
+
+```bash shouldWrap
+curl -X POST \
+  "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/functions/{slug}/deployments" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -F "zip=@function.zip" \
+  -F 'environment={"MY_SECRET":"value"}'
+```
+
+| Field         | Type   | Required          | Description                                                |
+| ------------- | ------ | ----------------- | ---------------------------------------------------------- |
+| `zip`         | binary | First deploy only | ZIP of the bundled function. Omit to reuse existing bundle |
+| `runtime`     | string | No                | `nodejs24` is the only valid value                         |
+| `environment` | string | No                | JSON-encoded string-to-string map                          |
+
+The API returns immediately. Poll the get endpoint to check status.
+
+## Slugs
+
+The slug is the permanent identifier assigned at first deploy: either the key in `neon.ts` or the positional argument to `neonctl functions deploy`. It becomes part of the invocation URL and can't be changed. Slugs must match `^[a-z0-9]{1,20}$`: lowercase letters and digits only, 1 to 20 characters, no hyphens.
+
+## Deployment states
+
+| State       | Meaning                                 |
+| ----------- | --------------------------------------- |
+| `pending`   | Queued, not yet building                |
+| `building`  | Source is being compiled and bundled    |
+| `completed` | Function is live and accepting requests |
+| `failed`    | Build or deployment error               |
+
+## Manage functions
+
+### Check status
+
+<Tabs labels={["CLI", "API"]}>
+<TabItem>
+
+```bash
+neonctl functions get hello
+```
+
+</TabItem>
+<TabItem>
+
+```bash shouldWrap
+GET /projects/{project_id}/branches/{branch_id}/functions/{slug}
+```
+
+</TabItem>
+</Tabs>
+
+The response includes `invocation_url`, the public URL for your function:
+
+```
+https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech
+```
+
+### List functions
+
+<Tabs labels={["CLI", "API"]}>
+<TabItem>
+
+```bash
+neonctl functions list
+```
+
+</TabItem>
+<TabItem>
+
+```bash shouldWrap
+GET /projects/{project_id}/branches/{branch_id}/functions
+```
+
+</TabItem>
+</Tabs>
+
+### Delete a function
+
+<Tabs labels={["CLI", "API"]}>
+<TabItem>
+
+```bash
+neonctl functions delete hello
+```
+
+</TabItem>
+<TabItem>
+
+```bash shouldWrap
+DELETE /projects/{project_id}/branches/{branch_id}/functions/{slug}
+```
+
+</TabItem>
+</Tabs>
+
+<NeedHelp/>

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -2,9 +2,9 @@
 title: Deploy and manage functions
 subtitle: CLI and API reference for deploying and managing Neon Functions.
 summary: >-
-  Reference for deploying Neon Functions with neonctl functions deploy or the
-  Neon API, including flags, deployment states, and slug rules. Also covers
-  checking status, listing functions, and deleting them.
+  Reference for deploying Neon Functions with neonctl deploy, neonctl functions
+  deploy, or the Neon API, including flags, deployment states, and slug rules.
+  Also covers checking status, listing functions, and deleting them.
 enableTableOfContents: true
 ---
 
@@ -12,7 +12,30 @@ enableTableOfContents: true
 Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
 </Admonition>
 
-## Deploy with the CLI
+## Deploy with `neon.ts`
+
+If your project has a [`neon.ts`](/docs/compute/functions/reference/neon-ts) config, this is the recommended way to deploy. `neonctl deploy` reads the config and applies the entire branch policy in one step: services, per-branch tuning, and every function it declares:
+
+```bash
+neonctl deploy
+```
+
+| Flag                | Default           | Description                                                                                          |
+| ------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `--config`          | walks up from cwd | Path to the `neon.ts` policy                                                                         |
+| `--env`             | (none)            | Path to a `.env` file loaded before `neon.ts` is evaluated, so function `env` values resolve from it |
+| `--branch`          | linked branch     | Target branch ID or name                                                                             |
+| `--project-id`      | linked project    | Project ID                                                                                           |
+| `--update-existing` | `false`           | Auto-confirm overriding existing remote settings on the branch                                       |
+| `--allow-protected` | `false`           | Auto-confirm applying to a branch marked protected on Neon                                           |
+
+`neonctl deploy` is an alias for `neonctl config apply`. To preview what a deploy would change without applying it, run `neonctl config plan`.
+
+Note that `--env` here takes a path to a `.env` file. The `--env` flag on `neonctl functions deploy` below takes `KEY=VALUE` pairs instead.
+
+## Deploy with `neonctl functions deploy`
+
+To deploy one function directly, without a `neon.ts` config:
 
 ```bash shouldWrap
 neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
@@ -42,10 +65,6 @@ neonctl functions deploy hello --path . --env OPENAI_API_KEY=sk-...
 ```bash
 neonctl functions deploy hello --path . --branch feat/my-feature
 ```
-
-<Callout>
-If you use `neon.ts`, `neonctl deploy` applies your entire branch config (functions and all) in one step. See `neonctl deploy --help` for details.
-</Callout>
 
 ## Deploy with the API
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -41,14 +41,14 @@ neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE
 
 The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags errors.
 
-| Flag              | Default       | Description                                                         |
-| ----------------- | ------------- | ------------------------------------------------------------------- |
-| `--path`          | `.`           | Directory containing the function source                            |
-| `--entry`         | `index.ts`    | Entry file relative to `--path`                                     |
-| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment |
-| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                |
-| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                    |
-| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                |
+| Flag              | Default       | Description                                                                                                                                      |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--path`          | `.`           | Directory containing the function source                                                                                                         |
+| `--entry`         | `index.ts`    | Entry file relative to `--path`                                                                                                                  |
+| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neonctl deploy --env` |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                             |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                                 |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                             |
 
 **Examples:**
 
@@ -57,7 +57,7 @@ neonctl functions deploy hello --path . --entry functions/hello.ts
 ```
 
 ```bash
-neonctl functions deploy hello --path . --env OPENAI_API_KEY=sk-...
+neonctl functions deploy hello --path . --env RESEND_API_KEY=re_...
 ```
 
 ```bash

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -8,9 +8,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 ## Deploy with `neon.ts`
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -18,16 +18,16 @@ Neon Functions is currently in Private Preview, available for new projects in th
 neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
 ```
 
-The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags will error.
+The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags errors.
 
-| Flag              | Default       | Description                                                        |
-| ----------------- | ------------- | ------------------------------------------------------------------ |
-| `--path`          | `.`           | Directory containing the function source                           |
-| `--entry`         | `index.ts`    | Entry file relative to `--path`                                    |
-| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Baked into the deployment |
-| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value               |
-| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                   |
-| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes               |
+| Flag              | Default       | Description                                                         |
+| ----------------- | ------------- | ------------------------------------------------------------------- |
+| `--path`          | `.`           | Directory containing the function source                            |
+| `--entry`         | `index.ts`    | Entry file relative to `--path`                                     |
+| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                    |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                |
 
 **Examples:**
 
@@ -54,14 +54,16 @@ Bundle with esbuild, zip the output, then POST to the deploy endpoint.
 **1. Bundle:**
 
 ```bash
-esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=dist/index.js
+esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=dist/index.mjs
 ```
 
 **2. Zip:**
 
 ```bash
-zip -j function.zip dist/index.js
+zip -j function.zip dist/index.mjs
 ```
+
+The archive's entry file must be named `index.mjs`; the runtime imports it by that name.
 
 From Node.js, `buildFunctionBundle` from [`@neondatabase/config-runtime`](https://www.npmjs.com/package/@neondatabase/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
 
@@ -93,7 +95,7 @@ curl -X POST \
 | `runtime`     | string | No                | `nodejs24` is the only valid value                         |
 | `environment` | string | No                | JSON-encoded string-to-string map                          |
 
-The API returns immediately. Poll the get endpoint to check status.
+The API returns immediately. Poll the get endpoint (see [Check status](#check-status)) until the deployment completes.
 
 ## Slugs
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -36,15 +36,14 @@ Note that `--env` here takes a path to a `.env` file. The `--env` flag on `neonc
 To deploy one function directly, without a `neon.ts` config:
 
 ```bash shouldWrap
-neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
+neonctl functions deploy <slug> [--src <dir-or-entry-file>] [--env KEY=VALUE] [--wait]
 ```
 
-The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags errors.
+The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. See the [neonctl functions reference](/docs/cli/functions) for the full command surface.
 
 | Flag              | Default       | Description                                                                                                                                      |
 | ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--path`          | `.`           | Directory containing the function source                                                                                                         |
-| `--entry`         | `index.ts`    | Entry file relative to `--path`                                                                                                                  |
+| `--src`           | (none)        | Function source: a directory containing `index.ts`, `index.mjs`, or `index.js`, or a path to the entry file                                      |
 | `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neonctl deploy --env` |
 | `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                             |
 | `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                                 |
@@ -53,15 +52,15 @@ The CLI bundles with esbuild, zips the output, and uploads it. The first deploy 
 **Examples:**
 
 ```bash
-neonctl functions deploy hello --path . --entry functions/hello.ts
+neonctl functions deploy hello --src functions/hello.ts
 ```
 
 ```bash
-neonctl functions deploy hello --path . --env RESEND_API_KEY=re_...
+neonctl functions deploy hello --src . --env RESEND_API_KEY=re_...
 ```
 
 ```bash
-neonctl functions deploy hello --path . --branch feat/my-feature
+neonctl functions deploy hello --src functions/hello.ts --branch feat/my-feature
 ```
 
 ## Deploy with the API

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -1,0 +1,104 @@
+---
+title: Environment variables
+subtitle: Neon-injected variables and how to set your own secrets.
+summary: >-
+  Neon injects branch-scoped variables like DATABASE_URL into deployed
+  functions automatically. Set your own variables with --env at deploy time or
+  in neon.ts, and pull branch variables locally with neonctl env pull.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+## Neon-injected variables
+
+Neon injects connection strings and service URLs automatically at runtime. You don't declare these in `neon.ts` or pass them at deploy time. They're resolved from the branch the function is deployed to.
+
+`DATABASE_URL` and `DATABASE_URL_UNPOOLED` are only present when the branch has a Postgres database. On a functions-only branch, they're undefined.
+
+| Variable                | Description                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`          | Pooled Postgres connection string. Use this for most queries.                                                                |
+| `DATABASE_URL_UNPOOLED` | Direct (unpooled) connection string. Use for migrations, `LISTEN`/`NOTIFY`, and transactions that span multiple round-trips. |
+| `NEON_AUTH_BASE_URL`    | Base URL for Neon Auth. Present only when Neon Auth is enabled on the branch.                                                |
+| `NEON_DATA_API_URL`     | URL for the Neon Data API. Present only when the Data API is enabled on the branch.                                          |
+
+These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
+
+## User-defined variables
+
+User-defined variables are baked into the deployment at deploy time. Changing a variable requires a new deployment.
+
+### At deploy time
+
+Pass `--env KEY=VALUE` to `neonctl functions deploy`. The flag is repeatable:
+
+```bash shouldWrap
+neonctl functions deploy hello --path . --entry functions/hello.ts --env OPENAI_API_KEY=sk-...
+```
+
+A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
+
+- `--env KEY=value` adds or updates `KEY`
+- `--env KEY=` (empty value) deletes `KEY`
+- Variables you don't mention carry over unchanged
+
+### In neon.ts
+
+Declare variables under the function's `env` field. Values are resolved when `neonctl deploy` runs, so you can read from `process.env` to avoid hardcoding secrets:
+
+```ts filename="neon.ts"
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "My first function",
+        source: "./functions/hello.ts",
+        env: {
+          OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
+        },
+      },
+    },
+  },
+});
+```
+
+Load a `.env` file before running `neonctl deploy` to make secrets available during config evaluation:
+
+```bash
+neonctl deploy --env .env.production
+```
+
+The file isn't forwarded to the function directly. Only variables declared in the `env` field are deployed; `--env` just controls what `process.env` contains when `neon.ts` is evaluated.
+
+## Pull variables locally
+
+`neonctl env pull` writes the linked branch's Neon-injected variables to a local `.env` file:
+
+```bash
+neonctl env pull
+```
+
+By default this writes to `.env` if it exists, otherwise `.env.local`. Use `--file` to write to any file:
+
+```bash
+neonctl env pull --file .env.preview
+```
+
+To pull from a different branch, switch with `neonctl checkout` first.
+
+`env pull` writes only the Neon-managed variables (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and enabled service URLs) and preserves every other line in the file.
+
+## Constraints
+
+| Constraint                   | Value                                                               |
+| ---------------------------- | ------------------------------------------------------------------- |
+| Max variables per deployment | 1,000                                                               |
+| Max total size               | 64 KiB                                                              |
+| Reserved prefix              | `NEON_` (reserved for platform use, can't be set by user functions) |
+
+<NeedHelp/>

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -33,8 +33,13 @@ import { parseEnv } from '@neondatabase/env/v1';
 import config from './neon';
 
 const env = parseEnv(config);
-env.postgres.databaseUrl; // typed, validated
+env.postgres.databaseUrl;          // DATABASE_URL
+env.postgres.databaseUrlUnpooled;  // DATABASE_URL_UNPOOLED
+env.auth.baseUrl;                  // NEON_AUTH_BASE_URL (only when auth: true)
+env.auth.jwksUrl;                  // NEON_AUTH_JWKS_URL (only when auth: true)
 ```
+
+TypeScript narrows the shape based on your config: `env.auth` is only present when `auth: true` is set in `neon.ts`.
 
 ## User-defined variables
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -44,8 +44,10 @@ Each deployment carries its own snapshot of user-defined variables. To change on
 Pass `--env KEY=VALUE` to `neonctl functions deploy`. The flag is repeatable:
 
 ```bash shouldWrap
-neonctl functions deploy hello --path . --entry functions/hello.ts --env OPENAI_API_KEY=sk-...
+neonctl functions deploy hello --path . --entry functions/hello.ts --env RESEND_API_KEY=re_...
 ```
+
+Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
 
 A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
 
@@ -67,7 +69,7 @@ export default defineConfig({
         name: "My first function",
         source: "./functions/hello.ts",
         env: {
-          OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
+          RESEND_API_KEY: process.env.RESEND_API_KEY!,
         },
       },
     },
@@ -99,7 +101,7 @@ neonctl env pull --file .env.preview
 
 To pull from a different branch, switch with `neonctl checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and enabled service URLs) and preserves every other line in the file.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, plus the variables for every service enabled on the branch: the Neon Auth and Data API URLs, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the object storage credentials (`AWS_*`, `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names so the OpenAI SDKs work from the environment without configuration.
 
 ## Constraints
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -44,7 +44,7 @@ Each deployment carries its own snapshot of user-defined variables. To change on
 Pass `--env KEY=VALUE` to `neonctl functions deploy`. The flag is repeatable:
 
 ```bash shouldWrap
-neonctl functions deploy hello --path . --entry functions/hello.ts --env RESEND_API_KEY=re_...
+neonctl functions deploy hello --src functions/hello.ts --env RESEND_API_KEY=re_...
 ```
 
 Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -8,9 +8,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 ## Neon-injected variables
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -27,9 +27,19 @@ Neon injects connection strings and service URLs automatically at runtime. You d
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
+For type-safe access, the [`@neondatabase/env`](https://www.npmjs.com/package/@neondatabase/env) package ships `parseEnv`. It takes your `neon.ts` config and returns a typed env object validated against the services the config declares:
+
+```ts
+import { parseEnv } from '@neondatabase/env/v1';
+import config from './neon';
+
+const env = parseEnv(config);
+env.postgres.databaseUrl; // typed, validated
+```
+
 ## User-defined variables
 
-User-defined variables are baked into the deployment at deploy time. Changing a variable requires a new deployment.
+Each deployment carries its own snapshot of user-defined variables. To change one, deploy again.
 
 ### At deploy time
 
@@ -77,7 +87,7 @@ The file isn't forwarded to the function directly. Only variables declared in th
 
 ## Pull variables locally
 
-`neonctl env pull` writes the linked branch's Neon-injected variables to a local `.env` file:
+`neonctl link` and `neonctl checkout` pull the branch's Neon-injected variables into a local `.env` file automatically (pass `--no-env-pull` to skip). To re-pull at any time:
 
 ```bash
 neonctl env pull
@@ -89,7 +99,7 @@ By default this writes to `.env` if it exists, otherwise `.env.local`. Use `--fi
 neonctl env pull --file .env.preview
 ```
 
-To pull from a different branch, switch with `neonctl checkout` first.
+To pull from a different branch, switch with `neonctl checkout`; it pulls the new branch's variables as part of the switch.
 
 `env pull` writes only the Neon-managed variables (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and enabled service URLs) and preserves every other line in the file.
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -22,6 +22,7 @@ Neon injects connection strings and service URLs automatically at runtime. You d
 | `DATABASE_URL_UNPOOLED` | Direct (unpooled) connection string. Use for migrations, `LISTEN`/`NOTIFY`, and transactions that span multiple round-trips. |
 | `NEON_AUTH_BASE_URL`    | Base URL for Neon Auth. Present only when Neon Auth is enabled on the branch.                                                |
 | `NEON_DATA_API_URL`     | URL for the Neon Data API. Present only when the Data API is enabled on the branch.                                          |
+| `NEON_BRANCH`           | Branch name (e.g. `main`, `preview/foo`). Present on all branches.                                                           |
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
@@ -101,7 +102,7 @@ neonctl env pull --file .env.preview
 
 To pull from a different branch, switch with `neonctl checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, plus the variables for every service enabled on the branch: the Neon Auth and Data API URLs, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the object storage credentials (`AWS_*`, `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names so the OpenAI SDKs work from the environment without configuration.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH` (the branch name), plus the variables for every service enabled on the branch: the Neon Auth and Data API URLs, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the object storage credentials (`AWS_*`, `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names so the OpenAI SDKs work from the environment without configuration.
 
 ## Constraints
 

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -2,8 +2,8 @@
 title: Get started
 subtitle: Deploy your first Neon Function and call it over HTTP.
 summary: >-
-  Deploy your first Neon Function with neonctl: link a project, define the
-  function in neon.ts, develop locally with neonctl dev, and deploy with
+  Deploy your first Neon Function with neonctl: initialize a project, define
+  the function in neon.ts, develop locally with neonctl dev, and deploy with
   neonctl deploy. The function gets a public HTTPS URL with DATABASE_URL
   injected from the branch's Postgres database.
 enableTableOfContents: true
@@ -21,7 +21,7 @@ Neon Functions is currently in Private Preview, available for new projects in th
 - The latest `neonctl`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neonctl@latest`).
 - Node.js 18 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
-Functions are available on new projects in AWS us-east-2 only. You can create the project during `neonctl link` below.
+Functions are available on new projects in AWS us-east-2 only.
 
 ## Set up your project
 
@@ -32,17 +32,7 @@ mkdir my-function && cd my-function
 neonctl init --preview
 ```
 
-`init --preview` sets up the directory and installs the Neon preview packages.
-
-## Link your project
-
-Connect the directory to a Neon project (pick one or create it):
-
-```bash
-neonctl link
-```
-
-`link` also pulls the branch's Neon env vars into a local env file (`.env` if one exists, otherwise `.env.local`), so other tools can use them. You don't need the file for this guide; `neonctl dev` injects the vars itself. See [Environment variables](/docs/compute/functions/environment-variables#pull-variables-locally) for details.
+`init --preview` sets up the directory, installs the Neon preview packages, and connects the directory to a Neon project. There's no separate link step.
 
 To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
 
@@ -77,7 +67,19 @@ Install dependencies:
 npm install hono @neondatabase/serverless
 ```
 
-Write the handler. `DATABASE_URL` is injected automatically from the linked branch's Postgres database:
+A function is any module whose default export has a `fetch(request)` method that returns a `Response`. A Hono app exports exactly that shape, so a minimal function looks like this:
+
+```ts
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.get('/', (c) => c.text('Hello World!'));
+
+export default app;
+```
+
+For this guide, write a handler that queries Postgres instead. `DATABASE_URL` is injected automatically from the linked branch's Postgres database:
 
 ```ts filename="functions/hello.ts"
 import { Hono } from 'hono';
@@ -96,7 +98,7 @@ export default app;
 
 ## Develop locally
 
-`neonctl dev` serves all functions declared in `neon.ts` with hot reload. It injects `DATABASE_URL` and other Neon env vars from the linked branch.
+`neonctl dev` serves all functions declared in `neon.ts` with hot reload. It injects `DATABASE_URL` and other Neon env vars from the linked branch. See [Environment variables](/docs/compute/functions/environment-variables) for the full list and how to pull them into a local `.env` file.
 
 ```bash
 neonctl dev

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -21,6 +21,12 @@ enableTableOfContents: true
 
 Functions are available on new projects in AWS us-east-2 only.
 
+`neonctl init --preview` installs the `neon` and `neon-functions` agent skills for your AI editor automatically. To install them separately:
+
+```bash
+npx skills add neondatabase/agent-skills -s neon -s neon-functions -y
+```
+
 ## Set up your project
 
 Create a project directory and initialize it for the Functions preview:
@@ -136,7 +142,7 @@ Call it with curl:
 curl https://<branch_id>-hello.compute.c-1.us-east-2.aws.neon.tech
 ```
 
-You should see a JSON response with your branch's Postgres version:
+The response is a JSON object with your branch's Postgres version:
 
 ```json
 { "version": "PostgreSQL 17.x on ..., compiled by gcc ..." }

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -19,9 +19,9 @@ enableTableOfContents: true
 - The latest `neonctl`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neonctl@latest`).
 - Node.js 18 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
-Functions are available on new projects in AWS us-east-2 only.
+Functions are available on new projects in AWS us-east-2 only, created on or after June 15, 2026.
 
-`neonctl init --preview` installs the `neon` and `neon-functions` agent skills for your AI editor automatically. To install them separately:
+`neonctl init --preview` is designed to be run by your AI coding assistant. It outputs structured instructions that guide the agent through setup. To install skills separately:
 
 ```bash
 npx skills add neondatabase/agent-skills -s neon -s neon-functions -y
@@ -29,16 +29,21 @@ npx skills add neondatabase/agent-skills -s neon -s neon-functions -y
 
 ## Set up your project
 
-Create a project directory and initialize it for the Functions preview:
+Create your project directory:
 
 ```bash
 mkdir my-function && cd my-function
+```
+
+Then ask your AI coding assistant to run:
+
+```bash
 neonctl init --preview
 ```
 
-`neonctl init --preview` runs an interactive setup: it installs the Neon MCP server and agent skills for your editor and, in an empty directory, offers to scaffold the project from a Neon template. Scaffolding links the directory to a Neon project and pulls the branch's variables into a local `.env` file. If you build by hand instead, finish by running `neonctl link`.
+When your AI coding assistant runs `neonctl init --preview`, it receives structured JSON instructions for the full setup: MCP server and agent skills, optional template scaffolding, project linking, and env var pull. Sign-in opens a browser window. The agent will pause and wait for you to complete the OAuth step. If you ran init yourself and exited before the linking step, run `neonctl link` to connect the directory to your project manually.
 
-To go straight to a working example, run `neonctl bootstrap`. It scaffolds a starter template (a Hono API, an AI SDK agent, or a Mastra agent, all on Neon Functions) and links it. This guide builds the function by hand.
+To go straight to a working example, run `neonctl bootstrap`. It scaffolds a starter template and links it. Available templates: Hono API, AI SDK agent, Mastra agent, Realtime chat (Next.js + WebSockets), and Realtime counter (TanStack Router + SSE), all on Neon Functions. This guide builds the function by hand.
 
 ## Define your function
 
@@ -64,7 +69,7 @@ The key (`hello`) is the function's slug: its permanent identifier in CLI comman
 Install dependencies:
 
 ```bash
-npm install hono @neondatabase/serverless
+npm install @neondatabase/config @neondatabase/serverless hono
 ```
 
 A function is any module whose default export has a `fetch(request)` method that returns a `Response`. A Hono app exports exactly that shape, so a minimal function looks like this:

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -30,13 +30,9 @@ mkdir my-function && cd my-function
 neonctl init --preview
 ```
 
-`init --preview` sets up the directory, installs the Neon preview packages, and connects the directory to a Neon project. There's no separate link step.
+`neonctl init --preview` runs an interactive setup: it installs the Neon MCP server and agent skills for your editor and, in an empty directory, offers to scaffold the project from a Neon template. Scaffolding links the directory to a Neon project and pulls the branch's variables into a local `.env` file. If you build by hand instead, finish by running `neonctl link`.
 
-To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
-
-```bash
-neonctl checkout feat/my-feature
-```
+To go straight to a working example, run `neonctl bootstrap`. It scaffolds a starter template (a Hono API, an AI SDK agent, or a Mastra agent, all on Neon Functions) and links it. This guide builds the function by hand.
 
 ## Define your function
 

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -1,0 +1,149 @@
+---
+title: Get started
+subtitle: Deploy your first Neon Function and call it over HTTP.
+summary: >-
+  Deploy your first Neon Function with neonctl: link a project, define the
+  function in neon.ts, develop locally with neonctl dev, and deploy with
+  neonctl deploy. The function gets a public HTTPS URL with DATABASE_URL
+  injected from the branch's Postgres database.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+<Steps>
+
+## Prerequisites
+
+- A Neon account with Functions preview access. See [Preview access](/docs/compute/functions/preview-access).
+- The latest `neonctl`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neonctl@latest`).
+- Node.js 18 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
+
+Functions are available on new projects in AWS us-east-2 only. You can create the project during `neonctl link` below.
+
+## Set up your project
+
+Create a project directory and initialize it for the Functions preview:
+
+```bash
+mkdir my-function && cd my-function
+neonctl init --preview
+```
+
+`init --preview` sets up the directory and installs the Neon preview packages.
+
+## Link your project
+
+Connect the directory to a Neon project (pick one or create it):
+
+```bash
+neonctl link
+```
+
+To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
+
+```bash
+neonctl checkout feat/my-feature
+```
+
+## Define your function
+
+Create `neon.ts` at your project root. It declares your functions and is what `neonctl dev` and `neonctl deploy` read:
+
+```ts filename="neon.ts"
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "My first function",
+        source: "./functions/hello.ts",
+      },
+    },
+  },
+});
+```
+
+The key (`hello`) is the function's slug: its permanent identifier in CLI commands and the function URL. `name` is only a display label. See the [neon.ts reference](/docs/compute/functions/reference/neon-ts) for all options.
+
+Install dependencies:
+
+```bash
+npm install hono @neondatabase/serverless
+```
+
+Write the handler. `DATABASE_URL` is injected automatically from the linked branch's Postgres database:
+
+```ts filename="functions/hello.ts"
+import { Hono } from 'hono';
+import { neon } from '@neondatabase/serverless';
+
+const sql = neon(process.env.DATABASE_URL!);
+const app = new Hono();
+
+app.get('/', async (c) => {
+  const [row] = await sql`SELECT version()`;
+  return c.json(row);
+});
+
+export default app;
+```
+
+## Develop locally
+
+`neonctl dev` serves all functions declared in `neon.ts` with hot reload. It injects `DATABASE_URL` and other Neon env vars from the linked branch.
+
+```bash
+neonctl dev
+```
+
+The terminal prints the URL for each running function:
+
+```text
+  Neon Functions dev server
+
+  hello                http://localhost:8787
+```
+
+## Deploy
+
+`neonctl deploy` reads `neon.ts` and applies it to the linked branch, deploying every function it declares:
+
+```bash
+neonctl deploy
+```
+
+The CLI bundles each function with esbuild, uploads it, and waits for the deployment to complete. To deploy a single function directly without `neon.ts`, or to deploy through the API, see [Deploy and manage functions](/docs/compute/functions/deploy).
+
+## Invoke
+
+Once the deployment reaches `completed`, retrieve the invocation URL:
+
+```bash
+neonctl functions get hello
+```
+
+The `invocation_url` field contains the public URL for your function:
+
+```
+https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech
+```
+
+Call it with curl:
+
+```bash shouldWrap
+curl https://<branch_id>-hello.compute.c-1.us-east-2.aws.neon.tech
+```
+
+You should see a JSON response with your branch's Postgres version:
+
+```json
+{ "version": "PostgreSQL 17.x on ..., compiled by gcc ..." }
+```
+
+</Steps>
+
+<NeedHelp/>

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -42,6 +42,8 @@ Connect the directory to a Neon project (pick one or create it):
 neonctl link
 ```
 
+`link` also pulls the branch's Neon env vars into a local env file (`.env` if one exists, otherwise `.env.local`), so other tools can use them. You don't need the file for this guide; `neonctl dev` injects the vars itself. See [Environment variables](/docs/compute/functions/environment-variables#pull-variables-locally) for details.
+
 To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
 
 ```bash

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -9,9 +9,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 <Steps>
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,7 +7,7 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-12T16:38:29.112Z'
+updatedOn: '2026-06-12T21:36:14.443Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -18,7 +18,7 @@ During the private preview, Functions are available for new projects in the AWS 
 
 Functions are branch-scoped. When you branch a project, the function branches with it: the child branch inherits the function as it was at the branch point, and runs it at its own URL against its own isolated database state. Deploying to the child doesn't affect the parent.
 
-Functions use the [Workers-compatible](https://wintercg.org/) handler interface: a `fetch(request)` export that receives a standard `Request` and returns a `Response`. Hono is the recommended framework.
+Functions use the Workers-style handler interface standardized by [WinterTC](https://wintertc.org/): a `fetch(request)` export that receives a standard `Request` and returns a `Response`. Hono is the recommended framework.
 
 ## When to use Neon Functions
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -1,0 +1,49 @@
+---
+title: Neon Functions
+subtitle: Long-running Node.js compute, deployed on Neon.
+summary: >-
+  Neon Functions are long-running Node.js HTTP handlers deployed to Neon
+  branches, with DATABASE_URL injected from the branch's Postgres database.
+  Use them for AI agents, WebSocket servers, and webhook handlers that need
+  compute next to their data.
+enableTableOfContents: true
+updatedOn: '2026-06-10T03:57:18.581Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+Neon Functions give you long-running Node.js compute in the same AWS region as your database. Each function deploys to a Neon branch and gets a public HTTPS URL. If the branch has a Postgres database, `DATABASE_URL` is injected automatically. No configuration needed, no cross-region round trips.
+
+Functions are branch-scoped. When you branch a project, the function branches with it: the child branch inherits the function as it was at the branch point, and runs it at its own URL against its own isolated database state. Deploying to the child doesn't affect the parent.
+
+Functions use the [Workers-compatible](https://wintercg.org/) handler interface: a `fetch(request)` export that receives a standard `Request` and returns a `Response`. Hono is the recommended framework.
+
+## When to use Neon Functions
+
+- **AI agents**: hold connections open across multiple LLM calls and tool invocations, write results to Postgres
+- **Discord bots and WebSocket servers**: maintain long-lived bidirectional connections without a dedicated server
+- **Webhook handlers**: receive events and run multiple database queries without cross-region latency
+- **Post-response work**: use `waitUntil` to run follow-up tasks after the response is sent, such as logging, analytics writes, or triggering additional model calls
+- **Branch your backend**: each branch runs its own function version at its own URL, against its own isolated database state if the branch has one
+
+## Get started
+
+<DetailIconCards>
+
+<a href="/docs/compute/functions/preview-access" description="Request access and learn what's included in the private preview." icon="screen">Preview access</a>
+
+<a href="/docs/compute/functions/get-started" description="Deploy your first function and call it over HTTP in under 5 minutes." icon="code">Get started</a>
+
+<a href="/docs/compute/functions/environment-variables" description="Neon-injected variables and how to add your own secrets." icon="gear">Environment variables</a>
+
+<a href="/docs/compute/functions/deploy" description="CLI and API reference for deploying and managing functions." icon="cli">Deploy and manage</a>
+
+<a href="/docs/compute/functions/reference/neon-ts" description="Configuration schema for functions and branch policy." icon="setup">neon.ts reference</a>
+
+<a href="/docs/compute/functions/reference/runtime-limits" description="Timeouts, slug constraints, memory, and other hard limits." icon="sparkle">Runtime limits</a>
+
+</DetailIconCards>
+
+<NeedHelp/>

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,7 +7,7 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-12T21:36:14.443Z'
+updatedOn: '2026-06-15T11:31:11.292Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -43,6 +43,16 @@ Functions use the Workers-style handler interface standardized by [WinterTC](htt
 <a href="/docs/compute/functions/reference/neon-ts" description="Configuration schema for functions and branch policy." icon="setup">neon.ts reference</a>
 
 <a href="/docs/compute/functions/reference/runtime-limits" description="Timeouts, slug constraints, memory, and other hard limits." icon="sparkle">Runtime limits</a>
+
+</DetailIconCards>
+
+## Example apps
+
+<DetailIconCards>
+
+<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, holding connections open across multiple model calls and writing results to Postgres." icon="github">Rate My Pricing</a>
+
+<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that uses a JWT-protected Neon Function as its backend, handling long-running image generation without serverless timeouts." icon="github">Vibecastly</a>
 
 </DetailIconCards>
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,7 +7,7 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:31:11.292Z'
+updatedOn: '2026-06-15T14:31:22.519Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -46,14 +46,24 @@ Functions use the Workers-style handler interface standardized by [WinterTC](htt
 
 </DetailIconCards>
 
-## Example apps
+## Starter templates
 
-<DetailIconCards>
+Browse templates at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one directly with `neonctl bootstrap`:
 
-<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, holding connections open across multiple model calls and writing results to Postgres." icon="github">Rate My Pricing</a>
+```bash
+neonctl bootstrap
+```
 
-<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that uses a JWT-protected Neon Function as its backend, handling long-running image generation without serverless timeouts." icon="github">Vibecastly</a>
+Use `--template` to skip the interactive picker:
 
-</DetailIconCards>
+| Template        | What it builds                                                                         |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `hono`          | REST API with Drizzle and Postgres on Neon Functions                                   |
+| `ai-sdk`        | Image-generation agent with AI Gateway, Object Storage, and Postgres on Neon Functions |
+| `mastra`        | Personal assistant with AI Gateway and Postgres-backed memory on Neon Functions        |
+| `realtime-chat` | Realtime chat with Next.js, Neon Auth, and WebSockets on Neon Functions                |
+| `realtime-sse`  | Realtime counter with TanStack Router and SSE on Neon Functions                        |
+
+`neonctl bootstrap` scaffolds files, links to a Neon project, and pulls env vars. Then follow the README to set up and deploy.
 
 <NeedHelp/>

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,14 +7,14 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-10T03:57:18.581Z'
+updatedOn: '2026-06-12T16:38:29.112Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 Neon Functions give you long-running Node.js compute in the same AWS region as your database. Each function deploys to a Neon branch and gets a public HTTPS URL. If the branch has a Postgres database, `DATABASE_URL` is injected automatically. No configuration needed, no cross-region round trips.
+
+During the private preview, Functions are available for new projects in the AWS us-east-2 region only. See [Preview access](/docs/compute/functions/preview-access) for what's included.
 
 Functions are branch-scoped. When you branch a project, the function branches with it: the child branch inherits the function as it was at the branch point, and runs it at its own URL against its own isolated database state. Deploying to the child doesn't affect the parent.
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -8,13 +8,9 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
-
 ## Request access
 
-Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). The team will reach out with access details. Functions are available on new projects only; you can't enable them on an existing project.
+Sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends#access). The team will reach out with access details. Functions are available on new projects only.
 
 ## What's included
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -1,0 +1,49 @@
+---
+title: Preview access
+subtitle: What's included in the Neon Functions private preview.
+summary: >-
+  Neon Functions is in private preview for new projects in the AWS us-east-2
+  region. This page covers how to request access, what's included, and the
+  current limitations.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+## Request access
+
+Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). The team will reach out with access details. Functions are available on new projects only; you can't enable them on an existing project.
+
+## What's included
+
+- Deploy Node.js 24 HTTP handlers to Neon branches
+- Workers-compatible handler interface (`fetch(request)` export)
+- Long-running compute: WebSocket servers, SSE endpoints, AI agents
+- `DATABASE_URL` auto-injected from the branch's Postgres database
+- `neonctl dev` for local development with hot reload
+- `neonctl functions deploy` for CLI deployment
+- Neon API for programmatic deployment
+- Branch-scoped functions: each branch runs its own version at its own URL
+
+## What's not included
+
+**Memory is fixed at 2048 MiB.** Memory configuration isn't available during the preview.
+
+**Background jobs are not supported.** `waitUntil` runs post-response work for up to 15 minutes. It's for short cleanup tasks (analytics writes, audit logs), not long-running jobs. Use a dedicated queue or scheduler for work that needs its own lifecycle. `waitUntil` is currently a stub; see [Runtime limits](/docs/compute/functions/reference/runtime-limits) for details.
+
+**Billing isn't active yet.** Functions usage isn't billed during the private preview.
+
+**Available in AWS us-east-2 only.** Other regions aren't available during the preview.
+
+## Known limitations
+
+- `neonctl` ships `esbuild` for most platforms. If bundling fails with an `esbuild not found` error, install it (`npm install -g esbuild`) or set `NEON_ESBUILD_PATH` to an esbuild binary.
+- Slug names are restricted to `^[a-z0-9]{1,20}$`. No hyphens, no uppercase. Use the `name` field for a human-readable label.
+
+## Feedback
+
+The preview feedback channel will be shared in your access confirmation email.
+
+<NeedHelp/>

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -23,7 +23,8 @@ Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.
 - Long-running compute: WebSocket servers, SSE endpoints, AI agents
 - `DATABASE_URL` auto-injected from the branch's Postgres database
 - `neonctl dev` for local development with hot reload
-- `neonctl functions deploy` for CLI deployment
+- `neon.ts` config with `neonctl deploy` for declarative branch setup
+- `neonctl functions deploy` for direct CLI deployment
 - Neon API for programmatic deployment
 - Branch-scoped functions: each branch runs its own version at its own URL
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -38,6 +38,7 @@ Sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-bui
 
 - `neonctl` ships `esbuild` for most platforms. If bundling fails with an `esbuild not found` error, install it (`npm install -g esbuild`) or set `NEON_ESBUILD_PATH` to an esbuild binary.
 - Slug names are restricted to `^[a-z0-9]{1,20}$`. No hyphens, no uppercase. Use the `name` field for a human-readable label.
+- Logs from deployed functions can't be retrieved yet. Use `neonctl dev` to see output during development; deployed functions must record diagnostics themselves (in Postgres, or in the response).
 
 ## Feedback
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
 </Admonition>
 
-`neon.ts` is a TypeScript config file that declares which functions exist on a project and how each branch should be configured. Place it at the root of your project.
+`neon.ts` is a TypeScript config file that declares which functions and services exist on a project and how each branch should be configured. Place it at the root of your project.
 
 ```bash
 npm install @neondatabase/config

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -82,7 +82,7 @@ preview: {
 
 Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment. See [Slugs](/docs/compute/functions/deploy#slugs) for the full rules. Because slugs can't use separators, use `name` for a human-readable label, for example `slug: "myrestapi"` with `name: "My REST API"`.
 
-**`env`** values are resolved at deploy time (when `neonctl deploy` runs). Reading `process.env.X` here captures the value in your shell at deploy time, not at runtime inside the function. Use `neonctl deploy --env .env.production` to load a `.env` file before evaluation.
+**`env`** values are resolved at deploy time (when `neonctl deploy` runs). Reading `process.env.X` here captures the value in your shell at deploy time, not at runtime inside the function. Use `neonctl deploy --env .env.production` to load a `.env` file before evaluation. For typed access to these variables inside your function at runtime, see [Environment variables](/docs/compute/functions/environment-variables).
 
 **`dev`** settings apply only to `neonctl dev`. They never affect deploy.
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -30,7 +30,7 @@ export default defineConfig({
       hello: {
         name: "My first function",
         source: "./functions/hello.ts",
-        env: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+        env: { RESEND_API_KEY: process.env.RESEND_API_KEY! },
         dev: { port: 8787 },
       },
     },
@@ -88,7 +88,7 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 
 - `port`: the local server binds this exact port and fails if it's taken. When omitted, a free port is found automatically.
 
-The `preview` block also accepts `aiGateway` and `buckets` fields. They aren't part of the Functions preview and aren't covered here.
+The `preview` block also accepts `aiGateway` and `buckets` fields, which enable the [AI Gateway](/docs/ai-gateway/overview) and [Object Storage](/docs/storage/overview) previews on the branch and inject their credentials into deployed functions. They aren't part of the Functions preview and aren't covered here.
 
 ## `branch` closure
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -38,10 +38,12 @@ export default defineConfig({
     },
   },
   // Dynamic: per-branch tuning
-  branch: (branch) => ({
-    protected: branch.name === "main",
-    ...(branch.name !== "main" && { parent: "main", ttl: "7d" }),
-  }),
+  branch: (branch) => {
+    if (branch.name === "main") {
+      return { protected: true };
+    }
+    return { parent: "main", ttl: "7d" };
+  },
 });
 ```
 
@@ -74,7 +76,6 @@ preview: {
       env?: Record<string, string>,
       dev?: {
         port?: number,    // bind to this port in neonctl dev; omit for auto-assigned
-        portless?: boolean,
       },
     },
   },
@@ -88,7 +89,6 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 **`dev`** settings apply only to `neonctl dev`. They never affect deploy.
 
 - `port`: the local server binds this exact port and fails if it's taken. When omitted, a free port is found automatically.
-- `portless`: expose the function through the `portless` tool at a stable `<slug>.localhost` URL instead of a numbered port. Requires the `portless` binary on your PATH. Portless assigns the port itself, so `port` is ignored when this is set.
 
 The `preview` block also accepts `aiGateway` and `buckets` fields. They aren't part of the Functions preview and aren't covered here.
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -8,9 +8,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 `neon.ts` is a TypeScript config file that declares which functions and services exist on a project and how each branch should be configured. Place it at the root of your project.
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -1,0 +1,144 @@
+---
+title: neon.ts reference
+subtitle: Configuration schema for Neon Functions and branch policy.
+summary: >-
+  neon.ts declares which functions and services exist on a project and how
+  each branch is tuned. Reference for defineConfig: service toggles, function
+  definitions, and the per-branch tuning closure.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+`neon.ts` is a TypeScript config file that declares which functions exist on a project and how each branch should be configured. Place it at the root of your project.
+
+```bash
+npm install @neondatabase/config
+```
+
+## Shape
+
+```ts filename="neon.ts"
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  // Static: what exists on every branch
+  auth: true,
+  dataApi: false,
+  preview: {
+    functions: {
+      hello: {
+        name: "My first function",
+        source: "./functions/hello.ts",
+        env: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+        dev: { port: 8787 },
+      },
+    },
+  },
+  // Dynamic: per-branch tuning
+  branch: (branch) => ({
+    protected: branch.name === "main",
+    ...(branch.name !== "main" && { parent: "main", ttl: "7d" }),
+  }),
+});
+```
+
+`defineConfig` takes an object with two parts, both optional:
+
+- **Static fields** (`auth`, `dataApi`, `preview`): declare what services and functions exist. The same set applies to every branch. This is what determines which Neon service URLs (`NEON_AUTH_BASE_URL`, `NEON_DATA_API_URL`) are injected.
+- **`branch` closure**: receives a read-only `BranchTarget` and returns per-branch tuning. It can only adjust settings, not add or remove services or functions. Omit it if you don't need per-branch tuning.
+
+## Static fields
+
+### Services
+
+Static toggles declare which services exist on every branch and which Neon env vars are injected into deployed functions.
+
+| Field     | Values                               | Default | Injects              |
+| --------- | ------------------------------------ | ------- | -------------------- |
+| `auth`    | `true`, `false`, `{ enabled: bool }` | `false` | `NEON_AUTH_BASE_URL` |
+| `dataApi` | `true`, `false`                      | `false` | `NEON_DATA_API_URL`  |
+
+### `preview.functions`
+
+Declares functions as a record keyed by slug. Each key is the function's permanent slug: its operational identity used in CLI commands, API paths, and the invocation URL. The `name` field is display-only (shown in `neonctl functions list` and the console).
+
+```ts
+preview: {
+  functions: {
+    "<slug>": {
+      name: string,       // required: display name only, not used operationally
+      source: string,     // required: path to entry file, relative to neon.ts (or absolute)
+      env?: Record<string, string>,
+      dev?: {
+        port?: number,    // bind to this port in neonctl dev; omit for auto-assigned
+        portless?: boolean,
+      },
+    },
+  },
+},
+```
+
+Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment. See [Slugs](/docs/compute/functions/deploy#slugs) for the full rules. Because slugs can't use separators, use `name` for a human-readable label, for example `slug: "myrestapi"` with `name: "My REST API"`.
+
+**`env`** values are resolved at deploy time (when `neonctl deploy` runs). Reading `process.env.X` here captures the value in your shell at deploy time, not at runtime inside the function. Use `neonctl deploy --env .env.production` to load a `.env` file before evaluation.
+
+**`dev`** settings apply only to `neonctl dev`. They never affect deploy.
+
+- `port`: the local server binds this exact port and fails if it's taken. When omitted, a free port is found automatically.
+- `portless`: expose the function through the `portless` tool at a stable `<slug>.localhost` URL instead of a numbered port. Requires the `portless` binary on your PATH. Portless assigns the port itself, so `port` is ignored when this is set.
+
+The `preview` block also accepts `aiGateway` and `buckets` fields. They aren't part of the Functions preview and aren't covered here.
+
+## `branch` closure
+
+The `branch` closure receives a `BranchTarget` and returns a `BranchTuning`.
+
+### BranchTarget fields
+
+| Field         | Type                  | Description                                         |
+| ------------- | --------------------- | --------------------------------------------------- |
+| `name`        | `string`              | Branch name                                         |
+| `id`          | `string \| undefined` | Branch ID. `undefined` during pre-create evaluation |
+| `exists`      | `boolean`             | `false` during pre-create evaluation                |
+| `isDefault`   | `boolean`             | Whether this is the project's default branch        |
+| `isProtected` | `boolean`             | Whether the branch is marked protected in Neon      |
+| `parentId`    | `string \| undefined` | ID of the parent branch, if any                     |
+| `expiresAt`   | `string \| undefined` | Branch expiry timestamp, if set                     |
+
+### BranchTuning fields
+
+| Field                                            | Type                              | Description                                                               |
+| ------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------- |
+| `parent`                                         | `string`                          | Parent branch name or ID. Specifies which branch new branches derive from |
+| `protected`                                      | `boolean`                         | Mark the branch as protected                                              |
+| `ttl`                                            | `string \| number`                | Branch lifetime, e.g. `"7d"`, `"2h"`, or seconds as a number              |
+| `postgres.computeSettings.autoscalingLimitMinCu` | `0.25 \| 0.5 \| 1 \| 2 \| 4 \| 8` | Minimum compute units                                                     |
+| `postgres.computeSettings.autoscalingLimitMaxCu` | `0.25 \| 0.5 \| 1 \| 2 \| 4 \| 8` | Maximum compute units                                                     |
+| `postgres.computeSettings.suspendTimeout`        | `false \| string \| number`       | Idle suspend timeout. `false` disables suspend                            |
+
+## Apply to a branch
+
+```bash
+neonctl deploy
+```
+
+This is an alias for `neonctl config apply`. It reads `neon.ts` from the current directory, diffs it against the live branch state, and applies the changes.
+
+To preview what would change without applying:
+
+```bash
+neonctl config plan
+```
+
+To inspect the current live state of a branch as a `neon.ts`-shaped config:
+
+```bash
+neonctl config status
+```
+
+When `neonctl checkout` creates a new branch and a `neon.ts` exists in your project, the CLI applies the policy to the new branch automatically, including deploying its functions. Checking out an existing branch doesn't trigger an apply.
+
+<NeedHelp/>

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -1,0 +1,78 @@
+---
+title: Runtime limits
+subtitle: Hard constraints for Neon Functions.
+summary: >-
+  Hard limits for Neon Functions: lifecycle and eviction behavior, 15-minute
+  timeouts, slug constraints, and the Node.js 24 runtime. Functions are
+  long-running but still serverless.
+enableTableOfContents: true
+updatedOn: '2026-06-10T03:57:18.581Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+Neon Functions run on Node.js 24 in isolated microVMs.
+
+## Lifecycle
+
+Neon Functions are long-running. You can host WebSocket servers, SSE endpoints, and agents that stream responses over HTTP without hitting a short execution timeout. They're still serverless: if your function has no active connections, the platform shuts it down.
+
+The platform may also evict and restart your function for operational reasons. Active functions can run for hours before eviction occurs. Treat eviction like a process restart: WebSocket and SSE clients need to reconnect when the connection drops.
+
+The platform sends `SIGINT` before evicting to allow graceful shutdown. Register a handler to close open connections and flush in-flight work before the process exits:
+
+```ts
+process.on('SIGINT', () => {
+  pool.end().then(() => process.exit(0));
+});
+```
+
+Without it, open connections are abandoned on eviction and remain open until they time out.
+
+## Timeouts
+
+**Time to first byte: 15 minutes.** Your handler must begin returning a response within 15 minutes of receiving a request. This is a request-response runtime, not a background task runner. The limit prevents runaway functions that hold resources indefinitely with no way to cancel them. In practice most handlers complete in seconds. The 15-minute limit gives agent workloads like image or video generation enough time to finish.
+
+**Heartbeat: 15 minutes.** Active WebSocket connections and HTTP streams stay open as long as data flows. The timeout only fires when the connection goes silent. Send at least one byte every 15 minutes to keep a quiet stream alive.
+
+**`waitUntil`: 15 minutes.** Work registered with `waitUntil` runs after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
+
+```ts
+import { Hono } from 'hono';
+import { waitUntil } from '@neondatabase/functions/v1';
+
+const app = new Hono();
+
+app.post('/event', async (c) => {
+  const defer = waitUntil();
+  defer(writeAnalytics(c.req.raw));
+  return c.json({ ok: true });
+});
+
+export default app;
+```
+
+<Admonition type="note">
+`waitUntil` is currently a stub. The deferred promise is accepted but not yet wired to the host runtime. The API is stable. Use it now and it will work automatically once the runtime support ships.
+</Admonition>
+
+## Slug constraints
+
+Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment. See [Slugs](/docs/compute/functions/deploy#slugs) for the full rules.
+
+## Runtime
+
+| Property    | Value                                                                        |
+| ----------- | ---------------------------------------------------------------------------- |
+| Runtime     | Node.js 24                                                                   |
+| Isolation   | microVM per isolate                                                          |
+| Concurrency | 1 request at a time per isolate. Additional requests queue, they don't fail. |
+| Memory      | 2048 MiB (fixed during the private preview, not configurable)                |
+
+## Environment variables
+
+See [Environment variables](/docs/compute/functions/environment-variables#constraints) for limits on variable count, total size, and the reserved `NEON_` prefix.
+
+<NeedHelp/>

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-12T21:36:14.443Z'
+updatedOn: '2026-06-14T04:15:20.563Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -38,10 +38,6 @@ Without it, open connections are abandoned on eviction and remain open until the
 
 **`waitUntil`: 15 minutes.** Work registered with `waitUntil` continues after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
 
-<Admonition type="important">
-During the private preview, `waitUntil` is a no-op placeholder: it accepts the promise but does not keep the invocation alive. Await any work that has to finish before the response stream closes. The API is in place to code against, but don't rely on post-response execution until the runtime integration ships.
-</Admonition>
-
 ```ts
 import { Hono } from 'hono';
 import { waitUntil } from '@neondatabase/functions/v1';
@@ -61,15 +57,13 @@ export default app;
 
 ## Concurrency
 
-Each isolate handles one request at a time. The platform adds isolates on demand: requests that arrive while existing isolates are busy are served by newly booted isolates (cold start is on the order of a second), and requests that can't be placed queue rather than fail.
+Each isolate is a Node.js process. Requests are interleaved on the event loop, so multiple requests can be in flight on the same isolate concurrently. The platform adds isolates on demand under load: requests that can't be placed on an existing isolate are routed to a newly booted one or queued briefly.
 
-Streaming responses don't hold the slot. Once your handler returns a `Response`, the isolate can accept the next request, even while the response body is still streaming.
+Because each isolate is its own process and handles concurrent requests, module-scope state behaves as follows:
 
-Because each isolate is its own Node.js process, module-scope state multiplies with scale-out:
-
-- Each isolate creates its own `pg` pool, so the effective connection count is `max` × the number of isolates. Keep `max` small (for example, 5).
-- Module-scope initialization (seeding, migrations) runs once per isolate, not once per deployment. Make it idempotent, or serialize it with a Postgres advisory lock.
-- In-memory state (caches, counters, sessions) is per-isolate and disappears on eviction. Persist anything that matters in Postgres.
+- **Shared within an isolate**: module-scope objects (a `pg` pool, an in-memory cache) are shared across all requests on the same isolate. Create connection pools once at module scope and reuse them.
+- **Not shared across isolates**: each isolate has its own copy of module state. Keep `max` small on `pg` pools (for example, 5) — effective connection count is `max` × the number of live isolates. Module-scope initialization (seeding, migrations) runs once per isolate; make it idempotent or serialize with a Postgres advisory lock.
+- **Lost on eviction**: in-memory state disappears when an isolate is evicted. Persist anything that matters in Postgres.
 
 ## Slug constraints
 
@@ -77,12 +71,12 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 
 ## Runtime
 
-| Property    | Value                                                                                                   |
-| ----------- | ------------------------------------------------------------------------------------------------------- |
-| Runtime     | Node.js 24                                                                                              |
-| Isolation   | microVM per isolate                                                                                     |
-| Concurrency | 1 request at a time per isolate, scaling out with additional isolates. See [Concurrency](#concurrency). |
-| Memory      | 2048 MiB (fixed during the private preview, not configurable)                                           |
+| Property    | Value                                                                                                                                           |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime     | Node.js 24                                                                                                                                      |
+| Isolation   | microVM per isolate                                                                                                                             |
+| Concurrency | Multiple requests in flight per isolate (interleaved on the event loop), scaling out with additional isolates. See [Concurrency](#concurrency). |
+| Memory      | 2048 MiB (fixed during the private preview, not configurable)                                                                                   |
 
 ## Environment variables
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-12T16:38:29.112Z'
+updatedOn: '2026-06-12T21:36:14.443Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -22,6 +22,7 @@ The platform may also evict and restart your function for operational reasons. A
 The platform sends `SIGINT` before evicting to allow graceful shutdown. Register a handler to close open connections and flush in-flight work before the process exits:
 
 ```ts
+// pool is your module-scope pg.Pool
 process.on('SIGINT', () => {
   pool.end().then(() => process.exit(0));
 });
@@ -37,6 +38,10 @@ Without it, open connections are abandoned on eviction and remain open until the
 
 **`waitUntil`: 15 minutes.** Work registered with `waitUntil` continues after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
 
+<Admonition type="important">
+During the private preview, `waitUntil` is a no-op placeholder: it accepts the promise but does not keep the invocation alive. Await any work that has to finish before the response stream closes. The API is in place to code against, but don't rely on post-response execution until the runtime integration ships.
+</Admonition>
+
 ```ts
 import { Hono } from 'hono';
 import { waitUntil } from '@neondatabase/functions/v1';
@@ -44,14 +49,27 @@ import { waitUntil } from '@neondatabase/functions/v1';
 const app = new Hono();
 
 app.post('/event', async (c) => {
-  waitUntil(writeAnalytics(c.req.raw)); // your async follow-up work
+  const wait = waitUntil(); // returns the waitUntil function for this invocation
+  wait(writeAnalytics(c.req.raw)); // your async follow-up work
   return c.json({ ok: true });
 });
 
 export default app;
 ```
 
-`waitUntil` takes a promise and keeps the invocation alive until it settles, up to the 15-minute cap. It's the same shape as `waitUntil` on [Vercel](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) and Cloudflare Workers, and it's safe to call in `neonctl dev`.
+`waitUntil()` returns a function for the current invocation; pass that function a promise and the invocation stays alive until the promise settles, up to the 15-minute cap. The registered work is the same shape as `waitUntil` on [Vercel](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) and Cloudflare Workers, and it's safe to call in `neonctl dev`.
+
+## Concurrency
+
+Each isolate handles one request at a time. The platform adds isolates on demand: requests that arrive while existing isolates are busy are served by newly booted isolates (cold start is on the order of a second), and requests that can't be placed queue rather than fail.
+
+Streaming responses don't hold the slot. Once your handler returns a `Response`, the isolate can accept the next request, even while the response body is still streaming.
+
+Because each isolate is its own Node.js process, module-scope state multiplies with scale-out:
+
+- Each isolate creates its own `pg` pool, so the effective connection count is `max` × the number of isolates. Keep `max` small (for example, 5).
+- Module-scope initialization (seeding, migrations) runs once per isolate, not once per deployment. Make it idempotent, or serialize it with a Postgres advisory lock.
+- In-memory state (caches, counters, sessions) is per-isolate and disappears on eviction. Persist anything that matters in Postgres.
 
 ## Slug constraints
 
@@ -59,12 +77,12 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 
 ## Runtime
 
-| Property    | Value                                                                        |
-| ----------- | ---------------------------------------------------------------------------- |
-| Runtime     | Node.js 24                                                                   |
-| Isolation   | microVM per isolate                                                          |
-| Concurrency | 1 request at a time per isolate. Additional requests queue, they don't fail. |
-| Memory      | 2048 MiB (fixed during the private preview, not configurable)                |
+| Property    | Value                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| Runtime     | Node.js 24                                                                                              |
+| Isolation   | microVM per isolate                                                                                     |
+| Concurrency | 1 request at a time per isolate, scaling out with additional isolates. See [Concurrency](#concurrency). |
+| Memory      | 2048 MiB (fixed during the private preview, not configurable)                                           |
 
 ## Environment variables
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,12 +6,10 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-12T01:12:57.837Z'
+updatedOn: '2026-06-12T16:38:29.112Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 Neon Functions run on Node.js 24 in isolated microVMs.
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-10T12:55:19.407Z'
+updatedOn: '2026-06-12T01:12:57.837Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -37,7 +37,7 @@ Without it, open connections are abandoned on eviction and remain open until the
 
 **Heartbeat: 15 minutes.** Active WebSocket connections and HTTP streams stay open as long as data flows. The timeout only fires when the connection goes silent. Send at least one byte every 15 minutes to keep a quiet stream alive.
 
-**`waitUntil`: 15 minutes.** Work registered with `waitUntil` runs after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
+**`waitUntil`: 15 minutes.** Work registered with `waitUntil` continues after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
 
 ```ts
 import { Hono } from 'hono';
@@ -46,17 +46,14 @@ import { waitUntil } from '@neondatabase/functions/v1';
 const app = new Hono();
 
 app.post('/event', async (c) => {
-  const defer = waitUntil();
-  defer(writeAnalytics(c.req.raw)); // your async follow-up work
+  waitUntil(writeAnalytics(c.req.raw)); // your async follow-up work
   return c.json({ ok: true });
 });
 
 export default app;
 ```
 
-<Admonition type="note">
-`waitUntil` is currently a stub. The deferred promise is accepted but not yet wired to the host runtime. The API is stable. Use it now and it will work automatically once the runtime support ships.
-</Admonition>
+`waitUntil` takes a promise and keeps the invocation alive until it settles, up to the 15-minute cap. It's the same shape as `waitUntil` on [Vercel](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) and Cloudflare Workers, and it's safe to call in `neonctl dev`.
 
 ## Slug constraints
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-10T03:57:18.581Z'
+updatedOn: '2026-06-10T12:55:19.407Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -47,7 +47,7 @@ const app = new Hono();
 
 app.post('/event', async (c) => {
   const defer = waitUntil();
-  defer(writeAnalytics(c.req.raw));
+  defer(writeAnalytics(c.req.raw)); // your async follow-up work
   return c.json({ ok: true });
 });
 

--- a/content/docs/compute/functions/websockets.md
+++ b/content/docs/compute/functions/websockets.md
@@ -5,7 +5,7 @@ summary: >-
   Neon Functions support long-lived WebSocket connections via an upgrade export.
   Use the ws package alongside your fetch handler to accept WebSocket clients,
   and Postgres LISTEN/NOTIFY to broadcast across isolates.
-updatedOn: '2026-06-14T16:00:07.344Z'
+updatedOn: '2026-06-14T16:32:23.692Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -82,7 +82,7 @@ Type a message and press Enter. The server echoes it back.
 If your function uses Hono, export `fetch` from the Hono app and the `upgrade` handler separately. The runtime routes WebSocket upgrades directly to `upgrade`. Hono never sees the upgrade request, so Hono middleware and route guards don't apply. Handle auth in `upgrade` directly.
 
 <Admonition type="warning">
-`upgradeWebSocket` from `@hono/node-server` doesn't work with Neon Functions. It requires Hono's own `serve()` wrapper, which the runtime doesn't use. Use the `upgrade` export pattern shown here instead.
+`upgradeWebSocket` from `@hono/node-server` doesn't work with Neon Functions. It requires Hono's own `serve()` wrapper, which the runtime doesn't use. Use the `upgrade` export pattern shown here instead. For Hono-style `onOpen`/`onMessage`/`onClose` route declarations, use the `neon-functions` agent skill.
 </Admonition>
 
 ```ts filename="functions/hono-echo.ts"
@@ -181,18 +181,19 @@ Use `DATABASE_URL_UNPOOLED` for the `LISTEN` client. The pooled `DATABASE_URL` r
 Browsers can't set custom headers on a WebSocket connection, so you can't use `Authorization`. Pass the token as a query parameter and verify it in `upgrade` before calling `wss.handleUpgrade`:
 
 ```ts
-upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+async upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
   const url = new URL(req.url ?? '/', 'http://localhost');
   const token = url.searchParams.get('token');
+  const identity = token ? await verifyToken(token) : null; // e.g. jwtVerify with jose
 
-  if (!token || !isValidToken(token)) { // replace with your actual token verification
+  if (!identity) {
     socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
     socket.destroy();
     return;
   }
 
   wss.handleUpgrade(req, socket, head, (ws) => {
-    // authenticated
+    // authenticated — identity is in scope
   });
 },
 ```

--- a/content/docs/compute/functions/websockets.md
+++ b/content/docs/compute/functions/websockets.md
@@ -1,0 +1,208 @@
+---
+title: WebSocket servers
+subtitle: Host persistent WebSocket connections on Neon Functions.
+summary: >-
+  Neon Functions support long-lived WebSocket connections via an upgrade export.
+  Use the ws package alongside your fetch handler to accept WebSocket clients,
+  and Postgres LISTEN/NOTIFY to broadcast across isolates.
+updatedOn: '2026-06-14T16:00:07.344Z'
+---
+
+<PrivatePreviewEnquire/>
+
+Neon Functions stay alive as long as they have active connections, so a WebSocket server is a first-class use case. Your handler runs on the same branch as your Postgres database.
+
+## How it works
+
+Export an `upgrade` method alongside `fetch`. The runtime calls `upgrade` for WebSocket upgrade requests and `fetch` for everything else.
+
+```ts
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+
+export default {
+  fetch(request: Request) {
+    return new Response("...");
+  },
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    // handle the WebSocket upgrade
+  },
+};
+```
+
+<Admonition type="note">
+`neonctl dev` returns `200 OK` instead of `101 Switching Protocols` for WebSocket upgrade requests during the preview. Test WebSocket behavior against a deployed function (`neonctl deploy`).
+</Admonition>
+
+## Simple echo server
+
+`fetch` is required even if you only plan to serve WebSocket clients. `noServer: true` prevents the `ws` package from starting its own HTTP server; the runtime owns the server and passes the raw socket to `handleUpgrade`.
+
+```ts filename="functions/echo.ts"
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ noServer: true });
+
+export default {
+  fetch(request: Request) {
+    return new Response('This endpoint speaks WebSocket — send an Upgrade request.', {
+      headers: { 'content-type': 'text/plain' },
+    });
+  },
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.on('message', (data) => ws.send(data));
+    });
+  },
+};
+```
+
+Install the dependency:
+
+```bash
+npm install ws
+npm install --save-dev @types/ws
+```
+
+Deploy, then test with [`wscat`](https://github.com/websockets/wscat):
+
+```bash
+npm install -g wscat
+wscat --connect wss://<your-function-url>
+```
+
+Type a message and press Enter. The server echoes it back.
+
+## Hono app with WebSocket
+
+If your function uses Hono, export `fetch` from the Hono app and the `upgrade` handler separately. The runtime routes WebSocket upgrades directly to `upgrade`. Hono never sees the upgrade request, so Hono middleware and route guards don't apply. Handle auth in `upgrade` directly.
+
+<Admonition type="warning">
+`upgradeWebSocket` from `@hono/node-server` doesn't work with Neon Functions. It requires Hono's own `serve()` wrapper, which the runtime doesn't use. Use the `upgrade` export pattern shown here instead.
+</Admonition>
+
+```ts filename="functions/hono-echo.ts"
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { Hono } from 'hono';
+import { WebSocketServer } from 'ws';
+
+const app = new Hono();
+const wss = new WebSocketServer({ noServer: true });
+
+app.get('/', (c) => c.text('WebSocket server — connect via wss://'));
+
+export default {
+  fetch: (request: Request) => app.fetch(request),
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.on('message', (data) => ws.send(`echo: ${data}`));
+    });
+  },
+};
+```
+
+## Cross-isolate messaging with LISTEN/NOTIFY
+
+WebSocket connections are local to the isolate they land on, so clients on different isolates can't communicate through shared memory.
+
+For broadcast, use Postgres `LISTEN/NOTIFY`. Each isolate maintains one `LISTEN` connection at module scope and a `Set` of its connected clients. When a message arrives via `NOTIFY`, every isolate broadcasts it to its clients, so all users receive it regardless of which isolate they landed on.
+
+Install the additional dependencies:
+
+```bash
+npm install pg
+npm install --save-dev @types/pg
+```
+
+```ts filename="functions/chat.ts"
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { Hono } from 'hono';
+import { WebSocketServer, type WebSocket } from 'ws';
+import { Pool, Client } from 'pg';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+
+// One dedicated LISTEN client per isolate.
+const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener
+  .connect()
+  .then(() => listener.query('LISTEN chat'))
+  .catch((err) => console.error('[listen] failed:', err));
+
+const clients = new Set<WebSocket>();
+const CHANNEL = 'chat';
+
+listener.on('notification', (msg) => {
+  if (!msg.payload) return;
+  for (const ws of clients) {
+    if (ws.readyState === ws.OPEN) ws.send(msg.payload);
+  }
+});
+
+const wss = new WebSocketServer({ noServer: true });
+const app = new Hono();
+
+app.get('/', (c) => c.text('Realtime chat — connect over WebSocket'));
+
+export default {
+  fetch: (request: Request) => app.fetch(request),
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      clients.add(ws);
+      ws.on('close', () => clients.delete(ws));
+      ws.on('message', async (data) => {
+        const body = data.toString().trim();
+        if (!body) return;
+        await pool.query('SELECT pg_notify($1, $2)', [CHANNEL, body]);
+      });
+    });
+  },
+};
+
+process.on('SIGINT', () => {
+  Promise.allSettled([pool.end(), listener.end()]).then(() => process.exit(0));
+});
+```
+
+<Admonition type="note">
+Use `DATABASE_URL_UNPOOLED` for the `LISTEN` client. The pooled `DATABASE_URL` routes through PgBouncer, which doesn't support `LISTEN/NOTIFY`.
+</Admonition>
+
+## Authentication
+
+Browsers can't set custom headers on a WebSocket connection, so you can't use `Authorization`. Pass the token as a query parameter and verify it in `upgrade` before calling `wss.handleUpgrade`:
+
+```ts
+upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const token = url.searchParams.get('token');
+
+  if (!token || !isValidToken(token)) { // replace with your actual token verification
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    // authenticated
+  });
+},
+```
+
+For a complete example with JWT verification, Neon Auth integration, and client-side reconnection, see the [realtime chat example](https://github.com/neondatabase/examples/tree/main/with-realtime-chat).
+
+## Eviction and shutdown
+
+The platform sends `SIGINT` before evicting an isolate. Without a handler, open database connections are abandoned and stay open until they time out. The LISTEN/NOTIFY example above includes one: `Promise.allSettled([pool.end(), listener.end()])` drains the pool and listener before the process exits. Add equivalent cleanup for any other resources your function holds.
+
+See [Runtime limits](/docs/compute/functions/reference/runtime-limits#lifecycle) for eviction behavior and the heartbeat timeout.
+
+<NeedHelp/>

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-06-11T00:00:57.556Z'
 ---
 
 <TwinPaths>
@@ -46,7 +46,7 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your DB." icon="code" tag="coming soon">Compute</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Early Access">Functions</a>
 
 <a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-11T00:00:57.556Z'
+updatedOn: '2026-06-15T13:49:53.547Z'
 ---
 
 <TwinPaths>
@@ -46,7 +46,7 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Early Access">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Private Beta">Functions</a>
 
 <a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:52:28.996Z'
+updatedOn: '2026-06-15T14:13:17.342Z'
 ---
 
 <TwinPaths>
@@ -31,7 +31,7 @@ updatedOn: '2026-06-15T13:52:28.996Z'
 
 <div className="mt-12 mb-3.5 flex items-baseline justify-between gap-4">
   <h2 className="m-0!">Your Neon backend</h2>
-  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Join Early Access →</a>
+  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Get early access →</a>
 </div>
 
 Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless.

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:49:53.547Z'
+updatedOn: '2026-06-15T13:52:28.996Z'
 ---
 
 <TwinPaths>
@@ -44,11 +44,11 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
+<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Private Beta">Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Private Beta">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Private Beta">Functions</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
+<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Beta">AI Gateway</a>
 
 </DetailIconCards>
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -540,7 +540,6 @@
 
         - title: Neon Functions
           icon: features
-          tag: beta
           slug: compute/functions/overview
           items:
             - title: Overview

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -538,6 +538,28 @@
                     - title: Database integration
                       slug: auth/legacy/database-integration
 
+        - title: Neon Functions
+          icon: features
+          tag: beta
+          slug: compute/functions/overview
+          items:
+            - title: Overview
+              slug: compute/functions/overview
+            - title: Preview access
+              slug: compute/functions/preview-access
+            - title: Get started
+              slug: compute/functions/get-started
+            - title: Deploy and manage
+              slug: compute/functions/deploy
+            - title: Environment variables
+              slug: compute/functions/environment-variables
+            - section: Reference
+              items:
+                - title: neon.ts
+                  slug: compute/functions/reference/neon-ts
+                - title: Runtime limits
+                  slug: compute/functions/reference/runtime-limits
+
         - title: Postgres RLS
           icon: lock
           slug: guides/row-level-security

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -552,6 +552,8 @@
               slug: compute/functions/deploy
             - title: Environment variables
               slug: compute/functions/environment-variables
+            - title: WebSocket servers
+              slug: compute/functions/websockets
             - section: Reference
               items:
                 - title: neon.ts

--- a/content/docs/shared-content/private-preview-enquire.md
+++ b/content/docs/shared-content/private-preview-enquire.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-06-12T15:53:06.576Z'
+updatedOn: '2026-06-12T16:38:29.112Z'
 ---
 
 <Admonition type="comingSoon" title="Private Preview">


### PR DESCRIPTION
First draft, do not merge.

## NEON PREVIEW
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/introduction
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/deploy
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/environment-variables
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/websockets
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/get-started
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/overview
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/preview-access
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/reference/neon-ts
- https://neon-next-git-docs-neon-functions-neondatabase.vercel.app/docs/compute/functions/reference/runtime-limits