### PR TITLE
chore: add Lakebase Search RequestForm to 2026-06-12 changelog

### DIFF
--- a/content/changelog/2026-06-12.md
+++ b/content/changelog/2026-06-12.md
@@ -35,6 +35,8 @@ Both indexes live in storage rather than compute memory, so they're available im
 
 **Lakebase Search is in private preview.** [Request access](/docs/introduction/early-access) to try it, or see the [Lakebase Search overview](/docs/ai/lakebase-search) to learn more. To see both in action, [Build a dual-mode search app with lakebase_vector and lakebase_text](/guides/lakebase-vector-bm25-search) walks through building a Next.js knowledge base with semantic and keyword search.
 
+<RequestForm type="lakebase-search" />
+
 ## Cmd+K support for the Neon Console
 
 You can now press `Cmd+K` (Mac) or `Ctrl+K` (Windows/Linux) from anywhere in the Neon Console to open a searchable command bar with actions scoped to your current branch and project: navigate to branches, open the SQL editor, create a snapshot, go to settings, and more.


### PR DESCRIPTION
## What

Add an inline `<RequestForm type="lakebase-search" />` to the Lakebase Search section of the 2026-06-12 changelog.

## Why

Lets readers request Lakebase Search private-preview access directly from the changelog, alongside the existing "Request access" link and overview.