### PR TITLE
docs: Neon Functions, Storage, and AI Gateway private preview

### DIFF
--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -6,8 +6,10 @@ summary: >-
   Gateway by changing only the base URL. Supports streaming, prompt caching,
   and extended thinking on Claude models.
 enableTableOfContents: true
-updatedOn: '2026-06-15T08:51:16.298Z'
+updatedOn: '2026-06-15T13:34:36.031Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it when you need extended thinking or prompt caching, which require the native Anthropic SDK. For standard completions, the [chat completions](/docs/ai-gateway/chat-completions) endpoint works with all Anthropic models and doesn't require the Anthropic SDK.
 

--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway by changing only the base URL. Supports streaming, prompt caching,
   and extended thinking on Claude models.
 enableTableOfContents: true
-updatedOn: '2026-06-10T17:21:35.055Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
 The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it with the official Anthropic SDK by changing only the `base_url`. Prompt caching, extended thinking, and streaming all work without additional configuration.
@@ -176,7 +176,7 @@ print(message.usage)
 The gateway forwards these request headers to the upstream provider:
 `Accept`, `Anthropic-Beta`, `Anthropic-Version`, `Content-Type`, `User-Agent`.
 
-All other headers are stripped. The `Authorization` header is replaced with the workspace credential before forwarding — your `NEON_AI_GATEWAY_KEY` is never sent to Anthropic directly.
+All other headers are stripped. The `Authorization` header is replaced with the workspace credential before forwarding. Your `NEON_AI_GATEWAY_KEY` is never sent to Anthropic directly.
 
 ## Error handling
 
@@ -192,8 +192,8 @@ All other headers are stripped. The `Authorization` header is replaced with the 
 
 ## Next steps
 
-- [Models](/docs/ai-gateway/models) — full model catalog
-- [Chat completions](/docs/ai-gateway/chat-completions) — use any model including Anthropic via the unified endpoint
-- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+- [Models](/docs/ai-gateway/models): full model catalog
+- [Chat completions](/docs/ai-gateway/chat-completions): use any model including Anthropic via the unified endpoint
+- [Authentication](/docs/ai-gateway/authentication): credential scopes and branch binding
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway by changing only the base URL. Supports streaming, prompt caching,
   and extended thinking on Claude models.
 enableTableOfContents: true
-updatedOn: '2026-06-11T17:20:52.899Z'
+updatedOn: '2026-06-15T08:51:16.298Z'
 ---
 
 The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it when you need extended thinking or prompt caching, which require the native Anthropic SDK. For standard completions, the [chat completions](/docs/ai-gateway/chat-completions) endpoint works with all Anthropic models and doesn't require the Anthropic SDK.
@@ -36,7 +36,7 @@ import Anthropic from '@anthropic-ai/sdk';
 
 const client = new Anthropic({
   apiKey: process.env.NEON_AI_GATEWAY_KEY,
-  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/anthropic`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/anthropic`,
 });
 
 const message = await client.messages.create({
@@ -54,7 +54,7 @@ import os
 
 client = anthropic.Anthropic(
     api_key=os.environ['NEON_AI_GATEWAY_KEY'],
-    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/anthropic",
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/anthropic",
 )
 
 message = client.messages.create(
@@ -67,7 +67,7 @@ print(message.content[0].text)
 ```
 
 ```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/anthropic/v1/messages" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/anthropic/v1/messages" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -H "anthropic-version: 2023-06-01" \

--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -1,0 +1,199 @@
+---
+title: Anthropic Messages API
+subtitle: Use the Anthropic SDK with Neon AI Gateway
+summary: >-
+  The Anthropic Messages endpoint lets you use the Anthropic SDK with Neon AI
+  Gateway by changing only the base URL. Supports streaming, prompt caching,
+  and extended thinking on Claude models.
+enableTableOfContents: true
+updatedOn: '2026-06-10T17:21:35.055Z'
+---
+
+The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it with the official Anthropic SDK by changing only the `base_url`. Prompt caching, extended thinking, and streaming all work without additional configuration.
+
+**Base URL:** `https://<branch-host>/ai-gateway/anthropic`
+
+<Admonition type="note">
+The Anthropic SDK appends `/v1/messages` to the base URL automatically. Set the base URL to `/ai-gateway/anthropic` (without `/v1`).
+</Admonition>
+
+## Supported models
+
+This endpoint accepts Anthropic models only. Use the `databricks-` prefixed model IDs from the [AI Gateway catalog](/docs/ai-gateway/models):
+
+- `databricks-claude-opus-4-8`, `databricks-claude-opus-4-7`, `databricks-claude-opus-4-6`, `databricks-claude-opus-4-5`
+- `databricks-claude-sonnet-4-6`
+- `databricks-claude-haiku-4-5`
+
+Sending a non-Anthropic model ID returns `400 model is not available on this endpoint`. Use the [chat completions endpoint](/docs/ai-gateway/chat-completions) if you need to call multiple providers from the same code.
+
+## Basic request
+
+<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)", "cURL"]}>
+
+```typescript shouldWrap
+import Anthropic from '@anthropic-ai/sdk';
+
+const client = new Anthropic({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/anthropic`,
+});
+
+const message = await client.messages.create({
+  model: 'databricks-claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'What is Neon?' }],
+});
+
+console.log(message.content[0].text);
+```
+
+```python shouldWrap
+import anthropic
+import os
+
+client = anthropic.Anthropic(
+    api_key=os.environ['NEON_AI_GATEWAY_KEY'],
+    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/anthropic",
+)
+
+message = client.messages.create(
+    model='databricks-claude-sonnet-4-6',
+    max_tokens=1024,
+    messages=[{'role': 'user', 'content': 'What is Neon?'}],
+)
+
+print(message.content[0].text)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/anthropic/v1/messages" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "databricks-claude-sonnet-4-6",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "What is Neon?"}]
+  }'
+```
+
+</CodeTabs>
+
+## Streaming
+
+<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)", "cURL"]}>
+
+```typescript shouldWrap
+const stream = client.messages.stream({
+  model: 'databricks-claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'Explain database branching.' }],
+});
+
+for await (const event of stream) {
+  if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+    process.stdout.write(event.delta.text);
+  }
+}
+```
+
+```python shouldWrap
+with client.messages.stream(
+    model='databricks-claude-sonnet-4-6',
+    max_tokens=1024,
+    messages=[{'role': 'user', 'content': 'Explain database branching.'}],
+) as stream:
+    for text in stream.text_stream:
+        print(text, end='', flush=True)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/anthropic/v1/messages" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "databricks-claude-sonnet-4-6",
+    "max_tokens": 1024,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Explain database branching."}]
+  }'
+```
+
+</CodeTabs>
+
+## Prompt caching
+
+The gateway forwards the `cache_control` field to Anthropic unchanged. Prompt caching works exactly as described in the [Anthropic prompt caching docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
+
+<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)"]}>
+
+```typescript shouldWrap
+const message = await client.messages.create({
+  model: 'databricks-claude-sonnet-4-6',
+  max_tokens: 1024,
+  system: [
+    { type: 'text', text: 'You are a helpful assistant.' },
+    {
+      type: 'text',
+      text: longDocumentContent,
+      cache_control: { type: 'ephemeral' },
+    },
+  ],
+  messages: [{ role: 'user', content: 'Summarize the key points.' }],
+});
+
+console.log(message.usage);
+// { input_tokens: 50, output_tokens: 200,
+//   cache_creation_input_tokens: 10000, cache_read_input_tokens: 0 }
+```
+
+```python shouldWrap
+message = client.messages.create(
+    model='databricks-claude-sonnet-4-6',
+    max_tokens=1024,
+    system=[
+        {'type': 'text', 'text': 'You are a helpful assistant.'},
+        {
+            'type': 'text',
+            'text': long_document_content,
+            'cache_control': {'type': 'ephemeral'},
+        },
+    ],
+    messages=[{'role': 'user', 'content': 'Summarize the key points.'}],
+)
+
+print(message.usage)
+# input_tokens=50, output_tokens=200,
+# cache_creation_input_tokens=10000, cache_read_input_tokens=0
+```
+
+</CodeTabs>
+
+## Forwarded headers
+
+The gateway forwards these request headers to the upstream provider:
+`Accept`, `Anthropic-Beta`, `Anthropic-Version`, `Content-Type`, `User-Agent`.
+
+All other headers are stripped. The `Authorization` header is replaced with the workspace credential before forwarding — your `NEON_AI_GATEWAY_KEY` is never sent to Anthropic directly.
+
+## Error handling
+
+| Status                  | Message                                     | Cause                                                   |
+| ----------------------- | ------------------------------------------- | ------------------------------------------------------- |
+| `400 Bad Request`       | `unknown model`                             | Model ID not in the catalog                             |
+| `400 Bad Request`       | `model is not available on this endpoint`   | Non-Anthropic model ID sent to this endpoint            |
+| `401 Unauthorized`      | `invalid or missing credential`             | Missing or invalid `NEON_AI_GATEWAY_KEY`                |
+| `403 Forbidden`         | `credential not authorized for ai gateway`  | Credential lacks `ai_gateway:invoke` scope              |
+| `403 Forbidden`         | `credential not authorized for this branch` | Credential's branch not in the request branch's lineage |
+| `429 Too Many Requests` | `ai gateway quota exceeded`                 | Account quota blocked; check `Retry-After` header       |
+| `502 Bad Gateway`       | `upstream request failed`                   | Upstream Anthropic/Databricks error; retry              |
+
+## Next steps
+
+- [Models](/docs/ai-gateway/models) — full model catalog
+- [Chat completions](/docs/ai-gateway/chat-completions) — use any model including Anthropic via the unified endpoint
+- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -6,10 +6,10 @@ summary: >-
   Gateway by changing only the base URL. Supports streaming, prompt caching,
   and extended thinking on Claude models.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-11T17:20:52.899Z'
 ---
 
-The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it with the official Anthropic SDK by changing only the `base_url`. Prompt caching, extended thinking, and streaming all work without additional configuration.
+The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it when you need extended thinking or prompt caching, which require the native Anthropic SDK. For standard completions, the [chat completions](/docs/ai-gateway/chat-completions) endpoint works with all Anthropic models and doesn't require the Anthropic SDK.
 
 **Base URL:** `https://<branch-host>/ai-gateway/anthropic`
 
@@ -82,46 +82,7 @@ curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/anthropic/v1/messages" \
 
 ## Streaming
 
-<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)", "cURL"]}>
-
-```typescript shouldWrap
-const stream = client.messages.stream({
-  model: 'databricks-claude-sonnet-4-6',
-  max_tokens: 1024,
-  messages: [{ role: 'user', content: 'Explain database branching.' }],
-});
-
-for await (const event of stream) {
-  if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
-    process.stdout.write(event.delta.text);
-  }
-}
-```
-
-```python shouldWrap
-with client.messages.stream(
-    model='databricks-claude-sonnet-4-6',
-    max_tokens=1024,
-    messages=[{'role': 'user', 'content': 'Explain database branching.'}],
-) as stream:
-    for text in stream.text_stream:
-        print(text, end='', flush=True)
-```
-
-```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/anthropic/v1/messages" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
-  -H "Content-Type: application/json" \
-  -H "anthropic-version: 2023-06-01" \
-  -d '{
-    "model": "databricks-claude-sonnet-4-6",
-    "max_tokens": 1024,
-    "stream": true,
-    "messages": [{"role": "user", "content": "Explain database branching."}]
-  }'
-```
-
-</CodeTabs>
+Streaming works the same as with the Anthropic SDK directly. Use `client.messages.stream()` or pass `"stream": true` in a cURL request. The only change from standard usage is `base_url`.
 
 ## Prompt caching
 
@@ -171,6 +132,52 @@ print(message.usage)
 
 </CodeTabs>
 
+## Extended thinking
+
+The gateway forwards the `thinking` parameter to Anthropic unchanged. Set `budget_tokens` to control how many tokens Claude can use for thinking. `max_tokens` must be greater than `budget_tokens`.
+
+<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)"]}>
+
+```typescript shouldWrap
+const message = await client.messages.create({
+  model: 'databricks-claude-sonnet-4-6',
+  max_tokens: 16000,
+  thinking: {
+    type: 'enabled',
+    budget_tokens: 10000,
+  },
+  messages: [{ role: 'user', content: 'Design a database schema for a multi-tenant SaaS app.' }],
+});
+
+for (const block of message.content) {
+  if (block.type === 'thinking') {
+    console.log('Thinking:', block.thinking);
+  } else if (block.type === 'text') {
+    console.log(block.text);
+  }
+}
+```
+
+```python shouldWrap
+message = client.messages.create(
+    model='databricks-claude-sonnet-4-6',
+    max_tokens=16000,
+    thinking={
+        'type': 'enabled',
+        'budget_tokens': 10000,
+    },
+    messages=[{'role': 'user', 'content': 'Design a database schema for a multi-tenant SaaS app.'}],
+)
+
+for block in message.content:
+    if block.type == 'thinking':
+        print('Thinking:', block.thinking)
+    elif block.type == 'text':
+        print(block.text)
+```
+
+</CodeTabs>
+
 ## Forwarded headers
 
 The gateway forwards these request headers to the upstream provider:
@@ -180,15 +187,12 @@ All other headers are stripped. The `Authorization` header is replaced with the 
 
 ## Error handling
 
-| Status                  | Message                                     | Cause                                                   |
-| ----------------------- | ------------------------------------------- | ------------------------------------------------------- |
-| `400 Bad Request`       | `unknown model`                             | Model ID not in the catalog                             |
-| `400 Bad Request`       | `model is not available on this endpoint`   | Non-Anthropic model ID sent to this endpoint            |
-| `401 Unauthorized`      | `invalid or missing credential`             | Missing or invalid `NEON_AI_GATEWAY_KEY`                |
-| `403 Forbidden`         | `credential not authorized for ai gateway`  | Credential lacks `ai_gateway:invoke` scope              |
-| `403 Forbidden`         | `credential not authorized for this branch` | Credential's branch not in the request branch's lineage |
-| `429 Too Many Requests` | `ai gateway quota exceeded`                 | Account quota blocked; check `Retry-After` header       |
-| `502 Bad Gateway`       | `upstream request failed`                   | Upstream Anthropic/Databricks error; retry              |
+| Status            | Message                                   | Cause                                     |
+| ----------------- | ----------------------------------------- | ----------------------------------------- |
+| `400 Bad Request` | `unknown model`                           | Model ID not in the catalog               |
+| `400 Bad Request` | `model is not available on this endpoint` | Non-Anthropic model sent to this endpoint |
+
+For authentication, quota, and upstream errors, see [Troubleshooting](/docs/ai-gateway/troubleshooting).
 
 ## Next steps
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-15T08:44:06.988Z'
+updatedOn: '2026-06-15T11:36:12.057Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
@@ -46,7 +46,7 @@ export NEON_AI_GATEWAY_TOKEN=nt_live_...
 
 ## Pull credentials with neonctl
 
-For local development, `neonctl env pull` writes your AI Gateway credentials to your `.env` file automatically — no manual copy-paste from the API response:
+For local development, `neonctl env pull` writes your AI Gateway credentials to your `.env` file automatically, with no manual copy-paste from the API response:
 
 ```bash
 neonctl env pull .env

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,8 +7,10 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:36:12.057Z'
+updatedOn: '2026-06-15T13:34:36.031Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:34:05.027Z'
+updatedOn: '2026-06-08T16:41:51.165Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
@@ -30,7 +30,7 @@ This fetches your AI Gateway credential, Storage credentials, and database conne
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
   -H "Authorization: Bearer $NEON_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"scopes": ["ai_gateway:invoke"]}'
+  -d '{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}'
 ```
 
 Store the returned token as `NEON_AI_GATEWAY_KEY`.
@@ -90,12 +90,12 @@ This design lets you use a single credential across your entire development work
 
 ## Common auth errors
 
-| Error                     | Cause                                      | Fix                                                                 |
-| ------------------------- | ------------------------------------------ | ------------------------------------------------------------------- |
-| `401 Unauthorized`        | Missing or invalid credential              | Check that `NEON_AI_GATEWAY_KEY` is set and contains the full token |
-| `403 Forbidden`           | Credential lacks `ai_gateway:invoke` scope | Recreate the credential with the correct scope                      |
-| `403 Forbidden`           | Branch not in credential lineage           | Use a credential created on this branch or an ancestor branch       |
-| `503 Service Unavailable` | Auth store temporarily unavailable         | Retry the request                                                   |
+| Error                     | Cause                                      | Fix                                                                                                                             |
+| ------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `401 Unauthorized`        | Missing or invalid credential              | Check that `NEON_AI_GATEWAY_KEY` is set and contains the full token                                                             |
+| `403 Forbidden`           | Credential lacks `ai_gateway:invoke` scope | Recreate the credential with the correct scope                                                                                  |
+| `403 Forbidden`           | Branch not in credential lineage           | Use a credential created on this branch or an ancestor branch. The gateway returns: `credential not authorized for this branch` |
+| `503 Service Unavailable` | Auth store temporarily unavailable         | Retry the request                                                                                                               |
 
 ## Rotating credentials
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,10 +7,10 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:11:48.651Z'
+updatedOn: '2026-06-08T16:34:05.027Z'
 ---
 
-AI Gateway uses Neon bearer credentials — the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
+AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
 
 ## Creating a credential
 
@@ -73,7 +73,7 @@ client = OpenAI(
 A credential is bound to the branch it was created on. It is valid for:
 
 - That branch (the anchor branch)
-- Any branch descended from it — preview branches, feature branches, CI branches
+- Any branch descended from it: preview branches, feature branches, CI branches
 
 It is **not** valid for branches outside that lineage.
 
@@ -86,7 +86,7 @@ main  ──── credential valid here
 staging  ──── credential NOT valid here (different lineage)
 ```
 
-This design lets you use a single credential across your entire development workflow — local dev, preview deployments, and CI — without creating separate credentials for each environment.
+This design lets you use a single credential across your entire development workflow (local dev, preview deployments, and CI) without creating separate credentials for each environment.
 
 ## Common auth errors
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:53:15.172Z'
+updatedOn: '2026-06-11T11:29:12.425Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
@@ -61,6 +61,28 @@ client = OpenAI(
 ```
 
 </CodeTabs>
+
+## Credentials in Neon Functions
+
+When your code runs inside Neon Functions, the following environment variables are injected automatically — no credential creation step required:
+
+| Variable                   | Value                                                   |
+| -------------------------- | ------------------------------------------------------- |
+| `NEON_AI_GATEWAY_TOKEN`    | Bearer token for the AI Gateway                         |
+| `NEON_AI_GATEWAY_BASE_URL` | Branch gateway host with `https://` prefix, no path     |
+| `OPENAI_API_KEY`           | Same value as `NEON_AI_GATEWAY_TOKEN`                   |
+| `OPENAI_BASE_URL`          | Branch gateway host including the chat completions path |
+
+`OPENAI_BASE_URL` and `OPENAI_API_KEY` let standard OpenAI SDK calls work with zero configuration. The `NEON_AI_GATEWAY_*` aliases are useful when you want credentials that survive a user overriding the `OPENAI_*` variables with their own keys:
+
+```typescript
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
+});
+```
 
 ## How branch binding works
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-11T11:29:12.425Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
@@ -64,7 +64,7 @@ client = OpenAI(
 
 ## Credentials in Neon Functions
 
-When your code runs inside Neon Functions, the following environment variables are injected automatically — no credential creation step required:
+When your code runs inside Neon Functions, Neon injects the following environment variables automatically. No credential creation step required:
 
 | Variable                   | Value                                                   |
 | -------------------------- | ------------------------------------------------------- |
@@ -86,12 +86,12 @@ const client = new OpenAI({
 
 ## How branch binding works
 
-A credential is bound to the branch it was created on. It is valid for:
+Each credential is tied to the branch it was created on. It's valid for:
 
 - That branch (the anchor branch)
 - Any branch descended from it: preview branches, feature branches, CI branches
 
-It is **not** valid for branches outside that lineage.
+It's **not** valid for branches outside that lineage.
 
 This means a credential created on your `main` branch works in all branches that were forked from `main`. A credential created on a feature branch only works within that feature branch's descendants.
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-14T11:12:18.690Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
@@ -28,6 +28,22 @@ The response includes an `api_token` field. Store it as an environment variable:
 ```bash
 export NEON_AI_GATEWAY_KEY=nt_live_...
 ```
+
+## Pull credentials with neonctl
+
+For local development, `neonctl env pull` writes your AI Gateway credentials to your `.env` file automatically — no manual copy-paste from the API response:
+
+```bash
+neonctl env pull .env
+```
+
+This populates `NEON_AI_GATEWAY_TOKEN` and `NEON_AI_GATEWAY_BASE_URL` for the current branch alongside your database connection string. Running `neonctl config apply` or `neonctl deploy` also auto-pulls credentials after a successful apply. To check current credential status:
+
+```bash
+neonctl config status
+```
+
+For production deployments, use the [API-based workflow](#creating-a-credential) to create named credentials with optional expiry.
 
 ## Using your credential
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,24 +7,14 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:41:51.165Z'
+updatedOn: '2026-06-08T16:51:30.288Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
 
 ## Creating a credential
 
-A credential must include the `ai_gateway:invoke` scope.
-
-**Option 1: neonctl (recommended)**
-
-```bash
-neonctl env pull
-```
-
-This fetches your AI Gateway credential, Storage credentials, and database connection string together as environment variables, and writes them to a `.env` file. The AI Gateway credential is exported as `NEON_AI_GATEWAY_KEY`.
-
-**Option 2: Neon API**
+A credential must include the `ai_gateway:invoke` scope. Use the Neon API to create one:
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
@@ -33,7 +23,11 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}'
 ```
 
-Store the returned token as `NEON_AI_GATEWAY_KEY`.
+The response includes an `api_token` field. Store it as an environment variable:
+
+```bash
+export NEON_AI_GATEWAY_KEY=nt_live_...
+```
 
 ## Using your credential
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -1,0 +1,109 @@
+---
+title: AI Gateway authentication
+subtitle: How Neon credentials work with AI Gateway
+summary: >-
+  AI Gateway uses Neon bearer credentials with the ai_gateway:invoke scope.
+  Credentials are scoped to a branch and its descendants, so a credential
+  created on your main branch works in all preview branches. No provider
+  API keys are required.
+enableTableOfContents: true
+updatedOn: '2026-06-08T16:11:48.651Z'
+---
+
+AI Gateway uses Neon bearer credentials — the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
+
+## Creating a credential
+
+A credential must include the `ai_gateway:invoke` scope.
+
+**Option 1: neonctl (recommended)**
+
+```bash
+neonctl env pull
+```
+
+This fetches your AI Gateway credential, Storage credentials, and database connection string together as environment variables, and writes them to a `.env` file. The AI Gateway credential is exported as `NEON_AI_GATEWAY_KEY`.
+
+**Option 2: Neon API**
+
+```bash shouldWrap
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"scopes": ["ai_gateway:invoke"]}'
+```
+
+Store the returned token as `NEON_AI_GATEWAY_KEY`.
+
+## Using your credential
+
+Pass your credential as a bearer token on every request:
+
+```
+Authorization: Bearer <your-credential>
+```
+
+When using an AI SDK, set this as the `apiKey` parameter:
+
+<CodeTabs labels={["TypeScript", "Python"]}>
+
+```typescript
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+});
+```
+
+```python
+from openai import OpenAI
+import os
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+)
+```
+
+</CodeTabs>
+
+## How branch binding works
+
+A credential is bound to the branch it was created on. It is valid for:
+
+- That branch (the anchor branch)
+- Any branch descended from it — preview branches, feature branches, CI branches
+
+It is **not** valid for branches outside that lineage.
+
+This means a credential created on your `main` branch works in all branches that were forked from `main`. A credential created on a feature branch only works within that feature branch's descendants.
+
+```
+main  ──── credential valid here
+  └── preview/feature-x  ──── and here
+        └── preview/sub-branch  ──── and here
+staging  ──── credential NOT valid here (different lineage)
+```
+
+This design lets you use a single credential across your entire development workflow — local dev, preview deployments, and CI — without creating separate credentials for each environment.
+
+## Common auth errors
+
+| Error                     | Cause                                      | Fix                                                                 |
+| ------------------------- | ------------------------------------------ | ------------------------------------------------------------------- |
+| `401 Unauthorized`        | Missing or invalid credential              | Check that `NEON_AI_GATEWAY_KEY` is set and contains the full token |
+| `403 Forbidden`           | Credential lacks `ai_gateway:invoke` scope | Recreate the credential with the correct scope                      |
+| `403 Forbidden`           | Branch not in credential lineage           | Use a credential created on this branch or an ancestor branch       |
+| `503 Service Unavailable` | Auth store temporarily unavailable         | Retry the request                                                   |
+
+## Rotating credentials
+
+To rotate a credential, create a new one via `neonctl` or the Neon API, update your environment variables, then revoke the old credential via the Neon API:
+
+```bash shouldWrap
+curl -X DELETE "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials/{token_id}" \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,14 +7,26 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-14T11:12:18.690Z'
+updatedOn: '2026-06-15T08:44:06.988Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
 
 ## Creating a credential
 
-A credential must include the `ai_gateway:invoke` scope. Use the Neon API to create one:
+A credential must include the `ai_gateway:invoke` scope.
+
+<Tabs labels={["Console", "API"]}>
+<TabItem>
+
+In the Neon Console, select your branch and click **Credentials** under **APP BACKEND** in the sidebar. Click **Create credential**, give it a name, and check **ai_gateway:invoke**.
+
+After creation, the credentials are shown once. Copy the snippet or click **Download .env** before closing. The snippet includes `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_TOKEN`, and `NEON_AI_GATEWAY_BASE_URL`. `OPENAI_API_KEY` and `OPENAI_BASE_URL` let standard OpenAI SDK calls work without any configuration changes. The `NEON_AI_GATEWAY_*` aliases are useful when you need credentials that survive a user overriding the `OPENAI_*` variables.
+
+To view or revoke credentials later, return to the **Credentials** page and use the action menu (⋮) next to the credential.
+
+</TabItem>
+<TabItem>
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
@@ -26,8 +38,11 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
 The response includes an `api_token` field. Store it as an environment variable:
 
 ```bash
-export NEON_AI_GATEWAY_KEY=nt_live_...
+export NEON_AI_GATEWAY_TOKEN=nt_live_...
 ```
+
+</TabItem>
+</Tabs>
 
 ## Pull credentials with neonctl
 
@@ -61,8 +76,8 @@ When using an AI SDK, set this as the `apiKey` parameter:
 import OpenAI from 'openai';
 
 const client = new OpenAI({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
-  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 ```
 
@@ -71,8 +86,8 @@ from openai import OpenAI
 import os
 
 client = OpenAI(
-    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
-    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 ```
 
@@ -124,14 +139,16 @@ This design lets you use a single credential across your entire development work
 
 | Error                     | Cause                                      | Fix                                                                                                                             |
 | ------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `401 Unauthorized`        | Missing or invalid credential              | Check that `NEON_AI_GATEWAY_KEY` is set and contains the full token                                                             |
+| `401 Unauthorized`        | Missing or invalid credential              | Check that `NEON_AI_GATEWAY_TOKEN` is set and contains the full token                                                           |
 | `403 Forbidden`           | Credential lacks `ai_gateway:invoke` scope | Recreate the credential with the correct scope                                                                                  |
 | `403 Forbidden`           | Branch not in credential lineage           | Use a credential created on this branch or an ancestor branch. The gateway returns: `credential not authorized for this branch` |
 | `503 Service Unavailable` | Auth store temporarily unavailable         | Retry the request                                                                                                               |
 
 ## Rotating credentials
 
-To rotate a credential, create a new one via the Neon API (see [Creating a credential](#creating-a-credential)), update your environment variables, then revoke the old one:
+To rotate a credential: create a new one, update your environment variables, then revoke the old one.
+
+To revoke from the Console, open the **Credentials** page and use the action menu (⋮) next to the credential. To revoke via the API:
 
 ```bash shouldWrap
 curl -X DELETE "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials/{token_id}" \

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:51:30.288Z'
+updatedOn: '2026-06-08T16:53:15.172Z'
 ---
 
 AI Gateway uses Neon bearer credentials, the same credential system as [Neon Storage](/docs/introduction). No provider API keys are needed.
@@ -93,7 +93,7 @@ This design lets you use a single credential across your entire development work
 
 ## Rotating credentials
 
-To rotate a credential, create a new one via `neonctl` or the Neon API, update your environment variables, then revoke the old credential via the Neon API:
+To rotate a credential, create a new one via the Neon API (see [Creating a credential](#creating-a-credential)), update your environment variables, then revoke the old one:
 
 ```bash shouldWrap
 curl -X DELETE "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials/{token_id}" \

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -1,0 +1,204 @@
+---
+title: Chat completions
+subtitle: The OpenAI-compatible unified endpoint
+summary: >-
+  The chat completions endpoint is the recommended starting point for Neon AI
+  Gateway. It is OpenAI Chat Completions-compatible, works with any model in
+  the catalog, and lets you switch providers without changing your SDK code.
+enableTableOfContents: true
+updatedOn: '2026-06-08T16:11:48.651Z'
+---
+
+The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models) — Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
+
+**Base URL:** `https://<branch-host>/ai-gateway/mlflow/v1`
+
+## Setup
+
+Set these environment variables (or use `neonctl env pull` to fetch them automatically):
+
+```bash
+NEON_AI_GATEWAY_KEY=nt_live_...
+NEON_AI_GATEWAY_HOST=br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
+```
+
+## Basic request
+
+<CodeTabs labels={["TypeScript (OpenAI SDK)", "Python (OpenAI SDK)", "cURL"]}>
+
+```typescript shouldWrap
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+});
+
+const response = await client.chat.completions.create({
+  model: 'databricks-claude-sonnet-4-6',
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'What is Neon?' },
+  ],
+  max_tokens: 256,
+});
+
+console.log(response.choices[0].message.content);
+```
+
+```python shouldWrap
+from openai import OpenAI
+import os
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+)
+
+response = client.chat.completions.create(
+    model="databricks-claude-sonnet-4-6",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is Neon?"},
+    ],
+    max_tokens=256,
+)
+
+print(response.choices[0].message.content)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "databricks-claude-sonnet-4-6",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What is Neon?"}
+    ],
+    "max_tokens": 256
+  }'
+```
+
+</CodeTabs>
+
+## Streaming
+
+<CodeTabs labels={["TypeScript (OpenAI SDK)", "Python (OpenAI SDK)", "cURL"]}>
+
+```typescript shouldWrap
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+});
+
+const stream = await client.chat.completions.create({
+  model: 'databricks-claude-sonnet-4-6',
+  messages: [{ role: 'user', content: 'Explain branching in Postgres.' }],
+  stream: true,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? '');
+}
+```
+
+```python shouldWrap
+from openai import OpenAI
+import os
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+)
+
+with client.chat.completions.create(
+    model="databricks-claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Explain branching in Postgres."}],
+    stream=True,
+) as stream:
+    for chunk in stream:
+        print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "databricks-claude-sonnet-4-6",
+    "messages": [{"role": "user", "content": "Explain branching in Postgres."}],
+    "stream": true
+  }'
+```
+
+</CodeTabs>
+
+## Switching models
+
+Change the `model` field to use a different provider. Everything else stays the same.
+
+```typescript
+// Anthropic
+model: 'databricks-claude-sonnet-4-6'
+
+// OpenAI
+model: 'databricks-gpt-5-4'
+
+// Google
+model: 'databricks-gemini-2-5-flash'
+
+// Alibaba
+model: 'databricks-qwen35-122b-a10b'
+```
+
+See [Models](/docs/ai-gateway/models) for the full list.
+
+## Rate limiting
+
+When the upstream provider rate-limits a request, AI Gateway forwards the relevant headers so your client can back off correctly:
+
+| Header                           | Description                                |
+| -------------------------------- | ------------------------------------------ |
+| `Retry-After`                    | Seconds to wait before retrying (RFC 9110) |
+| `X-Ratelimit-Limit-Requests`     | Request limit                              |
+| `X-Ratelimit-Remaining-Requests` | Remaining requests                         |
+| `X-Ratelimit-Reset-Requests`     | Time until request limit resets            |
+| `X-Ratelimit-Limit-Tokens`       | Token limit                                |
+| `X-Ratelimit-Remaining-Tokens`   | Remaining tokens                           |
+| `X-Ratelimit-Reset-Tokens`       | Time until token limit resets              |
+| `Anthropic-Ratelimit-*`          | Anthropic-specific rate limit headers      |
+
+## Error handling
+
+| Status                  | Meaning               | Common cause                                                                    |
+| ----------------------- | --------------------- | ------------------------------------------------------------------------------- |
+| `400 Bad Request`       | Invalid request       | Unknown model ID, or model used on the wrong endpoint                           |
+| `401 Unauthorized`      | Authentication failed | Missing or invalid `NEON_AI_GATEWAY_KEY`                                        |
+| `403 Forbidden`         | Access denied         | Credential lacks `ai_gateway:invoke` scope, or branch not in credential lineage |
+| `429 Too Many Requests` | Rate limited          | Upstream provider rate limit — check `Retry-After` header                       |
+| `502 Bad Gateway`       | Upstream error        | Temporary issue with upstream Databricks workspace — retry                      |
+
+Error responses use the standard OpenAI error format:
+
+```json
+{
+  "error": {
+    "message": "unknown model",
+    "type": "invalid_request_error",
+    "code": "invalid_model"
+  }
+}
+```
+
+## Next steps
+
+- [Models](/docs/ai-gateway/models) — full model catalog
+- [Anthropic Messages API](/docs/ai-gateway/anthropic-messages) — native Anthropic features
+- [OpenAI Responses API](/docs/ai-gateway/openai-responses) — Responses API endpoint
+- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:41:51.165Z'
+updatedOn: '2026-06-08T16:51:30.288Z'
 ---
 
 The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
@@ -15,7 +15,7 @@ The chat completions endpoint is the recommended way to use Neon AI Gateway. It 
 
 ## Setup
 
-Set these environment variables (or use `neonctl env pull` to fetch them automatically):
+Set these environment variables. See [Get started](/docs/ai-gateway/get-started) for how to obtain them.
 
 ```bash
 NEON_AI_GATEWAY_KEY=nt_live_...

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,8 +6,10 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-15T08:51:16.298Z'
+updatedOn: '2026-06-15T13:34:36.031Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 The chat completions endpoint is the recommended way to use Neon AI Gateway. It's fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
 

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-15T08:51:16.298Z'
 ---
 
 The chat completions endpoint is the recommended way to use Neon AI Gateway. It's fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
@@ -19,7 +19,7 @@ Set these environment variables. See [Get started](/docs/ai-gateway/get-started)
 
 ```bash
 NEON_AI_GATEWAY_KEY=nt_live_...
-NEON_AI_GATEWAY_HOST=br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
+NEON_AI_GATEWAY_BASE_URL=https://br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
 ```
 
 ## Basic request
@@ -31,7 +31,7 @@ import OpenAI from 'openai';
 
 const client = new OpenAI({
   apiKey: process.env.NEON_AI_GATEWAY_KEY,
-  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const response = await client.chat.completions.create({
@@ -52,7 +52,7 @@ import os
 
 client = OpenAI(
     api_key=os.environ["NEON_AI_GATEWAY_KEY"],
-    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 response = client.chat.completions.create(
@@ -68,7 +68,7 @@ print(response.choices[0].message.content)
 ```
 
 ```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -94,7 +94,7 @@ import OpenAI from 'openai';
 
 const client = new OpenAI({
   apiKey: process.env.NEON_AI_GATEWAY_KEY,
-  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const stream = await client.chat.completions.create({
@@ -114,7 +114,7 @@ import os
 
 client = OpenAI(
     api_key=os.environ["NEON_AI_GATEWAY_KEY"],
-    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 with client.chat.completions.create(
@@ -127,7 +127,7 @@ with client.chat.completions.create(
 ```
 
 ```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:34:05.027Z'
+updatedOn: '2026-06-08T16:41:51.165Z'
 ---
 
 The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
@@ -174,13 +174,14 @@ When the upstream provider rate-limits a request, AI Gateway forwards the releva
 
 ## Error handling
 
-| Status                  | Meaning               | Common cause                                                                    |
-| ----------------------- | --------------------- | ------------------------------------------------------------------------------- |
-| `400 Bad Request`       | Invalid request       | Unknown model ID, or model used on the wrong endpoint                           |
-| `401 Unauthorized`      | Authentication failed | Missing or invalid `NEON_AI_GATEWAY_KEY`                                        |
-| `403 Forbidden`         | Access denied         | Credential lacks `ai_gateway:invoke` scope, or branch not in credential lineage |
-| `429 Too Many Requests` | Rate limited          | Upstream provider rate limit. Check the `Retry-After` header.                   |
-| `502 Bad Gateway`       | Upstream error        | Temporary issue with the upstream workspace. Retry the request.                 |
+| Status                         | Meaning               | Common cause                                                                    |
+| ------------------------------ | --------------------- | ------------------------------------------------------------------------------- |
+| `400 Bad Request`              | Invalid request       | Unknown model ID, or model used on the wrong endpoint                           |
+| `413 Request Entity Too Large` | Body too large        | Request body exceeds 32 MiB. Reduce the size of your request.                   |
+| `401 Unauthorized`             | Authentication failed | Missing or invalid `NEON_AI_GATEWAY_KEY`                                        |
+| `403 Forbidden`                | Access denied         | Credential lacks `ai_gateway:invoke` scope, or branch not in credential lineage |
+| `429 Too Many Requests`        | Rate limited          | Upstream provider rate limit. Check the `Retry-After` header.                   |
+| `502 Bad Gateway`              | Upstream error        | Temporary issue with the upstream workspace. Retry the request.                 |
 
 Error responses use the standard OpenAI error format:
 

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,10 +6,10 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:11:48.651Z'
+updatedOn: '2026-06-08T16:34:05.027Z'
 ---
 
-The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models) — Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
+The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
 
 **Base URL:** `https://<branch-host>/ai-gateway/mlflow/v1`
 
@@ -179,8 +179,8 @@ When the upstream provider rate-limits a request, AI Gateway forwards the releva
 | `400 Bad Request`       | Invalid request       | Unknown model ID, or model used on the wrong endpoint                           |
 | `401 Unauthorized`      | Authentication failed | Missing or invalid `NEON_AI_GATEWAY_KEY`                                        |
 | `403 Forbidden`         | Access denied         | Credential lacks `ai_gateway:invoke` scope, or branch not in credential lineage |
-| `429 Too Many Requests` | Rate limited          | Upstream provider rate limit — check `Retry-After` header                       |
-| `502 Bad Gateway`       | Upstream error        | Temporary issue with upstream Databricks workspace — retry                      |
+| `429 Too Many Requests` | Rate limited          | Upstream provider rate limit. Check the `Retry-After` header.                   |
+| `502 Bad Gateway`       | Upstream error        | Temporary issue with the upstream workspace. Retry the request.                 |
 
 Error responses use the standard OpenAI error format:
 

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:51:30.288Z'
+updatedOn: '2026-06-08T17:18:39.505Z'
 ---
 
 The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
@@ -84,6 +84,8 @@ curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completion
 </CodeTabs>
 
 ## Streaming
+
+Add `stream: true` to receive a server-sent events response.
 
 <CodeTabs labels={["TypeScript (OpenAI SDK)", "Python (OpenAI SDK)", "cURL"]}>
 

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,10 +6,10 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-10T17:02:23.973Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
-The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
+The chat completions endpoint is the recommended way to use Neon AI Gateway. It's fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
 
 **Base URL:** `https://<branch-host>/ai-gateway/mlflow/v1`
 
@@ -200,9 +200,9 @@ Error responses use the standard OpenAI error format:
 
 ## Next steps
 
-- [Models](/docs/ai-gateway/models) — full model catalog
-- [Anthropic Messages API](/docs/ai-gateway/anthropic-messages) — native Anthropic features
-- [OpenAI Responses API](/docs/ai-gateway/openai-responses) — Responses API endpoint
-- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+- [Models](/docs/ai-gateway/models): full model catalog
+- [Anthropic Messages API](/docs/ai-gateway/anthropic-messages): native Anthropic features
+- [OpenAI Responses API](/docs/ai-gateway/openai-responses): Responses API endpoint
+- [Authentication](/docs/ai-gateway/authentication): credential scopes and branch binding
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-08T17:18:39.505Z'
+updatedOn: '2026-06-10T17:02:23.973Z'
 ---
 
 The chat completions endpoint is the recommended way to use Neon AI Gateway. It is fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
@@ -176,14 +176,15 @@ When the upstream provider rate-limits a request, AI Gateway forwards the releva
 
 ## Error handling
 
-| Status                         | Meaning               | Common cause                                                                    |
-| ------------------------------ | --------------------- | ------------------------------------------------------------------------------- |
-| `400 Bad Request`              | Invalid request       | Unknown model ID, or model used on the wrong endpoint                           |
-| `413 Request Entity Too Large` | Body too large        | Request body exceeds 32 MiB. Reduce the size of your request.                   |
-| `401 Unauthorized`             | Authentication failed | Missing or invalid `NEON_AI_GATEWAY_KEY`                                        |
-| `403 Forbidden`                | Access denied         | Credential lacks `ai_gateway:invoke` scope, or branch not in credential lineage |
-| `429 Too Many Requests`        | Rate limited          | Upstream provider rate limit. Check the `Retry-After` header.                   |
-| `502 Bad Gateway`              | Upstream error        | Temporary issue with the upstream workspace. Retry the request.                 |
+| Status                         | Meaning                | Common cause                                                                                                                                 |
+| ------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400 Bad Request`              | Invalid request        | Unknown model ID, or model used on the wrong endpoint                                                                                        |
+| `413 Request Entity Too Large` | Body too large         | Request body exceeds 32 MiB. Reduce the size of your request.                                                                                |
+| `401 Unauthorized`             | Authentication failed  | Missing or invalid `NEON_AI_GATEWAY_KEY`                                                                                                     |
+| `403 Forbidden`                | Access denied          | Credential lacks `ai_gateway:invoke` scope, or branch not in credential lineage                                                              |
+| `429 Too Many Requests`        | Account quota exceeded | Your account's AI Gateway quota is blocked. Error code: `REQUEST_LIMIT_EXCEEDED`. Check `Retry-After` for when to retry, or contact support. |
+| `429 Too Many Requests`        | Upstream rate limited  | Upstream provider rate limit. Check the `Retry-After` and `X-Ratelimit-*` headers.                                                           |
+| `502 Bad Gateway`              | Upstream error         | Temporary issue with the upstream workspace. Retry the request.                                                                              |
 
 Error responses use the standard OpenAI error format:
 

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -1,0 +1,150 @@
+---
+title: Gemini API
+subtitle: Use the Google Gemini API with Neon AI Gateway
+summary: >-
+  The Gemini endpoint exposes the Google Gemini generateContent API through Neon
+  AI Gateway. Use the google-genai SDK with a custom base URL. Only the
+  generateContent action is supported.
+enableTableOfContents: true
+updatedOn: '2026-06-10T17:21:35.055Z'
+---
+
+The Gemini endpoint exposes the [Google Gemini generateContent API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use the `google-genai` SDK with a custom base URL, or call the API directly.
+
+**Endpoint pattern:** `https://<branch-host>/ai-gateway/gemini/v1beta/models/<model>:generateContent`
+
+<Admonition type="note">
+Only the `generateContent` action is supported. Requests to other actions (such as `streamGenerateContent` or `countTokens`) return `404 unsupported gemini action`. The `google-genai` SDK handles streaming via `generateContent` with a stream flag — this works correctly.
+</Admonition>
+
+## Supported models
+
+This endpoint accepts Google models only:
+
+| Model ID                           | Notes |
+| ---------------------------------- | ----- |
+| `databricks-gemini-3-5-flash`      |       |
+| `databricks-gemini-3-1-pro`        |       |
+| `databricks-gemini-3-1-flash-lite` |       |
+| `databricks-gemini-3-pro`          |       |
+| `databricks-gemini-3-flash`        |       |
+| `databricks-gemini-2-5-pro`        |       |
+| `databricks-gemini-2-5-flash`      |       |
+
+Sending a non-Google model ID returns `400 model is not available on this endpoint`. Use the [chat completions endpoint](/docs/ai-gateway/chat-completions) if you want to call Gemini models alongside other providers from the same code.
+
+## Basic request
+
+<CodeTabs labels={["TypeScript (google-genai)", "Python (google-genai)", "cURL"]}>
+
+```typescript shouldWrap
+import { GoogleGenAI } from '@google/genai';
+
+const client = new GoogleGenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  httpOptions: {
+    baseUrl: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/gemini`,
+  },
+});
+
+const response = await client.models.generateContent({
+  model: 'databricks-gemini-2-5-flash',
+  contents: [{ role: 'user', parts: [{ text: 'What is Neon?' }] }],
+});
+
+console.log(response.text);
+```
+
+```python shouldWrap
+from google import genai
+from google.genai import types
+import os
+
+client = genai.Client(
+    api_key=os.environ['NEON_AI_GATEWAY_KEY'],
+    http_options=types.HttpOptions(
+        base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/gemini",
+    ),
+)
+
+response = client.models.generate_content(
+    model='databricks-gemini-2-5-flash',
+    contents='What is Neon?',
+)
+
+print(response.text)
+```
+
+```bash shouldWrap
+curl -X POST \
+  "https://$NEON_AI_GATEWAY_HOST/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:generateContent" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contents": [{"role": "user", "parts": [{"text": "What is Neon?"}]}]
+  }'
+```
+
+</CodeTabs>
+
+## Streaming
+
+<CodeTabs labels={["TypeScript (google-genai)", "Python (google-genai)"]}>
+
+```typescript shouldWrap
+const stream = await client.models.generateContentStream({
+  model: 'databricks-gemini-2-5-flash',
+  contents: [{ role: 'user', parts: [{ text: 'Explain database branching.' }] }],
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.text ?? '');
+}
+```
+
+```python shouldWrap
+for chunk in client.models.generate_content_stream(
+    model='databricks-gemini-2-5-flash',
+    contents='Explain database branching.',
+):
+    print(chunk.text, end='', flush=True)
+```
+
+</CodeTabs>
+
+## URL structure
+
+The gateway uses the model ID and action directly in the URL path. The `google-genai` SDK constructs this automatically from the base URL and model parameter:
+
+```
+base_url: https://<branch-host>/ai-gateway/gemini
+model:    databricks-gemini-2-5-flash
+action:   generateContent (SDK default)
+
+→ https://<branch-host>/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:generateContent
+```
+
+When calling the REST API directly, the model ID and `:generateContent` action must appear in the path as shown above.
+
+## Error handling
+
+| Status                  | Message                                     | Cause                                                   |
+| ----------------------- | ------------------------------------------- | ------------------------------------------------------- |
+| `400 Bad Request`       | `unknown model`                             | Model ID not in the catalog                             |
+| `400 Bad Request`       | `model is not available on this endpoint`   | Non-Google model sent to this endpoint                  |
+| `400 Bad Request`       | `missing or invalid model`                  | No model field in request body                          |
+| `404 Not Found`         | `unsupported gemini action`                 | Action other than `generateContent` in the URL          |
+| `404 Not Found`         | `invalid gemini model path`                 | Malformed `model:action` segment in URL                 |
+| `401 Unauthorized`      | `invalid or missing credential`             | Missing or invalid `NEON_AI_GATEWAY_KEY`                |
+| `403 Forbidden`         | `credential not authorized for ai gateway`  | Credential lacks `ai_gateway:invoke` scope              |
+| `403 Forbidden`         | `credential not authorized for this branch` | Credential's branch not in the request branch's lineage |
+| `429 Too Many Requests` | `ai gateway quota exceeded`                 | Account quota blocked; check `Retry-After` header       |
+| `502 Bad Gateway`       | `upstream request failed`                   | Upstream Google/Databricks error; retry                 |
+
+## Next steps
+
+- [Models](/docs/ai-gateway/models) — full model catalog
+- [Chat completions](/docs/ai-gateway/chat-completions) — use Gemini models via the unified OpenAI-compatible endpoint
+- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -6,7 +6,7 @@ summary: >-
   AI Gateway. Use the google-genai SDK with a custom base URL. Only the
   generateContent action is supported.
 enableTableOfContents: true
-updatedOn: '2026-06-10T17:21:35.055Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
 The Gemini endpoint exposes the [Google Gemini generateContent API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use the `google-genai` SDK with a custom base URL, or call the API directly.
@@ -14,7 +14,7 @@ The Gemini endpoint exposes the [Google Gemini generateContent API](https://ai.g
 **Endpoint pattern:** `https://<branch-host>/ai-gateway/gemini/v1beta/models/<model>:generateContent`
 
 <Admonition type="note">
-Only the `generateContent` action is supported. Requests to other actions (such as `streamGenerateContent` or `countTokens`) return `404 unsupported gemini action`. The `google-genai` SDK handles streaming via `generateContent` with a stream flag — this works correctly.
+Only the `generateContent` action is supported. Requests to other actions (such as `streamGenerateContent` or `countTokens`) return `404 unsupported gemini action`. The `google-genai` SDK handles streaming via `generateContent` with a stream flag. This works correctly.
 </Admonition>
 
 ## Supported models
@@ -143,8 +143,8 @@ When calling the REST API directly, the model ID and `:generateContent` action m
 
 ## Next steps
 
-- [Models](/docs/ai-gateway/models) — full model catalog
-- [Chat completions](/docs/ai-gateway/chat-completions) — use Gemini models via the unified OpenAI-compatible endpoint
-- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+- [Models](/docs/ai-gateway/models): full model catalog
+- [Chat completions](/docs/ai-gateway/chat-completions): use Gemini models via the unified OpenAI-compatible endpoint
+- [Authentication](/docs/ai-gateway/authentication): credential scopes and branch binding
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -6,10 +6,10 @@ summary: >-
   AI Gateway. Use the google-genai SDK with a custom base URL. Only the
   generateContent action is supported.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-11T17:20:52.899Z'
 ---
 
-The Gemini endpoint exposes the [Google Gemini generateContent API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use the `google-genai` SDK with a custom base URL, or call the API directly.
+The Gemini endpoint exposes the [Google Gemini generateContent API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use it when you're already working with the `google-genai` SDK and want to keep your existing code. For most use cases, the [chat completions](/docs/ai-gateway/chat-completions) endpoint is simpler to set up and works with Gemini models via the OpenAI SDK.
 
 **Endpoint pattern:** `https://<branch-host>/ai-gateway/gemini/v1beta/models/<model>:generateContent`
 
@@ -128,18 +128,15 @@ When calling the REST API directly, the model ID and `:generateContent` action m
 
 ## Error handling
 
-| Status                  | Message                                     | Cause                                                   |
-| ----------------------- | ------------------------------------------- | ------------------------------------------------------- |
-| `400 Bad Request`       | `unknown model`                             | Model ID not in the catalog                             |
-| `400 Bad Request`       | `model is not available on this endpoint`   | Non-Google model sent to this endpoint                  |
-| `400 Bad Request`       | `missing or invalid model`                  | No model field in request body                          |
-| `404 Not Found`         | `unsupported gemini action`                 | Action other than `generateContent` in the URL          |
-| `404 Not Found`         | `invalid gemini model path`                 | Malformed `model:action` segment in URL                 |
-| `401 Unauthorized`      | `invalid or missing credential`             | Missing or invalid `NEON_AI_GATEWAY_KEY`                |
-| `403 Forbidden`         | `credential not authorized for ai gateway`  | Credential lacks `ai_gateway:invoke` scope              |
-| `403 Forbidden`         | `credential not authorized for this branch` | Credential's branch not in the request branch's lineage |
-| `429 Too Many Requests` | `ai gateway quota exceeded`                 | Account quota blocked; check `Retry-After` header       |
-| `502 Bad Gateway`       | `upstream request failed`                   | Upstream Google/Databricks error; retry                 |
+| Status            | Message                                   | Cause                                      |
+| ----------------- | ----------------------------------------- | ------------------------------------------ |
+| `400 Bad Request` | `unknown model`                           | Model ID not in the catalog                |
+| `400 Bad Request` | `model is not available on this endpoint` | Non-Google model sent to this endpoint     |
+| `400 Bad Request` | `missing or invalid model`                | No model field in request body             |
+| `404 Not Found`   | `unsupported gemini action`               | Action other than `generateContent` in URL |
+| `404 Not Found`   | `invalid gemini model path`               | Malformed `model:action` segment in URL    |
+
+For authentication, quota, and upstream errors, see [Troubleshooting](/docs/ai-gateway/troubleshooting).
 
 ## Next steps
 

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -6,7 +6,7 @@ summary: >-
   streamGenerateContent APIs through Neon AI Gateway. Use the google-genai SDK
   with a custom base URL.
 enableTableOfContents: true
-updatedOn: '2026-06-14T11:12:18.690Z'
+updatedOn: '2026-06-15T08:51:16.298Z'
 ---
 
 The Gemini endpoint exposes the [Google Gemini API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use it when you're already working with the `google-genai` SDK and want to keep your existing code. For most use cases, the [chat completions](/docs/ai-gateway/chat-completions) endpoint is simpler to set up and works with Gemini models via the OpenAI SDK.
@@ -45,7 +45,7 @@ import { GoogleGenAI } from '@google/genai';
 const client = new GoogleGenAI({
   apiKey: process.env.NEON_AI_GATEWAY_KEY,
   httpOptions: {
-    baseUrl: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/gemini`,
+    baseUrl: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini`,
   },
 });
 
@@ -65,7 +65,7 @@ import os
 client = genai.Client(
     api_key=os.environ['NEON_AI_GATEWAY_KEY'],
     http_options=types.HttpOptions(
-        base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/gemini",
+        base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/gemini",
     ),
 )
 
@@ -79,7 +79,7 @@ print(response.text)
 
 ```bash shouldWrap
 curl -X POST \
-  "https://$NEON_AI_GATEWAY_HOST/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:generateContent" \
+  "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:generateContent" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -2,19 +2,21 @@
 title: Gemini API
 subtitle: Use the Google Gemini API with Neon AI Gateway
 summary: >-
-  The Gemini endpoint exposes the Google Gemini generateContent API through Neon
-  AI Gateway. Use the google-genai SDK with a custom base URL. Only the
-  generateContent action is supported.
+  The Gemini endpoint exposes the Google Gemini generateContent and
+  streamGenerateContent APIs through Neon AI Gateway. Use the google-genai SDK
+  with a custom base URL.
 enableTableOfContents: true
-updatedOn: '2026-06-11T17:20:52.899Z'
+updatedOn: '2026-06-14T11:12:18.690Z'
 ---
 
-The Gemini endpoint exposes the [Google Gemini generateContent API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use it when you're already working with the `google-genai` SDK and want to keep your existing code. For most use cases, the [chat completions](/docs/ai-gateway/chat-completions) endpoint is simpler to set up and works with Gemini models via the OpenAI SDK.
+The Gemini endpoint exposes the [Google Gemini API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use it when you're already working with the `google-genai` SDK and want to keep your existing code. For most use cases, the [chat completions](/docs/ai-gateway/chat-completions) endpoint is simpler to set up and works with Gemini models via the OpenAI SDK.
 
-**Endpoint pattern:** `https://<branch-host>/ai-gateway/gemini/v1beta/models/<model>:generateContent`
+**Supported actions:** `:generateContent` and `:streamGenerateContent`
+
+**Endpoint pattern:** `https://<branch-host>/ai-gateway/gemini/v1beta/models/<model>:<action>`
 
 <Admonition type="note">
-Only the `generateContent` action is supported. Requests to other actions (such as `streamGenerateContent` or `countTokens`) return `404 unsupported gemini action`. The `google-genai` SDK handles streaming via `generateContent` with a stream flag. This works correctly.
+Only `generateContent` and `streamGenerateContent` are supported. Requests to other actions (such as `countTokens`) return `404 unsupported gemini action`.
 </Admonition>
 
 ## Supported models
@@ -119,22 +121,23 @@ The gateway uses the model ID and action directly in the URL path. The `google-g
 ```
 base_url: https://<branch-host>/ai-gateway/gemini
 model:    databricks-gemini-2-5-flash
-action:   generateContent (SDK default)
+action:   generateContent or streamGenerateContent
 
 → https://<branch-host>/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:generateContent
+→ https://<branch-host>/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:streamGenerateContent
 ```
 
-When calling the REST API directly, the model ID and `:generateContent` action must appear in the path as shown above.
+When calling the REST API directly, the model ID and action must appear in the path as shown above.
 
 ## Error handling
 
-| Status            | Message                                   | Cause                                      |
-| ----------------- | ----------------------------------------- | ------------------------------------------ |
-| `400 Bad Request` | `unknown model`                           | Model ID not in the catalog                |
-| `400 Bad Request` | `model is not available on this endpoint` | Non-Google model sent to this endpoint     |
-| `400 Bad Request` | `missing or invalid model`                | No model field in request body             |
-| `404 Not Found`   | `unsupported gemini action`               | Action other than `generateContent` in URL |
-| `404 Not Found`   | `invalid gemini model path`               | Malformed `model:action` segment in URL    |
+| Status            | Message                                   | Cause                                                                 |
+| ----------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| `400 Bad Request` | `unknown model`                           | Model ID not in the catalog                                           |
+| `400 Bad Request` | `model is not available on this endpoint` | Non-Google model sent to this endpoint                                |
+| `400 Bad Request` | `missing or invalid model`                | No model field in request body                                        |
+| `404 Not Found`   | `unsupported gemini action`               | Action other than `generateContent` or `streamGenerateContent` in URL |
+| `404 Not Found`   | `invalid gemini model path`               | Malformed `model:action` segment in URL                               |
 
 For authentication, quota, and upstream errors, see [Troubleshooting](/docs/ai-gateway/troubleshooting).
 

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -6,8 +6,10 @@ summary: >-
   streamGenerateContent APIs through Neon AI Gateway. Use the google-genai SDK
   with a custom base URL.
 enableTableOfContents: true
-updatedOn: '2026-06-15T08:51:16.298Z'
+updatedOn: '2026-06-15T13:34:36.031Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 The Gemini endpoint exposes the [Google Gemini API](https://ai.google.dev/api/generate-content) through Neon AI Gateway. Use it when you're already working with the `google-genai` SDK and want to keep your existing code. For most use cases, the [chat completions](/docs/ai-gateway/chat-completions) endpoint is simpler to set up and works with Gemini models via the OpenAI SDK.
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:41:51.165Z'
+updatedOn: '2026-06-08T16:51:30.288Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -19,32 +19,40 @@ Neon AI Gateway is currently in Private Preview. To request access, sign up at [
 
 Neon AI Gateway is invite-only during Private Preview. Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). You'll receive an email and a Discord invite when your account is enabled.
 
-## Set up your environment
+## Create a credential
 
-The easiest way to get your AI Gateway credential and branch host is with `neonctl`:
+Use the Neon API to create a credential with the `ai_gateway:invoke` scope:
+
+```bash shouldWrap
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}'
+```
+
+The response includes an `api_token` field — that is your credential. Store it as an environment variable:
 
 ```bash
-neonctl env pull
+export NEON_AI_GATEWAY_KEY=nt_live_...
 ```
 
-This writes a `.env` file containing your AI Gateway credential, branch host, database connection string, and any other Neon service credentials for the current branch.
+Your project ID and branch ID are available in the Neon Console URL or via `neonctl projects list` and `neonctl branches list`.
 
-<Admonition type="note">
-`neonctl env pull` support for AI Gateway is shipping with Private Preview. Environment variable names will be confirmed in the `neonctl` documentation when available.
-</Admonition>
+## Find your branch host
 
-<Admonition type="tip" title="Using the Neon API instead">
-If you prefer to create credentials manually, call `POST /projects/{project_id}/branches/{branch_id}/credentials` with `{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}`. See [Authentication](/docs/ai-gateway/authentication) for the full API example.
-</Admonition>
-
-Your `.env` file will contain values like:
+Your branch's AI Gateway host is available in the Neon Console on the AI Gateway page, or via the Neon API. It follows this format:
 
 ```
-NEON_AI_GATEWAY_KEY=nt_live_...
-NEON_AI_GATEWAY_HOST=br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
+br-<name>-api.<cell>.<region>.aws.neon.tech
 ```
 
-`NEON_AI_GATEWAY_HOST` is your branch's AI Gateway host. It is different from your database connection string.
+For example:
+
+```bash
+export NEON_AI_GATEWAY_HOST=br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
+```
+
+This is different from your database connection string.
 
 ## Install dependencies
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:34:05.027Z'
+updatedOn: '2026-06-08T16:41:51.165Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -27,10 +27,14 @@ The easiest way to get your AI Gateway credential and branch host is with `neonc
 neonctl env pull
 ```
 
-This writes a `.env` file containing `NEON_AI_GATEWAY_KEY`, `NEON_AI_GATEWAY_HOST`, your database connection string, and any other Neon service credentials for the current branch.
+This writes a `.env` file containing your AI Gateway credential, branch host, database connection string, and any other Neon service credentials for the current branch.
+
+<Admonition type="note">
+`neonctl env pull` support for AI Gateway is shipping with Private Preview. Environment variable names will be confirmed in the `neonctl` documentation when available.
+</Admonition>
 
 <Admonition type="tip" title="Using the Neon API instead">
-If you prefer to create credentials manually, call `POST /projects/{project_id}/branches/{branch_id}/credentials` with `scopes: ["ai_gateway:invoke"]`. See [Authentication](/docs/ai-gateway/authentication) for the full API example.
+If you prefer to create credentials manually, call `POST /projects/{project_id}/branches/{branch_id}/credentials` with `{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}`. See [Authentication](/docs/ai-gateway/authentication) for the full API example.
 </Admonition>
 
 Your `.env` file will contain values like:

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T17:00:11.574Z'
+updatedOn: '2026-06-08T17:01:35.240Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -30,7 +30,7 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}'
 ```
 
-The response includes an `api_token` field — that is your credential. Store it as an environment variable:
+The response includes an `api_token` field. That is your credential. Store it as an environment variable:
 
 ```bash
 export NEON_AI_GATEWAY_KEY=nt_live_...

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -1,0 +1,208 @@
+---
+title: Get started with Neon AI Gateway
+subtitle: Make your first inference request in minutes
+summary: >-
+  This quickstart walks you through getting a credential, finding your branch
+  host, and making your first request to the Neon AI Gateway using the OpenAI
+  SDK. No provider API keys required — authenticate with your Neon credential.
+enableTableOfContents: true
+updatedOn: '2026-06-08T16:11:48.651Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon AI Gateway is currently in Private Preview. To request access, sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
+</Admonition>
+
+<Steps>
+
+## Get access
+
+Neon AI Gateway is invite-only during Private Preview. Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). You'll receive an email and a Discord invite when your account is enabled.
+
+## Set up your environment
+
+The easiest way to get your AI Gateway credential and branch host is with `neonctl`:
+
+```bash
+neonctl env pull
+```
+
+This writes a `.env` file containing `NEON_AI_GATEWAY_KEY`, `NEON_AI_GATEWAY_HOST`, your database connection string, and any other Neon service credentials for the current branch.
+
+<Admonition type="tip" title="Using the Neon API instead">
+If you prefer to create credentials manually, call `POST /projects/{project_id}/branches/{branch_id}/credentials` with `scopes: ["ai_gateway:invoke"]`. See [Authentication](/docs/ai-gateway/authentication) for the full API example.
+</Admonition>
+
+Your `.env` file will contain values like:
+
+```
+NEON_AI_GATEWAY_KEY=nt_live_...
+NEON_AI_GATEWAY_HOST=br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
+```
+
+`NEON_AI_GATEWAY_HOST` is your branch's AI Gateway host. It is different from your database connection string.
+
+## Install dependencies
+
+<CodeTabs labels={["npm", "yarn", "pnpm", "pip"]}>
+
+```bash
+npm install openai dotenv
+```
+
+```bash
+yarn add openai dotenv
+```
+
+```bash
+pnpm add openai dotenv
+```
+
+```bash
+pip install openai python-dotenv
+```
+
+</CodeTabs>
+
+## Make your first request
+
+The chat completions endpoint is OpenAI-compatible — set `baseURL` to your branch host and `apiKey` to your credential. No other changes needed.
+
+<CodeTabs labels={["TypeScript", "Python", "cURL"]}>
+
+```typescript shouldWrap
+import OpenAI from 'openai';
+import 'dotenv/config';
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+});
+
+const response = await client.chat.completions.create({
+  model: 'databricks-claude-sonnet-4-6',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+
+console.log(response.choices[0].message.content);
+```
+
+```python shouldWrap
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+)
+
+response = client.chat.completions.create(
+    model="databricks-claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+
+print(response.choices[0].message.content)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "databricks-claude-sonnet-4-6",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+</CodeTabs>
+
+## Stream a response
+
+Add `stream: true` to receive a streamed response. Your existing streaming code works without changes — the gateway forwards `text/event-stream` responses from the upstream provider.
+
+<CodeTabs labels={["TypeScript", "Python", "cURL"]}>
+
+```typescript shouldWrap
+import OpenAI from 'openai';
+import 'dotenv/config';
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+});
+
+const stream = await client.chat.completions.create({
+  model: 'databricks-claude-sonnet-4-6',
+  messages: [{ role: 'user', content: 'Write a haiku about serverless databases.' }],
+  stream: true,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? '');
+}
+```
+
+```python shouldWrap
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+)
+
+with client.chat.completions.create(
+    model="databricks-claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Write a haiku about serverless databases."}],
+    stream=True,
+) as stream:
+    for chunk in stream:
+        print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "databricks-claude-sonnet-4-6",
+    "messages": [{"role": "user", "content": "Write a haiku about serverless databases."}],
+    "stream": true
+  }'
+```
+
+</CodeTabs>
+
+## Swap models
+
+Change the `model` field to use a different provider. No other code changes required.
+
+```typescript
+// Anthropic
+model: 'databricks-claude-sonnet-4-6'
+
+// OpenAI
+model: 'databricks-gpt-5-4'
+
+// Google
+model: 'databricks-gemini-2-5-flash'
+```
+
+See [Models](/docs/ai-gateway/models) for the full list of available model IDs.
+
+</Steps>
+
+## Next steps
+
+- [Models](/docs/ai-gateway/models) — full model catalog and which endpoint to use per provider
+- [Chat completions](/docs/ai-gateway/chat-completions) — detailed reference for the unified endpoint
+- [Anthropic Messages API](/docs/ai-gateway/anthropic-messages) — native Anthropic features including extended thinking and prompt caching
+- [Authentication](/docs/ai-gateway/authentication) — credential scopes, branch binding, and rotation
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,11 +6,11 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T17:15:18.099Z'
+updatedOn: '2026-06-08T18:39:44.797Z'
 ---
 
 <Admonition type="note" title="Private Preview">
-Neon AI Gateway is currently in Private Preview. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
+Neon AI Gateway is currently in Private Preview and available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
 </Admonition>
 
 <Steps>

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T17:01:35.240Z'
+updatedOn: '2026-06-08T17:15:18.099Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -55,6 +55,8 @@ export NEON_AI_GATEWAY_HOST=br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.te
 This is different from your database connection string.
 
 ## Install dependencies
+
+The quickstart uses the OpenAI SDK because the chat completions endpoint is OpenAI-compatible. It works with any model in the catalog, including Claude and Gemini.
 
 <CodeTabs labels={["npm", "yarn", "pnpm", "pip"]}>
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-12T16:38:18.194Z'
+updatedOn: '2026-06-15T08:51:16.298Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -47,7 +47,7 @@ br-<name>-api.<cell>.<region>.aws.neon.tech
 For example:
 
 ```bash
-export NEON_AI_GATEWAY_HOST=br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
+export NEON_AI_GATEWAY_BASE_URL=https://br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
 ```
 
 This is different from your database connection string.
@@ -88,7 +88,7 @@ import 'dotenv/config';
 
 const client = new OpenAI({
   apiKey: process.env.NEON_AI_GATEWAY_KEY,
-  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const response = await client.chat.completions.create({
@@ -108,7 +108,7 @@ load_dotenv()
 
 client = OpenAI(
     api_key=os.environ["NEON_AI_GATEWAY_KEY"],
-    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 response = client.chat.completions.create(
@@ -120,7 +120,7 @@ print(response.choices[0].message.content)
 ```
 
 ```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -143,7 +143,7 @@ import 'dotenv/config';
 
 const client = new OpenAI({
   apiKey: process.env.NEON_AI_GATEWAY_KEY,
-  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/mlflow/v1`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const stream = await client.chat.completions.create({
@@ -166,7 +166,7 @@ load_dotenv()
 
 client = OpenAI(
     api_key=os.environ["NEON_AI_GATEWAY_KEY"],
-    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/mlflow/v1",
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 with client.chat.completions.create(
@@ -179,7 +179,7 @@ with client.chat.completions.create(
 ```
 
 ```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completions" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T18:39:44.797Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -214,9 +214,9 @@ See [Models](/docs/ai-gateway/models) for the full list of available model IDs.
 
 ## Next steps
 
-- [Models](/docs/ai-gateway/models) — full model catalog and which endpoint to use per provider
-- [Chat completions](/docs/ai-gateway/chat-completions) — detailed reference for the unified endpoint
-- [Anthropic Messages API](/docs/ai-gateway/anthropic-messages) — native Anthropic features including extended thinking and prompt caching
-- [Authentication](/docs/ai-gateway/authentication) — credential scopes, branch binding, and rotation
+- [Models](/docs/ai-gateway/models): full model catalog and which endpoint to use per provider
+- [Chat completions](/docs/ai-gateway/chat-completions): detailed reference for the unified endpoint
+- [Anthropic Messages API](/docs/ai-gateway/anthropic-messages): native Anthropic features including extended thinking and prompt caching
+- [Authentication](/docs/ai-gateway/authentication): credential scopes, branch binding, and rotation
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -4,9 +4,9 @@ subtitle: Make your first inference request in minutes
 summary: >-
   This quickstart walks you through getting a credential, finding your branch
   host, and making your first request to the Neon AI Gateway using the OpenAI
-  SDK. No provider API keys required — authenticate with your Neon credential.
+  SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:11:48.651Z'
+updatedOn: '2026-06-08T16:34:05.027Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -66,7 +66,7 @@ pip install openai python-dotenv
 
 ## Make your first request
 
-The chat completions endpoint is OpenAI-compatible — set `baseURL` to your branch host and `apiKey` to your credential. No other changes needed.
+The chat completions endpoint is OpenAI-compatible. Set `baseURL` to your branch host and `apiKey` to your credential. No other changes needed.
 
 <CodeTabs labels={["TypeScript", "Python", "cURL"]}>
 
@@ -121,7 +121,7 @@ curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/mlflow/v1/chat/completion
 
 ## Stream a response
 
-Add `stream: true` to receive a streamed response. Your existing streaming code works without changes — the gateway forwards `text/event-stream` responses from the upstream provider.
+Add `stream: true` to receive a streamed response. Your existing streaming code works without changes. The gateway forwards `text/event-stream` responses from the upstream provider.
 
 <CodeTabs labels={["TypeScript", "Python", "cURL"]}>
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,18 +6,18 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:51:30.288Z'
+updatedOn: '2026-06-08T17:00:11.574Z'
 ---
 
 <Admonition type="note" title="Private Preview">
-Neon AI Gateway is currently in Private Preview. To request access, sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
+Neon AI Gateway is currently in Private Preview. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
 </Admonition>
 
 <Steps>
 
 ## Get access
 
-Neon AI Gateway is invite-only during Private Preview. Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). You'll receive an email and a Discord invite when your account is enabled.
+Neon AI Gateway is invite-only during Private Preview. Sign up for the waitlist at [We're building backends](https://neon.com/blog/were-building-backends). You'll receive an email and a Discord invite when your account is enabled.
 
 ## Create a credential
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,18 +6,16 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-12T16:38:18.194Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon AI Gateway is currently in Private Preview and available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
-</Admonition>
+<PrivatePreviewEnquire/>
 
 <Steps>
 
 ## Get access
 
-Neon AI Gateway is invite-only during Private Preview. Sign up for the waitlist at [We're building backends](https://neon.com/blog/were-building-backends). You'll receive an email and a Discord invite when your account is enabled.
+You need a new project in the AWS us-east-2 region, and foundation model access requires a paid Neon plan. When your account is enabled, you'll receive an email and a Discord invite.
 
 ## Create a credential
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   Use these IDs in the model field of any request regardless of which endpoint
   you are using.
 enableTableOfContents: true
-updatedOn: '2026-06-10T17:02:23.973Z'
+updatedOn: '2026-06-10T17:16:40.599Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Use these IDs in the `model` field of any request, regardless of which endpoint you use.
@@ -66,19 +66,19 @@ Use the `id` field in the `model` parameter of any inference request.
 
 ### OpenAI
 
-| Model ID                        | Notes |
-| ------------------------------- | ----- |
-| `databricks-gpt-5-5-pro`        |       |
-| `databricks-gpt-5-5`            |       |
-| `databricks-gpt-5-4`            |       |
-| `databricks-gpt-5-4-mini`       |       |
-| `databricks-gpt-5-4-nano`       |       |
-| `databricks-gpt-5-3-codex`      |       |
-| `databricks-gpt-5-2-codex`      |       |
-| `databricks-gpt-5-2`            |       |
-| `databricks-gpt-5-1-codex-max`  |       |
-| `databricks-gpt-5-1-codex-mini` |       |
-| `databricks-gpt-5-1`            |       |
+| Model ID                        | Notes                                                              |
+| ------------------------------- | ------------------------------------------------------------------ |
+| `databricks-gpt-5-5-pro`        | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `databricks-gpt-5-5`            |                                                                    |
+| `databricks-gpt-5-4`            |                                                                    |
+| `databricks-gpt-5-4-mini`       |                                                                    |
+| `databricks-gpt-5-4-nano`       |                                                                    |
+| `databricks-gpt-5-3-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `databricks-gpt-5-2-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `databricks-gpt-5-2`            |                                                                    |
+| `databricks-gpt-5-1-codex-max`  | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `databricks-gpt-5-1-codex-mini` | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `databricks-gpt-5-1`            |                                                                    |
 
 ### Alibaba
 
@@ -88,13 +88,14 @@ Use the `id` field in the `model` parameter of any inference request.
 
 ## Which endpoint to use
 
-You can use any model with the [Chat completions](/docs/ai-gateway/chat-completions) endpoint. It is provider-agnostic. Use a provider-specific endpoint when you need native features:
+Most models work with the [Chat completions](/docs/ai-gateway/chat-completions) endpoint. It is the recommended starting point and works with all providers. Use a provider-specific endpoint when required:
 
-| Provider  | Recommended endpoint                     | When to use the native endpoint                                                          |
-| --------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Anthropic | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/anthropic/v1/messages` for extended thinking and prompt caching         |
-| OpenAI    | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/openai/v1/responses` for the Responses API                              |
-| Google    | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
-| Alibaba   | `/ai-gateway/mlflow/v1/chat/completions` | —                                                                                        |
+| Provider                               | Recommended endpoint                     | Notes                                                                                    |
+| -------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Anthropic                              | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/anthropic/v1/messages` for extended thinking and prompt caching         |
+| OpenAI (most models)                   | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/openai/v1/responses` for Responses API features                         |
+| OpenAI (`gpt-5-5-pro`, codex variants) | `/ai-gateway/openai/v1/responses`        | These models require the Responses API and do not work with chat/completions             |
+| Google                                 | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
+| Alibaba                                | `/ai-gateway/mlflow/v1/chat/completions` |                                                                                          |
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   the databricks- prefix. Use these IDs in the model field of any request
   regardless of which endpoint you are using.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-12T17:35:46.364Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Use these IDs in the `model` field of any request, regardless of which endpoint you use.
@@ -15,6 +15,17 @@ Neon AI Gateway serves models hosted by Databricks. All model IDs use the `datab
 <Admonition type="note">
 Model availability may vary by region. The catalog expands over time, so check back for new additions.
 </Admonition>
+
+## Rate limits
+
+During the private preview, the following limits apply:
+
+| Limit                                   | Value         |
+| --------------------------------------- | ------------- |
+| Per model (tokens per minute)           | 200,000 TPM   |
+| All models combined (tokens per minute) | 1,000,000 TPM |
+
+If you hit a limit, you'll receive a `429 Too Many Requests` response. Requests resume when the rate limit window resets.
 
 ## List available models
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -3,14 +3,14 @@ title: AI Gateway models
 subtitle: Available models and how to specify them
 summary: >-
   Neon AI Gateway serves Databricks-hosted foundation models from Anthropic,
-  OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. All model IDs use
-  the databricks- prefix. Use these IDs in the model field of any request
-  regardless of which endpoint you are using.
+  OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. Model IDs use the
+  databricks- prefix, but the short form without the prefix also works. Use
+  either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-12T17:35:46.364Z'
+updatedOn: '2026-06-14T11:12:18.690Z'
 ---
 
-Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Use these IDs in the `model` field of any request, regardless of which endpoint you use.
+Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). You can also use the short form without the prefix (for example, `claude-sonnet-4-6`) — both are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
 
 <Admonition type="note">
 Model availability may vary by region. The catalog expands over time, so check back for new additions.
@@ -23,7 +23,7 @@ During the private preview, the following limits apply:
 | Limit                                   | Value         |
 | --------------------------------------- | ------------- |
 | Per model (tokens per minute)           | 200,000 TPM   |
-| All models combined (tokens per minute) | 1,000,000 TPM |
+| All models combined (tokens per minute) | 1,100,000 TPM |
 
 If you hit a limit, you'll receive a `429 Too Many Requests` response. Requests resume when the rate limit window resets.
 
@@ -36,19 +36,19 @@ curl "https://console.neon.tech/api/v2/ai_gateway/models" \
   -H "Authorization: Bearer $NEON_API_KEY"
 ```
 
-The response includes each model's `id`, `provider`, and `display_name`:
+The response includes each model's `id`, `provider`, `display_name`, and `dialects`. The `dialects` field lists which API surfaces that model supports:
 
 ```json
 {
   "models": [
-    { "id": "databricks-claude-sonnet-4-6", "provider": "anthropic", "display_name": "Claude Sonnet 4.6" },
-    { "id": "databricks-gpt-5-4", "provider": "openai", "display_name": "GPT-5.4" },
-    { "id": "databricks-gemini-2-5-flash", "provider": "google", "display_name": "Gemini 2.5 Flash" }
+    { "id": "databricks-claude-sonnet-4-6", "provider": "anthropic", "display_name": "Claude Sonnet 4.6", "dialects": ["chat_completions", "anthropic_messages"] },
+    { "id": "databricks-gpt-5-4", "provider": "openai", "display_name": "GPT-5.4", "dialects": ["chat_completions", "openai_responses"] },
+    { "id": "databricks-gemini-2-5-flash", "provider": "google", "display_name": "Gemini 2.5 Flash", "dialects": ["chat_completions", "gemini"] }
   ]
 }
 ```
 
-Use the `id` field in the `model` parameter of any inference request.
+Use the `id` field in the `model` parameter of any inference request. Models that list only `openai_responses` in `dialects` require the [OpenAI Responses API](/docs/ai-gateway/openai-responses) endpoint and don't work with chat completions.
 
 ## Available models
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,8 +7,10 @@ summary: >-
   databricks- prefix, but the short form without the prefix also works. Use
   either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:49:45.116Z'
+updatedOn: '2026-06-15T13:34:36.031Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Both forms are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,13 +7,13 @@ summary: >-
   Use these IDs in the model field of any request regardless of which endpoint
   you are using.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:11:48.651Z'
+updatedOn: '2026-06-08T16:34:05.027Z'
 ---
 
-Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix — for example, `databricks-claude-sonnet-4-6`. Use these IDs in the `model` field of any request, regardless of which endpoint you use.
+Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Use these IDs in the `model` field of any request, regardless of which endpoint you use.
 
 <Admonition type="note">
-Model availability may vary by region. The catalog expands over time — check back for new additions.
+Model availability may vary by region. The catalog expands over time, so check back for new additions.
 </Admonition>
 
 ## Available models
@@ -65,7 +65,7 @@ Model availability may vary by region. The catalog expands over time — check b
 
 ## Which endpoint to use
 
-You can use any model with the [Chat completions](/docs/ai-gateway/chat-completions) endpoint — it is provider-agnostic. Use a provider-specific endpoint when you need native features:
+You can use any model with the [Chat completions](/docs/ai-gateway/chat-completions) endpoint. It is provider-agnostic. Use a provider-specific endpoint when you need native features:
 
 | Provider  | Recommended endpoint                     | When to use the native endpoint                                                          |
 | --------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   databricks- prefix, but the short form without the prefix also works. Use
   either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:22:30.818Z'
+updatedOn: '2026-06-15T11:34:00.195Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). You can also use the short form without the prefix (for example, `claude-sonnet-4-6`) — both are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
@@ -30,29 +30,6 @@ During the private preview, the following limits apply:
 | All models combined (tokens per minute) | 1,100,000 TPM |
 
 If you hit a limit, you'll receive a `429 Too Many Requests` response. Requests resume when the rate limit window resets.
-
-## List available models
-
-You can fetch the current model catalog from the Neon API:
-
-```bash shouldWrap
-curl "https://console.neon.tech/api/v2/ai_gateway/models" \
-  -H "Authorization: Bearer $NEON_API_KEY"
-```
-
-The response includes each model's `id`, `provider`, `display_name`, and `dialects`. The `dialects` field lists which API surfaces that model supports:
-
-```json
-{
-  "models": [
-    { "id": "databricks-claude-sonnet-4-6", "provider": "anthropic", "display_name": "Claude Sonnet 4.6", "dialects": ["chat_completions", "anthropic_messages"] },
-    { "id": "databricks-gpt-5-4", "provider": "openai", "display_name": "GPT-5.4", "dialects": ["chat_completions", "openai_responses"] },
-    { "id": "databricks-gemini-2-5-flash", "provider": "google", "display_name": "Gemini 2.5 Flash", "dialects": ["chat_completions", "gemini"] }
-  ]
-}
-```
-
-Use the `id` field in the `model` parameter of any inference request. Models that list only `openai_responses` in `dialects` require the [OpenAI Responses API](/docs/ai-gateway/openai-responses) endpoint and don't work with chat completions.
 
 ## Available models
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   databricks- prefix, but the short form without the prefix also works. Use
   either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:36:12.057Z'
+updatedOn: '2026-06-15T11:49:45.116Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Both forms are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
@@ -19,6 +19,21 @@ Models are hosted by Databricks and served through Neon AI Gateway. By using the
 <Admonition type="note">
 Model availability may vary by region. The catalog expands over time, so check back for new additions.
 </Admonition>
+
+## Quick picks
+
+Not sure which model to use? Start here.
+
+| I want to...                            | Recommended model                                               |
+| --------------------------------------- | --------------------------------------------------------------- |
+| Build a general chat or reasoning app   | `databricks-claude-sonnet-4-6`                                  |
+| Understand images                       | `databricks-claude-sonnet-4-6` or `databricks-gemini-2-5-flash` |
+| Process audio or video                  | `databricks-gemini-3-5-flash`                                   |
+| Generate or review code                 | `databricks-gpt-5-3-codex`                                      |
+| Run extended or deep reasoning          | `databricks-claude-opus-4-7` or `databricks-gpt-5-1`            |
+| Handle very long documents (1M+ tokens) | `databricks-gemini-3-1-pro` or `databricks-claude-opus-4-7`     |
+| Keep costs low for lightweight tasks    | `databricks-claude-haiku-4-5` or `databricks-gpt-5-4-nano`      |
+| Use an open-weight model                | `databricks-gpt-oss-120b`                                       |
 
 ## Rate limits
 
@@ -33,87 +48,89 @@ If you hit a limit, you'll receive a `429 Too Many Requests` response. Requests 
 
 ## Available models
 
+Endpoints are shown in short form. See [Which endpoint to use](#which-endpoint-to-use) for full paths and when to prefer each one.
+
 ### Anthropic
 
-| Model ID                       | Inputs      | Context | Notes                                    |
-| ------------------------------ | ----------- | ------- | ---------------------------------------- |
-| `databricks-claude-opus-4-8`   | text, image | —       | Most capable Claude model                |
-| `databricks-claude-opus-4-7`   | text, image | 1M      | Extended thinking available              |
-| `databricks-claude-opus-4-6`   | text, image | 1M      | Adaptive thinking with max effort level  |
-| `databricks-claude-opus-4-5`   | text, image | 200K    | Extended thinking available              |
-| `databricks-claude-opus-4-1`   | text, image | 200K    |                                          |
-| `databricks-claude-sonnet-4-6` | text, image | —       | Recommended. Instant + extended thinking |
-| `databricks-claude-sonnet-4-5` | text, image | —       | Instant + extended thinking              |
-| `databricks-claude-sonnet-4`   | text, image | —       | Instant + extended thinking              |
-| `databricks-claude-haiku-4-5`  | text, image | —       | Fast and cost-effective                  |
+| Model ID                       | Inputs      | Context | Endpoints                                 | Notes                                    |
+| ------------------------------ | ----------- | ------- | ----------------------------------------- | ---------------------------------------- |
+| `databricks-claude-opus-4-8`   | text, image | —       | `chat/completions` · `anthropic/messages` | Most capable Claude model                |
+| `databricks-claude-opus-4-7`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Extended thinking available              |
+| `databricks-claude-opus-4-6`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Adaptive thinking with max effort level  |
+| `databricks-claude-opus-4-5`   | text, image | 200K    | `chat/completions` · `anthropic/messages` | Extended thinking available              |
+| `databricks-claude-opus-4-1`   | text, image | 200K    | `chat/completions` · `anthropic/messages` |                                          |
+| `databricks-claude-sonnet-4-6` | text, image | —       | `chat/completions` · `anthropic/messages` | Recommended. Instant + extended thinking |
+| `databricks-claude-sonnet-4-5` | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
+| `databricks-claude-sonnet-4`   | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
+| `databricks-claude-haiku-4-5`  | text, image | —       | `chat/completions` · `anthropic/messages` | Fast and cost-effective                  |
 
 ### Google
 
-| Model ID                           | Inputs                    | Context | Notes                 |
-| ---------------------------------- | ------------------------- | ------- | --------------------- |
-| `databricks-gemini-3-5-flash`      | text, image, video, audio | —       |                       |
-| `databricks-gemini-3-1-pro`        | text, image, video, audio | 1M      |                       |
-| `databricks-gemini-3-1-flash-lite` | text, image, video, audio | —       |                       |
-| `databricks-gemini-3-pro`          | text, image, video, audio | 1M      |                       |
-| `databricks-gemini-3-flash`        | text, image, video, audio | —       |                       |
-| `databricks-gemini-2-5-pro`        | text, image, video, audio | 1M      | Deep Think Mode       |
-| `databricks-gemini-2-5-flash`      | text, image, video, audio | 1M      |                       |
-| `databricks-gemma-3-12b`           | text, image               | 128K    | Chat completions only |
+| Model ID                           | Inputs                    | Context | Endpoints                     | Notes                 |
+| ---------------------------------- | ------------------------- | ------- | ----------------------------- | --------------------- |
+| `databricks-gemini-3-5-flash`      | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
+| `databricks-gemini-3-1-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
+| `databricks-gemini-3-1-flash-lite` | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
+| `databricks-gemini-3-pro`          | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
+| `databricks-gemini-3-flash`        | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
+| `databricks-gemini-2-5-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` | Deep Think Mode       |
+| `databricks-gemini-2-5-flash`      | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
+| `databricks-gemma-3-12b`           | text, image               | 128K    | `chat/completions`            | Chat completions only |
 
 ### OpenAI
 
 All OpenAI models have a 400K token context window and accept text and image inputs.
 
-| Model ID                        | Notes                                                                              |
-| ------------------------------- | ---------------------------------------------------------------------------------- |
-| `databricks-gpt-5-5-pro`        | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses). Prompt caching |
-| `databricks-gpt-5-5`            | Prompt caching                                                                     |
-| `databricks-gpt-5-4`            |                                                                                    |
-| `databricks-gpt-5-4-mini`       |                                                                                    |
-| `databricks-gpt-5-4-nano`       |                                                                                    |
-| `databricks-gpt-5-3-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
-| `databricks-gpt-5-2-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
-| `databricks-gpt-5-2`            |                                                                                    |
-| `databricks-gpt-5-1-codex-max`  | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
-| `databricks-gpt-5-1-codex-mini` | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
-| `databricks-gpt-5-1`            | Instant + Thinking modes                                                           |
-| `databricks-gpt-5`              |                                                                                    |
-| `databricks-gpt-5-mini`         |                                                                                    |
-| `databricks-gpt-5-nano`         |                                                                                    |
+| Model ID                        | Endpoints                               | Notes                                                                              |
+| ------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| `databricks-gpt-5-5-pro`        | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses). Prompt caching |
+| `databricks-gpt-5-5`            | `chat/completions` · `openai/responses` | Prompt caching                                                                     |
+| `databricks-gpt-5-4`            | `chat/completions` · `openai/responses` |                                                                                    |
+| `databricks-gpt-5-4-mini`       | `chat/completions` · `openai/responses` |                                                                                    |
+| `databricks-gpt-5-4-nano`       | `chat/completions` · `openai/responses` |                                                                                    |
+| `databricks-gpt-5-3-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-2-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-2`            | `chat/completions` · `openai/responses` |                                                                                    |
+| `databricks-gpt-5-1-codex-max`  | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-1-codex-mini` | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-1`            | `chat/completions` · `openai/responses` | Instant + Thinking modes                                                           |
+| `databricks-gpt-5`              | `chat/completions` · `openai/responses` |                                                                                    |
+| `databricks-gpt-5-mini`         | `chat/completions` · `openai/responses` |                                                                                    |
+| `databricks-gpt-5-nano`         | `chat/completions` · `openai/responses` |                                                                                    |
 
 ### Databricks
 
 Open-weight models hosted by Databricks. Text input only. Chat completions only.
 
-| Model ID                  | Context | Notes                       |
-| ------------------------- | ------- | --------------------------- |
-| `databricks-gpt-oss-120b` | 128K    | Adjustable reasoning effort |
-| `databricks-gpt-oss-20b`  | 128K    |                             |
+| Model ID                  | Context | Endpoints          | Notes                       |
+| ------------------------- | ------- | ------------------ | --------------------------- |
+| `databricks-gpt-oss-120b` | 128K    | `chat/completions` | Adjustable reasoning effort |
+| `databricks-gpt-oss-20b`  | 128K    | `chat/completions` |                             |
 
 ### Meta
 
-| Model ID                                 | Inputs      | Context | Notes                                                                                                                                                                                                              |
-| ---------------------------------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `databricks-llama-4-maverick`            | text, image | —       | [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                                      |
-| `databricks-meta-llama-3-3-70b-instruct` | text        | 128K    | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
-| `databricks-meta-llama-3-1-8b-instruct`  | text        | 128K    | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
+| Model ID                                 | Inputs      | Context | Endpoints          | Notes                                                                                                                                                                                                              |
+| ---------------------------------------- | ----------- | ------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `databricks-llama-4-maverick`            | text, image | —       | `chat/completions` | [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                                      |
+| `databricks-meta-llama-3-3-70b-instruct` | text        | 128K    | `chat/completions` | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
+| `databricks-meta-llama-3-1-8b-instruct`  | text        | 128K    | `chat/completions` | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
 
 ### Alibaba
 
 Text input only. Chat completions only.
 
-| Model ID                                 | Context | Notes                            |
-| ---------------------------------------- | ------- | -------------------------------- |
-| `databricks-qwen3-next-80b-a3b-instruct` | —       |                                  |
-| `databricks-qwen35-122b-a10b`            | 256K    | Always reasons before responding |
+| Model ID                                 | Context | Endpoints          | Notes                            |
+| ---------------------------------------- | ------- | ------------------ | -------------------------------- |
+| `databricks-qwen3-next-80b-a3b-instruct` | —       | `chat/completions` |                                  |
+| `databricks-qwen35-122b-a10b`            | 256K    | `chat/completions` | Always reasons before responding |
 
 ### DeepSeek
 
 Text input only. Chat completions only.
 
-| Model ID                   | Context | Notes |
-| -------------------------- | ------- | ----- |
-| `databricks-deepseek-v3-2` | —       |       |
+| Model ID                   | Context | Endpoints          | Notes |
+| -------------------------- | ------- | ------------------ | ----- |
+| `databricks-deepseek-v3-2` | —       | `chat/completions` |       |
 
 ## Which endpoint to use
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,10 +7,10 @@ summary: >-
   databricks- prefix, but the short form without the prefix also works. Use
   either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:34:00.195Z'
+updatedOn: '2026-06-15T11:35:31.736Z'
 ---
 
-Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). You can also use the short form without the prefix (for example, `claude-sonnet-4-6`) — both are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
+Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Both forms are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
 
 <Admonition type="important">
 Models are hosted by Databricks and served through Neon AI Gateway. By using these models, you are responsible for complying with each provider's applicable terms of use. See [Provider terms](#provider-terms) below.

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -1,0 +1,77 @@
+---
+title: AI Gateway models
+subtitle: Available models and how to specify them
+summary: >-
+  Neon AI Gateway serves Databricks-hosted foundation models from Anthropic,
+  OpenAI, Google, and Alibaba. All model IDs use the databricks- prefix.
+  Use these IDs in the model field of any request regardless of which endpoint
+  you are using.
+enableTableOfContents: true
+updatedOn: '2026-06-08T16:11:48.651Z'
+---
+
+Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix — for example, `databricks-claude-sonnet-4-6`. Use these IDs in the `model` field of any request, regardless of which endpoint you use.
+
+<Admonition type="note">
+Model availability may vary by region. The catalog expands over time — check back for new additions.
+</Admonition>
+
+## Available models
+
+### Anthropic
+
+| Model ID                       | Notes                          |
+| ------------------------------ | ------------------------------ |
+| `databricks-claude-opus-4-8`   | Most capable Claude model      |
+| `databricks-claude-opus-4-7`   |                                |
+| `databricks-claude-opus-4-6`   |                                |
+| `databricks-claude-opus-4-5`   |                                |
+| `databricks-claude-sonnet-4-6` | Recommended for most use cases |
+| `databricks-claude-haiku-4-5`  | Fast and cost-effective        |
+
+### Google
+
+| Model ID                           | Notes |
+| ---------------------------------- | ----- |
+| `databricks-gemini-3-5-flash`      |       |
+| `databricks-gemini-3-1-pro`        |       |
+| `databricks-gemini-3-1-flash-lite` |       |
+| `databricks-gemini-3-pro`          |       |
+| `databricks-gemini-3-flash`        |       |
+| `databricks-gemini-2-5-pro`        |       |
+| `databricks-gemini-2-5-flash`      |       |
+
+### OpenAI
+
+| Model ID                        | Notes |
+| ------------------------------- | ----- |
+| `databricks-gpt-5-5-pro`        |       |
+| `databricks-gpt-5-5`            |       |
+| `databricks-gpt-5-4`            |       |
+| `databricks-gpt-5-4-mini`       |       |
+| `databricks-gpt-5-4-nano`       |       |
+| `databricks-gpt-5-3-codex`      |       |
+| `databricks-gpt-5-2-codex`      |       |
+| `databricks-gpt-5-2`            |       |
+| `databricks-gpt-5-1-codex-max`  |       |
+| `databricks-gpt-5-1-codex-mini` |       |
+| `databricks-gpt-5-1`            |       |
+
+### Alibaba
+
+| Model ID                      | Notes |
+| ----------------------------- | ----- |
+| `databricks-qwen35-122b-a10b` |       |
+
+## Which endpoint to use
+
+You can use any model with the [Chat completions](/docs/ai-gateway/chat-completions) endpoint — it is provider-agnostic. Use a provider-specific endpoint when you need native features:
+
+| Provider  | Recommended endpoint                     | When to use the native endpoint                                                          |
+| --------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Anthropic | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/anthropic/v1/messages` for extended thinking and prompt caching         |
+| OpenAI    | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/openai/v1/responses` for the Responses API                              |
+| Google    | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
+| Alibaba   | `/ai-gateway/mlflow/v1/chat/completions` | —                                                                                        |
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   databricks- prefix, but the short form without the prefix also works. Use
   either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:35:31.736Z'
+updatedOn: '2026-06-15T11:36:12.057Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Both forms are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
@@ -138,6 +138,6 @@ Models are hosted by Databricks and served through Neon AI Gateway. You are resp
 | OpenAI        | [OpenAI Usage Policies](https://openai.com/policies/usage-policies)                                                                                                                 |
 | Google Gemini | [Google Cloud Acceptable Use Policy](https://cloud.google.com/terms/aup) · [Google Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy) |
 | Google Gemma  | [Gemma Terms of Use](https://ai.google.dev/gemma/terms) · [Gemma Prohibited Use Policy](https://ai.google.dev/gemma/prohibited_use_policy)                                          |
-| Meta          | See the Notes column in the [Meta models table](#meta) above — terms differ by Llama version.                                                                                       |
+| Meta          | Terms differ by Llama version. See the Notes column in the [Meta models table](#meta).                                                                                              |
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   databricks- prefix, but the short form without the prefix also works. Use
   either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-15T10:50:05.465Z'
+updatedOn: '2026-06-15T11:22:30.818Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). You can also use the short form without the prefix (for example, `claude-sonnet-4-6`) — both are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
@@ -58,79 +58,85 @@ Use the `id` field in the `model` parameter of any inference request. Models tha
 
 ### Anthropic
 
-| Model ID                       | Notes                          |
-| ------------------------------ | ------------------------------ |
-| `databricks-claude-opus-4-8`   | Most capable Claude model      |
-| `databricks-claude-opus-4-7`   |                                |
-| `databricks-claude-opus-4-6`   |                                |
-| `databricks-claude-opus-4-5`   |                                |
-| `databricks-claude-opus-4-1`   |                                |
-| `databricks-claude-sonnet-4-6` | Recommended for most use cases |
-| `databricks-claude-sonnet-4-5` |                                |
-| `databricks-claude-sonnet-4`   |                                |
-| `databricks-claude-haiku-4-5`  | Fast and cost-effective        |
+| Model ID                       | Inputs      | Context | Notes                                    |
+| ------------------------------ | ----------- | ------- | ---------------------------------------- |
+| `databricks-claude-opus-4-8`   | text, image | —       | Most capable Claude model                |
+| `databricks-claude-opus-4-7`   | text, image | 1M      | Extended thinking available              |
+| `databricks-claude-opus-4-6`   | text, image | 1M      | Adaptive thinking with max effort level  |
+| `databricks-claude-opus-4-5`   | text, image | 200K    | Extended thinking available              |
+| `databricks-claude-opus-4-1`   | text, image | 200K    |                                          |
+| `databricks-claude-sonnet-4-6` | text, image | —       | Recommended. Instant + extended thinking |
+| `databricks-claude-sonnet-4-5` | text, image | —       | Instant + extended thinking              |
+| `databricks-claude-sonnet-4`   | text, image | —       | Instant + extended thinking              |
+| `databricks-claude-haiku-4-5`  | text, image | —       | Fast and cost-effective                  |
 
 ### Google
 
-| Model ID                           | Notes                 |
-| ---------------------------------- | --------------------- |
-| `databricks-gemini-3-5-flash`      |                       |
-| `databricks-gemini-3-1-pro`        |                       |
-| `databricks-gemini-3-1-flash-lite` |                       |
-| `databricks-gemini-3-pro`          |                       |
-| `databricks-gemini-3-flash`        |                       |
-| `databricks-gemini-2-5-pro`        |                       |
-| `databricks-gemini-2-5-flash`      |                       |
-| `databricks-gemma-3-12b`           | Chat completions only |
+| Model ID                           | Inputs                    | Context | Notes                 |
+| ---------------------------------- | ------------------------- | ------- | --------------------- |
+| `databricks-gemini-3-5-flash`      | text, image, video, audio | —       |                       |
+| `databricks-gemini-3-1-pro`        | text, image, video, audio | 1M      |                       |
+| `databricks-gemini-3-1-flash-lite` | text, image, video, audio | —       |                       |
+| `databricks-gemini-3-pro`          | text, image, video, audio | 1M      |                       |
+| `databricks-gemini-3-flash`        | text, image, video, audio | —       |                       |
+| `databricks-gemini-2-5-pro`        | text, image, video, audio | 1M      | Deep Think Mode       |
+| `databricks-gemini-2-5-flash`      | text, image, video, audio | 1M      |                       |
+| `databricks-gemma-3-12b`           | text, image               | 128K    | Chat completions only |
 
 ### OpenAI
 
-| Model ID                        | Notes                                                              |
-| ------------------------------- | ------------------------------------------------------------------ |
-| `databricks-gpt-5-5-pro`        | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-5`            |                                                                    |
-| `databricks-gpt-5-4`            |                                                                    |
-| `databricks-gpt-5-4-mini`       |                                                                    |
-| `databricks-gpt-5-4-nano`       |                                                                    |
-| `databricks-gpt-5-3-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-2-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-2`            |                                                                    |
-| `databricks-gpt-5-1-codex-max`  | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-1-codex-mini` | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-1`            |                                                                    |
-| `databricks-gpt-5`              |                                                                    |
-| `databricks-gpt-5-mini`         |                                                                    |
-| `databricks-gpt-5-nano`         |                                                                    |
+All OpenAI models have a 400K token context window and accept text and image inputs.
+
+| Model ID                        | Notes                                                                              |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| `databricks-gpt-5-5-pro`        | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses). Prompt caching |
+| `databricks-gpt-5-5`            | Prompt caching                                                                     |
+| `databricks-gpt-5-4`            |                                                                                    |
+| `databricks-gpt-5-4-mini`       |                                                                                    |
+| `databricks-gpt-5-4-nano`       |                                                                                    |
+| `databricks-gpt-5-3-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-2-codex`      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-2`            |                                                                                    |
+| `databricks-gpt-5-1-codex-max`  | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-1-codex-mini` | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses)                 |
+| `databricks-gpt-5-1`            | Instant + Thinking modes                                                           |
+| `databricks-gpt-5`              |                                                                                    |
+| `databricks-gpt-5-mini`         |                                                                                    |
+| `databricks-gpt-5-nano`         |                                                                                    |
 
 ### Databricks
 
-Open-weight models hosted by Databricks. Chat completions only.
+Open-weight models hosted by Databricks. Text input only. Chat completions only.
 
-| Model ID                  | Notes |
-| ------------------------- | ----- |
-| `databricks-gpt-oss-120b` |       |
-| `databricks-gpt-oss-20b`  |       |
+| Model ID                  | Context | Notes                       |
+| ------------------------- | ------- | --------------------------- |
+| `databricks-gpt-oss-120b` | 128K    | Adjustable reasoning effort |
+| `databricks-gpt-oss-20b`  | 128K    |                             |
 
 ### Meta
 
-| Model ID                                 | Notes                                                                                                                                                                                                              |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `databricks-llama-4-maverick`            | [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                                      |
-| `databricks-meta-llama-3-3-70b-instruct` | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
-| `databricks-meta-llama-3-1-8b-instruct`  | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
+| Model ID                                 | Inputs      | Context | Notes                                                                                                                                                                                                              |
+| ---------------------------------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `databricks-llama-4-maverick`            | text, image | —       | [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                                      |
+| `databricks-meta-llama-3-3-70b-instruct` | text        | 128K    | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
+| `databricks-meta-llama-3-1-8b-instruct`  | text        | 128K    | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
 
 ### Alibaba
 
-| Model ID                                 | Notes |
-| ---------------------------------------- | ----- |
-| `databricks-qwen3-next-80b-a3b-instruct` |       |
-| `databricks-qwen35-122b-a10b`            |       |
+Text input only. Chat completions only.
+
+| Model ID                                 | Context | Notes                            |
+| ---------------------------------------- | ------- | -------------------------------- |
+| `databricks-qwen3-next-80b-a3b-instruct` | —       |                                  |
+| `databricks-qwen35-122b-a10b`            | 256K    | Always reasons before responding |
 
 ### DeepSeek
 
-| Model ID                   | Notes |
-| -------------------------- | ----- |
-| `databricks-deepseek-v3-2` |       |
+Text input only. Chat completions only.
+
+| Model ID                   | Context | Notes |
+| -------------------------- | ------- | ----- |
+| `databricks-deepseek-v3-2` | —       |       |
 
 ## Which endpoint to use
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -3,11 +3,11 @@ title: AI Gateway models
 subtitle: Available models and how to specify them
 summary: >-
   Neon AI Gateway serves Databricks-hosted foundation models from Anthropic,
-  OpenAI, Google, and Alibaba. All model IDs use the databricks- prefix.
-  Use these IDs in the model field of any request regardless of which endpoint
-  you are using.
+  OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. All model IDs use
+  the databricks- prefix. Use these IDs in the model field of any request
+  regardless of which endpoint you are using.
 enableTableOfContents: true
-updatedOn: '2026-06-10T17:16:40.599Z'
+updatedOn: '2026-06-11T11:29:12.425Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Use these IDs in the `model` field of any request, regardless of which endpoint you use.
@@ -49,20 +49,24 @@ Use the `id` field in the `model` parameter of any inference request.
 | `databricks-claude-opus-4-7`   |                                |
 | `databricks-claude-opus-4-6`   |                                |
 | `databricks-claude-opus-4-5`   |                                |
+| `databricks-claude-opus-4-1`   |                                |
 | `databricks-claude-sonnet-4-6` | Recommended for most use cases |
+| `databricks-claude-sonnet-4-5` |                                |
+| `databricks-claude-sonnet-4`   |                                |
 | `databricks-claude-haiku-4-5`  | Fast and cost-effective        |
 
 ### Google
 
-| Model ID                           | Notes |
-| ---------------------------------- | ----- |
-| `databricks-gemini-3-5-flash`      |       |
-| `databricks-gemini-3-1-pro`        |       |
-| `databricks-gemini-3-1-flash-lite` |       |
-| `databricks-gemini-3-pro`          |       |
-| `databricks-gemini-3-flash`        |       |
-| `databricks-gemini-2-5-pro`        |       |
-| `databricks-gemini-2-5-flash`      |       |
+| Model ID                           | Notes                 |
+| ---------------------------------- | --------------------- |
+| `databricks-gemini-3-5-flash`      |                       |
+| `databricks-gemini-3-1-pro`        |                       |
+| `databricks-gemini-3-1-flash-lite` |                       |
+| `databricks-gemini-3-pro`          |                       |
+| `databricks-gemini-3-flash`        |                       |
+| `databricks-gemini-2-5-pro`        |                       |
+| `databricks-gemini-2-5-flash`      |                       |
+| `databricks-gemma-3-12b`           | Chat completions only |
 
 ### OpenAI
 
@@ -79,12 +83,39 @@ Use the `id` field in the `model` parameter of any inference request.
 | `databricks-gpt-5-1-codex-max`  | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
 | `databricks-gpt-5-1-codex-mini` | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
 | `databricks-gpt-5-1`            |                                                                    |
+| `databricks-gpt-5`              |                                                                    |
+| `databricks-gpt-5-mini`         |                                                                    |
+| `databricks-gpt-5-nano`         |                                                                    |
+
+### Databricks
+
+Open-weight models hosted by Databricks. Chat completions only.
+
+| Model ID                  | Notes |
+| ------------------------- | ----- |
+| `databricks-gpt-oss-120b` |       |
+| `databricks-gpt-oss-20b`  |       |
+
+### Meta
+
+| Model ID                                 | Notes |
+| ---------------------------------------- | ----- |
+| `databricks-llama-4-maverick`            |       |
+| `databricks-meta-llama-3-3-70b-instruct` |       |
+| `databricks-meta-llama-3-1-8b-instruct`  |       |
 
 ### Alibaba
 
-| Model ID                      | Notes |
-| ----------------------------- | ----- |
-| `databricks-qwen35-122b-a10b` |       |
+| Model ID                                 | Notes |
+| ---------------------------------------- | ----- |
+| `databricks-qwen3-next-80b-a3b-instruct` |       |
+| `databricks-qwen35-122b-a10b`            |       |
+
+### DeepSeek
+
+| Model ID                   | Notes |
+| -------------------------- | ----- |
+| `databricks-deepseek-v3-2` |       |
 
 ## Which endpoint to use
 
@@ -95,7 +126,8 @@ Most models work with the [Chat completions](/docs/ai-gateway/chat-completions) 
 | Anthropic                              | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/anthropic/v1/messages` for extended thinking and prompt caching         |
 | OpenAI (most models)                   | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/openai/v1/responses` for Responses API features                         |
 | OpenAI (`gpt-5-5-pro`, codex variants) | `/ai-gateway/openai/v1/responses`        | These models require the Responses API and do not work with chat/completions             |
-| Google                                 | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
-| Alibaba                                | `/ai-gateway/mlflow/v1/chat/completions` |                                                                                          |
+| Google Gemini                          | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
+| Google Gemma 3 12B                     | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only; does not support the Gemini SDK endpoint                          |
+| Meta, DeepSeek, Databricks, Alibaba    | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only                                                                    |
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   Use these IDs in the model field of any request regardless of which endpoint
   you are using.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:34:05.027Z'
+updatedOn: '2026-06-10T17:02:23.973Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Use these IDs in the `model` field of any request, regardless of which endpoint you use.
@@ -15,6 +15,29 @@ Neon AI Gateway serves models hosted by Databricks. All model IDs use the `datab
 <Admonition type="note">
 Model availability may vary by region. The catalog expands over time, so check back for new additions.
 </Admonition>
+
+## List available models
+
+You can fetch the current model catalog from the Neon API:
+
+```bash shouldWrap
+curl "https://console.neon.tech/api/v2/ai_gateway/models" \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+The response includes each model's `id`, `provider`, and `display_name`:
+
+```json
+{
+  "models": [
+    { "id": "databricks-claude-sonnet-4-6", "provider": "anthropic", "display_name": "Claude Sonnet 4.6" },
+    { "id": "databricks-gpt-5-4", "provider": "openai", "display_name": "GPT-5.4" },
+    { "id": "databricks-gemini-2-5-flash", "provider": "google", "display_name": "Gemini 2.5 Flash" }
+  ]
+}
+```
+
+Use the `id` field in the `model` parameter of any inference request.
 
 ## Available models
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   the databricks- prefix. Use these IDs in the model field of any request
   regardless of which endpoint you are using.
 enableTableOfContents: true
-updatedOn: '2026-06-11T11:29:12.425Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. All model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Use these IDs in the `model` field of any request, regardless of which endpoint you use.
@@ -125,9 +125,9 @@ Most models work with the [Chat completions](/docs/ai-gateway/chat-completions) 
 | -------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
 | Anthropic                              | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/anthropic/v1/messages` for extended thinking and prompt caching         |
 | OpenAI (most models)                   | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/openai/v1/responses` for Responses API features                         |
-| OpenAI (`gpt-5-5-pro`, codex variants) | `/ai-gateway/openai/v1/responses`        | These models require the Responses API and do not work with chat/completions             |
+| OpenAI (`gpt-5-5-pro`, codex variants) | `/ai-gateway/openai/v1/responses`        | These models require the Responses API and don't work with chat/completions              |
 | Google Gemini                          | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
-| Google Gemma 3 12B                     | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only; does not support the Gemini SDK endpoint                          |
+| Google Gemma 3 12B                     | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                           |
 | Meta, DeepSeek, Databricks, Alibaba    | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only                                                                    |
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,10 +7,14 @@ summary: >-
   databricks- prefix, but the short form without the prefix also works. Use
   either form in the model field of any request.
 enableTableOfContents: true
-updatedOn: '2026-06-14T11:12:18.690Z'
+updatedOn: '2026-06-15T10:50:05.465Z'
 ---
 
 Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). You can also use the short form without the prefix (for example, `claude-sonnet-4-6`) — both are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
+
+<Admonition type="important">
+Models are hosted by Databricks and served through Neon AI Gateway. By using these models, you are responsible for complying with each provider's applicable terms of use. See [Provider terms](#provider-terms) below.
+</Admonition>
 
 <Admonition type="note">
 Model availability may vary by region. The catalog expands over time, so check back for new additions.
@@ -109,11 +113,11 @@ Open-weight models hosted by Databricks. Chat completions only.
 
 ### Meta
 
-| Model ID                                 | Notes |
-| ---------------------------------------- | ----- |
-| `databricks-llama-4-maverick`            |       |
-| `databricks-meta-llama-3-3-70b-instruct` |       |
-| `databricks-meta-llama-3-1-8b-instruct`  |       |
+| Model ID                                 | Notes                                                                                                                                                                                                              |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `databricks-llama-4-maverick`            | [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                                      |
+| `databricks-meta-llama-3-3-70b-instruct` | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
+| `databricks-meta-llama-3-1-8b-instruct`  | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
 
 ### Alibaba
 
@@ -140,5 +144,17 @@ Most models work with the [Chat completions](/docs/ai-gateway/chat-completions) 
 | Google Gemini                          | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
 | Google Gemma 3 12B                     | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                           |
 | Meta, DeepSeek, Databricks, Alibaba    | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only                                                                    |
+
+## Provider terms
+
+Models are hosted by Databricks and served through Neon AI Gateway. You are responsible for complying with each provider's applicable terms of use.
+
+| Provider      | Terms                                                                                                                                                                               |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Anthropic     | [Anthropic Usage Policy](https://www.anthropic.com/legal/aup)                                                                                                                       |
+| OpenAI        | [OpenAI Usage Policies](https://openai.com/policies/usage-policies)                                                                                                                 |
+| Google Gemini | [Google Cloud Acceptable Use Policy](https://cloud.google.com/terms/aup) · [Google Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy) |
+| Google Gemma  | [Gemma Terms of Use](https://ai.google.dev/gemma/terms) · [Gemma Prohibited Use Policy](https://ai.google.dev/gemma/prohibited_use_policy)                                          |
+| Meta          | See the Notes column in the [Meta models table](#meta) above — terms differ by Llama version.                                                                                       |
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/openai-responses.md
+++ b/content/docs/ai-gateway/openai-responses.md
@@ -6,8 +6,10 @@ summary: >-
   AI Gateway. Required for gpt-5-5-pro and codex model variants, which do not
   work with the chat completions endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T08:51:16.298Z'
+updatedOn: '2026-06-15T13:34:36.031Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 The OpenAI Responses endpoint exposes the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) through Neon AI Gateway. Use it with the OpenAI SDK's `responses.create()` method by changing only the `baseURL`.
 

--- a/content/docs/ai-gateway/openai-responses.md
+++ b/content/docs/ai-gateway/openai-responses.md
@@ -6,7 +6,7 @@ summary: >-
   AI Gateway. Required for gpt-5-5-pro and codex model variants, which do not
   work with the chat completions endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T17:20:52.899Z'
+updatedOn: '2026-06-15T08:51:16.298Z'
 ---
 
 The OpenAI Responses endpoint exposes the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) through Neon AI Gateway. Use it with the OpenAI SDK's `responses.create()` method by changing only the `baseURL`.
@@ -46,7 +46,7 @@ import OpenAI from 'openai';
 
 const client = new OpenAI({
   apiKey: process.env.NEON_AI_GATEWAY_KEY,
-  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/openai/v1`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1`,
 });
 
 const response = await client.responses.create({
@@ -63,7 +63,7 @@ import os
 
 client = OpenAI(
     api_key=os.environ['NEON_AI_GATEWAY_KEY'],
-    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/openai/v1",
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/openai/v1",
 )
 
 response = client.responses.create(
@@ -75,7 +75,7 @@ print(response.output_text)
 ```
 
 ```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/openai/v1/responses" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/openai/v1/responses" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -115,7 +115,7 @@ with client.responses.stream(
 ```
 
 ```bash shouldWrap
-curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/openai/v1/responses" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/openai/v1/responses" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/content/docs/ai-gateway/openai-responses.md
+++ b/content/docs/ai-gateway/openai-responses.md
@@ -6,7 +6,7 @@ summary: >-
   AI Gateway. Required for gpt-5-5-pro and codex model variants, which do not
   work with the chat completions endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-11T17:20:52.899Z'
 ---
 
 The OpenAI Responses endpoint exposes the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) through Neon AI Gateway. Use it with the OpenAI SDK's `responses.create()` method by changing only the `baseURL`.
@@ -129,15 +129,12 @@ curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/openai/v1/responses" \
 
 ## Error handling
 
-| Status                  | Message                                     | Cause                                                   |
-| ----------------------- | ------------------------------------------- | ------------------------------------------------------- |
-| `400 Bad Request`       | `unknown model`                             | Model ID not in the catalog                             |
-| `400 Bad Request`       | `model is not available on this endpoint`   | Non-OpenAI model sent to this endpoint                  |
-| `401 Unauthorized`      | `invalid or missing credential`             | Missing or invalid `NEON_AI_GATEWAY_KEY`                |
-| `403 Forbidden`         | `credential not authorized for ai gateway`  | Credential lacks `ai_gateway:invoke` scope              |
-| `403 Forbidden`         | `credential not authorized for this branch` | Credential's branch not in the request branch's lineage |
-| `429 Too Many Requests` | `ai gateway quota exceeded`                 | Account quota blocked; check `Retry-After` header       |
-| `502 Bad Gateway`       | `upstream request failed`                   | Upstream OpenAI/Databricks error; retry                 |
+| Status            | Message                                   | Cause                                  |
+| ----------------- | ----------------------------------------- | -------------------------------------- |
+| `400 Bad Request` | `unknown model`                           | Model ID not in the catalog            |
+| `400 Bad Request` | `model is not available on this endpoint` | Non-OpenAI model sent to this endpoint |
+
+For authentication, quota, and upstream errors, see [Troubleshooting](/docs/ai-gateway/troubleshooting).
 
 ## Next steps
 

--- a/content/docs/ai-gateway/openai-responses.md
+++ b/content/docs/ai-gateway/openai-responses.md
@@ -1,0 +1,148 @@
+---
+title: OpenAI Responses API
+subtitle: Use the OpenAI Responses API with Neon AI Gateway
+summary: >-
+  The OpenAI Responses endpoint exposes the OpenAI Responses API through Neon
+  AI Gateway. Required for gpt-5-5-pro and codex model variants, which do not
+  work with the chat completions endpoint.
+enableTableOfContents: true
+updatedOn: '2026-06-10T17:21:35.055Z'
+---
+
+The OpenAI Responses endpoint exposes the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) through Neon AI Gateway. Use it with the OpenAI SDK's `responses.create()` method by changing only the `baseURL`.
+
+**Base URL:** `https://<branch-host>/ai-gateway/openai/v1`
+
+<Admonition type="warning">
+`databricks-gpt-5-5-pro` and all codex model variants (`databricks-gpt-5-3-codex`, `databricks-gpt-5-2-codex`, `databricks-gpt-5-1-codex-max`, `databricks-gpt-5-1-codex-mini`) **require this endpoint**. They do not work with the [chat completions endpoint](/docs/ai-gateway/chat-completions).
+</Admonition>
+
+## Supported models
+
+This endpoint accepts OpenAI models only:
+
+| Model ID                        | Notes                  |
+| ------------------------------- | ---------------------- |
+| `databricks-gpt-5-5-pro`        | Requires this endpoint |
+| `databricks-gpt-5-5`            |                        |
+| `databricks-gpt-5-4`            |                        |
+| `databricks-gpt-5-4-mini`       |                        |
+| `databricks-gpt-5-4-nano`       |                        |
+| `databricks-gpt-5-3-codex`      | Requires this endpoint |
+| `databricks-gpt-5-2-codex`      | Requires this endpoint |
+| `databricks-gpt-5-2`            |                        |
+| `databricks-gpt-5-1-codex-max`  | Requires this endpoint |
+| `databricks-gpt-5-1-codex-mini` | Requires this endpoint |
+| `databricks-gpt-5-1`            |                        |
+
+Sending a non-OpenAI model ID returns `400 model is not available on this endpoint`.
+
+## Basic request
+
+<CodeTabs labels={["TypeScript (OpenAI SDK)", "Python (OpenAI SDK)", "cURL"]}>
+
+```typescript shouldWrap
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  baseURL: `https://${process.env.NEON_AI_GATEWAY_HOST}/ai-gateway/openai/v1`,
+});
+
+const response = await client.responses.create({
+  model: 'databricks-gpt-5-4',
+  input: [{ role: 'user', content: 'What is Neon?' }],
+});
+
+console.log(response.output_text);
+```
+
+```python shouldWrap
+from openai import OpenAI
+import os
+
+client = OpenAI(
+    api_key=os.environ['NEON_AI_GATEWAY_KEY'],
+    base_url=f"https://{os.environ['NEON_AI_GATEWAY_HOST']}/ai-gateway/openai/v1",
+)
+
+response = client.responses.create(
+    model='databricks-gpt-5-4',
+    input=[{'role': 'user', 'content': 'What is Neon?'}],
+)
+
+print(response.output_text)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/openai/v1/responses" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "databricks-gpt-5-4",
+    "input": [{"role": "user", "content": "What is Neon?"}]
+  }'
+```
+
+</CodeTabs>
+
+## Streaming
+
+<CodeTabs labels={["TypeScript (OpenAI SDK)", "Python (OpenAI SDK)", "cURL"]}>
+
+```typescript shouldWrap
+const stream = await client.responses.create({
+  model: 'databricks-gpt-5-4',
+  input: [{ role: 'user', content: 'Explain database branching.' }],
+  stream: true,
+});
+
+for await (const event of stream) {
+  if (event.type === 'response.output_text.delta') {
+    process.stdout.write(event.delta);
+  }
+}
+```
+
+```python shouldWrap
+with client.responses.stream(
+    model='databricks-gpt-5-4',
+    input=[{'role': 'user', 'content': 'Explain database branching.'}],
+) as stream:
+    for event in stream:
+        if event.type == 'response.output_text.delta':
+            print(event.delta, end='', flush=True)
+```
+
+```bash shouldWrap
+curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/openai/v1/responses" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "databricks-gpt-5-4",
+    "input": [{"role": "user", "content": "Explain database branching."}],
+    "stream": true
+  }'
+```
+
+</CodeTabs>
+
+## Error handling
+
+| Status                  | Message                                     | Cause                                                   |
+| ----------------------- | ------------------------------------------- | ------------------------------------------------------- |
+| `400 Bad Request`       | `unknown model`                             | Model ID not in the catalog                             |
+| `400 Bad Request`       | `model is not available on this endpoint`   | Non-OpenAI model sent to this endpoint                  |
+| `401 Unauthorized`      | `invalid or missing credential`             | Missing or invalid `NEON_AI_GATEWAY_KEY`                |
+| `403 Forbidden`         | `credential not authorized for ai gateway`  | Credential lacks `ai_gateway:invoke` scope              |
+| `403 Forbidden`         | `credential not authorized for this branch` | Credential's branch not in the request branch's lineage |
+| `429 Too Many Requests` | `ai gateway quota exceeded`                 | Account quota blocked; check `Retry-After` header       |
+| `502 Bad Gateway`       | `upstream request failed`                   | Upstream OpenAI/Databricks error; retry                 |
+
+## Next steps
+
+- [Models](/docs/ai-gateway/models) — full model catalog and which models require this endpoint
+- [Chat completions](/docs/ai-gateway/chat-completions) — use any model via the unified OpenAI-compatible endpoint
+- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/openai-responses.md
+++ b/content/docs/ai-gateway/openai-responses.md
@@ -6,7 +6,7 @@ summary: >-
   AI Gateway. Required for gpt-5-5-pro and codex model variants, which do not
   work with the chat completions endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-10T17:21:35.055Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
 The OpenAI Responses endpoint exposes the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) through Neon AI Gateway. Use it with the OpenAI SDK's `responses.create()` method by changing only the `baseURL`.
@@ -141,8 +141,8 @@ curl -X POST "https://$NEON_AI_GATEWAY_HOST/ai-gateway/openai/v1/responses" \
 
 ## Next steps
 
-- [Models](/docs/ai-gateway/models) — full model catalog and which models require this endpoint
-- [Chat completions](/docs/ai-gateway/chat-completions) — use any model via the unified OpenAI-compatible endpoint
-- [Authentication](/docs/ai-gateway/authentication) — credential scopes and branch binding
+- [Models](/docs/ai-gateway/models): full model catalog and which models require this endpoint
+- [Chat completions](/docs/ai-gateway/chat-completions): use any model via the unified OpenAI-compatible endpoint
+- [Authentication](/docs/ai-gateway/authentication): credential scopes and branch binding
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:08:43.679Z'
+updatedOn: '2026-06-15T14:32:24.523Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -34,14 +34,24 @@ During the private preview, AI Gateway is available for new projects in the AWS 
 
 </DetailIconCards>
 
-## Example apps
+## Starter templates
 
-<DetailIconCards>
+Browse templates at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one directly with `neonctl bootstrap`:
 
-<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, routing model calls through AI Gateway with no separate provider credentials required." icon="github">Rate My Pricing</a>
+```bash
+neonctl bootstrap
+```
 
-<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that routes OpenAI image generation and Claude moderation through the same AI Gateway config, from a single Neon Function." icon="github">Vibecastly</a>
+Use `--template` to skip the interactive picker:
 
-</DetailIconCards>
+| Template        | What it builds                                                                         |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `hono`          | REST API with Drizzle and Postgres on Neon Functions                                   |
+| `ai-sdk`        | Image-generation agent with AI Gateway, Object Storage, and Postgres on Neon Functions |
+| `mastra`        | Personal assistant with AI Gateway and Postgres-backed memory on Neon Functions        |
+| `realtime-chat` | Realtime chat with Next.js, Neon Auth, and WebSockets on Neon Functions                |
+| `realtime-sse`  | Realtime counter with TanStack Router and SSE on Neon Functions                        |
+
+`neonctl bootstrap` scaffolds files, links to a Neon project, and pulls env vars. Then follow the README to set up and deploy.
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -8,11 +8,11 @@ summary: >-
   SDKs work out of the box. Point them at your branch host and start calling
   models immediately.
 enableTableOfContents: true
-updatedOn: '2026-06-08T18:39:44.797Z'
+updatedOn: '2026-06-08T18:44:46.877Z'
 ---
 
 <Admonition type="note" title="Private Preview">
-Neon AI Gateway is currently in Private Preview and available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan. Free plan users receive access to open-source models on a round-robin basis.
+Neon AI Gateway is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
 </Admonition>
 
 Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agents. Use your branch credential to call foundation models from Anthropic, OpenAI, Google, and Alibaba. No provider API keys required. Your existing OpenAI or Anthropic SDK works without changes. Point it at your branch host and start making requests.

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -8,11 +8,11 @@ summary: >-
   SDKs work out of the box. Point them at your branch host and start calling
   models immediately.
 enableTableOfContents: true
-updatedOn: '2026-06-08T17:00:11.574Z'
+updatedOn: '2026-06-08T18:39:44.797Z'
 ---
 
 <Admonition type="note" title="Private Preview">
-Neon AI Gateway is currently in Private Preview. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan. Free plan users receive access to open-source models on a round-robin basis.
+Neon AI Gateway is currently in Private Preview and available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan. Free plan users receive access to open-source models on a round-robin basis.
 </Admonition>
 
 Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agents. Use your branch credential to call foundation models from Anthropic, OpenAI, Google, and Alibaba. No provider API keys required. Your existing OpenAI or Anthropic SDK works without changes. Point it at your branch host and start making requests.

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -2,25 +2,22 @@
 title: Neon AI Gateway
 subtitle: LLM inference built into your Neon branch
 summary: >-
-  Neon AI Gateway is the LLM inference layer in the Neon backend for apps and
-  agents. Use your branch credential to call foundation models from Anthropic,
-  OpenAI, Google, and Alibaba without managing provider API keys. Standard AI
-  SDKs work out of the box. Point them at your branch host and start calling
-  models immediately.
+  Neon AI Gateway is the LLM inference layer built into the Neon backend. One
+  Neon credential gives you access to 39 models across 7 providers. Standard AI
+  SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T11:29:12.425Z'
+updatedOn: '2026-06-11T16:33:40.799Z'
 ---
 
 <Admonition type="note" title="Private Preview">
 Neon AI Gateway is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
 </Admonition>
 
-Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agents. Use your branch credential to call foundation models from Anthropic, OpenAI, Google, and Alibaba. No provider API keys required. Your existing OpenAI or Anthropic SDK works without changes. Point it at your branch host and start making requests.
+Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
 
-- **No provider credentials to manage.** Authenticate with your existing Neon credential.
+- **One credential for all providers.** A single Neon credential gives you access to 39 models across Anthropic, OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. No separate provider accounts needed.
 - **Standard SDKs, one URL change.** OpenAI SDK, Anthropic SDK, and google-genai all work out of the box.
-- **Branches with your database.** Every branch gets its own gateway endpoint, so you can test AI features in preview branches without touching production.
-- **39 models across 7 providers.** Claude, GPT, Gemini, Llama, DeepSeek, and more, all accessible with the same credential.
+- **AI follows your branches.** Each branch has its own gateway endpoint. If you use Neon branches for preview deployments, AI requests from a feature branch are scoped to that branch. It's the same isolation your database already gets.
 - **Streaming support.** Server-sent events work on all endpoints with no extra configuration.
 
 ## Quickstart

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-12T16:38:18.194Z'
+updatedOn: '2026-06-15T10:38:48.744Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -31,6 +31,16 @@ During the private preview, AI Gateway is available for new projects in the AWS 
 <a href="/docs/ai-gateway/chat-completions" description="Use the OpenAI-compatible endpoint with any model in the catalog." icon="code">Chat completions</a>
 
 <a href="/docs/ai-gateway/authentication" description="Understand how Neon credentials work with AI Gateway." icon="lock-landscape">Authentication</a>
+
+</DetailIconCards>
+
+## Example apps
+
+<DetailIconCards>
+
+<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, routing model calls through AI Gateway — no separate provider credentials required." icon="github">Rate My Pricing</a>
+
+<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that routes OpenAI image generation and Claude moderation through the same AI Gateway config, from a single Neon Function." icon="github">Vibecastly</a>
 
 </DetailIconCards>
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,14 +6,14 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:47.636Z'
+updatedOn: '2026-06-15T15:43:05.726Z'
 ---
 
 <PrivatePreviewEnquire/>
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
 
-During the private preview, AI Gateway is available for new projects in the AWS us-east-2 region only, and foundation model access requires a paid Neon plan.
+During the private preview, AI Gateway is available for **new projects** in the **AWS us-east-2** region only, and foundation model access requires a paid Neon plan.
 
 - **One credential for all providers.** A single Neon credential gives you access to 39 models across Anthropic, OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. No separate provider accounts needed.
 - **Standard SDKs, one URL change.** OpenAI SDK, Anthropic SDK, and google-genai all work out of the box.

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -1,0 +1,40 @@
+---
+title: Neon AI Gateway
+subtitle: LLM inference built into your Neon branch
+summary: >-
+  Neon AI Gateway is the LLM inference layer in the Neon backend for apps and
+  agents. Use your branch credential to call foundation models from Anthropic,
+  OpenAI, Google, and Alibaba without managing provider API keys. Standard AI
+  SDKs work out of the box — point them at your branch host and start calling
+  models immediately.
+enableTableOfContents: true
+updatedOn: '2026-06-08T16:11:48.651Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon AI Gateway is currently in Private Preview. To request access, sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan. Free plan users receive access to open-source models on a round-robin basis.
+</Admonition>
+
+Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agents. Use your branch credential to call foundation models from Anthropic, OpenAI, Google, and Alibaba — no provider API keys required. Your existing OpenAI or Anthropic SDK works without changes; just point it at your branch host.
+
+- **No provider credentials to manage** — authenticate with your existing Neon credential
+- **Standard SDKs, one URL change** — OpenAI SDK, Anthropic SDK, and google-genai all work out of the box
+- **Branches with your database** — every branch gets its own gateway endpoint, so you can test AI features in preview branches without touching production
+- **20+ models across 4 providers** — Claude, GPT, Gemini, and Qwen, all accessible with the same credential
+- **Streaming support** — server-sent events work on all endpoints with no extra configuration
+
+## Quickstart
+
+<DetailIconCards>
+
+<a href="/docs/ai-gateway/get-started" description="Get a credential and make your first inference request in minutes." icon="todo">Quickstart</a>
+
+<a href="/docs/ai-gateway/models" description="Browse the full model catalog and learn how to specify models in requests." icon="database">Models</a>
+
+<a href="/docs/ai-gateway/chat-completions" description="Use the OpenAI-compatible endpoint with any model in the catalog." icon="code">Chat completions</a>
+
+<a href="/docs/ai-gateway/authentication" description="Understand how Neon credentials work with AI Gateway." icon="lock">Authentication</a>
+
+</DetailIconCards>
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T15:43:05.726Z'
+updatedOn: '2026-06-15T15:47:52.073Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -38,13 +38,13 @@ During the private preview, AI Gateway is available for **new projects** in the 
 
 Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/). Two templates use AI Gateway:
 
-**`ai-sdk`** — An image-generation agent that routes model calls through AI Gateway, stores results in Neon Storage, and writes metadata to Postgres on a Neon Function.
+**`ai-sdk`**: An image-generation agent that routes model calls through AI Gateway, stores results in Neon Storage, and writes metadata to Postgres on a Neon Function.
 
 ```bash
 neonctl bootstrap --template ai-sdk
 ```
 
-**`mastra`** — A personal assistant that uses AI Gateway for LLM calls with Postgres-backed memory on a Neon Function.
+**`mastra`**: A personal assistant that uses AI Gateway for LLM calls with Postgres-backed memory on a Neon Function.
 
 ```bash
 neonctl bootstrap --template mastra

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:36:06.097Z'
+updatedOn: '2026-06-15T14:41:04.978Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -36,6 +36,18 @@ During the private preview, AI Gateway is available for new projects in the AWS 
 
 ## Starter templates
 
-Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one with `neonctl bootstrap`.
+Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/). Two templates use AI Gateway:
+
+**`ai-sdk`** — An image-generation agent that routes model calls through AI Gateway, stores results in Neon Storage, and writes metadata to Postgres on a Neon Function.
+
+```bash
+neonctl bootstrap --template ai-sdk
+```
+
+**`mastra`** — A personal assistant that uses AI Gateway for LLM calls with Postgres-backed memory on a Neon Function.
+
+```bash
+neonctl bootstrap --template mastra
+```
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T10:38:48.744Z'
+updatedOn: '2026-06-15T11:08:43.679Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -38,7 +38,7 @@ During the private preview, AI Gateway is available for new projects in the AWS 
 
 <DetailIconCards>
 
-<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, routing model calls through AI Gateway — no separate provider credentials required." icon="github">Rate My Pricing</a>
+<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, routing model calls through AI Gateway with no separate provider credentials required." icon="github">Rate My Pricing</a>
 
 <a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that routes OpenAI image generation and Claude moderation through the same AI Gateway config, from a single Neon Function." icon="github">Vibecastly</a>
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -5,23 +5,23 @@ summary: >-
   Neon AI Gateway is the LLM inference layer in the Neon backend for apps and
   agents. Use your branch credential to call foundation models from Anthropic,
   OpenAI, Google, and Alibaba without managing provider API keys. Standard AI
-  SDKs work out of the box — point them at your branch host and start calling
+  SDKs work out of the box. Point them at your branch host and start calling
   models immediately.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:11:48.651Z'
+updatedOn: '2026-06-08T16:34:05.027Z'
 ---
 
 <Admonition type="note" title="Private Preview">
 Neon AI Gateway is currently in Private Preview. To request access, sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan. Free plan users receive access to open-source models on a round-robin basis.
 </Admonition>
 
-Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agents. Use your branch credential to call foundation models from Anthropic, OpenAI, Google, and Alibaba — no provider API keys required. Your existing OpenAI or Anthropic SDK works without changes; just point it at your branch host.
+Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agents. Use your branch credential to call foundation models from Anthropic, OpenAI, Google, and Alibaba. No provider API keys required. Your existing OpenAI or Anthropic SDK works without changes. Point it at your branch host and start making requests.
 
-- **No provider credentials to manage** — authenticate with your existing Neon credential
-- **Standard SDKs, one URL change** — OpenAI SDK, Anthropic SDK, and google-genai all work out of the box
-- **Branches with your database** — every branch gets its own gateway endpoint, so you can test AI features in preview branches without touching production
-- **20+ models across 4 providers** — Claude, GPT, Gemini, and Qwen, all accessible with the same credential
-- **Streaming support** — server-sent events work on all endpoints with no extra configuration
+- **No provider credentials to manage.** Authenticate with your existing Neon credential.
+- **Standard SDKs, one URL change.** OpenAI SDK, Anthropic SDK, and google-genai all work out of the box.
+- **Branches with your database.** Every branch gets its own gateway endpoint, so you can test AI features in preview branches without touching production.
+- **20+ models across 4 providers.** Claude, GPT, Gemini, and Qwen, all accessible with the same credential.
+- **Streaming support.** Server-sent events work on all endpoints with no extra configuration.
 
 ## Quickstart
 
@@ -33,7 +33,7 @@ Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agen
 
 <a href="/docs/ai-gateway/chat-completions" description="Use the OpenAI-compatible endpoint with any model in the catalog." icon="code">Chat completions</a>
 
-<a href="/docs/ai-gateway/authentication" description="Understand how Neon credentials work with AI Gateway." icon="lock">Authentication</a>
+<a href="/docs/ai-gateway/authentication" description="Understand how Neon credentials work with AI Gateway." icon="lock-landscape">Authentication</a>
 
 </DetailIconCards>
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -8,7 +8,7 @@ summary: >-
   SDKs work out of the box. Point them at your branch host and start calling
   models immediately.
 enableTableOfContents: true
-updatedOn: '2026-06-08T18:44:46.877Z'
+updatedOn: '2026-06-11T11:29:12.425Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -20,7 +20,7 @@ Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agen
 - **No provider credentials to manage.** Authenticate with your existing Neon credential.
 - **Standard SDKs, one URL change.** OpenAI SDK, Anthropic SDK, and google-genai all work out of the box.
 - **Branches with your database.** Every branch gets its own gateway endpoint, so you can test AI features in preview branches without touching production.
-- **20+ models across 4 providers.** Claude, GPT, Gemini, and Qwen, all accessible with the same credential.
+- **39 models across 7 providers.** Claude, GPT, Gemini, Llama, DeepSeek, and more, all accessible with the same credential.
 - **Streaming support.** Server-sent events work on all endpoints with no extra configuration.
 
 ## Quickstart

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -8,11 +8,11 @@ summary: >-
   SDKs work out of the box. Point them at your branch host and start calling
   models immediately.
 enableTableOfContents: true
-updatedOn: '2026-06-08T16:34:05.027Z'
+updatedOn: '2026-06-08T17:00:11.574Z'
 ---
 
 <Admonition type="note" title="Private Preview">
-Neon AI Gateway is currently in Private Preview. To request access, sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan. Free plan users receive access to open-source models on a round-robin basis.
+Neon AI Gateway is currently in Private Preview. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan. Free plan users receive access to open-source models on a round-robin basis.
 </Admonition>
 
 Neon AI Gateway is the LLM inference layer in the Neon backend for apps and agents. Use your branch credential to call foundation models from Anthropic, OpenAI, Google, and Alibaba. No provider API keys required. Your existing OpenAI or Anthropic SDK works without changes. Point it at your branch host and start making requests.

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,14 +6,14 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:33:40.799Z'
+updatedOn: '2026-06-12T16:38:18.194Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon AI Gateway is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends). Foundation model access requires a paid Neon plan.
-</Admonition>
+<PrivatePreviewEnquire/>
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
+
+During the private preview, AI Gateway is available for new projects in the AWS us-east-2 region only, and foundation model access requires a paid Neon plan.
 
 - **One credential for all providers.** A single Neon credential gives you access to 39 models across Anthropic, OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. No separate provider accounts needed.
 - **Standard SDKs, one URL change.** OpenAI SDK, Anthropic SDK, and google-genai all work out of the box.

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:32:24.523Z'
+updatedOn: '2026-06-15T14:36:06.097Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -36,22 +36,6 @@ During the private preview, AI Gateway is available for new projects in the AWS 
 
 ## Starter templates
 
-Browse templates at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one directly with `neonctl bootstrap`:
-
-```bash
-neonctl bootstrap
-```
-
-Use `--template` to skip the interactive picker:
-
-| Template        | What it builds                                                                         |
-| --------------- | -------------------------------------------------------------------------------------- |
-| `hono`          | REST API with Drizzle and Postgres on Neon Functions                                   |
-| `ai-sdk`        | Image-generation agent with AI Gateway, Object Storage, and Postgres on Neon Functions |
-| `mastra`        | Personal assistant with AI Gateway and Postgres-backed memory on Neon Functions        |
-| `realtime-chat` | Realtime chat with Next.js, Neon Auth, and WebSockets on Neon Functions                |
-| `realtime-sse`  | Realtime counter with TanStack Router and SSE on Neon Functions                        |
-
-`neonctl bootstrap` scaffolds files, links to a Neon project, and pulls env vars. Then follow the README to set up and deploy.
+Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one with `neonctl bootstrap`.
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/troubleshooting.md
+++ b/content/docs/ai-gateway/troubleshooting.md
@@ -1,0 +1,153 @@
+---
+title: AI Gateway troubleshooting
+subtitle: Common errors and how to fix them
+summary: >-
+  Solutions for common errors when using Neon AI Gateway, including
+  authentication failures, model errors, quota limits, and upstream issues.
+enableTableOfContents: true
+updatedOn: '2026-06-10T17:21:35.055Z'
+---
+
+## Authentication errors
+
+### `401 invalid or missing credential`
+
+The bearer token is missing, malformed, or has been revoked.
+
+**Fix:** Check that `NEON_AI_GATEWAY_KEY` is set and contains the full `nt_live_...` token returned when you created the credential. If the credential was revoked, create a new one. See [Authentication](/docs/ai-gateway/authentication#creating-a-credential).
+
+### `403 credential not authorized for ai gateway`
+
+The credential exists but lacks the `ai_gateway:invoke` scope.
+
+**Fix:** Create a new credential that includes `ai_gateway:invoke` in the `scopes` array. Scopes cannot be added to an existing credential. See [Authentication](/docs/ai-gateway/authentication#creating-a-credential).
+
+### `403 credential not authorized for this branch`
+
+The credential was issued on a branch that is not an ancestor of the branch in the request hostname.
+
+**Fix:** Use a credential issued on the current branch or an ancestor branch. See [Authentication](/docs/ai-gateway/authentication#how-branch-binding-works) for how branch lineage works.
+
+### `503 authorization temporarily unavailable`
+
+The credential store or branch resolver is temporarily unavailable.
+
+**Fix:** Retry the request. This is a transient infrastructure error, not a client error.
+
+---
+
+## Model errors
+
+### `400 unknown model`
+
+The `model` field in the request body does not match any entry in the AI Gateway catalog.
+
+**Fix:** Check the model ID. All model IDs use the `databricks-` prefix (e.g., `databricks-claude-sonnet-4-6`). See the [full model catalog](/docs/ai-gateway/models) for valid IDs.
+
+### `400 model is not available on this endpoint`
+
+The model exists in the catalog but does not work with the endpoint you are calling.
+
+**Fix:** Check which endpoint the model requires:
+
+- Anthropic models (`databricks-claude-*`) on `/openai/v1/responses` → use `/anthropic/v1/messages` or `/mlflow/v1/chat/completions`
+- OpenAI codex models or `gpt-5-5-pro` on `/mlflow/v1/chat/completions` → use `/openai/v1/responses`
+- Google models on `/anthropic/v1/messages` → use `/gemini/v1beta/...` or `/mlflow/v1/chat/completions`
+
+See [Which endpoint to use](/docs/ai-gateway/models#which-endpoint-to-use).
+
+### `400 missing or invalid model`
+
+The request body does not contain a valid `model` field.
+
+**Fix:** Include `"model": "<model-id>"` in the request body.
+
+---
+
+## Gemini-specific errors
+
+### `404 unsupported gemini action`
+
+The action in the Gemini endpoint URL is not `generateContent`.
+
+**Fix:** Only `generateContent` is supported. The URL must end with `:<model-id>:generateContent`. Other actions (`countTokens`, `streamGenerateContent`, etc.) are not available.
+
+### `404 invalid gemini model path`
+
+The `{modelAction}` segment in the Gemini URL path is malformed. It must follow the format `<model>:<action>` where both parts are non-empty.
+
+**Fix:** Ensure the URL path contains exactly one colon separating the model ID and action, e.g. `databricks-gemini-2-5-flash:generateContent`.
+
+---
+
+## Workspace resolution errors
+
+### `403` or `400` — `could not resolve workspace from host`
+
+The request host does not match the expected format or region.
+
+**Common causes:**
+
+- The host does not end with a trusted suffix (`.neon.tech` in production). Returns 403.
+- The host has no parseable AWS region label. Returns 400.
+- The region in the host has no configured workspace. Returns 404.
+
+**Fix:** Verify that you are using the correct AI Gateway host from the Neon Console or API. The host format for production is `<branch-id>-api.<cell>.<region>.aws.neon.tech`. Do not construct the host manually.
+
+---
+
+## Rate limiting and quota
+
+### `429` — upstream provider rate limit
+
+The request hit the upstream Databricks/provider rate limit.
+
+**Fix:** Implement exponential backoff. The response includes a `Retry-After` header and provider-specific rate limit headers (`X-Ratelimit-*`, `Anthropic-Ratelimit-*`). See [Rate limiting](/docs/ai-gateway/chat-completions#rate-limiting).
+
+### `429` — account quota exceeded
+
+Your account's AI Gateway quota is blocked. The response body is:
+
+```json
+{
+  "error_code": "REQUEST_LIMIT_EXCEEDED",
+  "message": "ai gateway quota exceeded"
+}
+```
+
+**Fix:** Check the `Retry-After` header — if present, the block is temporary and will lift at that time. If `Retry-After` is absent, the block is permanent until resolved. Contact support for a quota increase or to resolve a permanent block.
+
+---
+
+## Upstream errors
+
+### `502 upstream request failed`
+
+The gateway could not reach the upstream Databricks workspace, or the upstream returned an unexpected error.
+
+**Fix:** Retry the request. If the error persists, check the [Neon status page](https://neonstatus.com).
+
+---
+
+## Error response formats
+
+Most AI Gateway errors use the standard OpenAI error envelope:
+
+```json
+{
+  "error": {
+    "message": "unknown model"
+  }
+}
+```
+
+The quota block error uses a different shape:
+
+```json
+{
+  "error_code": "REQUEST_LIMIT_EXCEEDED",
+  "message": "ai gateway quota exceeded"
+}
+```
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/troubleshooting.md
+++ b/content/docs/ai-gateway/troubleshooting.md
@@ -5,7 +5,7 @@ summary: >-
   Solutions for common errors when using Neon AI Gateway, including
   authentication failures, model errors, quota limits, and upstream issues.
 enableTableOfContents: true
-updatedOn: '2026-06-10T17:21:35.055Z'
+updatedOn: '2026-06-11T16:21:17.644Z'
 ---
 
 ## Authentication errors
@@ -20,7 +20,7 @@ The bearer token is missing, malformed, or has been revoked.
 
 The credential exists but lacks the `ai_gateway:invoke` scope.
 
-**Fix:** Create a new credential that includes `ai_gateway:invoke` in the `scopes` array. Scopes cannot be added to an existing credential. See [Authentication](/docs/ai-gateway/authentication#creating-a-credential).
+**Fix:** Create a new credential that includes `ai_gateway:invoke` in the `scopes` array. You can't add scopes to an existing credential. See [Authentication](/docs/ai-gateway/authentication#creating-a-credential).
 
 ### `403 credential not authorized for this branch`
 
@@ -46,7 +46,7 @@ The `model` field in the request body does not match any entry in the AI Gateway
 
 ### `400 model is not available on this endpoint`
 
-The model exists in the catalog but does not work with the endpoint you are calling.
+The model exists in the catalog but doesn't work with the endpoint you're calling.
 
 **Fix:** Check which endpoint the model requires:
 
@@ -82,7 +82,7 @@ The `{modelAction}` segment in the Gemini URL path is malformed. It must follow 
 
 ## Workspace resolution errors
 
-### `403` or `400` — `could not resolve workspace from host`
+### `403` or `400`: `could not resolve workspace from host`
 
 The request host does not match the expected format or region.
 
@@ -98,13 +98,13 @@ The request host does not match the expected format or region.
 
 ## Rate limiting and quota
 
-### `429` — upstream provider rate limit
+### `429`: upstream provider rate limit
 
 The request hit the upstream Databricks/provider rate limit.
 
 **Fix:** Implement exponential backoff. The response includes a `Retry-After` header and provider-specific rate limit headers (`X-Ratelimit-*`, `Anthropic-Ratelimit-*`). See [Rate limiting](/docs/ai-gateway/chat-completions#rate-limiting).
 
-### `429` — account quota exceeded
+### `429`: account quota exceeded
 
 Your account's AI Gateway quota is blocked. The response body is:
 
@@ -115,7 +115,7 @@ Your account's AI Gateway quota is blocked. The response body is:
 }
 ```
 
-**Fix:** Check the `Retry-After` header — if present, the block is temporary and will lift at that time. If `Retry-After` is absent, the block is permanent until resolved. Contact support for a quota increase or to resolve a permanent block.
+**Fix:** Check the `Retry-After` header. If present, the block is temporary and will lift at that time. If absent, the block is permanent until resolved. Contact support for a quota increase or to resolve a permanent block.
 
 ---
 

--- a/content/docs/ai-gateway/troubleshooting.md
+++ b/content/docs/ai-gateway/troubleshooting.md
@@ -5,8 +5,10 @@ summary: >-
   Solutions for common errors when using Neon AI Gateway, including
   authentication failures, model errors, quota limits, and upstream issues.
 enableTableOfContents: true
-updatedOn: '2026-06-11T16:21:17.644Z'
+updatedOn: '2026-06-15T13:34:36.031Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 ## Authentication errors
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -63,7 +63,7 @@ esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=di
 zip -j function.zip dist/index.mjs
 ```
 
-The archive's entry file must be named `index.mjs`; the runtime imports it by that name.
+The archive's entry file must be named `index.mjs` or `index.js`; the runtime looks for those names.
 
 From Node.js, `buildFunctionBundle` from [`@neondatabase/config-runtime`](https://www.npmjs.com/package/@neondatabase/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -1,0 +1,176 @@
+---
+title: Deploy and manage functions
+subtitle: CLI and API reference for deploying and managing Neon Functions.
+summary: >-
+  Reference for deploying Neon Functions with neonctl functions deploy or the
+  Neon API, including flags, deployment states, and slug rules. Also covers
+  checking status, listing functions, and deleting them.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+## Deploy with the CLI
+
+```bash shouldWrap
+neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
+```
+
+The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags will error.
+
+| Flag              | Default       | Description                                                        |
+| ----------------- | ------------- | ------------------------------------------------------------------ |
+| `--path`          | `.`           | Directory containing the function source                           |
+| `--entry`         | `index.ts`    | Entry file relative to `--path`                                    |
+| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Baked into the deployment |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value               |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                   |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes               |
+
+**Examples:**
+
+```bash
+neonctl functions deploy hello --path . --entry functions/hello.ts
+```
+
+```bash
+neonctl functions deploy hello --path . --env OPENAI_API_KEY=sk-...
+```
+
+```bash
+neonctl functions deploy hello --path . --branch feat/my-feature
+```
+
+<Callout>
+If you use `neon.ts`, `neonctl deploy` applies your entire branch config (functions and all) in one step. See `neonctl deploy --help` for details.
+</Callout>
+
+## Deploy with the API
+
+Bundle with esbuild, zip the output, then POST to the deploy endpoint.
+
+**1. Bundle:**
+
+```bash
+esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=dist/index.js
+```
+
+**2. Zip:**
+
+```bash
+zip -j function.zip dist/index.js
+```
+
+From Node.js, `buildFunctionBundle` from [`@neondatabase/config-runtime`](https://www.npmjs.com/package/@neondatabase/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
+
+```ts
+import { buildFunctionBundle } from "@neondatabase/config-runtime/v1";
+
+const zip = await buildFunctionBundle({
+  slug: "hello",
+  name: "My first function",
+  source: "./functions/hello.ts",
+  env: {},
+  runtime: "nodejs24",
+});
+```
+
+**3. Deploy:**
+
+```bash shouldWrap
+curl -X POST \
+  "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/functions/{slug}/deployments" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -F "zip=@function.zip" \
+  -F 'environment={"MY_SECRET":"value"}'
+```
+
+| Field         | Type   | Required          | Description                                                |
+| ------------- | ------ | ----------------- | ---------------------------------------------------------- |
+| `zip`         | binary | First deploy only | ZIP of the bundled function. Omit to reuse existing bundle |
+| `runtime`     | string | No                | `nodejs24` is the only valid value                         |
+| `environment` | string | No                | JSON-encoded string-to-string map                          |
+
+The API returns immediately. Poll the get endpoint to check status.
+
+## Slugs
+
+The slug is the permanent identifier assigned at first deploy: either the key in `neon.ts` or the positional argument to `neonctl functions deploy`. It becomes part of the invocation URL and can't be changed. Slugs must match `^[a-z0-9]{1,20}$`: lowercase letters and digits only, 1 to 20 characters, no hyphens.
+
+## Deployment states
+
+| State       | Meaning                                 |
+| ----------- | --------------------------------------- |
+| `pending`   | Queued, not yet building                |
+| `building`  | Source is being compiled and bundled    |
+| `completed` | Function is live and accepting requests |
+| `failed`    | Build or deployment error               |
+
+## Manage functions
+
+### Check status
+
+<Tabs labels={["CLI", "API"]}>
+<TabItem>
+
+```bash
+neonctl functions get hello
+```
+
+</TabItem>
+<TabItem>
+
+```bash shouldWrap
+GET /projects/{project_id}/branches/{branch_id}/functions/{slug}
+```
+
+</TabItem>
+</Tabs>
+
+The response includes `invocation_url`, the public URL for your function:
+
+```
+https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech
+```
+
+### List functions
+
+<Tabs labels={["CLI", "API"]}>
+<TabItem>
+
+```bash
+neonctl functions list
+```
+
+</TabItem>
+<TabItem>
+
+```bash shouldWrap
+GET /projects/{project_id}/branches/{branch_id}/functions
+```
+
+</TabItem>
+</Tabs>
+
+### Delete a function
+
+<Tabs labels={["CLI", "API"]}>
+<TabItem>
+
+```bash
+neonctl functions delete hello
+```
+
+</TabItem>
+<TabItem>
+
+```bash shouldWrap
+DELETE /projects/{project_id}/branches/{branch_id}/functions/{slug}
+```
+
+</TabItem>
+</Tabs>
+
+<NeedHelp/>

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -2,9 +2,9 @@
 title: Deploy and manage functions
 subtitle: CLI and API reference for deploying and managing Neon Functions.
 summary: >-
-  Reference for deploying Neon Functions with neonctl functions deploy or the
-  Neon API, including flags, deployment states, and slug rules. Also covers
-  checking status, listing functions, and deleting them.
+  Reference for deploying Neon Functions with neonctl deploy, neonctl functions
+  deploy, or the Neon API, including flags, deployment states, and slug rules.
+  Also covers checking status, listing functions, and deleting them.
 enableTableOfContents: true
 ---
 
@@ -12,7 +12,30 @@ enableTableOfContents: true
 Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
 </Admonition>
 
-## Deploy with the CLI
+## Deploy with `neon.ts`
+
+If your project has a [`neon.ts`](/docs/compute/functions/reference/neon-ts) config, this is the recommended way to deploy. `neonctl deploy` reads the config and applies the entire branch policy in one step: services, per-branch tuning, and every function it declares:
+
+```bash
+neonctl deploy
+```
+
+| Flag                | Default           | Description                                                                                          |
+| ------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `--config`          | walks up from cwd | Path to the `neon.ts` policy                                                                         |
+| `--env`             | (none)            | Path to a `.env` file loaded before `neon.ts` is evaluated, so function `env` values resolve from it |
+| `--branch`          | linked branch     | Target branch ID or name                                                                             |
+| `--project-id`      | linked project    | Project ID                                                                                           |
+| `--update-existing` | `false`           | Auto-confirm overriding existing remote settings on the branch                                       |
+| `--allow-protected` | `false`           | Auto-confirm applying to a branch marked protected on Neon                                           |
+
+`neonctl deploy` is an alias for `neonctl config apply`. To preview what a deploy would change without applying it, run `neonctl config plan`.
+
+Note that `--env` here takes a path to a `.env` file. The `--env` flag on `neonctl functions deploy` below takes `KEY=VALUE` pairs instead.
+
+## Deploy with `neonctl functions deploy`
+
+To deploy one function directly, without a `neon.ts` config:
 
 ```bash shouldWrap
 neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
@@ -42,10 +65,6 @@ neonctl functions deploy hello --path . --env OPENAI_API_KEY=sk-...
 ```bash
 neonctl functions deploy hello --path . --branch feat/my-feature
 ```
-
-<Callout>
-If you use `neon.ts`, `neonctl deploy` applies your entire branch config (functions and all) in one step. See `neonctl deploy --help` for details.
-</Callout>
 
 ## Deploy with the API
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -41,14 +41,14 @@ neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE
 
 The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags errors.
 
-| Flag              | Default       | Description                                                         |
-| ----------------- | ------------- | ------------------------------------------------------------------- |
-| `--path`          | `.`           | Directory containing the function source                            |
-| `--entry`         | `index.ts`    | Entry file relative to `--path`                                     |
-| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment |
-| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                |
-| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                    |
-| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                |
+| Flag              | Default       | Description                                                                                                                                      |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--path`          | `.`           | Directory containing the function source                                                                                                         |
+| `--entry`         | `index.ts`    | Entry file relative to `--path`                                                                                                                  |
+| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neonctl deploy --env` |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                             |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                                 |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                             |
 
 **Examples:**
 
@@ -57,7 +57,7 @@ neonctl functions deploy hello --path . --entry functions/hello.ts
 ```
 
 ```bash
-neonctl functions deploy hello --path . --env OPENAI_API_KEY=sk-...
+neonctl functions deploy hello --path . --env RESEND_API_KEY=re_...
 ```
 
 ```bash

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -8,9 +8,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 ## Deploy with `neon.ts`
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -18,16 +18,16 @@ Neon Functions is currently in Private Preview, available for new projects in th
 neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
 ```
 
-The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags will error.
+The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags errors.
 
-| Flag              | Default       | Description                                                        |
-| ----------------- | ------------- | ------------------------------------------------------------------ |
-| `--path`          | `.`           | Directory containing the function source                           |
-| `--entry`         | `index.ts`    | Entry file relative to `--path`                                    |
-| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Baked into the deployment |
-| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value               |
-| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                   |
-| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes               |
+| Flag              | Default       | Description                                                         |
+| ----------------- | ------------- | ------------------------------------------------------------------- |
+| `--path`          | `.`           | Directory containing the function source                            |
+| `--entry`         | `index.ts`    | Entry file relative to `--path`                                     |
+| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                    |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                |
 
 **Examples:**
 
@@ -54,14 +54,16 @@ Bundle with esbuild, zip the output, then POST to the deploy endpoint.
 **1. Bundle:**
 
 ```bash
-esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=dist/index.js
+esbuild functions/hello.ts --bundle --platform=node --target=node24 --outfile=dist/index.mjs
 ```
 
 **2. Zip:**
 
 ```bash
-zip -j function.zip dist/index.js
+zip -j function.zip dist/index.mjs
 ```
+
+The archive's entry file must be named `index.mjs`; the runtime imports it by that name.
 
 From Node.js, `buildFunctionBundle` from [`@neondatabase/config-runtime`](https://www.npmjs.com/package/@neondatabase/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
 
@@ -93,7 +95,7 @@ curl -X POST \
 | `runtime`     | string | No                | `nodejs24` is the only valid value                         |
 | `environment` | string | No                | JSON-encoded string-to-string map                          |
 
-The API returns immediately. Poll the get endpoint to check status.
+The API returns immediately. Poll the get endpoint (see [Check status](#check-status)) until the deployment completes.
 
 ## Slugs
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -36,15 +36,14 @@ Note that `--env` here takes a path to a `.env` file. The `--env` flag on `neonc
 To deploy one function directly, without a `neon.ts` config:
 
 ```bash shouldWrap
-neonctl functions deploy <slug> [--path <dir>] [--entry <file>] [--env KEY=VALUE] [--wait]
+neonctl functions deploy <slug> [--src <dir-or-entry-file>] [--env KEY=VALUE] [--wait]
 ```
 
-The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. At least one of `--path`, `--entry`, `--env`, or `--runtime` is required; bare `neonctl functions deploy <slug>` with no flags errors.
+The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. See the [neonctl functions reference](/docs/cli/functions) for the full command surface.
 
 | Flag              | Default       | Description                                                                                                                                      |
 | ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--path`          | `.`           | Directory containing the function source                                                                                                         |
-| `--entry`         | `index.ts`    | Entry file relative to `--path`                                                                                                                  |
+| `--src`           | (none)        | Function source: a directory containing `index.ts`, `index.mjs`, or `index.js`, or a path to the entry file                                      |
 | `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neonctl deploy --env` |
 | `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                             |
 | `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                                 |
@@ -53,15 +52,15 @@ The CLI bundles with esbuild, zips the output, and uploads it. The first deploy 
 **Examples:**
 
 ```bash
-neonctl functions deploy hello --path . --entry functions/hello.ts
+neonctl functions deploy hello --src functions/hello.ts
 ```
 
 ```bash
-neonctl functions deploy hello --path . --env RESEND_API_KEY=re_...
+neonctl functions deploy hello --src . --env RESEND_API_KEY=re_...
 ```
 
 ```bash
-neonctl functions deploy hello --path . --branch feat/my-feature
+neonctl functions deploy hello --src functions/hello.ts --branch feat/my-feature
 ```
 
 ## Deploy with the API

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -1,0 +1,104 @@
+---
+title: Environment variables
+subtitle: Neon-injected variables and how to set your own secrets.
+summary: >-
+  Neon injects branch-scoped variables like DATABASE_URL into deployed
+  functions automatically. Set your own variables with --env at deploy time or
+  in neon.ts, and pull branch variables locally with neonctl env pull.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+## Neon-injected variables
+
+Neon injects connection strings and service URLs automatically at runtime. You don't declare these in `neon.ts` or pass them at deploy time. They're resolved from the branch the function is deployed to.
+
+`DATABASE_URL` and `DATABASE_URL_UNPOOLED` are only present when the branch has a Postgres database. On a functions-only branch, they're undefined.
+
+| Variable                | Description                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`          | Pooled Postgres connection string. Use this for most queries.                                                                |
+| `DATABASE_URL_UNPOOLED` | Direct (unpooled) connection string. Use for migrations, `LISTEN`/`NOTIFY`, and transactions that span multiple round-trips. |
+| `NEON_AUTH_BASE_URL`    | Base URL for Neon Auth. Present only when Neon Auth is enabled on the branch.                                                |
+| `NEON_DATA_API_URL`     | URL for the Neon Data API. Present only when the Data API is enabled on the branch.                                          |
+
+These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
+
+## User-defined variables
+
+User-defined variables are baked into the deployment at deploy time. Changing a variable requires a new deployment.
+
+### At deploy time
+
+Pass `--env KEY=VALUE` to `neonctl functions deploy`. The flag is repeatable:
+
+```bash shouldWrap
+neonctl functions deploy hello --path . --entry functions/hello.ts --env OPENAI_API_KEY=sk-...
+```
+
+A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
+
+- `--env KEY=value` adds or updates `KEY`
+- `--env KEY=` (empty value) deletes `KEY`
+- Variables you don't mention carry over unchanged
+
+### In neon.ts
+
+Declare variables under the function's `env` field. Values are resolved when `neonctl deploy` runs, so you can read from `process.env` to avoid hardcoding secrets:
+
+```ts filename="neon.ts"
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "My first function",
+        source: "./functions/hello.ts",
+        env: {
+          OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
+        },
+      },
+    },
+  },
+});
+```
+
+Load a `.env` file before running `neonctl deploy` to make secrets available during config evaluation:
+
+```bash
+neonctl deploy --env .env.production
+```
+
+The file isn't forwarded to the function directly. Only variables declared in the `env` field are deployed; `--env` just controls what `process.env` contains when `neon.ts` is evaluated.
+
+## Pull variables locally
+
+`neonctl env pull` writes the linked branch's Neon-injected variables to a local `.env` file:
+
+```bash
+neonctl env pull
+```
+
+By default this writes to `.env` if it exists, otherwise `.env.local`. Use `--file` to write to any file:
+
+```bash
+neonctl env pull --file .env.preview
+```
+
+To pull from a different branch, switch with `neonctl checkout` first.
+
+`env pull` writes only the Neon-managed variables (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and enabled service URLs) and preserves every other line in the file.
+
+## Constraints
+
+| Constraint                   | Value                                                               |
+| ---------------------------- | ------------------------------------------------------------------- |
+| Max variables per deployment | 1,000                                                               |
+| Max total size               | 64 KiB                                                              |
+| Reserved prefix              | `NEON_` (reserved for platform use, can't be set by user functions) |
+
+<NeedHelp/>

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -33,8 +33,13 @@ import { parseEnv } from '@neondatabase/env/v1';
 import config from './neon';
 
 const env = parseEnv(config);
-env.postgres.databaseUrl; // typed, validated
+env.postgres.databaseUrl;          // DATABASE_URL
+env.postgres.databaseUrlUnpooled;  // DATABASE_URL_UNPOOLED
+env.auth.baseUrl;                  // NEON_AUTH_BASE_URL (only when auth: true)
+env.auth.jwksUrl;                  // NEON_AUTH_JWKS_URL (only when auth: true)
 ```
+
+TypeScript narrows the shape based on your config: `env.auth` is only present when `auth: true` is set in `neon.ts`.
 
 ## User-defined variables
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -44,8 +44,10 @@ Each deployment carries its own snapshot of user-defined variables. To change on
 Pass `--env KEY=VALUE` to `neonctl functions deploy`. The flag is repeatable:
 
 ```bash shouldWrap
-neonctl functions deploy hello --path . --entry functions/hello.ts --env OPENAI_API_KEY=sk-...
+neonctl functions deploy hello --path . --entry functions/hello.ts --env RESEND_API_KEY=re_...
 ```
+
+Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
 
 A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
 
@@ -67,7 +69,7 @@ export default defineConfig({
         name: "My first function",
         source: "./functions/hello.ts",
         env: {
-          OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
+          RESEND_API_KEY: process.env.RESEND_API_KEY!,
         },
       },
     },
@@ -99,7 +101,7 @@ neonctl env pull --file .env.preview
 
 To pull from a different branch, switch with `neonctl checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and enabled service URLs) and preserves every other line in the file.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, plus the variables for every service enabled on the branch: the Neon Auth and Data API URLs, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the object storage credentials (`AWS_*`, `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names so the OpenAI SDKs work from the environment without configuration.
 
 ## Constraints
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -44,7 +44,7 @@ Each deployment carries its own snapshot of user-defined variables. To change on
 Pass `--env KEY=VALUE` to `neonctl functions deploy`. The flag is repeatable:
 
 ```bash shouldWrap
-neonctl functions deploy hello --path . --entry functions/hello.ts --env RESEND_API_KEY=re_...
+neonctl functions deploy hello --src functions/hello.ts --env RESEND_API_KEY=re_...
 ```
 
 Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -8,9 +8,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 ## Neon-injected variables
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -27,9 +27,19 @@ Neon injects connection strings and service URLs automatically at runtime. You d
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
+For type-safe access, the [`@neondatabase/env`](https://www.npmjs.com/package/@neondatabase/env) package ships `parseEnv`. It takes your `neon.ts` config and returns a typed env object validated against the services the config declares:
+
+```ts
+import { parseEnv } from '@neondatabase/env/v1';
+import config from './neon';
+
+const env = parseEnv(config);
+env.postgres.databaseUrl; // typed, validated
+```
+
 ## User-defined variables
 
-User-defined variables are baked into the deployment at deploy time. Changing a variable requires a new deployment.
+Each deployment carries its own snapshot of user-defined variables. To change one, deploy again.
 
 ### At deploy time
 
@@ -77,7 +87,7 @@ The file isn't forwarded to the function directly. Only variables declared in th
 
 ## Pull variables locally
 
-`neonctl env pull` writes the linked branch's Neon-injected variables to a local `.env` file:
+`neonctl link` and `neonctl checkout` pull the branch's Neon-injected variables into a local `.env` file automatically (pass `--no-env-pull` to skip). To re-pull at any time:
 
 ```bash
 neonctl env pull
@@ -89,7 +99,7 @@ By default this writes to `.env` if it exists, otherwise `.env.local`. Use `--fi
 neonctl env pull --file .env.preview
 ```
 
-To pull from a different branch, switch with `neonctl checkout` first.
+To pull from a different branch, switch with `neonctl checkout`; it pulls the new branch's variables as part of the switch.
 
 `env pull` writes only the Neon-managed variables (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and enabled service URLs) and preserves every other line in the file.
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -22,6 +22,7 @@ Neon injects connection strings and service URLs automatically at runtime. You d
 | `DATABASE_URL_UNPOOLED` | Direct (unpooled) connection string. Use for migrations, `LISTEN`/`NOTIFY`, and transactions that span multiple round-trips. |
 | `NEON_AUTH_BASE_URL`    | Base URL for Neon Auth. Present only when Neon Auth is enabled on the branch.                                                |
 | `NEON_DATA_API_URL`     | URL for the Neon Data API. Present only when the Data API is enabled on the branch.                                          |
+| `NEON_BRANCH`           | Branch name (e.g. `main`, `preview/foo`). Present on all branches.                                                           |
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
@@ -101,7 +102,7 @@ neonctl env pull --file .env.preview
 
 To pull from a different branch, switch with `neonctl checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, plus the variables for every service enabled on the branch: the Neon Auth and Data API URLs, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the object storage credentials (`AWS_*`, `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names so the OpenAI SDKs work from the environment without configuration.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH` (the branch name), plus the variables for every service enabled on the branch: the Neon Auth and Data API URLs, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the object storage credentials (`AWS_*`, `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names so the OpenAI SDKs work from the environment without configuration.
 
 ## Constraints
 

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -2,8 +2,8 @@
 title: Get started
 subtitle: Deploy your first Neon Function and call it over HTTP.
 summary: >-
-  Deploy your first Neon Function with neonctl: link a project, define the
-  function in neon.ts, develop locally with neonctl dev, and deploy with
+  Deploy your first Neon Function with neonctl: initialize a project, define
+  the function in neon.ts, develop locally with neonctl dev, and deploy with
   neonctl deploy. The function gets a public HTTPS URL with DATABASE_URL
   injected from the branch's Postgres database.
 enableTableOfContents: true
@@ -21,7 +21,7 @@ Neon Functions is currently in Private Preview, available for new projects in th
 - The latest `neonctl`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neonctl@latest`).
 - Node.js 18 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
-Functions are available on new projects in AWS us-east-2 only. You can create the project during `neonctl link` below.
+Functions are available on new projects in AWS us-east-2 only.
 
 ## Set up your project
 
@@ -32,17 +32,7 @@ mkdir my-function && cd my-function
 neonctl init --preview
 ```
 
-`init --preview` sets up the directory and installs the Neon preview packages.
-
-## Link your project
-
-Connect the directory to a Neon project (pick one or create it):
-
-```bash
-neonctl link
-```
-
-`link` also pulls the branch's Neon env vars into a local env file (`.env` if one exists, otherwise `.env.local`), so other tools can use them. You don't need the file for this guide; `neonctl dev` injects the vars itself. See [Environment variables](/docs/compute/functions/environment-variables#pull-variables-locally) for details.
+`init --preview` sets up the directory, installs the Neon preview packages, and connects the directory to a Neon project. There's no separate link step.
 
 To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
 
@@ -77,7 +67,19 @@ Install dependencies:
 npm install hono @neondatabase/serverless
 ```
 
-Write the handler. `DATABASE_URL` is injected automatically from the linked branch's Postgres database:
+A function is any module whose default export has a `fetch(request)` method that returns a `Response`. A Hono app exports exactly that shape, so a minimal function looks like this:
+
+```ts
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.get('/', (c) => c.text('Hello World!'));
+
+export default app;
+```
+
+For this guide, write a handler that queries Postgres instead. `DATABASE_URL` is injected automatically from the linked branch's Postgres database:
 
 ```ts filename="functions/hello.ts"
 import { Hono } from 'hono';
@@ -96,7 +98,7 @@ export default app;
 
 ## Develop locally
 
-`neonctl dev` serves all functions declared in `neon.ts` with hot reload. It injects `DATABASE_URL` and other Neon env vars from the linked branch.
+`neonctl dev` serves all functions declared in `neon.ts` with hot reload. It injects `DATABASE_URL` and other Neon env vars from the linked branch. See [Environment variables](/docs/compute/functions/environment-variables) for the full list and how to pull them into a local `.env` file.
 
 ```bash
 neonctl dev

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -21,6 +21,12 @@ enableTableOfContents: true
 
 Functions are available on new projects in AWS us-east-2 only.
 
+`neonctl init --preview` installs the `neon` and `neon-functions` agent skills for your AI editor automatically. To install them separately:
+
+```bash
+npx skills add neondatabase/agent-skills -s neon -s neon-functions -y
+```
+
 ## Set up your project
 
 Create a project directory and initialize it for the Functions preview:
@@ -136,7 +142,7 @@ Call it with curl:
 curl https://<branch_id>-hello.compute.c-1.us-east-2.aws.neon.tech
 ```
 
-You should see a JSON response with your branch's Postgres version:
+The response is a JSON object with your branch's Postgres version:
 
 ```json
 { "version": "PostgreSQL 17.x on ..., compiled by gcc ..." }

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -19,9 +19,9 @@ enableTableOfContents: true
 - The latest `neonctl`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neonctl@latest`).
 - Node.js 18 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
-Functions are available on new projects in AWS us-east-2 only.
+Functions are available on new projects in AWS us-east-2 only, created on or after June 15, 2026.
 
-`neonctl init --preview` installs the `neon` and `neon-functions` agent skills for your AI editor automatically. To install them separately:
+`neonctl init --preview` is designed to be run by your AI coding assistant. It outputs structured instructions that guide the agent through setup. To install skills separately:
 
 ```bash
 npx skills add neondatabase/agent-skills -s neon -s neon-functions -y
@@ -29,16 +29,21 @@ npx skills add neondatabase/agent-skills -s neon -s neon-functions -y
 
 ## Set up your project
 
-Create a project directory and initialize it for the Functions preview:
+Create your project directory:
 
 ```bash
 mkdir my-function && cd my-function
+```
+
+Then ask your AI coding assistant to run:
+
+```bash
 neonctl init --preview
 ```
 
-`neonctl init --preview` runs an interactive setup: it installs the Neon MCP server and agent skills for your editor and, in an empty directory, offers to scaffold the project from a Neon template. Scaffolding links the directory to a Neon project and pulls the branch's variables into a local `.env` file. If you build by hand instead, finish by running `neonctl link`.
+When your AI coding assistant runs `neonctl init --preview`, it receives structured JSON instructions for the full setup: MCP server and agent skills, optional template scaffolding, project linking, and env var pull. Sign-in opens a browser window. The agent will pause and wait for you to complete the OAuth step. If you ran init yourself and exited before the linking step, run `neonctl link` to connect the directory to your project manually.
 
-To go straight to a working example, run `neonctl bootstrap`. It scaffolds a starter template (a Hono API, an AI SDK agent, or a Mastra agent, all on Neon Functions) and links it. This guide builds the function by hand.
+To go straight to a working example, run `neonctl bootstrap`. It scaffolds a starter template and links it. Available templates: Hono API, AI SDK agent, Mastra agent, Realtime chat (Next.js + WebSockets), and Realtime counter (TanStack Router + SSE), all on Neon Functions. This guide builds the function by hand.
 
 ## Define your function
 
@@ -64,7 +69,7 @@ The key (`hello`) is the function's slug: its permanent identifier in CLI comman
 Install dependencies:
 
 ```bash
-npm install hono @neondatabase/serverless
+npm install @neondatabase/config @neondatabase/serverless hono
 ```
 
 A function is any module whose default export has a `fetch(request)` method that returns a `Response`. A Hono app exports exactly that shape, so a minimal function looks like this:

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -30,13 +30,9 @@ mkdir my-function && cd my-function
 neonctl init --preview
 ```
 
-`init --preview` sets up the directory, installs the Neon preview packages, and connects the directory to a Neon project. There's no separate link step.
+`neonctl init --preview` runs an interactive setup: it installs the Neon MCP server and agent skills for your editor and, in an empty directory, offers to scaffold the project from a Neon template. Scaffolding links the directory to a Neon project and pulls the branch's variables into a local `.env` file. If you build by hand instead, finish by running `neonctl link`.
 
-To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
-
-```bash
-neonctl checkout feat/my-feature
-```
+To go straight to a working example, run `neonctl bootstrap`. It scaffolds a starter template (a Hono API, an AI SDK agent, or a Mastra agent, all on Neon Functions) and links it. This guide builds the function by hand.
 
 ## Define your function
 

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -1,0 +1,149 @@
+---
+title: Get started
+subtitle: Deploy your first Neon Function and call it over HTTP.
+summary: >-
+  Deploy your first Neon Function with neonctl: link a project, define the
+  function in neon.ts, develop locally with neonctl dev, and deploy with
+  neonctl deploy. The function gets a public HTTPS URL with DATABASE_URL
+  injected from the branch's Postgres database.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+<Steps>
+
+## Prerequisites
+
+- A Neon account with Functions preview access. See [Preview access](/docs/compute/functions/preview-access).
+- The latest `neonctl`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neonctl@latest`).
+- Node.js 18 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
+
+Functions are available on new projects in AWS us-east-2 only. You can create the project during `neonctl link` below.
+
+## Set up your project
+
+Create a project directory and initialize it for the Functions preview:
+
+```bash
+mkdir my-function && cd my-function
+neonctl init --preview
+```
+
+`init --preview` sets up the directory and installs the Neon preview packages.
+
+## Link your project
+
+Connect the directory to a Neon project (pick one or create it):
+
+```bash
+neonctl link
+```
+
+To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
+
+```bash
+neonctl checkout feat/my-feature
+```
+
+## Define your function
+
+Create `neon.ts` at your project root. It declares your functions and is what `neonctl dev` and `neonctl deploy` read:
+
+```ts filename="neon.ts"
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "My first function",
+        source: "./functions/hello.ts",
+      },
+    },
+  },
+});
+```
+
+The key (`hello`) is the function's slug: its permanent identifier in CLI commands and the function URL. `name` is only a display label. See the [neon.ts reference](/docs/compute/functions/reference/neon-ts) for all options.
+
+Install dependencies:
+
+```bash
+npm install hono @neondatabase/serverless
+```
+
+Write the handler. `DATABASE_URL` is injected automatically from the linked branch's Postgres database:
+
+```ts filename="functions/hello.ts"
+import { Hono } from 'hono';
+import { neon } from '@neondatabase/serverless';
+
+const sql = neon(process.env.DATABASE_URL!);
+const app = new Hono();
+
+app.get('/', async (c) => {
+  const [row] = await sql`SELECT version()`;
+  return c.json(row);
+});
+
+export default app;
+```
+
+## Develop locally
+
+`neonctl dev` serves all functions declared in `neon.ts` with hot reload. It injects `DATABASE_URL` and other Neon env vars from the linked branch.
+
+```bash
+neonctl dev
+```
+
+The terminal prints the URL for each running function:
+
+```text
+  Neon Functions dev server
+
+  hello                http://localhost:8787
+```
+
+## Deploy
+
+`neonctl deploy` reads `neon.ts` and applies it to the linked branch, deploying every function it declares:
+
+```bash
+neonctl deploy
+```
+
+The CLI bundles each function with esbuild, uploads it, and waits for the deployment to complete. To deploy a single function directly without `neon.ts`, or to deploy through the API, see [Deploy and manage functions](/docs/compute/functions/deploy).
+
+## Invoke
+
+Once the deployment reaches `completed`, retrieve the invocation URL:
+
+```bash
+neonctl functions get hello
+```
+
+The `invocation_url` field contains the public URL for your function:
+
+```
+https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech
+```
+
+Call it with curl:
+
+```bash shouldWrap
+curl https://<branch_id>-hello.compute.c-1.us-east-2.aws.neon.tech
+```
+
+You should see a JSON response with your branch's Postgres version:
+
+```json
+{ "version": "PostgreSQL 17.x on ..., compiled by gcc ..." }
+```
+
+</Steps>
+
+<NeedHelp/>

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -42,6 +42,8 @@ Connect the directory to a Neon project (pick one or create it):
 neonctl link
 ```
 
+`link` also pulls the branch's Neon env vars into a local env file (`.env` if one exists, otherwise `.env.local`), so other tools can use them. You don't need the file for this guide; `neonctl dev` injects the vars itself. See [Environment variables](/docs/compute/functions/environment-variables#pull-variables-locally) for details.
+
 To target a specific branch, use `neonctl checkout`. It switches the branch pointer, and creates the branch if it doesn't exist:
 
 ```bash

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -9,9 +9,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 <Steps>
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,7 +7,7 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-12T16:38:29.112Z'
+updatedOn: '2026-06-12T21:36:14.443Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -18,7 +18,7 @@ During the private preview, Functions are available for new projects in the AWS 
 
 Functions are branch-scoped. When you branch a project, the function branches with it: the child branch inherits the function as it was at the branch point, and runs it at its own URL against its own isolated database state. Deploying to the child doesn't affect the parent.
 
-Functions use the [Workers-compatible](https://wintercg.org/) handler interface: a `fetch(request)` export that receives a standard `Request` and returns a `Response`. Hono is the recommended framework.
+Functions use the Workers-style handler interface standardized by [WinterTC](https://wintertc.org/): a `fetch(request)` export that receives a standard `Request` and returns a `Response`. Hono is the recommended framework.
 
 ## When to use Neon Functions
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,14 +7,14 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:47:36.989Z'
+updatedOn: '2026-06-15T15:43:05.726Z'
 ---
 
 <PrivatePreviewEnquire/>
 
 Neon Functions give you long-running Node.js compute in the same AWS region as your database. Each function deploys to a Neon branch and gets a public HTTPS URL. If the branch has a Postgres database, `DATABASE_URL` is injected automatically. No configuration needed, no cross-region round trips.
 
-During the private preview, Functions are available for new projects in the AWS us-east-2 region only. See [Preview access](/docs/compute/functions/preview-access) for what's included.
+During the private preview, Functions are available for **new projects** in the **AWS us-east-2** region only. See [Preview access](/docs/compute/functions/preview-access) for what's included.
 
 Functions are branch-scoped. When you branch a project, the function branches with it: the child branch inherits the function as it was at the branch point, and runs it at its own URL against its own isolated database state. Deploying to the child doesn't affect the parent.
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -1,0 +1,49 @@
+---
+title: Neon Functions
+subtitle: Long-running Node.js compute, deployed on Neon.
+summary: >-
+  Neon Functions are long-running Node.js HTTP handlers deployed to Neon
+  branches, with DATABASE_URL injected from the branch's Postgres database.
+  Use them for AI agents, WebSocket servers, and webhook handlers that need
+  compute next to their data.
+enableTableOfContents: true
+updatedOn: '2026-06-10T03:57:18.581Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+Neon Functions give you long-running Node.js compute in the same AWS region as your database. Each function deploys to a Neon branch and gets a public HTTPS URL. If the branch has a Postgres database, `DATABASE_URL` is injected automatically. No configuration needed, no cross-region round trips.
+
+Functions are branch-scoped. When you branch a project, the function branches with it: the child branch inherits the function as it was at the branch point, and runs it at its own URL against its own isolated database state. Deploying to the child doesn't affect the parent.
+
+Functions use the [Workers-compatible](https://wintercg.org/) handler interface: a `fetch(request)` export that receives a standard `Request` and returns a `Response`. Hono is the recommended framework.
+
+## When to use Neon Functions
+
+- **AI agents**: hold connections open across multiple LLM calls and tool invocations, write results to Postgres
+- **Discord bots and WebSocket servers**: maintain long-lived bidirectional connections without a dedicated server
+- **Webhook handlers**: receive events and run multiple database queries without cross-region latency
+- **Post-response work**: use `waitUntil` to run follow-up tasks after the response is sent, such as logging, analytics writes, or triggering additional model calls
+- **Branch your backend**: each branch runs its own function version at its own URL, against its own isolated database state if the branch has one
+
+## Get started
+
+<DetailIconCards>
+
+<a href="/docs/compute/functions/preview-access" description="Request access and learn what's included in the private preview." icon="screen">Preview access</a>
+
+<a href="/docs/compute/functions/get-started" description="Deploy your first function and call it over HTTP in under 5 minutes." icon="code">Get started</a>
+
+<a href="/docs/compute/functions/environment-variables" description="Neon-injected variables and how to add your own secrets." icon="gear">Environment variables</a>
+
+<a href="/docs/compute/functions/deploy" description="CLI and API reference for deploying and managing functions." icon="cli">Deploy and manage</a>
+
+<a href="/docs/compute/functions/reference/neon-ts" description="Configuration schema for functions and branch policy." icon="setup">neon.ts reference</a>
+
+<a href="/docs/compute/functions/reference/runtime-limits" description="Timeouts, slug constraints, memory, and other hard limits." icon="sparkle">Runtime limits</a>
+
+</DetailIconCards>
+
+<NeedHelp/>

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,7 +7,7 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-12T21:36:14.443Z'
+updatedOn: '2026-06-15T11:31:11.292Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -43,6 +43,16 @@ Functions use the Workers-style handler interface standardized by [WinterTC](htt
 <a href="/docs/compute/functions/reference/neon-ts" description="Configuration schema for functions and branch policy." icon="setup">neon.ts reference</a>
 
 <a href="/docs/compute/functions/reference/runtime-limits" description="Timeouts, slug constraints, memory, and other hard limits." icon="sparkle">Runtime limits</a>
+
+</DetailIconCards>
+
+## Example apps
+
+<DetailIconCards>
+
+<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, holding connections open across multiple model calls and writing results to Postgres." icon="github">Rate My Pricing</a>
+
+<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that uses a JWT-protected Neon Function as its backend, handling long-running image generation without serverless timeouts." icon="github">Vibecastly</a>
 
 </DetailIconCards>
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,7 +7,7 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-15T11:31:11.292Z'
+updatedOn: '2026-06-15T14:31:22.519Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -46,14 +46,24 @@ Functions use the Workers-style handler interface standardized by [WinterTC](htt
 
 </DetailIconCards>
 
-## Example apps
+## Starter templates
 
-<DetailIconCards>
+Browse templates at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one directly with `neonctl bootstrap`:
 
-<a href="https://github.com/andrelandgraf/rate-my-pricing" description="A pricing clarity scorer that runs an LLM agent on a Neon Function, holding connections open across multiple model calls and writing results to Postgres." icon="github">Rate My Pricing</a>
+```bash
+neonctl bootstrap
+```
 
-<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that uses a JWT-protected Neon Function as its backend, handling long-running image generation without serverless timeouts." icon="github">Vibecastly</a>
+Use `--template` to skip the interactive picker:
 
-</DetailIconCards>
+| Template        | What it builds                                                                         |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `hono`          | REST API with Drizzle and Postgres on Neon Functions                                   |
+| `ai-sdk`        | Image-generation agent with AI Gateway, Object Storage, and Postgres on Neon Functions |
+| `mastra`        | Personal assistant with AI Gateway and Postgres-backed memory on Neon Functions        |
+| `realtime-chat` | Realtime chat with Next.js, Neon Auth, and WebSockets on Neon Functions                |
+| `realtime-sse`  | Realtime counter with TanStack Router and SSE on Neon Functions                        |
+
+`neonctl bootstrap` scaffolds files, links to a Neon project, and pulls env vars. Then follow the README to set up and deploy.
 
 <NeedHelp/>

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,14 +7,14 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-10T03:57:18.581Z'
+updatedOn: '2026-06-12T16:38:29.112Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 Neon Functions give you long-running Node.js compute in the same AWS region as your database. Each function deploys to a Neon branch and gets a public HTTPS URL. If the branch has a Postgres database, `DATABASE_URL` is injected automatically. No configuration needed, no cross-region round trips.
+
+During the private preview, Functions are available for new projects in the AWS us-east-2 region only. See [Preview access](/docs/compute/functions/preview-access) for what's included.
 
 Functions are branch-scoped. When you branch a project, the function branches with it: the child branch inherits the function as it was at the branch point, and runs it at its own URL against its own isolated database state. Deploying to the child doesn't affect the parent.
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -8,13 +8,9 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
-
 ## Request access
 
-Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). The team will reach out with access details. Functions are available on new projects only; you can't enable them on an existing project.
+Sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends#access). The team will reach out with access details. Functions are available on new projects only.
 
 ## What's included
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -1,0 +1,49 @@
+---
+title: Preview access
+subtitle: What's included in the Neon Functions private preview.
+summary: >-
+  Neon Functions is in private preview for new projects in the AWS us-east-2
+  region. This page covers how to request access, what's included, and the
+  current limitations.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+## Request access
+
+Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends). The team will reach out with access details. Functions are available on new projects only; you can't enable them on an existing project.
+
+## What's included
+
+- Deploy Node.js 24 HTTP handlers to Neon branches
+- Workers-compatible handler interface (`fetch(request)` export)
+- Long-running compute: WebSocket servers, SSE endpoints, AI agents
+- `DATABASE_URL` auto-injected from the branch's Postgres database
+- `neonctl dev` for local development with hot reload
+- `neonctl functions deploy` for CLI deployment
+- Neon API for programmatic deployment
+- Branch-scoped functions: each branch runs its own version at its own URL
+
+## What's not included
+
+**Memory is fixed at 2048 MiB.** Memory configuration isn't available during the preview.
+
+**Background jobs are not supported.** `waitUntil` runs post-response work for up to 15 minutes. It's for short cleanup tasks (analytics writes, audit logs), not long-running jobs. Use a dedicated queue or scheduler for work that needs its own lifecycle. `waitUntil` is currently a stub; see [Runtime limits](/docs/compute/functions/reference/runtime-limits) for details.
+
+**Billing isn't active yet.** Functions usage isn't billed during the private preview.
+
+**Available in AWS us-east-2 only.** Other regions aren't available during the preview.
+
+## Known limitations
+
+- `neonctl` ships `esbuild` for most platforms. If bundling fails with an `esbuild not found` error, install it (`npm install -g esbuild`) or set `NEON_ESBUILD_PATH` to an esbuild binary.
+- Slug names are restricted to `^[a-z0-9]{1,20}$`. No hyphens, no uppercase. Use the `name` field for a human-readable label.
+
+## Feedback
+
+The preview feedback channel will be shared in your access confirmation email.
+
+<NeedHelp/>

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -23,7 +23,8 @@ Sign up for the waitlist at [neon.com/blog/were-building-backends](https://neon.
 - Long-running compute: WebSocket servers, SSE endpoints, AI agents
 - `DATABASE_URL` auto-injected from the branch's Postgres database
 - `neonctl dev` for local development with hot reload
-- `neonctl functions deploy` for CLI deployment
+- `neon.ts` config with `neonctl deploy` for declarative branch setup
+- `neonctl functions deploy` for direct CLI deployment
 - Neon API for programmatic deployment
 - Branch-scoped functions: each branch runs its own version at its own URL
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -38,6 +38,7 @@ Sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-bui
 
 - `neonctl` ships `esbuild` for most platforms. If bundling fails with an `esbuild not found` error, install it (`npm install -g esbuild`) or set `NEON_ESBUILD_PATH` to an esbuild binary.
 - Slug names are restricted to `^[a-z0-9]{1,20}$`. No hyphens, no uppercase. Use the `name` field for a human-readable label.
+- Logs from deployed functions can't be retrieved yet. Use `neonctl dev` to see output during development; deployed functions must record diagnostics themselves (in Postgres, or in the response).
 
 ## Feedback
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
 </Admonition>
 
-`neon.ts` is a TypeScript config file that declares which functions exist on a project and how each branch should be configured. Place it at the root of your project.
+`neon.ts` is a TypeScript config file that declares which functions and services exist on a project and how each branch should be configured. Place it at the root of your project.
 
 ```bash
 npm install @neondatabase/config

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -82,7 +82,7 @@ preview: {
 
 Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment. See [Slugs](/docs/compute/functions/deploy#slugs) for the full rules. Because slugs can't use separators, use `name` for a human-readable label, for example `slug: "myrestapi"` with `name: "My REST API"`.
 
-**`env`** values are resolved at deploy time (when `neonctl deploy` runs). Reading `process.env.X` here captures the value in your shell at deploy time, not at runtime inside the function. Use `neonctl deploy --env .env.production` to load a `.env` file before evaluation.
+**`env`** values are resolved at deploy time (when `neonctl deploy` runs). Reading `process.env.X` here captures the value in your shell at deploy time, not at runtime inside the function. Use `neonctl deploy --env .env.production` to load a `.env` file before evaluation. For typed access to these variables inside your function at runtime, see [Environment variables](/docs/compute/functions/environment-variables).
 
 **`dev`** settings apply only to `neonctl dev`. They never affect deploy.
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -30,7 +30,7 @@ export default defineConfig({
       hello: {
         name: "My first function",
         source: "./functions/hello.ts",
-        env: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+        env: { RESEND_API_KEY: process.env.RESEND_API_KEY! },
         dev: { port: 8787 },
       },
     },
@@ -88,7 +88,7 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 
 - `port`: the local server binds this exact port and fails if it's taken. When omitted, a free port is found automatically.
 
-The `preview` block also accepts `aiGateway` and `buckets` fields. They aren't part of the Functions preview and aren't covered here.
+The `preview` block also accepts `aiGateway` and `buckets` fields, which enable the [AI Gateway](/docs/ai-gateway/overview) and [Object Storage](/docs/storage/overview) previews on the branch and inject their credentials into deployed functions. They aren't part of the Functions preview and aren't covered here.
 
 ## `branch` closure
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -38,10 +38,12 @@ export default defineConfig({
     },
   },
   // Dynamic: per-branch tuning
-  branch: (branch) => ({
-    protected: branch.name === "main",
-    ...(branch.name !== "main" && { parent: "main", ttl: "7d" }),
-  }),
+  branch: (branch) => {
+    if (branch.name === "main") {
+      return { protected: true };
+    }
+    return { parent: "main", ttl: "7d" };
+  },
 });
 ```
 
@@ -74,7 +76,6 @@ preview: {
       env?: Record<string, string>,
       dev?: {
         port?: number,    // bind to this port in neonctl dev; omit for auto-assigned
-        portless?: boolean,
       },
     },
   },
@@ -88,7 +89,6 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 **`dev`** settings apply only to `neonctl dev`. They never affect deploy.
 
 - `port`: the local server binds this exact port and fails if it's taken. When omitted, a free port is found automatically.
-- `portless`: expose the function through the `portless` tool at a stable `<slug>.localhost` URL instead of a numbered port. Requires the `portless` binary on your PATH. Portless assigns the port itself, so `port` is ignored when this is set.
 
 The `preview` block also accepts `aiGateway` and `buckets` fields. They aren't part of the Functions preview and aren't covered here.
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -8,9 +8,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 `neon.ts` is a TypeScript config file that declares which functions and services exist on a project and how each branch should be configured. Place it at the root of your project.
 

--- a/content/docs/compute/functions/reference/neon-ts.md
+++ b/content/docs/compute/functions/reference/neon-ts.md
@@ -1,0 +1,144 @@
+---
+title: neon.ts reference
+subtitle: Configuration schema for Neon Functions and branch policy.
+summary: >-
+  neon.ts declares which functions and services exist on a project and how
+  each branch is tuned. Reference for defineConfig: service toggles, function
+  definitions, and the per-branch tuning closure.
+enableTableOfContents: true
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+`neon.ts` is a TypeScript config file that declares which functions exist on a project and how each branch should be configured. Place it at the root of your project.
+
+```bash
+npm install @neondatabase/config
+```
+
+## Shape
+
+```ts filename="neon.ts"
+import { defineConfig } from "@neondatabase/config/v1";
+
+export default defineConfig({
+  // Static: what exists on every branch
+  auth: true,
+  dataApi: false,
+  preview: {
+    functions: {
+      hello: {
+        name: "My first function",
+        source: "./functions/hello.ts",
+        env: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+        dev: { port: 8787 },
+      },
+    },
+  },
+  // Dynamic: per-branch tuning
+  branch: (branch) => ({
+    protected: branch.name === "main",
+    ...(branch.name !== "main" && { parent: "main", ttl: "7d" }),
+  }),
+});
+```
+
+`defineConfig` takes an object with two parts, both optional:
+
+- **Static fields** (`auth`, `dataApi`, `preview`): declare what services and functions exist. The same set applies to every branch. This is what determines which Neon service URLs (`NEON_AUTH_BASE_URL`, `NEON_DATA_API_URL`) are injected.
+- **`branch` closure**: receives a read-only `BranchTarget` and returns per-branch tuning. It can only adjust settings, not add or remove services or functions. Omit it if you don't need per-branch tuning.
+
+## Static fields
+
+### Services
+
+Static toggles declare which services exist on every branch and which Neon env vars are injected into deployed functions.
+
+| Field     | Values                               | Default | Injects              |
+| --------- | ------------------------------------ | ------- | -------------------- |
+| `auth`    | `true`, `false`, `{ enabled: bool }` | `false` | `NEON_AUTH_BASE_URL` |
+| `dataApi` | `true`, `false`                      | `false` | `NEON_DATA_API_URL`  |
+
+### `preview.functions`
+
+Declares functions as a record keyed by slug. Each key is the function's permanent slug: its operational identity used in CLI commands, API paths, and the invocation URL. The `name` field is display-only (shown in `neonctl functions list` and the console).
+
+```ts
+preview: {
+  functions: {
+    "<slug>": {
+      name: string,       // required: display name only, not used operationally
+      source: string,     // required: path to entry file, relative to neon.ts (or absolute)
+      env?: Record<string, string>,
+      dev?: {
+        port?: number,    // bind to this port in neonctl dev; omit for auto-assigned
+        portless?: boolean,
+      },
+    },
+  },
+},
+```
+
+Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment. See [Slugs](/docs/compute/functions/deploy#slugs) for the full rules. Because slugs can't use separators, use `name` for a human-readable label, for example `slug: "myrestapi"` with `name: "My REST API"`.
+
+**`env`** values are resolved at deploy time (when `neonctl deploy` runs). Reading `process.env.X` here captures the value in your shell at deploy time, not at runtime inside the function. Use `neonctl deploy --env .env.production` to load a `.env` file before evaluation.
+
+**`dev`** settings apply only to `neonctl dev`. They never affect deploy.
+
+- `port`: the local server binds this exact port and fails if it's taken. When omitted, a free port is found automatically.
+- `portless`: expose the function through the `portless` tool at a stable `<slug>.localhost` URL instead of a numbered port. Requires the `portless` binary on your PATH. Portless assigns the port itself, so `port` is ignored when this is set.
+
+The `preview` block also accepts `aiGateway` and `buckets` fields. They aren't part of the Functions preview and aren't covered here.
+
+## `branch` closure
+
+The `branch` closure receives a `BranchTarget` and returns a `BranchTuning`.
+
+### BranchTarget fields
+
+| Field         | Type                  | Description                                         |
+| ------------- | --------------------- | --------------------------------------------------- |
+| `name`        | `string`              | Branch name                                         |
+| `id`          | `string \| undefined` | Branch ID. `undefined` during pre-create evaluation |
+| `exists`      | `boolean`             | `false` during pre-create evaluation                |
+| `isDefault`   | `boolean`             | Whether this is the project's default branch        |
+| `isProtected` | `boolean`             | Whether the branch is marked protected in Neon      |
+| `parentId`    | `string \| undefined` | ID of the parent branch, if any                     |
+| `expiresAt`   | `string \| undefined` | Branch expiry timestamp, if set                     |
+
+### BranchTuning fields
+
+| Field                                            | Type                              | Description                                                               |
+| ------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------- |
+| `parent`                                         | `string`                          | Parent branch name or ID. Specifies which branch new branches derive from |
+| `protected`                                      | `boolean`                         | Mark the branch as protected                                              |
+| `ttl`                                            | `string \| number`                | Branch lifetime, e.g. `"7d"`, `"2h"`, or seconds as a number              |
+| `postgres.computeSettings.autoscalingLimitMinCu` | `0.25 \| 0.5 \| 1 \| 2 \| 4 \| 8` | Minimum compute units                                                     |
+| `postgres.computeSettings.autoscalingLimitMaxCu` | `0.25 \| 0.5 \| 1 \| 2 \| 4 \| 8` | Maximum compute units                                                     |
+| `postgres.computeSettings.suspendTimeout`        | `false \| string \| number`       | Idle suspend timeout. `false` disables suspend                            |
+
+## Apply to a branch
+
+```bash
+neonctl deploy
+```
+
+This is an alias for `neonctl config apply`. It reads `neon.ts` from the current directory, diffs it against the live branch state, and applies the changes.
+
+To preview what would change without applying:
+
+```bash
+neonctl config plan
+```
+
+To inspect the current live state of a branch as a `neon.ts`-shaped config:
+
+```bash
+neonctl config status
+```
+
+When `neonctl checkout` creates a new branch and a `neon.ts` exists in your project, the CLI applies the policy to the new branch automatically, including deploying its functions. Checking out an existing branch doesn't trigger an apply.
+
+<NeedHelp/>

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -1,0 +1,78 @@
+---
+title: Runtime limits
+subtitle: Hard constraints for Neon Functions.
+summary: >-
+  Hard limits for Neon Functions: lifecycle and eviction behavior, 15-minute
+  timeouts, slug constraints, and the Node.js 24 runtime. Functions are
+  long-running but still serverless.
+enableTableOfContents: true
+updatedOn: '2026-06-10T03:57:18.581Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+Neon Functions run on Node.js 24 in isolated microVMs.
+
+## Lifecycle
+
+Neon Functions are long-running. You can host WebSocket servers, SSE endpoints, and agents that stream responses over HTTP without hitting a short execution timeout. They're still serverless: if your function has no active connections, the platform shuts it down.
+
+The platform may also evict and restart your function for operational reasons. Active functions can run for hours before eviction occurs. Treat eviction like a process restart: WebSocket and SSE clients need to reconnect when the connection drops.
+
+The platform sends `SIGINT` before evicting to allow graceful shutdown. Register a handler to close open connections and flush in-flight work before the process exits:
+
+```ts
+process.on('SIGINT', () => {
+  pool.end().then(() => process.exit(0));
+});
+```
+
+Without it, open connections are abandoned on eviction and remain open until they time out.
+
+## Timeouts
+
+**Time to first byte: 15 minutes.** Your handler must begin returning a response within 15 minutes of receiving a request. This is a request-response runtime, not a background task runner. The limit prevents runaway functions that hold resources indefinitely with no way to cancel them. In practice most handlers complete in seconds. The 15-minute limit gives agent workloads like image or video generation enough time to finish.
+
+**Heartbeat: 15 minutes.** Active WebSocket connections and HTTP streams stay open as long as data flows. The timeout only fires when the connection goes silent. Send at least one byte every 15 minutes to keep a quiet stream alive.
+
+**`waitUntil`: 15 minutes.** Work registered with `waitUntil` runs after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
+
+```ts
+import { Hono } from 'hono';
+import { waitUntil } from '@neondatabase/functions/v1';
+
+const app = new Hono();
+
+app.post('/event', async (c) => {
+  const defer = waitUntil();
+  defer(writeAnalytics(c.req.raw));
+  return c.json({ ok: true });
+});
+
+export default app;
+```
+
+<Admonition type="note">
+`waitUntil` is currently a stub. The deferred promise is accepted but not yet wired to the host runtime. The API is stable. Use it now and it will work automatically once the runtime support ships.
+</Admonition>
+
+## Slug constraints
+
+Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment. See [Slugs](/docs/compute/functions/deploy#slugs) for the full rules.
+
+## Runtime
+
+| Property    | Value                                                                        |
+| ----------- | ---------------------------------------------------------------------------- |
+| Runtime     | Node.js 24                                                                   |
+| Isolation   | microVM per isolate                                                          |
+| Concurrency | 1 request at a time per isolate. Additional requests queue, they don't fail. |
+| Memory      | 2048 MiB (fixed during the private preview, not configurable)                |
+
+## Environment variables
+
+See [Environment variables](/docs/compute/functions/environment-variables#constraints) for limits on variable count, total size, and the reserved `NEON_` prefix.
+
+<NeedHelp/>

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-12T21:36:14.443Z'
+updatedOn: '2026-06-14T04:15:20.563Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -38,10 +38,6 @@ Without it, open connections are abandoned on eviction and remain open until the
 
 **`waitUntil`: 15 minutes.** Work registered with `waitUntil` continues after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
 
-<Admonition type="important">
-During the private preview, `waitUntil` is a no-op placeholder: it accepts the promise but does not keep the invocation alive. Await any work that has to finish before the response stream closes. The API is in place to code against, but don't rely on post-response execution until the runtime integration ships.
-</Admonition>
-
 ```ts
 import { Hono } from 'hono';
 import { waitUntil } from '@neondatabase/functions/v1';
@@ -61,15 +57,13 @@ export default app;
 
 ## Concurrency
 
-Each isolate handles one request at a time. The platform adds isolates on demand: requests that arrive while existing isolates are busy are served by newly booted isolates (cold start is on the order of a second), and requests that can't be placed queue rather than fail.
+Each isolate is a Node.js process. Requests are interleaved on the event loop, so multiple requests can be in flight on the same isolate concurrently. The platform adds isolates on demand under load: requests that can't be placed on an existing isolate are routed to a newly booted one or queued briefly.
 
-Streaming responses don't hold the slot. Once your handler returns a `Response`, the isolate can accept the next request, even while the response body is still streaming.
+Because each isolate is its own process and handles concurrent requests, module-scope state behaves as follows:
 
-Because each isolate is its own Node.js process, module-scope state multiplies with scale-out:
-
-- Each isolate creates its own `pg` pool, so the effective connection count is `max` × the number of isolates. Keep `max` small (for example, 5).
-- Module-scope initialization (seeding, migrations) runs once per isolate, not once per deployment. Make it idempotent, or serialize it with a Postgres advisory lock.
-- In-memory state (caches, counters, sessions) is per-isolate and disappears on eviction. Persist anything that matters in Postgres.
+- **Shared within an isolate**: module-scope objects (a `pg` pool, an in-memory cache) are shared across all requests on the same isolate. Create connection pools once at module scope and reuse them.
+- **Not shared across isolates**: each isolate has its own copy of module state. Keep `max` small on `pg` pools (for example, 5) — effective connection count is `max` × the number of live isolates. Module-scope initialization (seeding, migrations) runs once per isolate; make it idempotent or serialize with a Postgres advisory lock.
+- **Lost on eviction**: in-memory state disappears when an isolate is evicted. Persist anything that matters in Postgres.
 
 ## Slug constraints
 
@@ -77,12 +71,12 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 
 ## Runtime
 
-| Property    | Value                                                                                                   |
-| ----------- | ------------------------------------------------------------------------------------------------------- |
-| Runtime     | Node.js 24                                                                                              |
-| Isolation   | microVM per isolate                                                                                     |
-| Concurrency | 1 request at a time per isolate, scaling out with additional isolates. See [Concurrency](#concurrency). |
-| Memory      | 2048 MiB (fixed during the private preview, not configurable)                                           |
+| Property    | Value                                                                                                                                           |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime     | Node.js 24                                                                                                                                      |
+| Isolation   | microVM per isolate                                                                                                                             |
+| Concurrency | Multiple requests in flight per isolate (interleaved on the event loop), scaling out with additional isolates. See [Concurrency](#concurrency). |
+| Memory      | 2048 MiB (fixed during the private preview, not configurable)                                                                                   |
 
 ## Environment variables
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-12T16:38:29.112Z'
+updatedOn: '2026-06-12T21:36:14.443Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -22,6 +22,7 @@ The platform may also evict and restart your function for operational reasons. A
 The platform sends `SIGINT` before evicting to allow graceful shutdown. Register a handler to close open connections and flush in-flight work before the process exits:
 
 ```ts
+// pool is your module-scope pg.Pool
 process.on('SIGINT', () => {
   pool.end().then(() => process.exit(0));
 });
@@ -37,6 +38,10 @@ Without it, open connections are abandoned on eviction and remain open until the
 
 **`waitUntil`: 15 minutes.** Work registered with `waitUntil` continues after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
 
+<Admonition type="important">
+During the private preview, `waitUntil` is a no-op placeholder: it accepts the promise but does not keep the invocation alive. Await any work that has to finish before the response stream closes. The API is in place to code against, but don't rely on post-response execution until the runtime integration ships.
+</Admonition>
+
 ```ts
 import { Hono } from 'hono';
 import { waitUntil } from '@neondatabase/functions/v1';
@@ -44,14 +49,27 @@ import { waitUntil } from '@neondatabase/functions/v1';
 const app = new Hono();
 
 app.post('/event', async (c) => {
-  waitUntil(writeAnalytics(c.req.raw)); // your async follow-up work
+  const wait = waitUntil(); // returns the waitUntil function for this invocation
+  wait(writeAnalytics(c.req.raw)); // your async follow-up work
   return c.json({ ok: true });
 });
 
 export default app;
 ```
 
-`waitUntil` takes a promise and keeps the invocation alive until it settles, up to the 15-minute cap. It's the same shape as `waitUntil` on [Vercel](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) and Cloudflare Workers, and it's safe to call in `neonctl dev`.
+`waitUntil()` returns a function for the current invocation; pass that function a promise and the invocation stays alive until the promise settles, up to the 15-minute cap. The registered work is the same shape as `waitUntil` on [Vercel](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) and Cloudflare Workers, and it's safe to call in `neonctl dev`.
+
+## Concurrency
+
+Each isolate handles one request at a time. The platform adds isolates on demand: requests that arrive while existing isolates are busy are served by newly booted isolates (cold start is on the order of a second), and requests that can't be placed queue rather than fail.
+
+Streaming responses don't hold the slot. Once your handler returns a `Response`, the isolate can accept the next request, even while the response body is still streaming.
+
+Because each isolate is its own Node.js process, module-scope state multiplies with scale-out:
+
+- Each isolate creates its own `pg` pool, so the effective connection count is `max` × the number of isolates. Keep `max` small (for example, 5).
+- Module-scope initialization (seeding, migrations) runs once per isolate, not once per deployment. Make it idempotent, or serialize it with a Postgres advisory lock.
+- In-memory state (caches, counters, sessions) is per-isolate and disappears on eviction. Persist anything that matters in Postgres.
 
 ## Slug constraints
 
@@ -59,12 +77,12 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 
 ## Runtime
 
-| Property    | Value                                                                        |
-| ----------- | ---------------------------------------------------------------------------- |
-| Runtime     | Node.js 24                                                                   |
-| Isolation   | microVM per isolate                                                          |
-| Concurrency | 1 request at a time per isolate. Additional requests queue, they don't fail. |
-| Memory      | 2048 MiB (fixed during the private preview, not configurable)                |
+| Property    | Value                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| Runtime     | Node.js 24                                                                                              |
+| Isolation   | microVM per isolate                                                                                     |
+| Concurrency | 1 request at a time per isolate, scaling out with additional isolates. See [Concurrency](#concurrency). |
+| Memory      | 2048 MiB (fixed during the private preview, not configurable)                                           |
 
 ## Environment variables
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,12 +6,10 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-12T01:12:57.837Z'
+updatedOn: '2026-06-12T16:38:29.112Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Functions is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 Neon Functions run on Node.js 24 in isolated microVMs.
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-10T12:55:19.407Z'
+updatedOn: '2026-06-12T01:12:57.837Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -37,7 +37,7 @@ Without it, open connections are abandoned on eviction and remain open until the
 
 **Heartbeat: 15 minutes.** Active WebSocket connections and HTTP streams stay open as long as data flows. The timeout only fires when the connection goes silent. Send at least one byte every 15 minutes to keep a quiet stream alive.
 
-**`waitUntil`: 15 minutes.** Work registered with `waitUntil` runs after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
+**`waitUntil`: 15 minutes.** Work registered with `waitUntil` continues after the response is sent. It's for cleanup: analytics writes, audit logs, short follow-up calls. It's not a background job runner. Use a dedicated system for work that needs its own lifecycle or cancellation.
 
 ```ts
 import { Hono } from 'hono';
@@ -46,17 +46,14 @@ import { waitUntil } from '@neondatabase/functions/v1';
 const app = new Hono();
 
 app.post('/event', async (c) => {
-  const defer = waitUntil();
-  defer(writeAnalytics(c.req.raw)); // your async follow-up work
+  waitUntil(writeAnalytics(c.req.raw)); // your async follow-up work
   return c.json({ ok: true });
 });
 
 export default app;
 ```
 
-<Admonition type="note">
-`waitUntil` is currently a stub. The deferred promise is accepted but not yet wired to the host runtime. The API is stable. Use it now and it will work automatically once the runtime support ships.
-</Admonition>
+`waitUntil` takes a promise and keeps the invocation alive until it settles, up to the 15-minute cap. It's the same shape as `waitUntil` on [Vercel](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) and Cloudflare Workers, and it's safe to call in `neonctl dev`.
 
 ## Slug constraints
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-10T03:57:18.581Z'
+updatedOn: '2026-06-10T12:55:19.407Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -47,7 +47,7 @@ const app = new Hono();
 
 app.post('/event', async (c) => {
   const defer = waitUntil();
-  defer(writeAnalytics(c.req.raw));
+  defer(writeAnalytics(c.req.raw)); // your async follow-up work
   return c.json({ ok: true });
 });
 

--- a/content/docs/compute/functions/websockets.md
+++ b/content/docs/compute/functions/websockets.md
@@ -5,7 +5,7 @@ summary: >-
   Neon Functions support long-lived WebSocket connections via an upgrade export.
   Use the ws package alongside your fetch handler to accept WebSocket clients,
   and Postgres LISTEN/NOTIFY to broadcast across isolates.
-updatedOn: '2026-06-14T16:00:07.344Z'
+updatedOn: '2026-06-14T16:32:23.692Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -82,7 +82,7 @@ Type a message and press Enter. The server echoes it back.
 If your function uses Hono, export `fetch` from the Hono app and the `upgrade` handler separately. The runtime routes WebSocket upgrades directly to `upgrade`. Hono never sees the upgrade request, so Hono middleware and route guards don't apply. Handle auth in `upgrade` directly.
 
 <Admonition type="warning">
-`upgradeWebSocket` from `@hono/node-server` doesn't work with Neon Functions. It requires Hono's own `serve()` wrapper, which the runtime doesn't use. Use the `upgrade` export pattern shown here instead.
+`upgradeWebSocket` from `@hono/node-server` doesn't work with Neon Functions. It requires Hono's own `serve()` wrapper, which the runtime doesn't use. Use the `upgrade` export pattern shown here instead. For Hono-style `onOpen`/`onMessage`/`onClose` route declarations, use the `neon-functions` agent skill.
 </Admonition>
 
 ```ts filename="functions/hono-echo.ts"
@@ -181,18 +181,19 @@ Use `DATABASE_URL_UNPOOLED` for the `LISTEN` client. The pooled `DATABASE_URL` r
 Browsers can't set custom headers on a WebSocket connection, so you can't use `Authorization`. Pass the token as a query parameter and verify it in `upgrade` before calling `wss.handleUpgrade`:
 
 ```ts
-upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+async upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
   const url = new URL(req.url ?? '/', 'http://localhost');
   const token = url.searchParams.get('token');
+  const identity = token ? await verifyToken(token) : null; // e.g. jwtVerify with jose
 
-  if (!token || !isValidToken(token)) { // replace with your actual token verification
+  if (!identity) {
     socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
     socket.destroy();
     return;
   }
 
   wss.handleUpgrade(req, socket, head, (ws) => {
-    // authenticated
+    // authenticated — identity is in scope
   });
 },
 ```

--- a/content/docs/compute/functions/websockets.md
+++ b/content/docs/compute/functions/websockets.md
@@ -1,0 +1,208 @@
+---
+title: WebSocket servers
+subtitle: Host persistent WebSocket connections on Neon Functions.
+summary: >-
+  Neon Functions support long-lived WebSocket connections via an upgrade export.
+  Use the ws package alongside your fetch handler to accept WebSocket clients,
+  and Postgres LISTEN/NOTIFY to broadcast across isolates.
+updatedOn: '2026-06-14T16:00:07.344Z'
+---
+
+<PrivatePreviewEnquire/>
+
+Neon Functions stay alive as long as they have active connections, so a WebSocket server is a first-class use case. Your handler runs on the same branch as your Postgres database.
+
+## How it works
+
+Export an `upgrade` method alongside `fetch`. The runtime calls `upgrade` for WebSocket upgrade requests and `fetch` for everything else.
+
+```ts
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+
+export default {
+  fetch(request: Request) {
+    return new Response("...");
+  },
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    // handle the WebSocket upgrade
+  },
+};
+```
+
+<Admonition type="note">
+`neonctl dev` returns `200 OK` instead of `101 Switching Protocols` for WebSocket upgrade requests during the preview. Test WebSocket behavior against a deployed function (`neonctl deploy`).
+</Admonition>
+
+## Simple echo server
+
+`fetch` is required even if you only plan to serve WebSocket clients. `noServer: true` prevents the `ws` package from starting its own HTTP server; the runtime owns the server and passes the raw socket to `handleUpgrade`.
+
+```ts filename="functions/echo.ts"
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ noServer: true });
+
+export default {
+  fetch(request: Request) {
+    return new Response('This endpoint speaks WebSocket — send an Upgrade request.', {
+      headers: { 'content-type': 'text/plain' },
+    });
+  },
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.on('message', (data) => ws.send(data));
+    });
+  },
+};
+```
+
+Install the dependency:
+
+```bash
+npm install ws
+npm install --save-dev @types/ws
+```
+
+Deploy, then test with [`wscat`](https://github.com/websockets/wscat):
+
+```bash
+npm install -g wscat
+wscat --connect wss://<your-function-url>
+```
+
+Type a message and press Enter. The server echoes it back.
+
+## Hono app with WebSocket
+
+If your function uses Hono, export `fetch` from the Hono app and the `upgrade` handler separately. The runtime routes WebSocket upgrades directly to `upgrade`. Hono never sees the upgrade request, so Hono middleware and route guards don't apply. Handle auth in `upgrade` directly.
+
+<Admonition type="warning">
+`upgradeWebSocket` from `@hono/node-server` doesn't work with Neon Functions. It requires Hono's own `serve()` wrapper, which the runtime doesn't use. Use the `upgrade` export pattern shown here instead.
+</Admonition>
+
+```ts filename="functions/hono-echo.ts"
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { Hono } from 'hono';
+import { WebSocketServer } from 'ws';
+
+const app = new Hono();
+const wss = new WebSocketServer({ noServer: true });
+
+app.get('/', (c) => c.text('WebSocket server — connect via wss://'));
+
+export default {
+  fetch: (request: Request) => app.fetch(request),
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.on('message', (data) => ws.send(`echo: ${data}`));
+    });
+  },
+};
+```
+
+## Cross-isolate messaging with LISTEN/NOTIFY
+
+WebSocket connections are local to the isolate they land on, so clients on different isolates can't communicate through shared memory.
+
+For broadcast, use Postgres `LISTEN/NOTIFY`. Each isolate maintains one `LISTEN` connection at module scope and a `Set` of its connected clients. When a message arrives via `NOTIFY`, every isolate broadcasts it to its clients, so all users receive it regardless of which isolate they landed on.
+
+Install the additional dependencies:
+
+```bash
+npm install pg
+npm install --save-dev @types/pg
+```
+
+```ts filename="functions/chat.ts"
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { Hono } from 'hono';
+import { WebSocketServer, type WebSocket } from 'ws';
+import { Pool, Client } from 'pg';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+
+// One dedicated LISTEN client per isolate.
+const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener
+  .connect()
+  .then(() => listener.query('LISTEN chat'))
+  .catch((err) => console.error('[listen] failed:', err));
+
+const clients = new Set<WebSocket>();
+const CHANNEL = 'chat';
+
+listener.on('notification', (msg) => {
+  if (!msg.payload) return;
+  for (const ws of clients) {
+    if (ws.readyState === ws.OPEN) ws.send(msg.payload);
+  }
+});
+
+const wss = new WebSocketServer({ noServer: true });
+const app = new Hono();
+
+app.get('/', (c) => c.text('Realtime chat — connect over WebSocket'));
+
+export default {
+  fetch: (request: Request) => app.fetch(request),
+
+  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      clients.add(ws);
+      ws.on('close', () => clients.delete(ws));
+      ws.on('message', async (data) => {
+        const body = data.toString().trim();
+        if (!body) return;
+        await pool.query('SELECT pg_notify($1, $2)', [CHANNEL, body]);
+      });
+    });
+  },
+};
+
+process.on('SIGINT', () => {
+  Promise.allSettled([pool.end(), listener.end()]).then(() => process.exit(0));
+});
+```
+
+<Admonition type="note">
+Use `DATABASE_URL_UNPOOLED` for the `LISTEN` client. The pooled `DATABASE_URL` routes through PgBouncer, which doesn't support `LISTEN/NOTIFY`.
+</Admonition>
+
+## Authentication
+
+Browsers can't set custom headers on a WebSocket connection, so you can't use `Authorization`. Pass the token as a query parameter and verify it in `upgrade` before calling `wss.handleUpgrade`:
+
+```ts
+upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const token = url.searchParams.get('token');
+
+  if (!token || !isValidToken(token)) { // replace with your actual token verification
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    // authenticated
+  });
+},
+```
+
+For a complete example with JWT verification, Neon Auth integration, and client-side reconnection, see the [realtime chat example](https://github.com/neondatabase/examples/tree/main/with-realtime-chat).
+
+## Eviction and shutdown
+
+The platform sends `SIGINT` before evicting an isolate. Without a handler, open database connections are abandoned and stay open until they time out. The LISTEN/NOTIFY example above includes one: `Promise.allSettled([pool.end(), listener.end()])` drains the pool and listener before the process exits. Add equivalent cleanup for any other resources your function holds.
+
+See [Runtime limits](/docs/compute/functions/reference/runtime-limits#lifecycle) for eviction behavior and the heartbeat timeout.
+
+<NeedHelp/>

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-06-08T16:11:48.651Z'
 ---
 
 <TwinPaths>
@@ -48,7 +48,7 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your DB." icon="code" tag="coming soon">Compute</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
+<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Early Access">AI Gateway</a>
 
 </DetailIconCards>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-08T16:11:48.651Z'
+updatedOn: '2026-06-15T13:50:46.182Z'
 ---
 
 <TwinPaths>
@@ -44,11 +44,11 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
+<a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your database." icon="data" tag="coming soon">Storage</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your DB." icon="code" tag="coming soon">Compute</a>
+<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your database." icon="code" tag="coming soon">Compute</a>
 
-<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Early Access">AI Gateway</a>
+<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Beta">AI Gateway</a>
 
 </DetailIconCards>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:55:42.119Z'
+updatedOn: '2026-06-15T14:12:52.406Z'
 ---
 
 <TwinPaths>
@@ -31,7 +31,7 @@ updatedOn: '2026-06-15T13:55:42.119Z'
 
 <div className="mt-12 mb-3.5 flex items-baseline justify-between gap-4">
   <h2 className="m-0!">Your Neon backend</h2>
-  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Join Early Access →</a>
+  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Get early access →</a>
 </div>
 
 Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless.

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-06-11T00:00:57.556Z'
 ---
 
 <TwinPaths>
@@ -46,7 +46,7 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your DB." icon="code" tag="coming soon">Compute</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Early Access">Functions</a>
 
 <a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T14:47:36.989Z'
+updatedOn: '2026-06-15T15:38:36.952Z'
 ---
 
 <TwinPaths>
@@ -44,11 +44,11 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Private Beta">Storage</a>
+<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Private Preview">Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Private Beta">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Private Preview">Functions</a>
 
-<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Beta">AI Gateway</a>
+<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Preview">AI Gateway</a>
 
 </DetailIconCards>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-11T00:00:57.556Z'
+updatedOn: '2026-06-15T13:49:53.547Z'
 ---
 
 <TwinPaths>
@@ -46,7 +46,7 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Early Access">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Private Beta">Functions</a>
 
 <a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:51:54.492Z'
+updatedOn: '2026-06-15T13:55:23.496Z'
 ---
 
 <TwinPaths>
@@ -46,9 +46,9 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Private Beta">Storage</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your database." icon="code" tag="coming soon">Compute</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Private Beta">Functions</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
+<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Beta">AI Gateway</a>
 
 </DetailIconCards>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:50:15.456Z'
+updatedOn: '2026-06-15T13:51:54.492Z'
 ---
 
 <TwinPaths>
@@ -44,9 +44,9 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your DB." icon="data" tag="Private Beta">Storage</a>
+<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Private Beta">Storage</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your DB." icon="code" tag="coming soon">Compute</a>
+<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your database." icon="code" tag="coming soon">Compute</a>
 
 <a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:50:46.182Z'
+updatedOn: '2026-06-15T13:55:42.119Z'
 ---
 
 <TwinPaths>
@@ -44,9 +44,9 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your database." icon="data" tag="coming soon">Storage</a>
+<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Private Beta">Storage</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your database." icon="code" tag="coming soon">Compute</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Private Beta">Functions</a>
 
 <a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Beta">AI Gateway</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-06-08T19:26:22.039Z'
 ---
 
 <TwinPaths>
@@ -44,7 +44,7 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
+<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your DB." icon="data" tag="Early Access">Storage</a>
 
 <a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your DB." icon="code" tag="coming soon">Compute</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:52:28.996Z'
+updatedOn: '2026-06-15T14:13:17.342Z'
 ---
 
 <TwinPaths>
@@ -31,7 +31,7 @@ updatedOn: '2026-06-15T13:52:28.996Z'
 
 <div className="mt-12 mb-3.5 flex items-baseline justify-between gap-4">
   <h2 className="m-0!">Your Neon backend</h2>
-  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Join Early Access →</a>
+  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Get early access →</a>
 </div>
 
 Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless.

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:55:23.496Z'
+updatedOn: '2026-06-15T14:13:05.669Z'
 ---
 
 <TwinPaths>
@@ -31,7 +31,7 @@ updatedOn: '2026-06-15T13:55:23.496Z'
 
 <div className="mt-12 mb-3.5 flex items-baseline justify-between gap-4">
   <h2 className="m-0!">Your Neon backend</h2>
-  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Join Early Access →</a>
+  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Get early access →</a>
 </div>
 
 Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless.

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-08T19:26:22.039Z'
+updatedOn: '2026-06-15T13:50:15.456Z'
 ---
 
 <TwinPaths>
@@ -44,7 +44,7 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your DB." icon="data" tag="Early Access">Storage</a>
+<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your DB." icon="data" tag="Private Beta">Storage</a>
 
 <a href="https://neon.com/blog/were-building-backends#access" description="Serverless compute, deployed alongside your DB." icon="code" tag="coming soon">Compute</a>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T13:49:53.547Z'
+updatedOn: '2026-06-15T13:52:28.996Z'
 ---
 
 <TwinPaths>
@@ -44,11 +44,11 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 
 <a href="/docs/data-api/overview" description="HTTPS queries with no backend code. Drop-in compatible with Supabase." icon="binary-code">Data API</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="S3-compatible object storage that branches with your DB." icon="data" tag="coming soon">Storage</a>
+<a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Private Beta">Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your DB." icon="code" tag="Private Beta">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Private Beta">Functions</a>
 
-<a href="https://neon.com/blog/were-building-backends#access" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="coming soon">AI Gateway</a>
+<a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Beta">AI Gateway</a>
 
 </DetailIconCards>
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -538,6 +538,31 @@
                     - title: Database integration
                       slug: auth/legacy/database-integration
 
+        - title: Storage
+          icon: data
+          slug: storage/overview
+          items:
+            - section: Get started
+              items:
+                - title: Overview
+                  slug: storage/overview
+                - title: Quickstart
+                  slug: storage/get-started
+            - section: Guides
+              items:
+                - title: Buckets
+                  slug: storage/buckets
+                - title: Objects
+                  slug: storage/objects
+                - title: Authentication
+                  slug: storage/authentication
+            - section: Reference
+              items:
+                - title: S3 compatibility
+                  slug: storage/s3-compatibility
+                - title: Troubleshooting
+                  slug: storage/troubleshooting
+
         - title: Postgres RLS
           icon: lock
           slug: guides/row-level-security

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -540,7 +540,6 @@
 
         - title: Neon Functions
           icon: features
-          tag: beta
           slug: compute/functions/overview
           items:
             - title: Overview

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -538,6 +538,28 @@
                     - title: Database integration
                       slug: auth/legacy/database-integration
 
+        - title: Neon Functions
+          icon: features
+          tag: beta
+          slug: compute/functions/overview
+          items:
+            - title: Overview
+              slug: compute/functions/overview
+            - title: Preview access
+              slug: compute/functions/preview-access
+            - title: Get started
+              slug: compute/functions/get-started
+            - title: Deploy and manage
+              slug: compute/functions/deploy
+            - title: Environment variables
+              slug: compute/functions/environment-variables
+            - section: Reference
+              items:
+                - title: neon.ts
+                  slug: compute/functions/reference/neon-ts
+                - title: Runtime limits
+                  slug: compute/functions/reference/runtime-limits
+
         - title: Postgres RLS
           icon: lock
           slug: guides/row-level-security

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -552,6 +552,8 @@
               slug: compute/functions/deploy
             - title: Environment variables
               slug: compute/functions/environment-variables
+            - title: WebSocket servers
+              slug: compute/functions/websockets
             - section: Reference
               items:
                 - title: neon.ts

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -538,6 +538,35 @@
                     - title: Database integration
                       slug: auth/legacy/database-integration
 
+        - title: AI Gateway
+          icon: sparkle
+          slug: ai-gateway/overview
+          items:
+            - section: Get started
+              items:
+                - title: Overview
+                  slug: ai-gateway/overview
+                - title: Quickstart
+                  slug: ai-gateway/get-started
+                - title: Models
+                  slug: ai-gateway/models
+            - section: APIs
+              items:
+                - title: Chat completions
+                  slug: ai-gateway/chat-completions
+                - title: Anthropic Messages API
+                  slug: ai-gateway/anthropic-messages
+                - title: OpenAI Responses API
+                  slug: ai-gateway/openai-responses
+                - title: Gemini API
+                  slug: ai-gateway/gemini
+            - section: Reference
+              items:
+                - title: Authentication
+                  slug: ai-gateway/authentication
+                - title: Troubleshooting
+                  slug: ai-gateway/troubleshooting
+
         - title: Postgres RLS
           icon: lock
           slug: guides/row-level-security

--- a/content/docs/shared-content/private-preview-enquire.md
+++ b/content/docs/shared-content/private-preview-enquire.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-06-12T15:53:06.576Z'
+updatedOn: '2026-06-12T16:38:29.112Z'
 ---
 
 <Admonition type="comingSoon" title="Private Preview">

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:26:22.039Z'
+updatedOn: '2026-06-08T19:36:47.586Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -15,8 +15,8 @@ Neon Storage uses the same credential system as AI Gateway and Functions. You cr
 
 A Storage credential requires at minimum one of:
 
-- `storage:read` — allows GetObject, HeadObject, ListObjects, and ListBuckets
-- `storage:write` — allows all read operations plus PutObject and DeleteObject
+- `storage:read`: allows GetObject, HeadObject, ListObjects, and ListBuckets
+- `storage:write`: allows all read operations plus PutObject and DeleteObject
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
@@ -25,7 +25,7 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
 ```
 
-The response includes these fields (returned once only — store them immediately):
+The response includes these fields. Both secrets are returned once only, so store them immediately:
 
 ```json
 {

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -1,0 +1,147 @@
+---
+title: Storage authentication
+subtitle: How Neon credentials map to S3 access keys
+summary: >-
+  Neon Storage uses Neon credentials with storage:read and storage:write scopes.
+  Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
+  are scoped to a branch and valid for that branch and all its descendants.
+enableTableOfContents: true
+updatedOn: '2026-06-08T19:26:22.039Z'
+---
+
+Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
+
+## Creating a credential
+
+A Storage credential requires at minimum one of:
+
+- `storage:read` — allows GetObject, HeadObject, ListObjects, and ListBuckets
+- `storage:write` — allows all read operations plus PutObject and DeleteObject
+
+```bash shouldWrap
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
+```
+
+The response includes these fields (returned once only — store them immediately):
+
+```json
+{
+  "token_id": "550e8400-e29b-41d4-a716-446655440000",
+  "token_id_short": "550e8400e29b",
+  "api_token": "nt_live_550e8400e29b_...",
+  "s3_secret_access_key": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+  "scopes": ["storage:read", "storage:write"],
+  "branch_id": "br-winter-pond-aptw82ef",
+  "created_at": "2026-06-08T00:00:00Z"
+}
+```
+
+## Mapping to your S3 SDK
+
+| Neon credential field  | S3 SDK parameter  |
+| ---------------------- | ----------------- |
+| `token_id`             | Access Key ID     |
+| `s3_secret_access_key` | Secret Access Key |
+| `us-east-2`            | Region            |
+
+<Admonition type="warning">
+Both `api_token` and `s3_secret_access_key` are returned exactly once at creation. They cannot be retrieved again. Store them in a secrets manager or environment variables before the response is lost.
+</Admonition>
+
+Configure your S3 client using these values:
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { S3Client } from '@aws-sdk/client-s3';
+
+const client = new S3Client({
+  region: 'us-east-2',
+  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  credentials: {
+    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID,   // token_id
+    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY, // s3_secret_access_key
+  },
+  forcePathStyle: true,
+});
+```
+
+```python shouldWrap
+import boto3, os
+
+client = boto3.client(
+    's3',
+    region_name='us-east-2',
+    endpoint_url=f"https://{os.environ['NEON_STORAGE_HOST']}",
+    aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],      # token_id
+    aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],  # s3_secret_access_key
+)
+```
+
+```bash
+export AWS_ACCESS_KEY_ID=$NEON_STORAGE_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$NEON_STORAGE_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=us-east-2
+```
+
+</CodeTabs>
+
+<Admonition type="note">
+`forcePathStyle: true` is required for the AWS SDK for JavaScript when using a custom S3 endpoint.
+</Admonition>
+
+## Read vs write scopes
+
+Issue separate credentials for read and write access when you want to limit exposure:
+
+- **Server-side code** that uploads files: `storage:write` (includes read)
+- **Client-side or CDN code** that only fetches: `storage:read`
+- **Presigned URLs**: generated server-side from a `storage:write` credential; the URL itself requires no credential in the browser
+
+## How branch binding works
+
+A credential is bound to the branch it was created on. It is valid for:
+
+- That branch (the anchor branch)
+- Any branch descended from it: preview branches, feature branches, CI branches
+
+It is **not** valid for branches outside that lineage.
+
+```
+main  ──── credential valid here
+  └── preview/feature-x  ──── and here
+        └── preview/sub-branch  ──── and here
+staging  ──── credential NOT valid here (different lineage)
+```
+
+## Listing credentials
+
+```bash shouldWrap
+curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+This returns credential metadata. Secrets are never returned after creation.
+
+## Revoking credentials
+
+```bash shouldWrap
+curl -X DELETE "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials/{token_id}" \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+To rotate a credential, create a new one, update your environment variables, then revoke the old one.
+
+## Common errors
+
+| Error                       | Cause                               | Fix                                                                                      |
+| --------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| `403 InvalidAccessKeyId`    | `token_id` is wrong or revoked      | Check `NEON_STORAGE_ACCESS_KEY_ID` is set to the full UUID                               |
+| `403 SignatureDoesNotMatch` | Wrong secret access key             | Check `NEON_STORAGE_SECRET_ACCESS_KEY` is the 64-char hex value from credential creation |
+| `403 AccessDenied`          | Credential lacks the required scope | Recreate with `storage:write` for uploads/deletes                                        |
+| `403 AccessDenied`          | Branch not in credential lineage    | Use a credential created on this branch or an ancestor                                   |
+
+<NeedHelp/>

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:36:47.586Z'
+updatedOn: '2026-06-10T16:53:44.852Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -60,7 +60,7 @@ import { S3Client } from '@aws-sdk/client-s3';
 
 const client = new S3Client({
   region: 'us-east-2',
-  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  endpoint: process.env.NEON_STORAGE_ENDPOINT,
   credentials: {
     accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID,   // token_id
     secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY, // s3_secret_access_key
@@ -75,7 +75,7 @@ import boto3, os
 client = boto3.client(
     's3',
     region_name='us-east-2',
-    endpoint_url=f"https://{os.environ['NEON_STORAGE_HOST']}",
+    endpoint_url=os.environ['NEON_STORAGE_ENDPOINT'],
     aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],      # token_id
     aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],  # s3_secret_access_key
 )

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:42:07.067Z'
+updatedOn: '2026-06-14T10:35:51.194Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -96,6 +96,22 @@ export AWS_DEFAULT_REGION=us-east-2
 <Admonition type="note">
 `forcePathStyle: true` is required for the AWS SDK for JavaScript when using a custom S3 endpoint.
 </Admonition>
+
+## Pull credentials with neonctl
+
+For local development, `neonctl env pull` writes storage credentials to your `.env` file automatically — no manual copy-paste from the API response:
+
+```bash
+neonctl env pull .env
+```
+
+This populates `NEON_STORAGE_ENDPOINT`, `NEON_STORAGE_ACCESS_KEY_ID`, and `NEON_STORAGE_SECRET_ACCESS_KEY` for the current branch alongside your database connection string. To check the current credential status:
+
+```bash
+neonctl config status
+```
+
+For production deployments, use the [API-based workflow](#creating-a-credential) to create named, scoped credentials with optional expiry.
 
 ## Read vs write scopes
 

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-11T12:24:01.926Z'
+updatedOn: '2026-06-11T14:15:18.616Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -35,7 +35,7 @@ The response includes these fields. Both secrets are returned once only, so stor
   "token_id_short": "550e8400e29b",
   "name": "my-app-credential",
   "api_token": "nt_live_550e8400e29b_...",
-  "s3_secret_access_key": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+  "s3_secret_access_key": "a665a459...",
   "scopes": ["storage:read", "storage:write"],
   "branch_id": "br-winter-pond-aptw82ef",
   "created_at": "2026-06-08T00:00:00Z",

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-11T11:35:46.410Z'
+updatedOn: '2026-06-11T12:24:01.926Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -15,8 +15,8 @@ Neon Storage uses the same credential system as AI Gateway and Functions. You cr
 
 A Storage credential requires at minimum one of:
 
-- `storage:read`: allows GetObject, HeadObject, ListObjects, and ListBuckets
-- `storage:write`: allows all read operations plus PutObject and DeleteObject
+- [`storage:read`](#read-vs-write-scopes): allows GetObject, HeadObject, ListObjects, and ListBuckets
+- [`storage:write`](#read-vs-write-scopes): allows all read operations plus PutObject and DeleteObject
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:24:23.574Z'
+updatedOn: '2026-06-11T14:42:07.067Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -103,13 +103,13 @@ Issue separate credentials for read and write access when you want to limit expo
 
 - **Server-side code** that uploads files: `storage:write` (includes read)
 - **Client-side or CDN code** that only fetches: `storage:read`
-- **Presigned URLs**: generated server-side from a `storage:write` credential; the URL itself requires no credential in the browser
+- **Presigned URLs**: generate these server-side from a `storage:write` credential. The URL itself requires no credential in the browser.
 
-Scope enforcement is applied by the S3 data plane. A credential without a storage scope returns `403 AccessDenied` on all S3 operations. Server-side COPY requires both `storage:read` and `storage:write`.
+The S3 data plane enforces scope on every request. A credential without a storage scope returns `403 AccessDenied` on all S3 operations. Server-side COPY requires both `storage:read` and `storage:write`.
 
 ## Credentials in Neon Functions
 
-When your code runs inside Neon Functions, storage credentials are injected automatically. No credential creation step is required:
+When your code runs inside Neon Functions, Neon injects storage credentials automatically. You don't need to create a credential:
 
 | Variable                         | Value                             |
 | -------------------------------- | --------------------------------- |
@@ -119,7 +119,7 @@ When your code runs inside Neon Functions, storage credentials are injected auto
 | `NEON_STORAGE_SECRET_ACCESS_KEY` | S3 Secret Access Key              |
 | `NEON_STORAGE_FORCE_PATH_STYLE`  | Always `"true"`                   |
 
-Credentials are branch-scoped and tied to the function's serving branch. They cannot be overridden by user-supplied environment variables of the same name (the injected secret access key always wins). Use them directly with your S3 client:
+Credentials are branch-scoped and tied to the function's serving branch. User-supplied environment variables with the same name can't override the injected values (the injected secret access key always wins). Use them directly with your S3 client:
 
 ```typescript
 import { S3Client } from '@aws-sdk/client-s3';
@@ -137,12 +137,12 @@ const client = new S3Client({
 
 ## How branch binding works
 
-A credential is bound to the branch it was created on. It is valid for:
+Each credential is tied to the branch it was created on. It is valid for:
 
 - That branch (the anchor branch)
 - Any branch descended from it: preview branches, feature branches, CI branches
 
-It is **not** valid for branches outside that lineage.
+It's **not** valid for branches outside that lineage.
 
 ```
 main  ──── credential valid here

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,8 +6,10 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-15T08:44:47.016Z'
+updatedOn: '2026-06-15T13:33:22.356Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
 

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-14T10:35:51.194Z'
+updatedOn: '2026-06-15T08:44:47.016Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -17,6 +17,25 @@ A Storage credential requires at minimum one of:
 
 - [`storage:read`](#read-vs-write-scopes): allows GetObject, HeadObject, ListObjects, and ListBuckets
 - [`storage:write`](#read-vs-write-scopes): allows all read operations plus PutObject and DeleteObject
+
+<Tabs labels={["Console", "API"]}>
+<TabItem>
+
+In the Neon Console, select your branch and click **Credentials** under **APP BACKEND** in the sidebar. Click **Create credential**, give it a name, and check the storage scopes you need.
+
+After creation, the credentials are shown once. Copy the snippet or click **Download .env** before closing:
+
+```text
+AWS_ENDPOINT_URL_S3=https://br-cool-darkness-a1b2c3d4.storage.c-1.us-east-2.aws.neon.build
+AWS_ACCESS_KEY_ID=nak_live_...
+AWS_SECRET_ACCESS_KEY=nsk_live_...
+AWS_REGION=us-east-2
+```
+
+To view or revoke credentials later, return to the **Credentials** page and use the action menu (⋮) next to the credential.
+
+</TabItem>
+<TabItem>
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
@@ -42,6 +61,9 @@ The response includes these fields. Both secrets are returned once only, so stor
   "expires_at": null
 }
 ```
+
+</TabItem>
+</Tabs>
 
 ## Mapping to your S3 SDK
 
@@ -169,6 +191,8 @@ staging  ──── credential NOT valid here (different lineage)
 
 ## Listing credentials
 
+The **Credentials** page in the Console shows all credentials for the current branch — name, key ID, creation date, and last used time. To list via the API:
+
 ```bash shouldWrap
 curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
   -H "Authorization: Bearer $NEON_API_KEY"
@@ -177,6 +201,8 @@ curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id
 This returns credential metadata. Secrets are never returned after creation.
 
 ## Revoking credentials
+
+To revoke from the Console, open the **Credentials** page and use the action menu (⋮) next to the credential. To revoke via the API:
 
 ```bash shouldWrap
 curl -X DELETE "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials/{token_id}" \

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-10T16:53:44.852Z'
+updatedOn: '2026-06-11T11:35:46.410Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -22,8 +22,10 @@ A Storage credential requires at minimum one of:
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
   -H "Authorization: Bearer $NEON_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
+  -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user", "name": "my-app-credential"}'
 ```
+
+The `name` and `expires_at` fields are optional. Set `expires_at` to an ISO 8601 timestamp to create a short-lived credential.
 
 The response includes these fields. Both secrets are returned once only, so store them immediately:
 
@@ -31,11 +33,13 @@ The response includes these fields. Both secrets are returned once only, so stor
 {
   "token_id": "550e8400-e29b-41d4-a716-446655440000",
   "token_id_short": "550e8400e29b",
+  "name": "my-app-credential",
   "api_token": "nt_live_550e8400e29b_...",
   "s3_secret_access_key": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
   "scopes": ["storage:read", "storage:write"],
   "branch_id": "br-winter-pond-aptw82ef",
-  "created_at": "2026-06-08T00:00:00Z"
+  "created_at": "2026-06-08T00:00:00Z",
+  "expires_at": null
 }
 ```
 
@@ -100,6 +104,36 @@ Issue separate credentials for read and write access when you want to limit expo
 - **Server-side code** that uploads files: `storage:write` (includes read)
 - **Client-side or CDN code** that only fetches: `storage:read`
 - **Presigned URLs**: generated server-side from a `storage:write` credential; the URL itself requires no credential in the browser
+
+Scope enforcement is applied by the S3 data plane. A credential without a storage scope returns `403 AccessDenied` on all S3 operations. Server-side COPY requires both `storage:read` and `storage:write`.
+
+## Credentials in Neon Functions
+
+When your code runs inside Neon Functions, storage credentials are injected automatically — no credential creation step required:
+
+| Variable                         | Value                             |
+| -------------------------------- | --------------------------------- |
+| `NEON_STORAGE_ENDPOINT`          | Branch S3 endpoint URL            |
+| `NEON_STORAGE_REGION`            | Storage region (e.g. `us-east-2`) |
+| `NEON_STORAGE_ACCESS_KEY_ID`     | S3 Access Key ID                  |
+| `NEON_STORAGE_SECRET_ACCESS_KEY` | S3 Secret Access Key              |
+| `NEON_STORAGE_FORCE_PATH_STYLE`  | Always `"true"`                   |
+
+Credentials are branch-scoped and tied to the function's serving branch. They cannot be overridden by user-supplied environment variables of the same name (the injected secret access key always wins). Use them directly with your S3 client:
+
+```typescript
+import { S3Client } from '@aws-sdk/client-s3';
+
+const client = new S3Client({
+  region: process.env.NEON_STORAGE_REGION,
+  endpoint: process.env.NEON_STORAGE_ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY!,
+  },
+  forcePathStyle: true,
+});
+```
 
 ## How branch binding works
 

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:15:18.616Z'
+updatedOn: '2026-06-11T14:24:23.574Z'
 ---
 
 Neon Storage uses the same credential system as AI Gateway and Functions. You create a scoped credential via the Neon API, and it maps directly to the S3 Access Key ID and Secret Access Key your SDK expects. No AWS account or IAM configuration required.
@@ -109,7 +109,7 @@ Scope enforcement is applied by the S3 data plane. A credential without a storag
 
 ## Credentials in Neon Functions
 
-When your code runs inside Neon Functions, storage credentials are injected automatically — no credential creation step required:
+When your code runs inside Neon Functions, storage credentials are injected automatically. No credential creation step is required:
 
 | Variable                         | Value                             |
 | -------------------------------- | --------------------------------- |

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -1,0 +1,171 @@
+---
+title: Buckets
+subtitle: Create and manage storage buckets
+summary: >-
+  Neon Storage buckets hold your objects and branch with your database. Create
+  buckets via the Neon Console, the Neon API, or the S3 API. Set the access
+  level to private or public_read to control who can read objects.
+enableTableOfContents: true
+updatedOn: '2026-06-08T19:26:22.039Z'
+---
+
+A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch — each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
+
+## Create a bucket
+
+You can create a bucket from the Neon Console, the Neon API, or directly via the S3 API.
+
+**Neon Console**
+
+In the Neon Console, navigate to your project, select a branch, and open the **Storage** tab. Click **New bucket**, enter a name, choose an access level, and click **Create**.
+
+**Neon API**
+
+```bash shouldWrap
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/buckets" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-bucket", "access_level": "private"}'
+```
+
+**S3 API**
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { S3Client, CreateBucketCommand } from '@aws-sdk/client-s3';
+
+const client = new S3Client({
+  region: 'us-east-2',
+  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  credentials: {
+    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID,
+    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY,
+  },
+  forcePathStyle: true,
+});
+
+await client.send(new CreateBucketCommand({ Bucket: 'my-bucket' }));
+```
+
+```python shouldWrap
+import boto3, os
+
+client = boto3.client(
+    's3',
+    region_name='us-east-2',
+    endpoint_url=f"https://{os.environ['NEON_STORAGE_HOST']}",
+    aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],
+    aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],
+)
+
+client.create_bucket(Bucket='my-bucket')
+```
+
+```bash shouldWrap
+aws s3api create-bucket \
+  --bucket my-bucket \
+  --region us-east-2 \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+<Admonition type="note">
+`NEON_STORAGE_HOST` is your branch's storage endpoint. See [Get started](/docs/storage/get-started) for how to obtain it.
+</Admonition>
+
+## List buckets
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { S3Client, ListBucketsCommand } from '@aws-sdk/client-s3';
+
+const { Buckets } = await client.send(new ListBucketsCommand({}));
+console.log(Buckets);
+```
+
+```python
+response = client.list_buckets()
+print(response['Buckets'])
+```
+
+```bash
+aws s3api list-buckets --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+## Delete a bucket
+
+Buckets must be empty before deletion. Delete all objects first, then delete the bucket.
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { S3Client, DeleteBucketCommand } from '@aws-sdk/client-s3';
+
+await client.send(new DeleteBucketCommand({ Bucket: 'my-bucket' }));
+```
+
+```python
+client.delete_bucket(Bucket='my-bucket')
+```
+
+```bash
+aws s3api delete-bucket \
+  --bucket my-bucket \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+## Access levels
+
+Every bucket has an access level that controls who can read objects in it.
+
+| Access level  | Reads                                 | Writes                     |
+| ------------- | ------------------------------------- | -------------------------- |
+| `private`     | Require a valid credential            | Require a valid credential |
+| `public_read` | Open to anyone (no credential needed) | Require a valid credential |
+
+The default is `private`. Set the access level when creating a bucket via the Neon API, or change it from the **Storage** tab in the Console.
+
+<Admonition type="note">
+Access level is set through the Neon Console or API, not through the S3 API. S3 ACL and bucket policy mutation requests (PutBucketAcl, PutBucketPolicy) return `501 Not Implemented`. If you need to change access level on an existing bucket, use the Console or Neon API.
+</Admonition>
+
+**public_read example**
+
+Creating a `public_read` bucket allows anyone to fetch objects without a credential:
+
+```bash shouldWrap
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/buckets" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-public-bucket", "access_level": "public_read"}'
+```
+
+Objects in this bucket are accessible at:
+
+```
+https://<branch-id>.storage.c-<N>.us-east-2.aws.neon.tech/my-public-bucket/<object-key>
+```
+
+## Bucket branching
+
+When you create a new branch, it inherits all buckets from its parent at the point of forking. From that point on, each branch has its own independent view of storage:
+
+- Creating or deleting a bucket on a child branch does not affect the parent.
+- Objects uploaded to a child branch are only visible on that branch and its descendants.
+- The parent branch continues to see its own state unchanged.
+
+This makes it safe to test bucket changes in a preview branch without affecting production.
+
+## Next steps
+
+- [Objects](/docs/storage/objects) — upload, download, list, and delete objects
+- [Authentication](/docs/storage/authentication) — credential scopes and branch binding
+
+<NeedHelp/>

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,7 +6,7 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-11T12:20:31.702Z'
+updatedOn: '2026-06-11T12:24:01.926Z'
 ---
 
 A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch. Each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
@@ -132,7 +132,7 @@ aws s3api list-buckets --endpoint-url "$NEON_STORAGE_ENDPOINT"
 
 ## Delete a bucket
 
-Buckets must be empty before deletion. Delete all objects first, then delete the bucket.
+Buckets must be empty before deletion. [Delete all objects](/docs/storage/objects#delete-objects) first, then delete the bucket.
 
 <CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
 

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,7 +6,7 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-08T21:59:22.991Z'
+updatedOn: '2026-06-10T16:53:44.852Z'
 ---
 
 A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch. Each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
@@ -37,7 +37,7 @@ import { S3Client, CreateBucketCommand } from '@aws-sdk/client-s3';
 
 const client = new S3Client({
   region: 'us-east-2',
-  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  endpoint: process.env.NEON_STORAGE_ENDPOINT,
   credentials: {
     accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID,
     secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY,
@@ -54,7 +54,7 @@ import boto3, os
 client = boto3.client(
     's3',
     region_name='us-east-2',
-    endpoint_url=f"https://{os.environ['NEON_STORAGE_HOST']}",
+    endpoint_url=os.environ['NEON_STORAGE_ENDPOINT'],
     aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],
     aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],
 )
@@ -66,7 +66,7 @@ client.create_bucket(Bucket='my-bucket')
 aws s3api create-bucket \
   --bucket my-bucket \
   --region us-east-2 \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>
@@ -78,7 +78,7 @@ neonctl bucket create my-public-bucket --access-level public_read
 ```
 
 <Admonition type="note">
-`NEON_STORAGE_HOST` is your branch's storage endpoint. See [Get started](/docs/storage/get-started) for how to obtain it.
+`NEON_STORAGE_ENDPOINT` is your branch's storage endpoint. See [Get started](/docs/storage/get-started) for how to obtain it.
 </Admonition>
 
 ## List buckets
@@ -102,7 +102,7 @@ print(response['Buckets'])
 ```
 
 ```bash
-aws s3api list-buckets --endpoint-url "https://$NEON_STORAGE_HOST"
+aws s3api list-buckets --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>
@@ -130,7 +130,7 @@ client.delete_bucket(Bucket='my-bucket')
 ```bash
 aws s3api delete-bucket \
   --bucket my-bucket \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,7 +6,7 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-11T12:58:10.626Z'
+updatedOn: '2026-06-11T14:24:23.574Z'
 ---
 
 A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch and inherit from parent branches when a new branch is created. No data is copied on fork.
@@ -170,7 +170,7 @@ This makes it safe to test bucket changes in a preview branch without affecting 
 
 ## Next steps
 
-- [Objects](/docs/storage/objects) — upload, download, list, and delete objects
-- [Authentication](/docs/storage/authentication) — credential scopes and branch binding
+- [Objects](/docs/storage/objects): upload, download, list, and delete objects
+- [Authentication](/docs/storage/authentication): credential scopes and branch binding
 
 <NeedHelp/>

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,7 +6,7 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-10T16:53:44.852Z'
+updatedOn: '2026-06-11T12:20:31.702Z'
 ---
 
 A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch. Each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
@@ -81,6 +81,29 @@ neonctl bucket create my-public-bucket --access-level public_read
 `NEON_STORAGE_ENDPOINT` is your branch's storage endpoint. See [Get started](/docs/storage/get-started) for how to obtain it.
 </Admonition>
 
+## Access levels
+
+Every bucket has an access level that controls who can read objects in it.
+
+| Access level  | Reads                                 | Writes                     |
+| ------------- | ------------------------------------- | -------------------------- |
+| `private`     | Require a valid credential            | Require a valid credential |
+| `public_read` | Open to anyone (no credential needed) | Require a valid credential |
+
+The default is `private`. Set the access level when creating a bucket via the Neon API, or change it from the **Storage** tab in the Console.
+
+<Admonition type="note">
+Access level is set through the Neon Console or API, not through the S3 API. S3 ACL and bucket policy mutation requests (PutBucketAcl, PutBucketPolicy) return `501 Not Implemented`. If you need to change access level on an existing bucket, use the Console or Neon API.
+</Admonition>
+
+**public_read example**
+
+Objects in a `public_read` bucket are accessible at:
+
+```
+https://<branch-id>.storage.c-<N>.us-east-2.aws.neon.tech/my-public-bucket/<object-key>
+```
+
 ## List buckets
 
 <CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
@@ -134,29 +157,6 @@ aws s3api delete-bucket \
 ```
 
 </CodeTabs>
-
-## Access levels
-
-Every bucket has an access level that controls who can read objects in it.
-
-| Access level  | Reads                                 | Writes                     |
-| ------------- | ------------------------------------- | -------------------------- |
-| `private`     | Require a valid credential            | Require a valid credential |
-| `public_read` | Open to anyone (no credential needed) | Require a valid credential |
-
-The default is `private`. Set the access level when creating a bucket via the Neon API, or change it from the **Storage** tab in the Console.
-
-<Admonition type="note">
-Access level is set through the Neon Console or API, not through the S3 API. S3 ACL and bucket policy mutation requests (PutBucketAcl, PutBucketPolicy) return `501 Not Implemented`. If you need to change access level on an existing bucket, use the Console or Neon API.
-</Admonition>
-
-**public_read example**
-
-Objects in a `public_read` bucket are accessible at:
-
-```
-https://<branch-id>.storage.c-<N>.us-east-2.aws.neon.tech/my-public-bucket/<object-key>
-```
 
 ## Bucket branching
 

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,10 +6,10 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-11T12:24:01.926Z'
+updatedOn: '2026-06-11T12:58:10.626Z'
 ---
 
-A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch. Each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
+A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch and inherit from parent branches when a new branch is created. No data is copied on fork.
 
 ## Create a bucket
 
@@ -160,7 +160,7 @@ aws s3api delete-bucket \
 
 ## Bucket branching
 
-When you create a new branch, it inherits all buckets from its parent at the point of forking. From that point on, each branch has its own independent view of storage:
+When you create a new branch, it inherits all buckets from its parent at the point of forking. No data is copied. From that point on:
 
 - Creating or deleting a bucket on a child branch does not affect the parent.
 - Objects uploaded to a child branch are only visible on that branch and its descendants.

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,20 +6,24 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:36:47.586Z'
+updatedOn: '2026-06-08T21:59:22.991Z'
 ---
 
 A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch. Each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
 
 ## Create a bucket
 
-You can create a bucket from the Neon Console, the Neon API, or directly via the S3 API.
+You can create a bucket from the Neon Console, the Neon CLI, the Neon API, or directly via the S3 API.
 
 **Neon Console**
 
 In the Neon Console, navigate to your project, select a branch, and open the **Storage** tab. Click **New bucket**, enter a name, choose an access level, and click **Create**.
 
-**Neon API**
+<CodeTabs labels={["neonctl", "Neon API", "TypeScript", "Python", "AWS CLI"]}>
+
+```bash
+neonctl bucket create my-bucket
+```
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/buckets" \
@@ -27,10 +31,6 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -H "Content-Type: application/json" \
   -d '{"name": "my-bucket", "access_level": "private"}'
 ```
-
-**S3 API**
-
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
 
 ```typescript shouldWrap
 import { S3Client, CreateBucketCommand } from '@aws-sdk/client-s3';
@@ -71,13 +71,23 @@ aws s3api create-bucket \
 
 </CodeTabs>
 
+To create a `public_read` bucket with neonctl:
+
+```bash
+neonctl bucket create my-public-bucket --access-level public_read
+```
+
 <Admonition type="note">
 `NEON_STORAGE_HOST` is your branch's storage endpoint. See [Get started](/docs/storage/get-started) for how to obtain it.
 </Admonition>
 
 ## List buckets
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+
+```bash
+neonctl bucket list
+```
 
 ```typescript shouldWrap
 import { S3Client, ListBucketsCommand } from '@aws-sdk/client-s3';
@@ -101,7 +111,11 @@ aws s3api list-buckets --endpoint-url "https://$NEON_STORAGE_HOST"
 
 Buckets must be empty before deletion. Delete all objects first, then delete the bucket.
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+
+```bash
+neonctl bucket delete my-bucket
+```
 
 ```typescript shouldWrap
 import { S3Client, DeleteBucketCommand } from '@aws-sdk/client-s3';
@@ -138,16 +152,7 @@ Access level is set through the Neon Console or API, not through the S3 API. S3 
 
 **public_read example**
 
-Creating a `public_read` bucket allows anyone to fetch objects without a credential:
-
-```bash shouldWrap
-curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/buckets" \
-  -H "Authorization: Bearer $NEON_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "my-public-bucket", "access_level": "public_read"}'
-```
-
-Objects in this bucket are accessible at:
+Objects in a `public_read` bucket are accessible at:
 
 ```
 https://<branch-id>.storage.c-<N>.us-east-2.aws.neon.tech/my-public-bucket/<object-key>

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,8 +6,10 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:24:23.574Z'
+updatedOn: '2026-06-15T13:33:22.356Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch and inherit from parent branches when a new branch is created. No data is copied on fork.
 

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,10 +6,10 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:26:22.039Z'
+updatedOn: '2026-06-08T19:36:47.586Z'
 ---
 
-A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch — each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
+A bucket is a named container for objects in Neon Storage. Buckets are scoped to a branch. Each branch has its own view of storage, and buckets inherit from parent branches when a new branch is created.
 
 ## Create a bucket
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:36:47.586Z'
+updatedOn: '2026-06-10T16:53:44.852Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -47,19 +47,30 @@ Your project ID and branch ID are available in the Neon Console URL or via `neon
 
 ## Find your branch endpoint
 
-Your branch's storage endpoint is available in the Console on the **Storage** tab, or via the Neon API. It follows this format:
+Fetch your branch's storage state from the Neon API. The response includes the full S3 endpoint URL, the region, and whether path-style addressing is required:
 
-```
-<branch-id>.storage.c-<N>.us-east-2.aws.neon.tech
+```bash shouldWrap
+curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/storage" \
+  -H "Authorization: Bearer $NEON_API_KEY"
 ```
 
-For example:
+```json
+{
+  "enabled": true,
+  "s3_endpoint": "https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech",
+  "region": "us-east-2",
+  "force_path_style": true
+}
+```
+
+Set these as environment variables:
 
 ```bash
-export NEON_STORAGE_HOST=br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech
+export NEON_STORAGE_ENDPOINT=https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech
+export NEON_STORAGE_REGION=us-east-2
 ```
 
-This is different from your database connection string.
+A `404` response means Storage is not yet enabled for that branch. Make sure you're using a project in the AWS us-east-2 region.
 
 ## Install dependencies
 
@@ -93,7 +104,7 @@ import 'dotenv/config';
 
 export const client = new S3Client({
   region: 'us-east-2',
-  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  endpoint: process.env.NEON_STORAGE_ENDPOINT,
   credentials: {
     accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID!,
     secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY!,
@@ -112,7 +123,7 @@ load_dotenv()
 client = boto3.client(
     's3',
     region_name='us-east-2',
-    endpoint_url=f"https://{os.environ['NEON_STORAGE_HOST']}",
+    endpoint_url=os.environ['NEON_STORAGE_ENDPOINT'],
     aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],
     aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],
 )
@@ -168,11 +179,11 @@ print('Uploaded!')
 # Create a bucket
 aws s3api create-bucket \
   --bucket my-bucket \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "https://$NEON_STORAGE_ENDPOINT"
 
 # Upload a file
 aws s3 cp hello.txt s3://my-bucket/hello.txt \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "https://$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>
@@ -201,7 +212,7 @@ print(response['Body'].read().decode('utf-8'))  # Hello from Neon Storage!
 
 ```bash shouldWrap
 aws s3 cp s3://my-bucket/hello.txt ./downloaded.txt \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "https://$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,12 +6,12 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:42:07.067Z'
+updatedOn: '2026-06-12T16:38:26.381Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Storage is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
+
+To follow this guide, you need a new project in the AWS us-east-2 region.
 
 <Steps>
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:24:23.574Z'
+updatedOn: '2026-06-11T14:42:07.067Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -26,7 +26,7 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
 ```
 
-The response includes your S3 credentials. Store them immediately. They are returned only once. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for how each field maps to your S3 client.
+The response includes your S3 credentials. Store them immediately. You'll only get them once. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for how each field maps to your S3 client.
 
 ```json
 {

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -1,0 +1,217 @@
+---
+title: Get started with Neon Storage
+subtitle: Upload your first file in minutes
+summary: >-
+  This quickstart walks you through creating a storage credential, configuring
+  your S3 client, creating a bucket, and uploading and downloading your first
+  file. Any AWS S3-compatible SDK works — just point it at your branch endpoint.
+enableTableOfContents: true
+updatedOn: '2026-06-08T19:26:22.039Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Storage is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+<Steps>
+
+## Create a credential
+
+Use the Neon API to create a credential with storage access:
+
+```bash shouldWrap
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
+```
+
+The response includes your S3 credentials. Store them immediately — they are returned only once:
+
+```json
+{
+  "token_id": "550e8400-e29b-41d4-a716-446655440000",
+  "s3_secret_access_key": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+  ...
+}
+```
+
+Set these as environment variables:
+
+```bash
+export NEON_STORAGE_ACCESS_KEY_ID=550e8400-e29b-41d4-a716-446655440000   # token_id
+export NEON_STORAGE_SECRET_ACCESS_KEY=a665a45920422f9d...                 # s3_secret_access_key
+```
+
+Your project ID and branch ID are available in the Neon Console URL or via `neonctl projects list` and `neonctl branches list`.
+
+## Find your branch endpoint
+
+Your branch's storage endpoint is available in the Console on the **Storage** tab, or via the Neon API. It follows this format:
+
+```
+<branch-id>.storage.c-<N>.us-east-2.aws.neon.tech
+```
+
+For example:
+
+```bash
+export NEON_STORAGE_HOST=br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech
+```
+
+This is different from your database connection string.
+
+## Install dependencies
+
+<CodeTabs labels={["npm", "yarn", "pnpm", "pip"]}>
+
+```bash
+npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner dotenv
+```
+
+```bash
+yarn add @aws-sdk/client-s3 @aws-sdk/s3-request-presigner dotenv
+```
+
+```bash
+pnpm add @aws-sdk/client-s3 @aws-sdk/s3-request-presigner dotenv
+```
+
+```bash
+pip install boto3 python-dotenv
+```
+
+</CodeTabs>
+
+## Configure your S3 client
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { S3Client } from '@aws-sdk/client-s3';
+import 'dotenv/config';
+
+export const client = new S3Client({
+  region: 'us-east-2',
+  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  credentials: {
+    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY!,
+  },
+  forcePathStyle: true,
+});
+```
+
+```python shouldWrap
+import boto3
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+client = boto3.client(
+    's3',
+    region_name='us-east-2',
+    endpoint_url=f"https://{os.environ['NEON_STORAGE_HOST']}",
+    aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],
+    aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],
+)
+```
+
+```bash
+# Add to ~/.aws/credentials or export as env vars
+export AWS_ACCESS_KEY_ID=$NEON_STORAGE_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$NEON_STORAGE_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=us-east-2
+```
+
+</CodeTabs>
+
+## Create a bucket and upload a file
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { CreateBucketCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { client } from './client';
+
+// Create a bucket
+await client.send(new CreateBucketCommand({ Bucket: 'my-bucket' }));
+
+// Upload a file
+await client.send(new PutObjectCommand({
+  Bucket: 'my-bucket',
+  Key: 'hello.txt',
+  Body: 'Hello from Neon Storage!',
+  ContentType: 'text/plain',
+}));
+
+console.log('Uploaded!');
+```
+
+```python shouldWrap
+# Create a bucket
+client.create_bucket(Bucket='my-bucket')
+
+# Upload a file
+client.put_object(
+    Bucket='my-bucket',
+    Key='hello.txt',
+    Body='Hello from Neon Storage!',
+    ContentType='text/plain',
+)
+
+print('Uploaded!')
+```
+
+```bash shouldWrap
+# Create a bucket
+aws s3api create-bucket \
+  --bucket my-bucket \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+
+# Upload a file
+aws s3 cp hello.txt s3://my-bucket/hello.txt \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+## Download a file
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { client } from './client';
+
+const response = await client.send(new GetObjectCommand({
+  Bucket: 'my-bucket',
+  Key: 'hello.txt',
+}));
+
+const text = await response.Body?.transformToString();
+console.log(text); // Hello from Neon Storage!
+```
+
+```python
+response = client.get_object(Bucket='my-bucket', Key='hello.txt')
+print(response['Body'].read().decode('utf-8'))  # Hello from Neon Storage!
+```
+
+```bash shouldWrap
+aws s3 cp s3://my-bucket/hello.txt ./downloaded.txt \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+</Steps>
+
+## Next steps
+
+- [Buckets](/docs/storage/buckets) — access levels, bucket branching, and the Console UI
+- [Objects](/docs/storage/objects) — list, delete, multipart uploads, and presigned URLs
+- [Authentication](/docs/storage/authentication) — credential scopes, branch binding, and rotation
+
+<NeedHelp/>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:15:18.616Z'
+updatedOn: '2026-06-11T14:24:23.574Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -26,7 +26,7 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
 ```
 
-The response includes your S3 credentials. Store them immediately — they are returned only once. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for how each field maps to your S3 client.
+The response includes your S3 credentials. Store them immediately. They are returned only once. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for how each field maps to your S3 client.
 
 ```json
 {
@@ -221,8 +221,8 @@ aws s3 cp s3://my-bucket/hello.txt ./downloaded.txt \
 
 ## Next steps
 
-- [Buckets](/docs/storage/buckets) — access levels, bucket branching, and the Console UI
-- [Objects](/docs/storage/objects) — list, delete, multipart uploads, and presigned URLs
-- [Authentication](/docs/storage/authentication) — credential scopes, branch binding, and rotation
+- [Buckets](/docs/storage/buckets): access levels, bucket branching, and the Console UI
+- [Objects](/docs/storage/objects): list, delete, multipart uploads, and presigned URLs
+- [Authentication](/docs/storage/authentication): credential scopes, branch binding, and rotation
 
 <NeedHelp/>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-10T16:54:18.281Z'
+updatedOn: '2026-06-11T12:24:01.926Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -26,7 +26,7 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
 ```
 
-The response includes your S3 credentials. Store them immediately. They are returned only once:
+The response includes your S3 credentials. Store them immediately — they are returned only once. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for how each field maps to your S3 client.
 
 ```json
 {

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -4,9 +4,9 @@ subtitle: Upload your first file in minutes
 summary: >-
   This quickstart walks you through creating a storage credential, configuring
   your S3 client, creating a bucket, and uploading and downloading your first
-  file. Any AWS S3-compatible SDK works — just point it at your branch endpoint.
+  file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:26:22.039Z'
+updatedOn: '2026-06-08T19:36:47.586Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -26,7 +26,7 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["storage:read", "storage:write"], "principal_type": "user"}'
 ```
 
-The response includes your S3 credentials. Store them immediately — they are returned only once:
+The response includes your S3 credentials. Store them immediately. They are returned only once:
 
 ```json
 {

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-10T16:53:44.852Z'
+updatedOn: '2026-06-10T16:54:18.281Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -179,11 +179,11 @@ print('Uploaded!')
 # Create a bucket
 aws s3api create-bucket \
   --bucket my-bucket \
-  --endpoint-url "https://$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 
 # Upload a file
 aws s3 cp hello.txt s3://my-bucket/hello.txt \
-  --endpoint-url "https://$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>
@@ -212,7 +212,7 @@ print(response['Body'].read().decode('utf-8'))  # Hello from Neon Storage!
 
 ```bash shouldWrap
 aws s3 cp s3://my-bucket/hello.txt ./downloaded.txt \
-  --endpoint-url "https://$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-11T12:24:01.926Z'
+updatedOn: '2026-06-11T14:15:18.616Z'
 ---
 
 <Admonition type="note" title="Private Preview">
@@ -31,7 +31,7 @@ The response includes your S3 credentials. Store them immediately — they are r
 ```json
 {
   "token_id": "550e8400-e29b-41d4-a716-446655440000",
-  "s3_secret_access_key": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+  "s3_secret_access_key": "a665a459...",
   ...
 }
 ```

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:24:23.574Z'
+updatedOn: '2026-06-11T14:42:07.067Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch inherits the parent's objects at the moment of forking without copying any data.
@@ -137,7 +137,7 @@ aws s3 cp s3://my-bucket/images/photo.jpg ./photo.jpg \
 
 </CodeTabs>
 
-**Range requests** are supported for partial downloads:
+You can use range requests for partial downloads:
 
 ```typescript shouldWrap
 const response = await client.send(new GetObjectCommand({

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,10 +6,10 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-11T12:24:01.926Z'
+updatedOn: '2026-06-11T12:58:10.626Z'
 ---
 
-Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
+Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch inherits the parent's objects at the moment of forking without copying any data.
 
 The examples below use an S3 client configured with your branch endpoint and credentials. See [Get started](/docs/storage/get-started) to set that up, or [Authentication](/docs/storage/authentication) if you need to create a credential.
 
@@ -370,7 +370,7 @@ print(url)
 
 ## Object branching
 
-Objects branch with your database. When you fork a branch, the child starts with the same view of storage as the parent at that point in time:
+Objects branch with your database. When you fork a branch, the child immediately inherits the parent's buckets and objects at that point in time. No data is copied. From that point:
 
 - Uploading a new object to a child branch is only visible on that branch and its descendants.
 - Deleting an object on a child branch does not affect the parent.

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -1,0 +1,345 @@
+---
+title: Objects
+subtitle: Upload, download, list, and delete files
+summary: >-
+  Work with objects in Neon Storage using any S3-compatible SDK or the AWS CLI.
+  Supports single-part and multipart uploads, range requests, batch deletes,
+  and presigned URLs for browser-side access.
+enableTableOfContents: true
+updatedOn: '2026-06-08T19:26:22.039Z'
+---
+
+Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database — each branch has its own view of storage.
+
+## Upload
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { client } from './client';
+
+await client.send(new PutObjectCommand({
+  Bucket: 'my-bucket',
+  Key: 'images/photo.jpg',
+  Body: fileBuffer,
+  ContentType: 'image/jpeg',
+  Metadata: {
+    'uploaded-by': 'user-123',
+  },
+}));
+```
+
+```python shouldWrap
+client.put_object(
+    Bucket='my-bucket',
+    Key='images/photo.jpg',
+    Body=file_bytes,
+    ContentType='image/jpeg',
+    Metadata={'uploaded-by': 'user-123'},
+)
+```
+
+```bash shouldWrap
+aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
+  --content-type image/jpeg \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+## Multipart upload
+
+For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control.
+
+<CodeTabs labels={["TypeScript", "Python"]}>
+
+```typescript shouldWrap
+import { Upload } from '@aws-sdk/lib-storage';
+import { client } from './client';
+import { createReadStream } from 'fs';
+
+const upload = new Upload({
+  client,
+  params: {
+    Bucket: 'my-bucket',
+    Key: 'large-file.zip',
+    Body: createReadStream('./large-file.zip'),
+  },
+  partSize: 10 * 1024 * 1024, // 10 MiB per part
+});
+
+await upload.done();
+```
+
+```python shouldWrap
+import boto3
+
+# boto3 handles multipart automatically via upload_file/upload_fileobj
+client.upload_file(
+    './large-file.zip',
+    'my-bucket',
+    'large-file.zip',
+    Config=boto3.s3.transfer.TransferConfig(
+        multipart_threshold=10 * 1024 * 1024,
+        multipart_chunksize=10 * 1024 * 1024,
+    ),
+)
+```
+
+</CodeTabs>
+
+## Download
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { client } from './client';
+
+const response = await client.send(new GetObjectCommand({
+  Bucket: 'my-bucket',
+  Key: 'images/photo.jpg',
+}));
+
+// Stream to a file
+const stream = response.Body as NodeJS.ReadableStream;
+stream.pipe(fs.createWriteStream('./photo.jpg'));
+```
+
+```python
+response = client.get_object(Bucket='my-bucket', Key='images/photo.jpg')
+with open('./photo.jpg', 'wb') as f:
+    f.write(response['Body'].read())
+```
+
+```bash shouldWrap
+aws s3 cp s3://my-bucket/images/photo.jpg ./photo.jpg \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+**Range requests** are supported for partial downloads:
+
+```typescript shouldWrap
+const response = await client.send(new GetObjectCommand({
+  Bucket: 'my-bucket',
+  Key: 'video.mp4',
+  Range: 'bytes=0-1048575', // first 1 MiB
+}));
+```
+
+## List objects
+
+Use a prefix and delimiter to simulate a folder structure.
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { client } from './client';
+
+const response = await client.send(new ListObjectsV2Command({
+  Bucket: 'my-bucket',
+  Prefix: 'images/',
+  Delimiter: '/',
+}));
+
+// Objects in images/
+console.log(response.Contents);
+
+// Sub-folders (common prefixes)
+console.log(response.CommonPrefixes);
+```
+
+```python
+response = client.list_objects_v2(
+    Bucket='my-bucket',
+    Prefix='images/',
+    Delimiter='/',
+)
+
+# Objects in images/
+print(response.get('Contents', []))
+
+# Sub-folders
+print(response.get('CommonPrefixes', []))
+```
+
+```bash shouldWrap
+aws s3 ls s3://my-bucket/images/ \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+For buckets with more than 1,000 objects, paginate using `ContinuationToken`:
+
+```typescript shouldWrap
+let token: string | undefined;
+do {
+  const response = await client.send(new ListObjectsV2Command({
+    Bucket: 'my-bucket',
+    ContinuationToken: token,
+  }));
+  for (const obj of response.Contents ?? []) {
+    console.log(obj.Key);
+  }
+  token = response.NextContinuationToken;
+} while (token);
+```
+
+## Delete objects
+
+**Single object:**
+
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { DeleteObjectCommand } from '@aws-sdk/client-s3';
+
+await client.send(new DeleteObjectCommand({
+  Bucket: 'my-bucket',
+  Key: 'images/photo.jpg',
+}));
+```
+
+```python
+client.delete_object(Bucket='my-bucket', Key='images/photo.jpg')
+```
+
+```bash shouldWrap
+aws s3 rm s3://my-bucket/images/photo.jpg \
+  --endpoint-url "https://$NEON_STORAGE_HOST"
+```
+
+</CodeTabs>
+
+**Batch delete (up to 1,000 objects per request):**
+
+<CodeTabs labels={["TypeScript", "Python"]}>
+
+```typescript shouldWrap
+import { DeleteObjectsCommand } from '@aws-sdk/client-s3';
+
+await client.send(new DeleteObjectsCommand({
+  Bucket: 'my-bucket',
+  Delete: {
+    Objects: [
+      { Key: 'images/photo1.jpg' },
+      { Key: 'images/photo2.jpg' },
+    ],
+  },
+}));
+```
+
+```python
+client.delete_objects(
+    Bucket='my-bucket',
+    Delete={
+        'Objects': [
+            {'Key': 'images/photo1.jpg'},
+            {'Key': 'images/photo2.jpg'},
+        ]
+    },
+)
+```
+
+</CodeTabs>
+
+**Delete a folder (all objects under a prefix):**
+
+Use the Neon API to delete all objects with a given prefix in one call:
+
+```bash shouldWrap
+curl -X DELETE \
+  "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/buckets/my-bucket/objects-by-prefix?prefix=images/" \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+## Presigned URLs
+
+Generate a time-limited URL that allows a browser or unauthenticated client to upload or download a specific object — without exposing your credentials.
+
+**Presigned GET (download):**
+
+<CodeTabs labels={["TypeScript", "Python"]}>
+
+```typescript shouldWrap
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { client } from './client';
+
+const url = await getSignedUrl(
+  client,
+  new GetObjectCommand({ Bucket: 'my-bucket', Key: 'report.pdf' }),
+  { expiresIn: 3600 }, // 1 hour
+);
+
+console.log(url); // share this URL — no credentials needed
+```
+
+```python
+url = client.generate_presigned_url(
+    'get_object',
+    Params={'Bucket': 'my-bucket', 'Key': 'report.pdf'},
+    ExpiresIn=3600,  # 1 hour
+)
+print(url)
+```
+
+</CodeTabs>
+
+**Presigned PUT (upload from browser):**
+
+<CodeTabs labels={["TypeScript", "Python"]}>
+
+```typescript shouldWrap
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { client } from './client';
+
+const url = await getSignedUrl(
+  client,
+  new PutObjectCommand({
+    Bucket: 'my-bucket',
+    Key: 'uploads/user-avatar.png',
+    ContentType: 'image/png',
+  }),
+  { expiresIn: 300 }, // 5 minutes
+);
+
+// On the client side:
+// await fetch(url, { method: 'PUT', body: file, headers: { 'Content-Type': 'image/png' } });
+```
+
+```python
+url = client.generate_presigned_url(
+    'put_object',
+    Params={
+        'Bucket': 'my-bucket',
+        'Key': 'uploads/user-avatar.png',
+        'ContentType': 'image/png',
+    },
+    ExpiresIn=300,
+)
+print(url)
+```
+
+</CodeTabs>
+
+## Object branching
+
+Objects branch with your database. When you fork a branch, the child starts with the same view of storage as the parent at that point in time:
+
+- Uploading a new object to a child branch is only visible on that branch and its descendants.
+- Deleting an object on a child branch does not affect the parent.
+- The parent's objects remain unchanged regardless of what happens on child branches.
+
+## Next steps
+
+- [Buckets](/docs/storage/buckets) — set access levels, understand bucket branching
+- [Authentication](/docs/storage/authentication) — credential scopes and read vs write access
+
+<NeedHelp/>

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:36:47.586Z'
+updatedOn: '2026-06-08T21:59:22.991Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
@@ -91,7 +91,13 @@ client.upload_file(
 
 ## Download
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+
+```bash
+# Downloads to ./photo.jpg by default; use --file to specify a different path
+neonctl bucket object get my-bucket/images/photo.jpg
+neonctl bucket object get my-bucket/images/photo.jpg --file ./downloads/photo.jpg
+```
 
 ```typescript shouldWrap
 import { GetObjectCommand } from '@aws-sdk/client-s3';
@@ -134,7 +140,15 @@ const response = await client.send(new GetObjectCommand({
 
 Use a prefix and delimiter to simulate a folder structure.
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+
+```bash
+# List all objects in a bucket
+neonctl bucket object list my-bucket
+
+# List objects under a prefix, showing folders
+neonctl bucket object list my-bucket/images/ --delimiter /
+```
 
 ```typescript shouldWrap
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
@@ -194,7 +208,11 @@ do {
 
 **Single object:**
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+
+```bash
+neonctl bucket object delete my-bucket/images/photo.jpg
+```
 
 ```typescript shouldWrap
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
@@ -250,13 +268,20 @@ client.delete_objects(
 
 **Delete a folder (all objects under a prefix):**
 
-Use the Neon API to delete all objects with a given prefix in one call:
+<CodeTabs labels={["neonctl", "Neon API"]}>
+
+```bash
+# The prefix must end with /
+neonctl bucket object delete my-bucket/images/ --recursive
+```
 
 ```bash shouldWrap
 curl -X DELETE \
   "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/buckets/my-bucket/objects-by-prefix?prefix=images/" \
   -H "Authorization: Bearer $NEON_API_KEY"
 ```
+
+</CodeTabs>
 
 ## Presigned URLs
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-11T12:58:10.626Z'
+updatedOn: '2026-06-11T14:24:23.574Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch inherits the parent's objects at the moment of forking without copying any data.
@@ -378,7 +378,7 @@ Objects branch with your database. When you fork a branch, the child immediately
 
 ## Next steps
 
-- [Buckets](/docs/storage/buckets) — set access levels, understand bucket branching
-- [Authentication](/docs/storage/authentication) — credential scopes and read vs write access
+- [Buckets](/docs/storage/buckets): set access levels, understand bucket branching
+- [Authentication](/docs/storage/authentication): credential scopes and read vs write access
 
 <NeedHelp/>

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,8 +6,10 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:42:07.067Z'
+updatedOn: '2026-06-15T13:33:22.356Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch inherits the parent's objects at the moment of forking without copying any data.
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,14 +6,19 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-11T11:35:46.410Z'
+updatedOn: '2026-06-11T11:39:34.297Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
 
 ## Upload
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+
+```bash
+neonctl bucket object put my-bucket/images/photo.jpg --file ./photo.jpg
+neonctl bucket object put my-bucket/images/photo.jpg --file ./photo.jpg --content-type image/jpeg
+```
 
 ```typescript shouldWrap
 import { PutObjectCommand } from '@aws-sdk/client-s3';
@@ -49,7 +54,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 </CodeTabs>
 
 <Admonition type="note">
-The Neon CLI does not support uploading objects. Use the AWS SDK or AWS CLI with your branch endpoint and SigV4 credentials.
+`neonctl bucket object put` uploads via a presigned URL and supports files up to the presign size limit. For large or streaming uploads use the AWS SDK with multipart upload.
 </Admonition>
 
 ## Multipart upload

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,16 +6,20 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-10T16:53:44.852Z'
+updatedOn: '2026-06-10T16:57:38.985Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
 
 ## Upload
 
-Uploads use the S3-compatible API directly. `neonctl` does not currently support object uploads.
+<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+```bash
+# --file is required; --content-type is optional
+neonctl bucket object put my-bucket/images/photo.jpg --file ./photo.jpg
+neonctl bucket object put my-bucket/images/photo.jpg --file ./photo.jpg --content-type image/jpeg
+```
 
 ```typescript shouldWrap
 import { PutObjectCommand } from '@aws-sdk/client-s3';
@@ -49,6 +53,10 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 ```
 
 </CodeTabs>
+
+<Admonition type="note">
+`neonctl bucket object put` supports files up to 100 MB. For larger files use the TypeScript or Python SDK with multipart upload.
+</Admonition>
 
 ## Multipart upload
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,12 +6,14 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-08T21:59:22.991Z'
+updatedOn: '2026-06-08T22:01:37.795Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
 
 ## Upload
+
+Uploads use the S3-compatible API directly. `neonctl` does not currently support object uploads.
 
 <CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-08T22:01:37.795Z'
+updatedOn: '2026-06-10T16:53:44.852Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
@@ -45,7 +45,7 @@ client.put_object(
 ```bash shouldWrap
 aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
   --content-type image/jpeg \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>
@@ -123,7 +123,7 @@ with open('./photo.jpg', 'wb') as f:
 
 ```bash shouldWrap
 aws s3 cp s3://my-bucket/images/photo.jpg ./photo.jpg \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>
@@ -185,7 +185,7 @@ print(response.get('CommonPrefixes', []))
 
 ```bash shouldWrap
 aws s3 ls s3://my-bucket/images/ \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>
@@ -231,7 +231,7 @@ client.delete_object(Bucket='my-bucket', Key='images/photo.jpg')
 
 ```bash shouldWrap
 aws s3 rm s3://my-bucket/images/photo.jpg \
-  --endpoint-url "https://$NEON_STORAGE_HOST"
+  --endpoint-url "$NEON_STORAGE_ENDPOINT"
 ```
 
 </CodeTabs>

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,10 +6,10 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:26:22.039Z'
+updatedOn: '2026-06-08T19:36:47.586Z'
 ---
 
-Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database — each branch has its own view of storage.
+Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
 
 ## Upload
 
@@ -260,7 +260,7 @@ curl -X DELETE \
 
 ## Presigned URLs
 
-Generate a time-limited URL that allows a browser or unauthenticated client to upload or download a specific object — without exposing your credentials.
+Generate a time-limited URL that allows a browser or unauthenticated client to upload or download a specific object, without exposing your credentials.
 
 **Presigned GET (download):**
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-11T11:39:34.297Z'
+updatedOn: '2026-06-11T11:44:51.348Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
@@ -152,11 +152,14 @@ Use a prefix and delimiter to simulate a folder structure.
 <CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
 
 ```bash
-# List all objects in a bucket
+# Folder-collapsed view by default (same as aws s3 ls)
 neonctl bucket object list my-bucket
 
-# List objects under a prefix, showing folders
-neonctl bucket object list my-bucket/images/ --delimiter /
+# List objects under a prefix
+neonctl bucket object list my-bucket/images/
+
+# Flat listing of every key, no folder collapsing
+neonctl bucket object list my-bucket --recursive
 ```
 
 ```typescript shouldWrap

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,20 +6,14 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-10T16:57:38.985Z'
+updatedOn: '2026-06-11T11:35:46.410Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
 
 ## Upload
 
-<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
-
-```bash
-# --file is required; --content-type is optional
-neonctl bucket object put my-bucket/images/photo.jpg --file ./photo.jpg
-neonctl bucket object put my-bucket/images/photo.jpg --file ./photo.jpg --content-type image/jpeg
-```
+<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
 
 ```typescript shouldWrap
 import { PutObjectCommand } from '@aws-sdk/client-s3';
@@ -55,7 +49,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 </CodeTabs>
 
 <Admonition type="note">
-`neonctl bucket object put` supports files up to 100 MB. For larger files use the TypeScript or Python SDK with multipart upload.
+The Neon CLI does not support uploading objects. Use the AWS SDK or AWS CLI with your branch endpoint and SigV4 credentials.
 </Admonition>
 
 ## Multipart upload

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,10 +6,12 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-11T11:44:51.348Z'
+updatedOn: '2026-06-11T12:24:01.926Z'
 ---
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch has its own view of storage.
+
+The examples below use an S3 client configured with your branch endpoint and credentials. See [Get started](/docs/storage/get-started) to set that up, or [Authentication](/docs/storage/authentication) if you need to create a credential.
 
 ## Upload
 
@@ -54,7 +56,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 </CodeTabs>
 
 <Admonition type="note">
-`neonctl bucket object put` uploads via a presigned URL and supports files up to the presign size limit. For large or streaming uploads use the AWS SDK with multipart upload.
+`neonctl bucket object put` uploads via a presigned URL and supports files up to the presign size limit. For large or streaming uploads use the AWS SDK with [multipart upload](#multipart-upload).
 </Admonition>
 
 ## Multipart upload

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-12T16:38:26.381Z'
+updatedOn: '2026-06-15T10:38:40.119Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -32,6 +32,14 @@ During the private preview, Storage is available for new projects in the AWS us-
 <a href="/docs/storage/objects" description="Upload, download, list, delete, and generate presigned URLs for objects." icon="data">Objects</a>
 
 <a href="/docs/storage/authentication" description="Understand how Neon credentials map to S3 access keys." icon="lock-landscape">Authentication</a>
+
+</DetailIconCards>
+
+## Example apps
+
+<DetailIconCards>
+
+<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that stores user photos and generated images in branch-scoped Neon Storage buckets, served via presigned URLs from a Neon Function." icon="github">Vibecastly</a>
 
 </DetailIconCards>
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T10:38:40.119Z'
+updatedOn: '2026-06-15T14:32:45.581Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -35,12 +35,24 @@ During the private preview, Storage is available for new projects in the AWS us-
 
 </DetailIconCards>
 
-## Example apps
+## Starter templates
 
-<DetailIconCards>
+Browse templates at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one directly with `neonctl bootstrap`:
 
-<a href="https://github.com/andrelandgraf/vibecastly" description="An AI image studio that stores user photos and generated images in branch-scoped Neon Storage buckets, served via presigned URLs from a Neon Function." icon="github">Vibecastly</a>
+```bash
+neonctl bootstrap
+```
 
-</DetailIconCards>
+Use `--template` to skip the interactive picker:
+
+| Template        | What it builds                                                                         |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `hono`          | REST API with Drizzle and Postgres on Neon Functions                                   |
+| `ai-sdk`        | Image-generation agent with AI Gateway, Object Storage, and Postgres on Neon Functions |
+| `mastra`        | Personal assistant with AI Gateway and Postgres-backed memory on Neon Functions        |
+| `realtime-chat` | Realtime chat with Next.js, Neon Auth, and WebSockets on Neon Functions                |
+| `realtime-sse`  | Realtime counter with TanStack Router and SSE on Neon Functions                        |
+
+`neonctl bootstrap` scaffolds files, links to a Neon project, and pulls env vars. Then follow the README to set up and deploy.
 
 <NeedHelp/>

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,14 +7,14 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:36:47.586Z'
+updatedOn: '2026-06-12T16:38:26.381Z'
 ---
 
-<Admonition type="note" title="Private Preview">
-Neon Storage is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
-</Admonition>
+<PrivatePreviewEnquire/>
 
 Neon Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
+
+During the private preview, Storage is available for new projects in the AWS us-east-2 region only.
 
 - **Branches with your database.** Each branch has its own view of storage. Test file uploads and deletions in preview branches without touching production data.
 - **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, and any other S3-compatible tool works out of the box.

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -1,0 +1,38 @@
+---
+title: Neon Storage
+subtitle: S3-compatible object storage that branches with your database
+summary: >-
+  Neon Storage is S3-compatible object storage built into the Neon backend.
+  Every branch gets its own isolated storage namespace. Use any AWS S3 SDK
+  or tool — point it at your branch endpoint and authenticate with your Neon
+  credential.
+enableTableOfContents: true
+updatedOn: '2026-06-08T19:26:22.039Z'
+---
+
+<Admonition type="note" title="Private Preview">
+Neon Storage is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
+</Admonition>
+
+Neon Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool — point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
+
+- **Branches with your database.** Each branch has its own view of storage. Test file uploads and deletions in preview branches without touching production data.
+- **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, and any other S3-compatible tool works out of the box.
+- **Two access modes.** `private` buckets require authentication for all operations. `public_read` buckets allow anonymous reads with authenticated writes.
+- **One credential system.** The same Neon credential system used by AI Gateway and Functions.
+
+## Quickstart
+
+<DetailIconCards>
+
+<a href="/docs/storage/get-started" description="Create a credential, configure your S3 client, and upload your first file." icon="todo">Quickstart</a>
+
+<a href="/docs/storage/buckets" description="Create and manage buckets, set access levels, and understand how buckets branch." icon="database">Buckets</a>
+
+<a href="/docs/storage/objects" description="Upload, download, list, delete, and generate presigned URLs for objects." icon="data">Objects</a>
+
+<a href="/docs/storage/authentication" description="Understand how Neon credentials map to S3 access keys." icon="lock-landscape">Authentication</a>
+
+</DetailIconCards>
+
+<NeedHelp/>

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -4,17 +4,17 @@ subtitle: S3-compatible object storage that branches with your database
 summary: >-
   Neon Storage is S3-compatible object storage built into the Neon backend.
   Every branch gets its own isolated storage namespace. Use any AWS S3 SDK
-  or tool — point it at your branch endpoint and authenticate with your Neon
+  or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-08T19:26:22.039Z'
+updatedOn: '2026-06-08T19:36:47.586Z'
 ---
 
 <Admonition type="note" title="Private Preview">
 Neon Storage is currently in Private Preview, available for new projects in the AWS us-east-2 region only. To request access, sign up at [We're building backends](https://neon.com/blog/were-building-backends).
 </Admonition>
 
-Neon Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool — point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
+Neon Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
 
 - **Branches with your database.** Each branch has its own view of storage. Test file uploads and deletions in preview branches without touching production data.
 - **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, and any other S3-compatible tool works out of the box.

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:35:48.581Z'
+updatedOn: '2026-06-15T14:40:49.535Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -37,6 +37,10 @@ During the private preview, Storage is available for new projects in the AWS us-
 
 ## Starter templates
 
-Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one with `neonctl bootstrap`.
+Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/). The `ai-sdk` template uses Neon Storage — it's an image-generation agent that stores uploaded photos and AI-generated images in branch-scoped buckets, served via presigned URLs from a Neon Function:
+
+```bash
+neonctl bootstrap --template ai-sdk
+```
 
 <NeedHelp/>

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,14 +7,14 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:06.925Z'
+updatedOn: '2026-06-15T15:43:05.726Z'
 ---
 
 <PrivatePreviewEnquire/>
 
 Neon Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
 
-During the private preview, Storage is available for new projects in the AWS us-east-2 region only.
+During the private preview, Storage is available for **new projects** in the **AWS us-east-2** region only.
 
 - **Branches with your database.** Each branch has its own view of storage. Test file uploads and deletions in preview branches without touching production data.
 - **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, and any other S3-compatible tool works out of the box.

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T15:43:05.726Z'
+updatedOn: '2026-06-15T15:46:37.989Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -37,7 +37,7 @@ During the private preview, Storage is available for **new projects** in the **A
 
 ## Starter templates
 
-Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/). The `ai-sdk` template uses Neon Storage — it's an image-generation agent that stores uploaded photos and AI-generated images in branch-scoped buckets, served via presigned URLs from a Neon Function:
+Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/). The `ai-sdk` template uses Neon Storage: an image-generation agent that stores uploaded photos and AI-generated images in branch-scoped buckets, served via presigned URLs from a Neon Function:
 
 ```bash
 neonctl bootstrap --template ai-sdk

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:32:45.581Z'
+updatedOn: '2026-06-15T14:35:48.581Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -37,22 +37,6 @@ During the private preview, Storage is available for new projects in the AWS us-
 
 ## Starter templates
 
-Browse templates at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one directly with `neonctl bootstrap`:
-
-```bash
-neonctl bootstrap
-```
-
-Use `--template` to skip the interactive picker:
-
-| Template        | What it builds                                                                         |
-| --------------- | -------------------------------------------------------------------------------------- |
-| `hono`          | REST API with Drizzle and Postgres on Neon Functions                                   |
-| `ai-sdk`        | Image-generation agent with AI Gateway, Object Storage, and Postgres on Neon Functions |
-| `mastra`        | Personal assistant with AI Gateway and Postgres-backed memory on Neon Functions        |
-| `realtime-chat` | Realtime chat with Next.js, Neon Auth, and WebSockets on Neon Functions                |
-| `realtime-sse`  | Realtime counter with TanStack Router and SSE on Neon Functions                        |
-
-`neonctl bootstrap` scaffolds files, links to a Neon project, and pulls env vars. Then follow the README to set up and deploy.
+Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/), or scaffold one with `neonctl bootstrap`.
 
 <NeedHelp/>

--- a/content/docs/storage/s3-compatibility.md
+++ b/content/docs/storage/s3-compatibility.md
@@ -6,8 +6,10 @@ summary: >-
   for JavaScript, boto3, and the AWS CLI. Not all S3 operations are supported.
   This page lists what works, what returns 501, and known limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-08T22:07:44.844Z'
+updatedOn: '2026-06-15T13:33:22.356Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 Neon Storage is compatible with the S3 API for core operations. It works with the AWS SDK for JavaScript (`@aws-sdk/client-s3`), boto3, the AWS CLI, and other S3-compatible tools. Not all S3 API operations are available.
 

--- a/content/docs/storage/s3-compatibility.md
+++ b/content/docs/storage/s3-compatibility.md
@@ -1,0 +1,109 @@
+---
+title: S3 compatibility
+subtitle: Which S3 operations Neon Storage supports
+summary: >-
+  Neon Storage implements core S3 operations. It is compatible with the AWS SDK
+  for JavaScript, boto3, and the AWS CLI. Not all S3 operations are supported.
+  This page lists what works, what returns 501, and known limitations.
+enableTableOfContents: true
+updatedOn: '2026-06-08T22:07:44.844Z'
+---
+
+Neon Storage is compatible with the S3 API for core operations. It works with the AWS SDK for JavaScript (`@aws-sdk/client-s3`), boto3, the AWS CLI, and other S3-compatible tools. Not all S3 API operations are available.
+
+<Admonition type="note">
+Configure your S3 client with `forcePathStyle: true` (JavaScript) or `endpoint_url` (Python/CLI). Neon Storage uses path-style addressing only. See [Get started](/docs/storage/get-started) for setup details.
+</Admonition>
+
+## Supported operations
+
+### Buckets
+
+| Operation                                                                   | Notes                                                            |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `ListBuckets`                                                               | Lists all buckets on the current branch                          |
+| `CreateBucket`                                                              | Creates a bucket on the current branch                           |
+| `HeadBucket`                                                                | Checks if a bucket exists                                        |
+| `DeleteBucket`                                                              | Bucket must be empty first                                       |
+| `ListObjectsV2`                                                             | Supports `prefix`, `delimiter`, `max-keys`, `continuation-token` |
+| `GetBucketLocation`                                                         | Returns the configured region                                    |
+| `GetBucketCors` / `PutBucketCors` / `DeleteBucketCors`                      | CORS configuration                                               |
+| `GetBucketAcl`                                                              | Read-only; returns the stored ACL                                |
+| `GetBucketPolicy`                                                           | Read-only; returns the stored policy                             |
+| `GetBucketTagging` / `PutBucketTagging` / `DeleteBucketTagging`             | Tag management                                                   |
+| `GetBucketVersioning`                                                       | Returns stored config; versioning is not enforced                |
+| `GetBucketLifecycle` / `PutBucketLifecycle` / `DeleteBucketLifecycle`       | Config is stored but rules are not enforced                      |
+| `GetObjectLockConfiguration` / `PutObjectLockConfiguration`                 | Config is stored; enforcement is limited                         |
+| `GetPublicAccessBlock` / `PutPublicAccessBlock` / `DeletePublicAccessBlock` | Supported                                                        |
+
+### Objects
+
+| Operation                                                       | Notes                                                                                          |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `GetObject`                                                     | Supports `Range` header for partial reads                                                      |
+| `HeadObject`                                                    | Returns object metadata                                                                        |
+| `PutObject`                                                     | Supports `Content-Type`, `Content-Disposition`, `Cache-Control`, custom `x-amz-meta-*` headers |
+| `DeleteObject`                                                  | Soft-deletes the object on the current branch                                                  |
+| `DeleteObjects`                                                 | Batch delete up to 1,000 keys per request                                                      |
+| `GetObjectAcl`                                                  | Read-only                                                                                      |
+| `GetObjectTagging` / `PutObjectTagging` / `DeleteObjectTagging` | Tag management                                                                                 |
+| `GetObjectAttributes`                                           | Returns ETag, size, and checksum                                                               |
+
+### Multipart upload
+
+| Operation                 | Notes                                          |
+| ------------------------- | ---------------------------------------------- |
+| `CreateMultipartUpload`   | Initiates a multipart upload                   |
+| `UploadPart`              | Uploads a single part                          |
+| `UploadPartCopy`          | Copies a part from another object              |
+| `CompleteMultipartUpload` | Finalises the upload                           |
+| `AbortMultipartUpload`    | Cancels and cleans up                          |
+| `ListMultipartUploads`    | Lists in-progress uploads                      |
+| `ListParts`               | Lists uploaded parts for an in-progress upload |
+
+### Presigned requests
+
+| Operation                   | Notes                                                             |
+| --------------------------- | ----------------------------------------------------------------- |
+| Presigned GET / PUT         | Supported via `X-Amz-Algorithm=AWS4-HMAC-SHA256` query parameters |
+| Browser form uploads (POST) | Supported                                                         |
+| Presigned URL expiry        | Configurable via `X-Amz-Expires`                                  |
+
+### CORS
+
+| Operation                                              | Notes                     |
+| ------------------------------------------------------ | ------------------------- |
+| `OPTIONS` preflight                                    | Handled automatically     |
+| `GetBucketCors` / `PutBucketCors` / `DeleteBucketCors` | Full CORS rule management |
+
+## Not supported
+
+The following operations return `501 Not Implemented`:
+
+| Operation                                                                  | Category                      |
+| -------------------------------------------------------------------------- | ----------------------------- |
+| `PutBucketAcl`, `PutBucketPolicy`, `PutObjectAcl`                          | ACL/policy writes via S3 wire |
+| `GetBucketNotificationConfiguration`, `PutBucketNotificationConfiguration` | Event notifications           |
+| `GetBucketLogging`, `PutBucketLogging`                                     | Server-side logging           |
+| `GetBucketEncryption`, `PutBucketEncryption`                               | Encryption configuration      |
+| `GetBucketReplication`, `PutBucketReplication`                             | Cross-region replication      |
+| `GetBucketWebsite`, `PutBucketWebsite`                                     | Static website hosting        |
+| `GetBucketAccelerateConfiguration`, `PutBucketAccelerateConfiguration`     | Transfer acceleration         |
+| `SelectObjectContent`                                                      | S3 Select queries             |
+| `RestoreObject`                                                            | Glacier restore               |
+| `GetObjectTorrent`                                                         | BitTorrent                    |
+
+<Admonition type="note">
+To set a bucket's access level (`private` or `public_read`), use the [Neon Console or API](/docs/storage/buckets#access-levels) instead of `PutBucketAcl` or `PutBucketPolicy`.
+</Admonition>
+
+## Known limitations
+
+- **Path-style addressing only.** Virtual-hosted-style requests (`bucket.host/key`) are not supported. Always set `forcePathStyle: true` in the AWS SDK for JavaScript, or use `endpoint_url` in boto3.
+- **SigV4 only.** AWS Signature Version 2 (SigV2) is not supported.
+- **Lifecycle rules stored but not enforced.** `PutBucketLifecycle` accepts and stores configuration, but expiration and transition rules do not run.
+- **Versioning stored but not enforced.** Versioning configuration is stored and echoed. Objects always return `x-amz-version-id: null`.
+- **No bucket notifications.** SNS/SQS integration is not available.
+- **Branches, not regions.** Buckets are scoped to a branch, not an AWS region. `GetBucketLocation` returns the configured region string but bucket selection is always branch-based.
+
+<NeedHelp/>

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-08T22:07:44.844Z'
+updatedOn: '2026-06-10T16:53:44.852Z'
 ---
 
 ## Authentication errors
@@ -50,7 +50,7 @@ If you forget to set the custom endpoint, the SDK will route requests to AWS S3 
 
 ```typescript
 const client = new S3Client({
-  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  endpoint: process.env.NEON_STORAGE_ENDPOINT,
   // ...
 });
 ```

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -1,0 +1,138 @@
+---
+title: Storage troubleshooting
+subtitle: Common errors and how to fix them
+summary: >-
+  Solutions for common errors when using Neon Storage, including authentication
+  failures, access denied errors, SDK configuration issues, and S3
+  compatibility limitations.
+enableTableOfContents: true
+updatedOn: '2026-06-08T22:07:44.844Z'
+---
+
+## Authentication errors
+
+### `403 InvalidAccessKeyId`
+
+The Access Key ID is wrong, missing, or the credential has been revoked.
+
+**Fix:** Check that `NEON_STORAGE_ACCESS_KEY_ID` is set to the full `token_id` UUID from the credential response (e.g. `550e8400-e29b-41d4-a716-446655440000`). This is not the same as the `token_id_short`. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for the correct field mapping.
+
+### `403 SignatureDoesNotMatch`
+
+The Secret Access Key is wrong.
+
+**Fix:** Check that `NEON_STORAGE_SECRET_ACCESS_KEY` is set to the `s3_secret_access_key` field from the credential response. This is the 64-character hex string, not the `api_token`. Both are returned only once at creation — if you no longer have the `s3_secret_access_key`, revoke the credential and create a new one.
+
+### `403 AccessDenied` — missing scope
+
+The credential does not have the required scope for the operation.
+
+**Fix:** Check which scopes the credential was created with:
+
+- `storage:read` allows GetObject, HeadObject, ListBuckets, and ListObjectsV2
+- `storage:write` allows all reads plus PutObject, DeleteObject, CreateBucket, and DeleteBucket
+
+To add write access, create a new credential with `storage:write`. Scopes cannot be added to an existing credential.
+
+### `403 AccessDenied` — wrong branch
+
+The credential was issued on a branch that is not an ancestor of the branch you are making requests against.
+
+**Fix:** Use a credential issued on the target branch or one of its ancestor branches. See [Authentication](/docs/storage/authentication#how-branch-binding-works) for how branch binding works.
+
+## SDK configuration errors
+
+### Requests go to AWS instead of Neon
+
+If you forget to set the custom endpoint, the SDK will route requests to AWS S3 and fail with a credentials error or bucket-not-found.
+
+**Fix:** Always set the `endpoint` (JavaScript) or `endpoint_url` (Python/CLI) to your branch storage host:
+
+```typescript
+const client = new S3Client({
+  endpoint: `https://${process.env.NEON_STORAGE_HOST}`,
+  // ...
+});
+```
+
+### `NoSuchBucket` on every request
+
+The bucket name is being treated as a subdomain instead of a path segment. This happens when `forcePathStyle` is not set.
+
+**Fix:** Add `forcePathStyle: true` to your `S3Client` configuration:
+
+```typescript
+const client = new S3Client({
+  forcePathStyle: true, // required for Neon Storage
+  // ...
+});
+```
+
+Without this, the AWS SDK for JavaScript uses virtual-hosted-style addressing (`my-bucket.storage.example.com/key`) which Neon Storage does not support.
+
+### SigV2 errors
+
+If you see signature-related errors mentioning `AWS2` or `AWSAccessKeyId`, your client is using the older AWS Signature Version 2.
+
+**Fix:** Use AWS Signature Version 4 (SigV4). The AWS SDK v3 for JavaScript and boto3 use SigV4 by default. If you are using an older SDK or a custom HTTP client, update it or configure it to use SigV4 explicitly.
+
+## Access level errors
+
+### Anonymous GET returns `403 AccessDenied`
+
+The bucket's access level is `private` (the default), which requires authentication for all reads.
+
+**Fix:** If the bucket should allow public reads, set its access level to `public_read` using the Neon Console or API. See [Access levels](/docs/storage/buckets#access-levels). Note: you cannot change access level via the S3 API (`PutBucketAcl` returns `501`).
+
+## S3 operation errors
+
+### `501 Not Implemented`
+
+You are calling an S3 operation that Neon Storage does not support.
+
+**Common causes:**
+
+- `PutBucketAcl` or `PutBucketPolicy` — use the Neon Console or API to set bucket access level instead
+- `PutBucketNotificationConfiguration` — event notifications are not supported
+- `PutBucketLogging` — server-side access logging is not supported
+
+See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the full list of unsupported operations.
+
+### Lifecycle rules not running
+
+`PutBucketLifecycle` succeeds and the configuration is stored, but expiration and transition rules do not execute.
+
+**Status:** Lifecycle enforcement is not available in Private Preview. The API accepts and echoes the configuration so tools that read lifecycle rules will work, but the rules have no effect.
+
+## Connection and performance errors
+
+### `503 Service Unavailable`
+
+The request exceeded the per-IP or per-tenant rate limit.
+
+**Fix:** Reduce request frequency or add retry logic with exponential backoff. The response may include a `Retry-After` header indicating how long to wait.
+
+### Large downloads timing out mid-stream
+
+The connection drops during a large object download.
+
+**Fix:** Use range requests to download large objects in chunks:
+
+```typescript
+// Download in 10 MiB chunks
+const chunkSize = 10 * 1024 * 1024;
+let start = 0;
+
+while (true) {
+  const response = await client.send(new GetObjectCommand({
+    Bucket: 'my-bucket',
+    Key: 'large-file.zip',
+    Range: `bytes=${start}-${start + chunkSize - 1}`,
+  }));
+  // process response.Body
+  if (response.ContentRange?.endsWith(response.ContentLength?.toString() ?? '')) break;
+  start += chunkSize;
+}
+```
+
+<NeedHelp/>

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,8 +6,10 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:42:07.067Z'
+updatedOn: '2026-06-15T13:33:22.356Z'
 ---
+
+<PrivatePreviewEnquire/>
 
 ## Authentication errors
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:24:23.574Z'
+updatedOn: '2026-06-11T14:33:47.211Z'
 ---
 
 ## Authentication errors
@@ -82,7 +82,11 @@ If you see signature-related errors mentioning `AWS2` or `AWSAccessKeyId`, your 
 
 The bucket's access level is `private` (the default), which requires authentication for all reads.
 
-**Fix:** If the bucket should allow public reads, set its access level to `public_read` using the Neon Console or API. See [Access levels](/docs/storage/buckets#access-levels). Note: you cannot change access level via the S3 API (`PutBucketAcl` returns `501`).
+**Fix:** If the bucket should allow public reads, set its access level to `public_read` using the Neon Console or API. See [Access levels](/docs/storage/buckets#access-levels).
+
+<Admonition type="note">
+You cannot change access level via the S3 API. `PutBucketAcl` returns `501 Not Implemented`.
+</Admonition>
 
 ## S3 operation errors
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-10T16:53:44.852Z'
+updatedOn: '2026-06-11T14:24:23.574Z'
 ---
 
 ## Authentication errors
@@ -21,9 +21,9 @@ The Access Key ID is wrong, missing, or the credential has been revoked.
 
 The Secret Access Key is wrong.
 
-**Fix:** Check that `NEON_STORAGE_SECRET_ACCESS_KEY` is set to the `s3_secret_access_key` field from the credential response. This is the 64-character hex string, not the `api_token`. Both are returned only once at creation — if you no longer have the `s3_secret_access_key`, revoke the credential and create a new one.
+**Fix:** Check that `NEON_STORAGE_SECRET_ACCESS_KEY` is set to the `s3_secret_access_key` field from the credential response. This is the 64-character hex string, not the `api_token`. Both are returned only once at creation. If you no longer have the `s3_secret_access_key`, revoke the credential and create a new one.
 
-### `403 AccessDenied` — missing scope
+### `403 AccessDenied`: missing scope
 
 The credential does not have the required scope for the operation.
 
@@ -34,7 +34,7 @@ The credential does not have the required scope for the operation.
 
 To add write access, create a new credential with `storage:write`. Scopes cannot be added to an existing credential.
 
-### `403 AccessDenied` — wrong branch
+### `403 AccessDenied`: wrong branch
 
 The credential was issued on a branch that is not an ancestor of the branch you are making requests against.
 
@@ -92,9 +92,9 @@ You are calling an S3 operation that Neon Storage does not support.
 
 **Common causes:**
 
-- `PutBucketAcl` or `PutBucketPolicy` — use the Neon Console or API to set bucket access level instead
-- `PutBucketNotificationConfiguration` — event notifications are not supported
-- `PutBucketLogging` — server-side access logging is not supported
+- `PutBucketAcl` or `PutBucketPolicy`: use the Neon Console or API to set bucket access level instead
+- `PutBucketNotificationConfiguration`: event notifications are not supported
+- `PutBucketLogging`: server-side access logging is not supported
 
 See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the full list of unsupported operations.
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-11T14:33:47.211Z'
+updatedOn: '2026-06-11T14:42:07.067Z'
 ---
 
 ## Authentication errors
@@ -32,7 +32,7 @@ The credential does not have the required scope for the operation.
 - `storage:read` allows GetObject, HeadObject, ListBuckets, and ListObjectsV2
 - `storage:write` allows all reads plus PutObject, DeleteObject, CreateBucket, and DeleteBucket
 
-To add write access, create a new credential with `storage:write`. Scopes cannot be added to an existing credential.
+To add write access, create a new credential with `storage:write`. You can't add scopes to an existing credential.
 
 ### `403 AccessDenied`: wrong branch
 
@@ -57,7 +57,7 @@ const client = new S3Client({
 
 ### `NoSuchBucket` on every request
 
-The bucket name is being treated as a subdomain instead of a path segment. This happens when `forcePathStyle` is not set.
+Without `forcePathStyle: true`, the SDK treats the bucket name as a subdomain instead of a path segment.
 
 **Fix:** Add `forcePathStyle: true` to your `S3Client` configuration:
 
@@ -68,13 +68,13 @@ const client = new S3Client({
 });
 ```
 
-Without this, the AWS SDK for JavaScript uses virtual-hosted-style addressing (`my-bucket.storage.example.com/key`) which Neon Storage does not support.
+Without this, the AWS SDK for JavaScript uses virtual-hosted-style addressing (`my-bucket.storage.example.com/key`) which Neon Storage doesn't support.
 
 ### SigV2 errors
 
 If you see signature-related errors mentioning `AWS2` or `AWSAccessKeyId`, your client is using the older AWS Signature Version 2.
 
-**Fix:** Use AWS Signature Version 4 (SigV4). The AWS SDK v3 for JavaScript and boto3 use SigV4 by default. If you are using an older SDK or a custom HTTP client, update it or configure it to use SigV4 explicitly.
+**Fix:** Use AWS Signature Version 4 (SigV4). The AWS SDK v3 for JavaScript and boto3 use SigV4 by default. If you're using an older SDK or a custom HTTP client, update it or configure it to use SigV4 explicitly.
 
 ## Access level errors
 
@@ -106,7 +106,7 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 
 `PutBucketLifecycle` succeeds and the configuration is stored, but expiration and transition rules do not execute.
 
-**Status:** Lifecycle enforcement is not available in Private Preview. The API accepts and echoes the configuration so tools that read lifecycle rules will work, but the rules have no effect.
+**Status:** Lifecycle enforcement isn't available in Private Preview. The API accepts and echoes the configuration so tools that read lifecycle rules will work, but the rules have no effect.
 
 ## Connection and performance errors
 


### PR DESCRIPTION
## Summary

- Adds documentation for three new private preview services: Neon Functions, Neon Storage, and Neon AI Gateway
- Updates the introduction page to show all three as active "Private Beta" cards with real doc links
- Adds `<PrivatePreviewEnquire/>` to all sub-pages across all three services
- Includes starter templates section on each overview page linking to [build-on-neon.vercel.app](https://build-on-neon.vercel.app/) with `neonctl bootstrap`
- Adds navigation entries for Functions, Storage, and AI Gateway

## Test plan

- [ ] Check intro page cards render as active (green) with "Private Beta" badge
- [ ] Verify `<PrivatePreviewEnquire/>` admonition appears on all sub-pages
- [ ] Confirm navigation sidebar shows all three service sections
- [ ] Test `neonctl bootstrap` template commands in starter templates sections
- [ ] Review Vercel preview for Functions, Storage, and AI Gateway overview pages

This pull request and its description were written by Isaac.