### PR TITLE
chore: add backend platform RequestForm to 2026-06-12 changelog

### DIFF
--- a/content/changelog/2026-06-12.md
+++ b/content/changelog/2026-06-12.md
@@ -10,7 +10,7 @@ Just a reminder that three new services are on their way to Neon.
 - **Compute**: Serverless functions that run alongside Postgres
 - **AI Gateway**: Route and log LLM calls to OpenAI, Anthropic, or Gemini through a single proxy built into your Neon project
 
-[Sign up for early access](https://neon.com/docs/introduction/roadmap#now-shipping-neon-is-a-complete-backend-platform)
+<RequestForm type="backend-platform" />
 
 ## Lakebase Search (Private Preview)
 


### PR DESCRIPTION
## What

Replace the external "Sign up for early access" link in the early-access section of the 2026-06-12 changelog with an inline `<RequestForm type="backend-platform" />`.

## Why

Lets readers request early access to the Neon backend platform (Storage, Compute, AI Gateway) directly from the changelog without navigating away to the roadmap page.