### PR TITLE
Add /mts homepage alternate with startups credits callout

### DIFF
--- a/src/app/mts/page.jsx
+++ b/src/app/mts/page.jsx
@@ -1,0 +1,45 @@
+import AI from 'components/pages/home/ai';
+import Auth from 'components/pages/home/auth';
+import Autoscaling from 'components/pages/home/autoscaling';
+import BackedBy from 'components/pages/home/backed-by';
+import Branching from 'components/pages/home/branching';
+import CTA from 'components/pages/home/cta';
+import Features from 'components/pages/home/features';
+import HeroMts from 'components/pages/home/hero-mts';
+import SpeedScale from 'components/pages/home/speed-scale';
+import TocWrapper from 'components/pages/home/toc-wrapper/toc-wrapper';
+import JsonLd from 'components/shared/json-ld';
+import Layout from 'components/shared/layout';
+import SEO_DATA from 'constants/seo-data';
+import { generateOrganizationSchema } from 'lib/schema';
+import getMetadata from 'utils/get-metadata';
+
+export const metadata = getMetadata({
+  ...SEO_DATA.index,
+  robotsNoindex: 'noindex',
+});
+
+const MtsPage = () => {
+  const organizationSchema = generateOrganizationSchema();
+
+  return (
+    <Layout isHeaderSticky isHeaderStickyOverlay>
+      <JsonLd data={organizationSchema} />
+      <HeroMts />
+      <TocWrapper>
+        <AI />
+        <Autoscaling />
+        <Branching />
+        <Auth />
+        <Features />
+      </TocWrapper>
+      <SpeedScale />
+      <BackedBy />
+      <CTA />
+    </Layout>
+  );
+};
+
+export default MtsPage;
+
+export const revalidate = false;

--- a/src/components/pages/home/hero-mts/hero-mts.jsx
+++ b/src/components/pages/home/hero-mts/hero-mts.jsx
@@ -90,7 +90,7 @@ const HeroMts = () => (
           quality={100}
           alt=""
         />
-        <span className="relative z-10 inline-flex shrink-0 items-center rounded-full bg-green-45 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
+        <span className="relative z-10 inline-flex shrink-0 items-center bg-[linear-gradient(90deg,rgba(57,165,125,0.6)_50%,transparent_50%)] bg-[size:200%_100%] bg-left bg-no-repeat px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
           Startups
         </span>
         <span className="relative z-10 text-base leading-snug font-medium tracking-extra-tight text-black-pure">

--- a/src/components/pages/home/hero-mts/hero-mts.jsx
+++ b/src/components/pages/home/hero-mts/hero-mts.jsx
@@ -1,0 +1,215 @@
+import Image from 'next/image';
+
+import Button from 'components/shared/button';
+import Container from 'components/shared/container';
+import Link from 'components/shared/link';
+import Logos from 'components/shared/logos';
+import PauseableVideo from 'components/shared/pauseable-video';
+import SectionLabel from 'components/shared/section-label';
+import Tooltip from 'components/shared/tooltip';
+import LINKS from 'constants/links';
+import AIGatewayIcon from 'icons/home/hero/ai-gateway.svg';
+import ComputeIcon from 'icons/home/hero/compute.svg';
+import DatabaseIcon from 'icons/home/hero/database.svg';
+import LockIcon from 'icons/home/hero/lock.svg';
+import StorageIcon from 'icons/home/hero/storage.svg';
+import mobileBgIllustration from 'images/pages/home/hero/bg-illustration.jpg';
+import { cn } from 'utils/cn';
+
+const logos = [
+  'replit',
+  'outfront',
+  'doordash',
+  'bcg',
+  'pepsi',
+  'retool',
+  'meta',
+  'bitso',
+  'framer',
+];
+
+const productFeatures = [
+  {
+    title: 'Postgres Database',
+    description: 'Serverless Postgres that scales and branches with your app.',
+    icon: DatabaseIcon,
+  },
+  {
+    title: 'Authentication',
+    description: 'Managed auth with users and sessions stored in Postgres.',
+    icon: LockIcon,
+  },
+  {
+    title: 'Compute',
+    description: 'Functions without timeouts running close to your database.',
+    icon: ComputeIcon,
+    comingSoon: true,
+  },
+  {
+    title: 'Storage',
+    description: 'S3-compatible object storage that branches with your projects.',
+    icon: StorageIcon,
+    comingSoon: true,
+  },
+  {
+    title: 'AI Gateway',
+    description: 'One API for all frontier & open-source models, powered by Databricks.',
+    icon: AIGatewayIcon,
+    comingSoon: true,
+  },
+];
+
+const HeroMts = () => (
+  <section className="hero relative mt-16 safe-paddings lg:mt-14">
+    <Container
+      className="relative z-30 pt-88 pb-2 xl:px-16 xl:pt-[216px] lg:pt-[208px] md:px-5! md:pt-[212px]"
+      size="1600"
+    >
+      <Link href="#backed-by-giants">
+        <SectionLabel theme="white" icon="databricks">
+          A DATABRICKS COMPANY
+        </SectionLabel>
+      </Link>
+
+      <h1 className="mt-5 max-w-236 text-[68px] leading-dense tracking-tighter xl:max-w-[760px] xl:text-[52px] lg:max-w-[640px] lg:text-[44px] md:mt-4 sm:text-[28px]">
+        Neon is the Postgres backend
+        <br />
+        designed for apps and agents.
+      </h1>
+
+      <Link
+        className="group mt-8 inline-flex max-w-full items-center gap-x-3 rounded-full border border-gray-new-20 bg-gray-new-8 py-2 pr-4 pl-2 transition-colors duration-200 hover:border-gray-new-30 lg:mt-7"
+        to={LINKS.startups}
+      >
+        <span className="inline-flex shrink-0 items-center rounded-full bg-green-44 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
+          Startups
+        </span>
+        <span className="text-base leading-snug tracking-extra-tight text-gray-new-80">
+          Qualifying startups get up to{' '}
+          <span className="font-medium text-white">$100K in credits</span> to scale on Neon
+          <span className="ml-1 inline-block transition-transform duration-200 group-hover:translate-x-0.5">
+            &rarr;
+          </span>
+        </span>
+      </Link>
+
+      <div className="mt-8 flex gap-x-5 lg:mt-7 lg:gap-x-4">
+        <Button theme="white-filled" size="new" to={LINKS.signup}>
+          Get started
+        </Button>
+        <Button theme="outlined" size="new" to={LINKS.docsHome}>
+          Read the docs
+        </Button>
+      </div>
+
+      <div className="relative mt-12 flex border-t border-gray-new-20 pt-12 lg:mt-11 lg:pt-11 sm:mt-10 sm:pt-10">
+        <ul className="flex flex-row gap-x-11 gap-y-10 xl:-mx-16 xl:no-scrollbars xl:flex xl:snap-x xl:snap-mandatory xl:scroll-px-16 xl:gap-x-8 xl:overflow-x-auto xl:px-16 lg:-mx-5 lg:scroll-px-5 lg:px-5">
+          {productFeatures.map(({ title, description, icon: Icon, comingSoon }) => {
+            const tooltipId = `home-hero-${title.toLowerCase().replace(/\s+/g, '-')}-tooltip`;
+            const tooltipProps = comingSoon
+              ? {
+                  'data-tooltip-id': tooltipId,
+                }
+              : {};
+
+            return (
+              <li
+                className="min-w-0 text-white xl:w-69 xl:shrink-0 xl:snap-start sm:w-60"
+                key={title}
+                {...tooltipProps}
+              >
+                <div className={cn('flex items-center gap-x-3', comingSoon ? 'mb-2.5' : 'mb-3.5')}>
+                  <Image
+                    className="size-4 shrink-0"
+                    src={Icon}
+                    width={16}
+                    height={16}
+                    loading="eager"
+                    alt=""
+                  />
+                  <span
+                    className={cn(
+                      'text-base leading-none font-medium tracking-extra-tight',
+                      comingSoon ? 'text-gray-new-60' : 'text-white'
+                    )}
+                  >
+                    {title}
+                  </span>
+                  {comingSoon && (
+                    <>
+                      <span className="inline-flex items-center rounded-full bg-green-44 px-2 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
+                        early access
+                      </span>
+                      <Tooltip
+                        className="-mt-6 max-w-[310px]! border-gray-new-30! bg-gray-new-8! px-3.5! py-2.5! md:-mt-2 [&.react-tooltip\_\_place-right]:-ml-17!"
+                        id={tooltipId}
+                        place="right"
+                        clickable
+                      >
+                        <p className="mb-2 text-base leading-snug tracking-extra-tight text-white">
+                          Subscribe to get early access to the Neon backend platform.
+                        </p>
+                        <Link
+                          class="border-b border-dashed border-gray-new-50 pb-0 text-sm leading-tight tracking-extra-tight text-gray-new-80 transition-colors duration-200"
+                          to="docs/introduction/roadmap#now-shipping-neon-is-a-complete-backend-platform"
+                          theme="gray-80"
+                        >
+                          Register for access
+                        </Link>
+                      </Tooltip>
+                    </>
+                  )}
+                </div>
+                <p className="max-w-[290px] text-base tracking-extra-tight text-gray-new-50">
+                  {description}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="relative mt-40 select-none xl:mt-28 lg:mt-24 md:mt-20 sm:mt-16">
+        <Logos className="max-w-full p-0!" logos={logos} size="md" />
+      </div>
+    </Container>
+
+    <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden">
+      {/*
+        Video optimization parameters:
+          mp4 av1: ffmpeg -i hero.mov -c:v libaom-av1 -crf 25 -b:v 0 -pix_fmt yuv420p10le -vf scale=2880:-2 -cpu-used 0 -tiles 4x2 -row-mt 1 -threads 16 -strict experimental -tag:v av01 -movflags faststart -an hero-av1.mp4
+          mp4: ffmpeg -i hero.mov -c:v libx265 -crf 25 -pix_fmt yuv420p10le -vf scale=2880:-2 -preset veryslow -tag:v hvc1 -movflags faststart -an hero.mp4
+          webm: ffmpeg -i hero.mov -c:v libvpx-vp9 -pix_fmt yuv420p10le -crf 35 -vf scale=2880:-2 -deadline best -an hero.webm
+      */}
+      <PauseableVideo
+        className={cn(
+          'relative -top-16 left-1/2 w-[1920px] -translate-x-1/2',
+          'xl:-top-[50px] xl:w-[1304px] lg:-top-2 lg:w-[1016px] sm:hidden'
+        )}
+        width={1920}
+        height={832}
+        poster={`${LINKS.cdn}/public/pages/home/hero/poster.jpg`}
+      >
+        <source
+          src={`${LINKS.cdn}/public/pages/home/hero/hero-av1.mp4`}
+          type="video/mp4; codecs=av01.0.05M.08,opus"
+        />
+        <source src={`${LINKS.cdn}/public/pages/home/hero/hero.mp4`} type="video/mp4" />
+        <source src={`${LINKS.cdn}/public/pages/home/hero/hero.webm`} type="video/webm" />
+      </PauseableVideo>
+      <Image
+        className="relative left-[40%] hidden w-[752px] max-w-none -translate-x-1/2 sm:block"
+        src={mobileBgIllustration}
+        width={752}
+        height={326}
+        quality={100}
+        alt=""
+        priority
+      />
+    </div>
+
+    <div className="absolute bottom-0 z-20 h-[88px] w-full bg-[linear-gradient(0deg,#000_0%,rgba(0,0,0,0.00)_100%)] xl:h-[165px] lg:h-[156px] sm:h-[258px]" />
+  </section>
+);
+
+export default HeroMts;

--- a/src/components/pages/home/hero-mts/hero-mts.jsx
+++ b/src/components/pages/home/hero-mts/hero-mts.jsx
@@ -13,6 +13,7 @@ import ComputeIcon from 'icons/home/hero/compute.svg';
 import DatabaseIcon from 'icons/home/hero/database.svg';
 import LockIcon from 'icons/home/hero/lock.svg';
 import StorageIcon from 'icons/home/hero/storage.svg';
+import bgNoise from 'images/pages/home/backed-by/bg-noise.jpg';
 import mobileBgIllustration from 'images/pages/home/hero/bg-illustration.jpg';
 import { cn } from 'utils/cn';
 
@@ -78,13 +79,21 @@ const HeroMts = () => (
       </h1>
 
       <Link
-        className="group mt-8 inline-flex max-w-full items-center gap-x-3 rounded-full bg-green-45 py-2.5 pr-5 pl-2.5 shadow-[0_0_40px_-8px_rgba(0,229,153,0.6)] transition-all duration-200 hover:bg-[#54f0b8] hover:shadow-[0_0_48px_-6px_rgba(0,229,153,0.8)] lg:mt-7"
+        className="group relative mt-8 inline-flex max-w-full items-center gap-x-3 overflow-hidden bg-[#E4F1EB] py-3 pr-5 pl-3 text-black-pure lg:mt-7"
         to={LINKS.startups}
       >
-        <span className="inline-flex shrink-0 items-center rounded-full bg-black-pure/15 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
+        <Image
+          className="pointer-events-none absolute inset-0 z-0 h-full w-full object-cover object-right"
+          src={bgNoise}
+          width={1175}
+          height={927}
+          quality={100}
+          alt=""
+        />
+        <span className="relative z-10 inline-flex shrink-0 items-center rounded-full bg-black-pure/10 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
           Startups
         </span>
-        <span className="text-base leading-snug font-medium tracking-extra-tight text-black-pure">
+        <span className="relative z-10 text-base leading-snug font-medium tracking-extra-tight text-black-pure">
           Qualifying startups get up to <span className="font-semibold">$100K in credits</span> to
           scale on Neon
           <span className="ml-1 inline-block transition-transform duration-200 group-hover:translate-x-0.5">

--- a/src/components/pages/home/hero-mts/hero-mts.jsx
+++ b/src/components/pages/home/hero-mts/hero-mts.jsx
@@ -78,15 +78,15 @@ const HeroMts = () => (
       </h1>
 
       <Link
-        className="group mt-8 inline-flex max-w-full items-center gap-x-3 rounded-full border border-gray-new-20 bg-gray-new-8 py-2 pr-4 pl-2 transition-colors duration-200 hover:border-gray-new-30 lg:mt-7"
+        className="group mt-8 inline-flex max-w-full items-center gap-x-3 rounded-full bg-green-45 py-2.5 pr-5 pl-2.5 shadow-[0_0_40px_-8px_rgba(0,229,153,0.6)] transition-all duration-200 hover:bg-[#54f0b8] hover:shadow-[0_0_48px_-6px_rgba(0,229,153,0.8)] lg:mt-7"
         to={LINKS.startups}
       >
-        <span className="inline-flex shrink-0 items-center rounded-full bg-green-44 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
+        <span className="inline-flex shrink-0 items-center rounded-full bg-black-pure/15 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
           Startups
         </span>
-        <span className="text-base leading-snug tracking-extra-tight text-gray-new-80">
-          Qualifying startups get up to{' '}
-          <span className="font-medium text-white">$100K in credits</span> to scale on Neon
+        <span className="text-base leading-snug font-medium tracking-extra-tight text-black-pure">
+          Qualifying startups get up to <span className="font-semibold">$100K in credits</span> to
+          scale on Neon
           <span className="ml-1 inline-block transition-transform duration-200 group-hover:translate-x-0.5">
             &rarr;
           </span>

--- a/src/components/pages/home/hero-mts/hero-mts.jsx
+++ b/src/components/pages/home/hero-mts/hero-mts.jsx
@@ -90,7 +90,7 @@ const HeroMts = () => (
           quality={100}
           alt=""
         />
-        <span className="relative z-10 inline-flex shrink-0 items-center rounded-full bg-black-pure/10 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
+        <span className="relative z-10 inline-flex shrink-0 items-center rounded-full bg-green-45 px-2.5 py-1 font-mono text-[13px] leading-none font-medium tracking-extra-tight text-black-pure uppercase">
           Startups
         </span>
         <span className="relative z-10 text-base leading-snug font-medium tracking-extra-tight text-black-pure">

--- a/src/components/pages/home/hero-mts/index.js
+++ b/src/components/pages/home/hero-mts/index.js
@@ -1,0 +1,3 @@
+import HeroMts from './hero-mts';
+
+export default HeroMts;


### PR DESCRIPTION
## Summary

Adds a `noindex` alternate of the homepage at `/mts`, following the same pattern as the existing `/home` alternate. The only difference from the production homepage is a hero callout that links to the startups page: "Qualifying startups get up to **\$100K in credits** to scale on Neon."

The hero is duplicated into a dedicated `hero-mts` component so the production homepage's shared `Hero` is left completely untouched — this alternate cannot affect neon.com.

## Files changed

- `src/app/mts/page.jsx` — the `/mts` route (noindex, mirrors the homepage)
- `src/components/pages/home/hero-mts/hero-mts.jsx` — hero variant with the startups callout
- `src/components/pages/home/hero-mts/index.js`

## Notes for reviewers

- `/mts` is reachable only by direct URL (no header nav entry), matching the `/home` alternate convention.
- The callout uses the hero's existing dark-theme tokens (green-44 badge, gray borders) and links to `LINKS.startups` (`/startups`). The `$100K` figure matches the startups page copy.