### PR TITLE
feat: update homepage hero headline

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -72,9 +72,9 @@ const Hero = () => (
       </Link>
 
       <h1 className="mt-5 max-w-236 text-[68px] leading-dense tracking-tighter xl:max-w-[760px] xl:text-[52px] lg:max-w-[640px] lg:text-[44px] md:mt-4 sm:text-[28px]">
-        Ship faster on the backend
+        Neon is the Postgres backend
         <br />
-        platform for apps and agents.
+        designed for apps and agents.
       </h1>
 
       <div className="mt-8 flex gap-x-5 lg:mt-7 lg:gap-x-4">


### PR DESCRIPTION
## What

Updates the homepage hero `<h1>` copy.

- **Before:** "Ship faster on the backend platform for apps and agents."
- **After:** "Neon is the Postgres backend designed for apps and agents."

## Notes

- Single-file copy change in `src/components/pages/home/hero/hero.jsx`. Layout and styling are unchanged; the two-line break (`<br />`) is preserved.