### PR TITLE
chore: add early-access request forms to 2026-06-12 changelog

### DIFF
--- a/content/changelog/2026-06-12.md
+++ b/content/changelog/2026-06-12.md
@@ -16,6 +16,8 @@ Just a reminder that three new services are on their way to Neon.
 
 Lakebase Search brings scalable vector and BM25 full-text search to Neon through two new Postgres extensions, so you can handle semantic and keyword search in a single database without running separate search infrastructure.
 
+<RequestForm type="lakebase-search" />
+
 - [**`lakebase_vector`**](/docs/extensions/lakebase-vector) adds the `lakebase_ann` index type for approximate nearest-neighbor vector search. Drop-in compatible with `pgvector`: same types, operators, and query syntax. A single index scales to over 1 billion vectors, with builds 50–100x faster than HNSW.
 
   ```sql
@@ -35,7 +37,6 @@ Both indexes live in storage rather than compute memory, so they're available im
 
 **Lakebase Search is in private preview.** [Request access](/docs/introduction/early-access) to try it, or see the [Lakebase Search overview](/docs/ai/lakebase-search) to learn more. To see both in action, [Build a dual-mode search app with lakebase_vector and lakebase_text](/guides/lakebase-vector-bm25-search) walks through building a Next.js knowledge base with semantic and keyword search.
 
-<RequestForm type="lakebase-search" />
 
 ## Run `neonctl psql` without installing the psql client
 

--- a/content/changelog/2026-06-12.md
+++ b/content/changelog/2026-06-12.md
@@ -10,7 +10,7 @@ Just a reminder that three new services are on their way to Neon.
 - **Compute**: Serverless functions that run alongside Postgres
 - **AI Gateway**: Route and log LLM calls to OpenAI, Anthropic, or Gemini through a single proxy built into your Neon project
 
-[Sign up for early access](https://neon.com/docs/introduction/roadmap#now-shipping-neon-is-a-complete-backend-platform)
+<RequestForm type="backend-platform" />
 
 ## Lakebase Search (Private Preview)
 
@@ -34,6 +34,8 @@ Lakebase Search brings scalable vector and BM25 full-text search to Neon through
 Both indexes live in storage rather than compute memory, so they're available immediately after a cold start. Because Neon branches are copy-on-write, your search indexes are available on every branch without reindexing.
 
 **Lakebase Search is in private preview.** [Request access](/docs/introduction/early-access) to try it, or see the [Lakebase Search overview](/docs/ai/lakebase-search) to learn more. To see both in action, [Build a dual-mode search app with lakebase_vector and lakebase_text](/guides/lakebase-vector-bm25-search) walks through building a Next.js knowledge base with semantic and keyword search.
+
+<RequestForm type="lakebase-search" />
 
 ## Run `neonctl psql` without installing the psql client
 


### PR DESCRIPTION
## What

- Replace the external "Sign up for early access" link in the early-access section with an inline `<RequestForm type="backend-platform" />`.
- Add a `<RequestForm type="lakebase-search" />` to the Lakebase Search section.

## Why

Lets readers request access to the Neon backend platform (Storage, Compute, AI Gateway) and to Lakebase Search private preview directly from the changelog, without navigating away.

Supersedes #5062 and #5063 (both closed); this branch is rebased on current `main`.