### PR TITLE
docs: add private preview tag

### DIFF
--- a/content/docs/cli/bucket.md
+++ b/content/docs/cli/bucket.md
@@ -11,6 +11,8 @@ summary: >-
 enableTableOfContents: true
 ---
 
+<PrivatePreviewEnquire/>
+
 The `bucket` command manages branch object-storage buckets and their objects. Buckets belong to a branch; the `object` subcommands work with the objects inside a bucket.
 
 <CliSubcommands command="bucket" />

--- a/content/docs/cli/dev.md
+++ b/content/docs/cli/dev.md
@@ -9,6 +9,8 @@ summary: >-
 enableTableOfContents: true
 ---
 
+<PrivatePreviewEnquire/>
+
 The `dev` command runs [Neon Functions](/docs/compute/functions/overview) locally with a dev server and hot reload. Serve one function from its entry module, or every function declared in your `neon.ts` policy.
 
 ## Usage

--- a/content/docs/cli/functions.md
+++ b/content/docs/cli/functions.md
@@ -10,6 +10,8 @@ summary: >-
 enableTableOfContents: true
 ---
 
+<PrivatePreviewEnquire/>
+
 The `functions` command manages [Neon Functions](/docs/compute/functions/overview) on a branch. This is the command reference; for the full deployment workflow, see [Deploy functions](/docs/compute/functions/deploy). To run functions locally, see [`neonctl dev`](/docs/cli/dev).
 
 <CliSubcommands command="functions" />

--- a/content/docs/shared-content/private-preview-enquire.md
+++ b/content/docs/shared-content/private-preview-enquire.md
@@ -1,7 +1,7 @@
 ---
-updatedOn: '2025-09-25T10:33:00.978Z'
+updatedOn: '2026-06-12T15:53:06.576Z'
 ---
 
-<Admonition type="comingSoon" title="Early Access">
-This feature is currently available in Early Access for invited users. Want to try it out? Message us from the [Console](https://console.neon.tech/app/projects?modal=feedback) or on [Discord](https://discord.gg/92vNTzKDGp) and we'll send you an invite.
+<Admonition type="comingSoon" title="Private Preview">
+This feature is in private preview: it's not ready for production use, and it may be briefly unavailable as we deploy updates. To get access, [sign up here](https://neon.com/blog/were-building-backends#access).
 </Admonition>


### PR DESCRIPTION
Repurposes existing PrivatePreviewEnquire tag. Using for new backend services.