### PR TITLE
fix: make oss form wording clearer

### DIFF
--- a/src/components/shared/program-form/data.js
+++ b/src/components/shared/program-form/data.js
@@ -18,7 +18,7 @@ const OPENSOURCE = {
   title: 'Apply for the Open Source Program',
   description:
     'Get credits, cash and visibility for open source that helps developers build on Neon',
-  placeholder: 'Project URL',
+  placeholder: 'Website URL',
   buttonText: 'Apply',
   eventName: 'Open Source Program Application Submitted',
   showGithubUrl: true,


### PR DESCRIPTION
A user told me Project URL was confusing and they were not sure if its their website or neons project url. This should clarify that!