### PR TITLE
Update topbar callout to promote Lakebase Search

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'New in Neon: Lakebase Search brings scalable vector and BM25 full-text search to Postgres, scaling from 0 to 1B vectors on a single index. Read the docs.'
+text: "New in Neon: vector (ANN) and text (BM25) search extensions optimized for Neon's lakebase architecture. Read the docs."
 link:
   url: 'https://neon.com/docs/ai/lakebase-search'
   target: '_blank'

--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'New in Neon: Vector and BM25 full-text search extensions built for lakebase architecture, plus major CLI updates. See what shipped this week.'
+text: 'New in Neon: Lakebase Search brings scalable vector and BM25 full-text search to Postgres, scaling from 0 to 1B vectors on a single index. Read the docs.'
 link:
-  url: 'https://neon.com/docs/changelog/2026-06-12'
+  url: 'https://neon.com/docs/ai/lakebase-search'
   target: '_blank'


### PR DESCRIPTION
## Summary

Updates the site topbar banner to call out Lakebase Search specifically and link to its docs page (`/docs/ai/lakebase-search`) instead of the weekly changelog.

New banner copy:

> New in Neon: vector (ANN) and text (BM25) search extensions optimized for Neon's lakebase architecture. Read the docs.

## Files changed

- `content/config/topbar.yaml` — banner text and link target

## Notes for reviewers

- The banner truncates on narrower viewports; the trimmed copy fits comfortably on desktop.
- Link opens the [Lakebase Search docs](https://neon.com/docs/ai/lakebase-search) in a new tab, matching the previous banner's `target: _blank`.