### PR TITLE
backend request on docs home

### DIFF
--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -1,15 +1,15 @@
 ---
 title: Neon AI Gateway
-subtitle: LLM inference built into your Neon branch
+subtitle: One API for all frontier & open-source models. At-cost rates.
 summary: >-
   Neon AI Gateway is the LLM inference layer built into the Neon backend. One
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T17:21:55.421Z'
+updatedOn: '2026-06-15T17:25:12.087Z'
 ---
 
-<RequestForm type="backend-platform" />
+<RequestForm type="backend-platform" title="Get early access to Neon AI Gateway" description="Neon AI Gateway is in private preview. Drop your email and we'll reach out with access." />
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,10 +6,10 @@ summary: >-
   Neon credential gives you access to 39 models across 7 providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T15:47:52.073Z'
+updatedOn: '2026-06-15T17:21:55.421Z'
 ---
 
-<PrivatePreviewEnquire/>
+<RequestForm type="backend-platform" />
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,10 +7,10 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-15T15:43:05.726Z'
+updatedOn: '2026-06-15T17:21:55.421Z'
 ---
 
-<PrivatePreviewEnquire/>
+<RequestForm type="backend-platform" />
 
 Neon Functions give you long-running Node.js compute in the same AWS region as your database. Each function deploys to a Neon branch and gets a public HTTPS URL. If the branch has a Postgres database, `DATABASE_URL` is injected automatically. No configuration needed, no cross-region round trips.
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -7,10 +7,10 @@ summary: >-
   Use them for AI agents, WebSocket servers, and webhook handlers that need
   compute next to their data.
 enableTableOfContents: true
-updatedOn: '2026-06-15T17:21:55.421Z'
+updatedOn: '2026-06-15T17:25:12.087Z'
 ---
 
-<RequestForm type="backend-platform" />
+<RequestForm type="backend-platform" title="Get early access to Neon Functions" description="Neon Functions are in private preview. Drop your email and we'll reach out with access." />
 
 Neon Functions give you long-running Node.js compute in the same AWS region as your database. Each function deploys to a Neon branch and gets a public HTTPS URL. If the branch has a Postgres database, `DATABASE_URL` is injected automatically. No configuration needed, no cross-region round trips.
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T17:16:55.141Z'
+updatedOn: '2026-06-15T17:18:06.665Z'
 ---
 
 <TwinPaths>
@@ -29,7 +29,7 @@ updatedOn: '2026-06-15T17:16:55.141Z'
   />
 </TwinPaths>
 
-## Your Neon backend
+## Neon Backend Primitives
 
 Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless.
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T17:18:06.665Z'
+updatedOn: '2026-06-15T17:50:24.620Z'
 ---
 
 <TwinPaths>
@@ -29,7 +29,7 @@ updatedOn: '2026-06-15T17:18:06.665Z'
   />
 </TwinPaths>
 
-## Neon Backend Primitives
+## Products
 
 Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless.
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T17:12:16.796Z'
+updatedOn: '2026-06-15T17:16:55.141Z'
 ---
 
 <TwinPaths>
@@ -29,10 +29,7 @@ updatedOn: '2026-06-15T17:12:16.796Z'
   />
 </TwinPaths>
 
-<div className="mt-12 mb-3.5 flex items-baseline justify-between gap-4">
-  <h2 className="m-0!">Your Neon backend</h2>
-  <a href="https://neon.com/blog/were-building-backends#access" className="text-sm font-medium text-[#00CC88] hover:underline dark:text-[#00E599]">Get early access →</a>
-</div>
+## Your Neon backend
 
 Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless.
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-06-15T15:38:36.952Z'
+updatedOn: '2026-06-15T17:12:16.796Z'
 ---
 
 <TwinPaths>
@@ -51,6 +51,8 @@ Build backends for web apps and agents with Neon Postgres, Auth, Storage, and AI
 <a href="/docs/ai-gateway/overview" description="LLM gateway for AI workloads, integrated with Neon Auth." icon="sparkle" tag="Private Preview">AI Gateway</a>
 
 </DetailIconCards>
+
+<RequestForm type="backend-platform" />
 
 ## Connect your framework
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,10 +7,10 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T15:46:37.989Z'
+updatedOn: '2026-06-15T17:21:55.421Z'
 ---
 
-<PrivatePreviewEnquire/>
+<RequestForm type="backend-platform" />
 
 Neon Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,10 +7,10 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T17:21:55.421Z'
+updatedOn: '2026-06-15T17:25:12.087Z'
 ---
 
-<RequestForm type="backend-platform" />
+<RequestForm type="backend-platform" title="Get early access to Neon Storage" description="Neon Storage is in private preview. Drop your email and we'll reach out with access." />
 
 Neon Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
 

--- a/next.config.js
+++ b/next.config.js
@@ -184,6 +184,11 @@ const defaultConfig = {
 
     return [
       {
+        source: '/backend',
+        destination: '/docs/introduction#products',
+        permanent: false,
+      },
+      {
         source: '/cookie-policy',
         destination: 'https://www.databricks.com/legal/cookienotice',
         permanent: true,

--- a/src/components/shared/request-form/request-form.jsx
+++ b/src/components/shared/request-form/request-form.jsx
@@ -21,9 +21,29 @@ import sendGtagEvent from 'utils/send-gtag-event';
 
 import DATA from './data';
 
-const RequestForm = ({ type }) => {
-  const { title, description, placeholder, buttonText, confirmation, options, extendedOptions } =
-    DATA[type];
+const RequestForm = ({
+  type,
+  title: titleOverride,
+  description: descriptionOverride,
+  buttonText: buttonTextOverride,
+  confirmation: confirmationOverride,
+}) => {
+  const {
+    title: defaultTitle,
+    description: defaultDescription,
+    placeholder,
+    buttonText: defaultButtonText,
+    confirmation: defaultConfirmation,
+    options,
+    extendedOptions,
+  } = DATA[type];
+
+  // Allow pages to override the display copy while keeping the type-based analytics.
+  const title = titleOverride || defaultTitle;
+  const description = descriptionOverride || defaultDescription;
+  const buttonText = buttonTextOverride || defaultButtonText;
+  const confirmation = confirmationOverride || defaultConfirmation;
+
   const hasOptions = Array.isArray(options) && options.length > 0;
 
   const isRecognized = false;
@@ -220,6 +240,10 @@ const RequestForm = ({ type }) => {
 
 RequestForm.propTypes = {
   type: PropTypes.oneOf(Object.keys(DATA)).isRequired,
+  title: PropTypes.string,
+  description: PropTypes.string,
+  buttonText: PropTypes.string,
+  confirmation: PropTypes.string,
 };
 
 export default RequestForm;


### PR DESCRIPTION
## Summary

Adds the backend platform early-access request form to the docs home page. The "Your Neon backend" section already lists the platform services (Storage, Functions, and AI Gateway are in Private Preview) with a "Get early access" link out to the blog. This puts the `RequestForm type="backend-platform"` form inline right below those cards, so readers can request access without leaving the docs home.

It's the same form already used on the [roadmap](/docs/introduction/roadmap) page.

## Pages changed

- content/docs/introduction.md