### PR TITLE
Fixes found by doc consistency checker

### DIFF
--- a/content/docs/ai/ai-scale-with-neon.md
+++ b/content/docs/ai/ai-scale-with-neon.md
@@ -77,7 +77,7 @@ To learn more about Neon's autoscaling feature and how to enable it, refer to ou
 
 ## Storage
 
-On the Free plan, you get 0.5 GB of storage plus 0.5 GB of storage per branch. Storage on paid plans is usage based. See [Neon plans](/docs/introduction/plans) for details.
+On the Free plan, you get 0.5 GB of storage per project. Storage on paid plans is usage based. See [Neon plans](/docs/introduction/plans) for details.
 
 ## Read replicas
 

--- a/content/docs/get-started/built-to-scale.md
+++ b/content/docs/get-started/built-to-scale.md
@@ -24,7 +24,7 @@ Neon fits into every stage of growth, from the first side project to operating l
 
 When you’re looking for a free plan to run Postgres, what you want is simplicity and enough room to build. Neon’s Free plan abstracts most configuration work, delivers real-world performance, and gives you access to core Neon features like branching and autoscaling.
 
-- You get a [Free Plan with real resources](https://neon.com/blog/why-so-many-projects-in-the-neon-free-plan), including up to 100 projects, compute endpoints with up to 2 CPUs, and 0.5 GB of storage per project - enough to build and test real applications
+- You get a [Free Plan with real resources](https://neon.com/blog/why-so-many-projects-in-the-neon-free-plan), including up to 100 projects, compute endpoints with up to 2 CU, and 0.5 GB of storage per project - enough to build and test real applications
 - You get a Postgres connection string in a second so you can start building right away
 - [Scale to zero](https://neon.com/docs/introduction/scale-to-zero) ensures idle databases don’t eat up your compute limits: only active time counts
 - Standard Postgres compatibility means you can plug Neon into [any framework, ORM, or tool that speaks Postgres](https://neon.com/docs/get-started/frameworks)

--- a/content/docs/guides/ai-agent-integration.md
+++ b/content/docs/guides/ai-agent-integration.md
@@ -73,7 +73,7 @@ Each organization has different limits that apply to all projects created within
 
 | Limit                    | Free Organization | Paid Organization | Notes                                                                                                            |
 | ------------------------ | ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Max branches**         | 10 per project    | 1,000 per project | Includes all branches (production, development, snapshots)                                                       |
+| **Max branches**         | 10 per project    | 5,000 per project | Includes all branches (production, development, snapshots)                                                       |
 | **Max manual snapshots** | 1 per project     | 100 per project   | Manual snapshots only. On paid plans, scheduled backup snapshots do not count. Critical for versioning workflows |
 | **Compute range**        | 0.25 - 2 CU       | 0.25 - 16 CU      | CU = Compute Units (~4GB RAM per CU)                                                                             |
 | **History window**       | 1 day             | Up to 7 days      | Point-in-time recovery window                                                                                    |
@@ -429,7 +429,7 @@ Development branches are:
 - **Easy to reset**: Restore development branch to match production anytime
 
 <Admonition type="note">
-**Branch limits:** Remember that Free organization projects have a **10 branch maximum** (including main branch, development branches, and snapshots), while Paid organization projects support up to **1,000 branches**. Implement branch cleanup for temporary development branches to stay within limits.
+**Branch limits:** Remember that Free organization projects have a **10 branch maximum** (including main branch, development branches, and snapshots), while Paid organization projects support up to **5,000 branches**. Implement branch cleanup for temporary development branches to stay within limits.
 </Admonition>
 
 Example creating a development branch using the [Create branch](https://api-docs.neon.tech/reference/createprojectbranch) API:

--- a/content/docs/guides/ai-agent-integration.md
+++ b/content/docs/guides/ai-agent-integration.md
@@ -73,7 +73,7 @@ Each organization has different limits that apply to all projects created within
 
 | Limit                    | Free Organization | Paid Organization | Notes                                                                                                            |
 | ------------------------ | ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Max branches**         | 10 per project    | 5,000 per project | Includes all branches (production, development, snapshots)                                                       |
+| **Max branches**         | 10 per project    | Custom limits available | Includes all branches (production, development, snapshots)                                                       |
 | **Max manual snapshots** | 1 per project     | 100 per project   | Manual snapshots only. On paid plans, scheduled backup snapshots do not count. Critical for versioning workflows |
 | **Compute range**        | 0.25 - 2 CU       | 0.25 - 16 CU      | CU = Compute Units (~4GB RAM per CU)                                                                             |
 | **History window**       | 1 day             | Up to 7 days      | Point-in-time recovery window                                                                                    |
@@ -429,7 +429,7 @@ Development branches are:
 - **Easy to reset**: Restore development branch to match production anytime
 
 <Admonition type="note">
-**Branch limits:** Remember that Free organization projects have a **10 branch maximum** (including main branch, development branches, and snapshots), while Paid organization projects support up to **5,000 branches**. Implement branch cleanup for temporary development branches to stay within limits.
+**Branch limits:** Remember that Free organization projects have a **10 branch maximum** (including main branch, development branches, and snapshots), while Paid organization projects have **custom limits available** (see [Agent plan pricing](/docs/introduction/agent-plan#pricing)). Implement branch cleanup for temporary development branches to stay within limits.
 </Admonition>
 
 Example creating a development branch using the [Create branch](https://api-docs.neon.tech/reference/createprojectbranch) API:

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -82,7 +82,7 @@ On the **Free** plan, there is no monthly cost. You get usage allowances for pro
 
 ### Who it's for
 
-- **Free**: Prototypes, side projects, and small teams. Includes 100 projects, 100 CU-hours/project, 0.5 GB storage per branch, and 5 GB of egress. Upgrade if you need more resources or features.
+- **Free**: Prototypes, side projects, and small teams. Includes 100 projects, 100 CU-hours/project, 0.5 GB storage per project, and 5 GB of egress. Upgrade if you need more resources or features.
 - **Launch**: Startups and growing teams needing more resources, features, and flexibility. Pay only for what you use.
 - **Scale**: Production-grade workloads and large teams. Higher limits, advanced features, full support, compliance, additional security, and SLAs. Pay only for what you use.
 

--- a/content/docs/introduction/usage-calculations.md
+++ b/content/docs/introduction/usage-calculations.md
@@ -81,7 +81,7 @@ Sum each metric's cost to get the total. Rates differ by plan (see [Plans](/docs
 | Private transfer | GB x rate                         | n/a          | $0.01/GB     |
 | Extra branches   | branch-months x rate              | $1.50/mo     | $1.50/mo     |
 
-Agent and Enterprise rates match Scale. Enterprise plans may include custom negotiated pricing.
+Agent plan rates match Scale except compute, which is billed at $0.106/CU-hr (the Launch rate). Enterprise rates match Scale, and Enterprise plans may include custom negotiated pricing.
 
 ### Example: compute
 


### PR DESCRIPTION
A cross-doc consistency sweep surfaced several small factual mismatches in plan-limit and pricing wording. Fixed here:

  - Free-plan storage: per-branch → per-project (`plans.md`, `ai-scale-with-neon.md`)
  - Agent compute rate: corrected from "matches Scale" to the Launch rate (`usage-calculations.md`)
  - Free-plan compute unit: "CPUs" → "CU" (`built-to-scale.md`)
  - Paid-org branch limit: stale 1,000 → 5,000 per project (`ai-agent-integration.md`)

  Report-only review; all values verified against the canonical plans/pricing pages.