### PR TITLE
docs: fix AI Gateway env var name and model IDs

### DIFF
--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway by changing only the base URL. Supports streaming, prompt caching,
   and extended thinking on Claude models.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:47.636Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -21,11 +21,11 @@ The Anthropic SDK appends `/v1/messages` to the base URL automatically. Set the 
 
 ## Supported models
 
-This endpoint accepts Anthropic models only. Use the `databricks-` prefixed model IDs from the [AI Gateway catalog](/docs/ai-gateway/models):
+This endpoint accepts Anthropic models only. See the [AI Gateway catalog](/docs/ai-gateway/models) for the full list. Supported models:
 
-- `databricks-claude-opus-4-8`, `databricks-claude-opus-4-7`, `databricks-claude-opus-4-6`, `databricks-claude-opus-4-5`
-- `databricks-claude-sonnet-4-6`
-- `databricks-claude-haiku-4-5`
+- `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5`
+- `claude-sonnet-4-6`
+- `claude-haiku-4-5`
 
 Sending a non-Anthropic model ID returns `400 model is not available on this endpoint`. Use the [chat completions endpoint](/docs/ai-gateway/chat-completions) if you need to call multiple providers from the same code.
 
@@ -37,12 +37,12 @@ Sending a non-Anthropic model ID returns `400 model is not available on this end
 import Anthropic from '@anthropic-ai/sdk';
 
 const client = new Anthropic({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
   baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/anthropic`,
 });
 
 const message = await client.messages.create({
-  model: 'databricks-claude-sonnet-4-6',
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   messages: [{ role: 'user', content: 'What is Neon?' }],
 });
@@ -55,12 +55,12 @@ import anthropic
 import os
 
 client = anthropic.Anthropic(
-    api_key=os.environ['NEON_AI_GATEWAY_KEY'],
+    api_key=os.environ['NEON_AI_GATEWAY_TOKEN'],
     base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/anthropic",
 )
 
 message = client.messages.create(
-    model='databricks-claude-sonnet-4-6',
+    model='claude-sonnet-4-6',
     max_tokens=1024,
     messages=[{'role': 'user', 'content': 'What is Neon?'}],
 )
@@ -70,11 +70,11 @@ print(message.content[0].text)
 
 ```bash shouldWrap
 curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/anthropic/v1/messages" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -H "anthropic-version: 2023-06-01" \
   -d '{
-    "model": "databricks-claude-sonnet-4-6",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 1024,
     "messages": [{"role": "user", "content": "What is Neon?"}]
   }'
@@ -94,7 +94,7 @@ The gateway forwards the `cache_control` field to Anthropic unchanged. Prompt ca
 
 ```typescript shouldWrap
 const message = await client.messages.create({
-  model: 'databricks-claude-sonnet-4-6',
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   system: [
     { type: 'text', text: 'You are a helpful assistant.' },
@@ -114,7 +114,7 @@ console.log(message.usage);
 
 ```python shouldWrap
 message = client.messages.create(
-    model='databricks-claude-sonnet-4-6',
+    model='claude-sonnet-4-6',
     max_tokens=1024,
     system=[
         {'type': 'text', 'text': 'You are a helpful assistant.'},
@@ -142,7 +142,7 @@ The gateway forwards the `thinking` parameter to Anthropic unchanged. Set `budge
 
 ```typescript shouldWrap
 const message = await client.messages.create({
-  model: 'databricks-claude-sonnet-4-6',
+  model: 'claude-sonnet-4-6',
   max_tokens: 16000,
   thinking: {
     type: 'enabled',
@@ -162,7 +162,7 @@ for (const block of message.content) {
 
 ```python shouldWrap
 message = client.messages.create(
-    model='databricks-claude-sonnet-4-6',
+    model='claude-sonnet-4-6',
     max_tokens=16000,
     thinking={
         'type': 'enabled',
@@ -185,7 +185,7 @@ for block in message.content:
 The gateway forwards these request headers to the upstream provider:
 `Accept`, `Anthropic-Beta`, `Anthropic-Version`, `Content-Type`, `User-Agent`.
 
-All other headers are stripped. The `Authorization` header is replaced with the workspace credential before forwarding. Your `NEON_AI_GATEWAY_KEY` is never sent to Anthropic directly.
+All other headers are stripped. The `Authorization` header is replaced with the workspace credential before forwarding. Your `NEON_AI_GATEWAY_TOKEN` is never sent to Anthropic directly.
 
 ## Error handling
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:47.636Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -23,7 +23,7 @@ A credential must include the `ai_gateway:invoke` scope.
 
 In the Neon Console, select your branch and click **Credentials** under **APP BACKEND** in the sidebar. Click **Create credential**, give it a name, and check **ai_gateway:invoke**.
 
-After creation, the credentials are shown once. Copy the snippet or click **Download .env** before closing. The snippet includes `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_TOKEN`, and `NEON_AI_GATEWAY_BASE_URL`. `OPENAI_API_KEY` and `OPENAI_BASE_URL` let standard OpenAI SDK calls work without any configuration changes. The `NEON_AI_GATEWAY_*` aliases are useful when you need credentials that survive a user overriding the `OPENAI_*` variables.
+After creation, the credential is shown once. Copy the snippet or click **Download .env** before closing. The snippet includes all four gateway env vars (see [Environment variables](#environment-variables) below).
 
 To view or revoke credentials later, return to the **Credentials** page and use the action menu (⋮) next to the credential.
 
@@ -95,18 +95,52 @@ client = OpenAI(
 
 </CodeTabs>
 
+## Environment variables
+
+Neon provides four gateway env vars. Two follow OpenAI's standard naming so existing SDKs pick them up automatically. Two use `NEON_`-prefixed names that survive a user overriding the `OPENAI_*` variables with their own provider keys.
+
+| Variable                   | Value                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `OPENAI_API_KEY`           | Bearer token (`nt_live_...`)                                                                            |
+| `OPENAI_BASE_URL`          | Full OpenAI Responses dialect URL: `https://<branch-host>/ai-gateway/openai/v1` — **includes the path** |
+| `NEON_AI_GATEWAY_TOKEN`    | Same bearer token as `OPENAI_API_KEY`                                                                   |
+| `NEON_AI_GATEWAY_BASE_URL` | Bare branch host: `https://<branch-host>` — **no path**; append `/ai-gateway/<dialect>/v1` yourself     |
+
+`OPENAI_BASE_URL` and `NEON_AI_GATEWAY_BASE_URL` point at different URLs. `OPENAI_BASE_URL` already includes `/ai-gateway/openai/v1`, so `new OpenAI()` picks it up with zero config and calls the Responses API. `NEON_AI_GATEWAY_BASE_URL` is the bare host — append the dialect path yourself:
+
+```
+NEON_AI_GATEWAY_BASE_URL + /ai-gateway/mlflow/v1   → chat completions (all providers)
+NEON_AI_GATEWAY_BASE_URL + /ai-gateway/openai/v1   → OpenAI Responses API (= OPENAI_BASE_URL)
+NEON_AI_GATEWAY_BASE_URL + /ai-gateway/anthropic   → Anthropic Messages API
+NEON_AI_GATEWAY_BASE_URL + /ai-gateway/gemini      → Gemini generateContent API
+```
+
 ## Credentials in Neon Functions
 
-When your code runs inside Neon Functions, Neon injects the following environment variables automatically. No credential creation step required:
+When your code runs inside Neon Functions, all four env vars are injected automatically. No credential creation step required:
 
 | Variable                   | Value                                                   |
 | -------------------------- | ------------------------------------------------------- |
 | `NEON_AI_GATEWAY_TOKEN`    | Bearer token for the AI Gateway                         |
 | `NEON_AI_GATEWAY_BASE_URL` | Branch gateway host with `https://` prefix, no path     |
 | `OPENAI_API_KEY`           | Same value as `NEON_AI_GATEWAY_TOKEN`                   |
-| `OPENAI_BASE_URL`          | Branch gateway host including the chat completions path |
+| `OPENAI_BASE_URL`          | Branch gateway host including the OpenAI Responses path |
 
-`OPENAI_BASE_URL` and `OPENAI_API_KEY` let standard OpenAI SDK calls work with zero configuration. The `NEON_AI_GATEWAY_*` aliases are useful when you want credentials that survive a user overriding the `OPENAI_*` variables with their own keys:
+`new OpenAI()` works with zero configuration because `OPENAI_API_KEY` and `OPENAI_BASE_URL` are already set:
+
+```typescript
+import OpenAI from 'openai';
+
+// Reads OPENAI_API_KEY + OPENAI_BASE_URL from the environment automatically.
+const client = new OpenAI();
+
+const response = await client.responses.create({
+  model: 'gpt-5-mini',
+  input: 'What is Neon?',
+});
+```
+
+For the chat completions endpoint or when you need credentials that survive a user overriding `OPENAI_*` with their own keys, use the `NEON_AI_GATEWAY_*` vars:
 
 ```typescript
 import OpenAI from 'openai';

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,12 +6,12 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:47.636Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
 
-The chat completions endpoint is the recommended way to use Neon AI Gateway. It's fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models): Anthropic, OpenAI, Google, and Alibaba. Switch models by changing a single field.
+The chat completions endpoint is the recommended way to use Neon AI Gateway. It's fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) and works with every model in the [AI Gateway catalog](/docs/ai-gateway/models). Switch models by changing a single field.
 
 **Base URL:** `https://<branch-host>/ai-gateway/mlflow/v1`
 
@@ -20,7 +20,7 @@ The chat completions endpoint is the recommended way to use Neon AI Gateway. It'
 Set these environment variables. See [Get started](/docs/ai-gateway/get-started) for how to obtain them.
 
 ```bash
-NEON_AI_GATEWAY_KEY=nt_live_...
+NEON_AI_GATEWAY_TOKEN=nt_live_...
 NEON_AI_GATEWAY_BASE_URL=https://br-winter-pond-aptw82ef-api.c2.us-east-2.aws.neon.tech
 ```
 
@@ -32,12 +32,12 @@ NEON_AI_GATEWAY_BASE_URL=https://br-winter-pond-aptw82ef-api.c2.us-east-2.aws.ne
 import OpenAI from 'openai';
 
 const client = new OpenAI({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
   baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const response = await client.chat.completions.create({
-  model: 'databricks-claude-sonnet-4-6',
+  model: 'claude-sonnet-4-6',
   messages: [
     { role: 'system', content: 'You are a helpful assistant.' },
     { role: 'user', content: 'What is Neon?' },
@@ -53,12 +53,12 @@ from openai import OpenAI
 import os
 
 client = OpenAI(
-    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
     base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 response = client.chat.completions.create(
-    model="databricks-claude-sonnet-4-6",
+    model="claude-sonnet-4-6",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "What is Neon?"},
@@ -71,10 +71,10 @@ print(response.choices[0].message.content)
 
 ```bash shouldWrap
 curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "databricks-claude-sonnet-4-6",
+    "model": "claude-sonnet-4-6",
     "messages": [
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "What is Neon?"}
@@ -95,12 +95,12 @@ Add `stream: true` to receive a server-sent events response.
 import OpenAI from 'openai';
 
 const client = new OpenAI({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
   baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const stream = await client.chat.completions.create({
-  model: 'databricks-claude-sonnet-4-6',
+  model: 'claude-sonnet-4-6',
   messages: [{ role: 'user', content: 'Explain branching in Postgres.' }],
   stream: true,
 });
@@ -115,12 +115,12 @@ from openai import OpenAI
 import os
 
 client = OpenAI(
-    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
     base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 with client.chat.completions.create(
-    model="databricks-claude-sonnet-4-6",
+    model="claude-sonnet-4-6",
     messages=[{"role": "user", "content": "Explain branching in Postgres."}],
     stream=True,
 ) as stream:
@@ -130,10 +130,10 @@ with client.chat.completions.create(
 
 ```bash shouldWrap
 curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "databricks-claude-sonnet-4-6",
+    "model": "claude-sonnet-4-6",
     "messages": [{"role": "user", "content": "Explain branching in Postgres."}],
     "stream": true
   }'
@@ -147,13 +147,13 @@ Change the `model` field to use a different provider. Everything else stays the 
 
 ```typescript
 // Anthropic
-model: 'databricks-claude-sonnet-4-6'
+model: 'claude-sonnet-4-6'
 
 // OpenAI
-model: 'databricks-gpt-5-4'
+model: 'gpt-5-4'
 
 // Google
-model: 'databricks-gemini-2-5-flash'
+model: 'gemini-2-5-flash'
 
 // Alibaba
 model: 'databricks-qwen35-122b-a10b'
@@ -182,7 +182,7 @@ When the upstream provider rate-limits a request, AI Gateway forwards the releva
 | ------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `400 Bad Request`              | Invalid request        | Unknown model ID, or model used on the wrong endpoint                                                                                        |
 | `413 Request Entity Too Large` | Body too large         | Request body exceeds 32 MiB. Reduce the size of your request.                                                                                |
-| `401 Unauthorized`             | Authentication failed  | Missing or invalid `NEON_AI_GATEWAY_KEY`                                                                                                     |
+| `401 Unauthorized`             | Authentication failed  | Missing or invalid `NEON_AI_GATEWAY_TOKEN`                                                                                                   |
 | `403 Forbidden`                | Access denied          | Credential lacks `ai_gateway:invoke` scope, or branch not in credential lineage                                                              |
 | `429 Too Many Requests`        | Account quota exceeded | Your account's AI Gateway quota is blocked. Error code: `REQUEST_LIMIT_EXCEEDED`. Check `Retry-After` for when to retry, or contact support. |
 | `429 Too Many Requests`        | Upstream rate limited  | Upstream provider rate limit. Check the `Retry-After` and `X-Ratelimit-*` headers.                                                           |

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -6,7 +6,7 @@ summary: >-
   streamGenerateContent APIs through Neon AI Gateway. Use the google-genai SDK
   with a custom base URL.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:47.636Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -25,15 +25,15 @@ Only `generateContent` and `streamGenerateContent` are supported. Requests to ot
 
 This endpoint accepts Google models only:
 
-| Model ID                           | Notes |
-| ---------------------------------- | ----- |
-| `databricks-gemini-3-5-flash`      |       |
-| `databricks-gemini-3-1-pro`        |       |
-| `databricks-gemini-3-1-flash-lite` |       |
-| `databricks-gemini-3-pro`          |       |
-| `databricks-gemini-3-flash`        |       |
-| `databricks-gemini-2-5-pro`        |       |
-| `databricks-gemini-2-5-flash`      |       |
+| Model ID                | Notes |
+| ----------------------- | ----- |
+| `gemini-3-5-flash`      |       |
+| `gemini-3-1-pro`        |       |
+| `gemini-3-1-flash-lite` |       |
+| `gemini-3-pro`          |       |
+| `gemini-3-flash`        |       |
+| `gemini-2-5-pro`        |       |
+| `gemini-2-5-flash`      |       |
 
 Sending a non-Google model ID returns `400 model is not available on this endpoint`. Use the [chat completions endpoint](/docs/ai-gateway/chat-completions) if you want to call Gemini models alongside other providers from the same code.
 
@@ -45,14 +45,14 @@ Sending a non-Google model ID returns `400 model is not available on this endpoi
 import { GoogleGenAI } from '@google/genai';
 
 const client = new GoogleGenAI({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
   httpOptions: {
     baseUrl: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini`,
   },
 });
 
 const response = await client.models.generateContent({
-  model: 'databricks-gemini-2-5-flash',
+  model: 'gemini-2-5-flash',
   contents: [{ role: 'user', parts: [{ text: 'What is Neon?' }] }],
 });
 
@@ -65,14 +65,14 @@ from google.genai import types
 import os
 
 client = genai.Client(
-    api_key=os.environ['NEON_AI_GATEWAY_KEY'],
+    api_key=os.environ['NEON_AI_GATEWAY_TOKEN'],
     http_options=types.HttpOptions(
         base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/gemini",
     ),
 )
 
 response = client.models.generate_content(
-    model='databricks-gemini-2-5-flash',
+    model='gemini-2-5-flash',
     contents='What is Neon?',
 )
 
@@ -81,8 +81,8 @@ print(response.text)
 
 ```bash shouldWrap
 curl -X POST \
-  "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:generateContent" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/gemini/v1beta/models/gemini-2-5-flash:generateContent" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "contents": [{"role": "user", "parts": [{"text": "What is Neon?"}]}]
@@ -97,7 +97,7 @@ curl -X POST \
 
 ```typescript shouldWrap
 const stream = await client.models.generateContentStream({
-  model: 'databricks-gemini-2-5-flash',
+  model: 'gemini-2-5-flash',
   contents: [{ role: 'user', parts: [{ text: 'Explain database branching.' }] }],
 });
 
@@ -108,7 +108,7 @@ for await (const chunk of stream) {
 
 ```python shouldWrap
 for chunk in client.models.generate_content_stream(
-    model='databricks-gemini-2-5-flash',
+    model='gemini-2-5-flash',
     contents='Explain database branching.',
 ):
     print(chunk.text, end='', flush=True)
@@ -122,11 +122,11 @@ The gateway uses the model ID and action directly in the URL path. The `google-g
 
 ```
 base_url: https://<branch-host>/ai-gateway/gemini
-model:    databricks-gemini-2-5-flash
+model:    gemini-2-5-flash
 action:   generateContent or streamGenerateContent
 
-→ https://<branch-host>/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:generateContent
-→ https://<branch-host>/ai-gateway/gemini/v1beta/models/databricks-gemini-2-5-flash:streamGenerateContent
+→ https://<branch-host>/ai-gateway/gemini/v1beta/models/gemini-2-5-flash:generateContent
+→ https://<branch-host>/ai-gateway/gemini/v1beta/models/gemini-2-5-flash:streamGenerateContent
 ```
 
 When calling the REST API directly, the model ID and action must appear in the path as shown above.

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:47.636Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -19,7 +19,9 @@ You need a new project in the AWS us-east-2 region, and foundation model access 
 
 ## Create a credential
 
-Use the Neon API to create a credential with the `ai_gateway:invoke` scope:
+In the Neon Console, select your branch, click **Credentials** under **APP BACKEND**, then click **Create credential** and check **ai_gateway:invoke**. Copy the credential before closing — it's shown only once.
+
+Or use the API:
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
@@ -28,13 +30,15 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
   -d '{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}'
 ```
 
-The response includes an `api_token` field. That is your credential. Store it as an environment variable:
+<Callout title="Using neon.ts?">
+If your project has a `neon.ts` file, declare `preview: { aiGateway: true }` and run `neonctl deploy`. Credentials are provisioned and pulled into your local `.env` automatically — no manual creation needed. See [Authentication](/docs/ai-gateway/authentication) for details.
+</Callout>
+
+Store the credential as an environment variable:
 
 ```bash
-export NEON_AI_GATEWAY_KEY=nt_live_...
+export NEON_AI_GATEWAY_TOKEN=nt_live_...
 ```
-
-Your project ID and branch ID are available in the Neon Console URL or via `neonctl projects list` and `neonctl branches list`.
 
 ## Find your branch host
 
@@ -87,12 +91,12 @@ import OpenAI from 'openai';
 import 'dotenv/config';
 
 const client = new OpenAI({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
   baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const response = await client.chat.completions.create({
-  model: 'databricks-claude-sonnet-4-6',
+  model: 'claude-sonnet-4-6',
   messages: [{ role: 'user', content: 'Hello!' }],
 });
 
@@ -107,12 +111,12 @@ import os
 load_dotenv()
 
 client = OpenAI(
-    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
     base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 response = client.chat.completions.create(
-    model="databricks-claude-sonnet-4-6",
+    model="claude-sonnet-4-6",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 
@@ -121,10 +125,10 @@ print(response.choices[0].message.content)
 
 ```bash shouldWrap
 curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "databricks-claude-sonnet-4-6",
+    "model": "claude-sonnet-4-6",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```
@@ -142,12 +146,12 @@ import OpenAI from 'openai';
 import 'dotenv/config';
 
 const client = new OpenAI({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
   baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
 });
 
 const stream = await client.chat.completions.create({
-  model: 'databricks-claude-sonnet-4-6',
+  model: 'claude-sonnet-4-6',
   messages: [{ role: 'user', content: 'Write a haiku about serverless databases.' }],
   stream: true,
 });
@@ -165,12 +169,12 @@ import os
 load_dotenv()
 
 client = OpenAI(
-    api_key=os.environ["NEON_AI_GATEWAY_KEY"],
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
     base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/mlflow/v1",
 )
 
 with client.chat.completions.create(
-    model="databricks-claude-sonnet-4-6",
+    model="claude-sonnet-4-6",
     messages=[{"role": "user", "content": "Write a haiku about serverless databases."}],
     stream=True,
 ) as stream:
@@ -180,10 +184,10 @@ with client.chat.completions.create(
 
 ```bash shouldWrap
 curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/mlflow/v1/chat/completions" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "databricks-claude-sonnet-4-6",
+    "model": "claude-sonnet-4-6",
     "messages": [{"role": "user", "content": "Write a haiku about serverless databases."}],
     "stream": true
   }'
@@ -197,13 +201,13 @@ Change the `model` field to use a different provider. No other code changes requ
 
 ```typescript
 // Anthropic
-model: 'databricks-claude-sonnet-4-6'
+model: 'claude-sonnet-4-6'
 
 // OpenAI
-model: 'databricks-gpt-5-4'
+model: 'gpt-5-4'
 
 // Google
-model: 'databricks-gemini-2-5-flash'
+model: 'gemini-2-5-flash'
 ```
 
 See [Models](/docs/ai-gateway/models) for the full list of available model IDs.

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -3,16 +3,15 @@ title: AI Gateway models
 subtitle: Available models and how to specify them
 summary: >-
   Neon AI Gateway serves Databricks-hosted foundation models from Anthropic,
-  OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. Model IDs use the
-  databricks- prefix, but the short form without the prefix also works. Use
-  either form in the model field of any request.
+  OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. Use short model IDs
+  like claude-sonnet-4-6 or gpt-5-mini. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-06-15T18:57:11.444Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
 
-Neon AI Gateway serves models hosted by Databricks. Model IDs use the `databricks-` prefix (for example, `databricks-claude-sonnet-4-6`). Both forms are accepted. Use either form in the `model` field of any request, regardless of which endpoint you use.
+Neon AI Gateway serves models hosted by Databricks. Use short model IDs in the `model` field — for example, `claude-sonnet-4-6`, `gpt-5-mini`, `gemini-2-5-flash`. The `databricks-` prefixed form is also accepted. The Neon Console and most examples use the short form.
 
 <Admonition type="important">
 Models are hosted by Databricks and served through Neon AI Gateway. By using these models, you are responsible for complying with each provider's applicable terms of use. See [Provider terms](#provider-terms) below.
@@ -26,16 +25,16 @@ Model availability may vary by region. The catalog expands over time, so check b
 
 Not sure which model to use? Start here.
 
-| I want to...                            | Recommended model                                               |
-| --------------------------------------- | --------------------------------------------------------------- |
-| Build a general chat or reasoning app   | `databricks-claude-sonnet-4-6`                                  |
-| Understand images                       | `databricks-claude-sonnet-4-6` or `databricks-gemini-2-5-flash` |
-| Process audio or video                  | `databricks-gemini-3-5-flash`                                   |
-| Generate or review code                 | `databricks-gpt-5-3-codex`                                      |
-| Run extended or deep reasoning          | `databricks-claude-opus-4-7` or `databricks-gpt-5-1`            |
-| Handle very long documents (1M+ tokens) | `databricks-gemini-3-1-pro` or `databricks-claude-opus-4-7`     |
-| Keep costs low for lightweight tasks    | `databricks-claude-haiku-4-5` or `databricks-gpt-5-4-nano`      |
-| Use an open-weight model                | `databricks-gpt-oss-120b`                                       |
+| I want to...                            | Recommended model                         |
+| --------------------------------------- | ----------------------------------------- |
+| Build a general chat or reasoning app   | `claude-sonnet-4-6`                       |
+| Understand images                       | `claude-sonnet-4-6` or `gemini-2-5-flash` |
+| Process audio or video                  | `gemini-3-5-flash`                        |
+| Generate or review code                 | `gpt-5-3-codex`                           |
+| Run extended or deep reasoning          | `claude-opus-4-7` or `gpt-5-1`            |
+| Handle very long documents (1M+ tokens) | `gemini-3-1-pro` or `claude-opus-4-7`     |
+| Keep costs low for lightweight tasks    | `claude-haiku-4-5` or `gpt-5-4-nano`      |
+| Use an open-weight model                | `gpt-oss-120b`                            |
 
 ## Rate limits
 
@@ -54,49 +53,49 @@ Endpoints are shown in short form. See [Which endpoint to use](#which-endpoint-t
 
 ### Anthropic
 
-| Model ID                       | Inputs      | Context | Endpoints                                 | Notes                                    |
-| ------------------------------ | ----------- | ------- | ----------------------------------------- | ---------------------------------------- |
-| `databricks-claude-opus-4-8`   | text, image | —       | `chat/completions` · `anthropic/messages` | Most capable Claude model                |
-| `databricks-claude-opus-4-7`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Extended thinking available              |
-| `databricks-claude-opus-4-6`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Adaptive thinking with max effort level  |
-| `databricks-claude-opus-4-5`   | text, image | 200K    | `chat/completions` · `anthropic/messages` | Extended thinking available              |
-| `databricks-claude-opus-4-1`   | text, image | 200K    | `chat/completions` · `anthropic/messages` |                                          |
-| `databricks-claude-sonnet-4-6` | text, image | —       | `chat/completions` · `anthropic/messages` | Recommended. Instant + extended thinking |
-| `databricks-claude-sonnet-4-5` | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
-| `databricks-claude-sonnet-4`   | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
-| `databricks-claude-haiku-4-5`  | text, image | —       | `chat/completions` · `anthropic/messages` | Fast and cost-effective                  |
+| Model ID            | Inputs      | Context | Endpoints                                 | Notes                                    |
+| ------------------- | ----------- | ------- | ----------------------------------------- | ---------------------------------------- |
+| `claude-opus-4-8`   | text, image | —       | `chat/completions` · `anthropic/messages` | Most capable Claude model                |
+| `claude-opus-4-7`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Extended thinking available              |
+| `claude-opus-4-6`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Adaptive thinking with max effort level  |
+| `claude-opus-4-5`   | text, image | 200K    | `chat/completions` · `anthropic/messages` | Extended thinking available              |
+| `claude-opus-4-1`   | text, image | 200K    | `chat/completions` · `anthropic/messages` |                                          |
+| `claude-sonnet-4-6` | text, image | —       | `chat/completions` · `anthropic/messages` | Recommended. Instant + extended thinking |
+| `claude-sonnet-4-5` | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
+| `claude-sonnet-4`   | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
+| `claude-haiku-4-5`  | text, image | —       | `chat/completions` · `anthropic/messages` | Fast and cost-effective                  |
 
 ### Google
 
-| Model ID                           | Inputs                    | Context | Endpoints                     | Notes                 |
-| ---------------------------------- | ------------------------- | ------- | ----------------------------- | --------------------- |
-| `databricks-gemini-3-5-flash`      | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
-| `databricks-gemini-3-1-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
-| `databricks-gemini-3-1-flash-lite` | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
-| `databricks-gemini-3-pro`          | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
-| `databricks-gemini-3-flash`        | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
-| `databricks-gemini-2-5-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` | Deep Think Mode       |
-| `databricks-gemini-2-5-flash`      | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
-| `databricks-gemma-3-12b`           | text, image               | 128K    | `chat/completions`            | Chat completions only |
+| Model ID                | Inputs                    | Context | Endpoints                     | Notes                 |
+| ----------------------- | ------------------------- | ------- | ----------------------------- | --------------------- |
+| `gemini-3-5-flash`      | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
+| `gemini-3-1-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
+| `gemini-3-1-flash-lite` | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
+| `gemini-3-pro`          | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
+| `gemini-3-flash`        | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
+| `gemini-2-5-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` | Deep Think Mode       |
+| `gemini-2-5-flash`      | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
+| `gemma-3-12b`           | text, image               | 128K    | `chat/completions`            | Chat completions only |
 
 ### OpenAI
 
 All OpenAI models have a 400K token context window and accept text and image inputs.
 
-| Model ID                        | Endpoints                               | Notes                                                              |
-| ------------------------------- | --------------------------------------- | ------------------------------------------------------------------ |
-| `databricks-gpt-5-4`            | `chat/completions` · `openai/responses` |                                                                    |
-| `databricks-gpt-5-4-mini`       | `chat/completions` · `openai/responses` |                                                                    |
-| `databricks-gpt-5-4-nano`       | `chat/completions` · `openai/responses` |                                                                    |
-| `databricks-gpt-5-3-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-2-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-2`            | `chat/completions` · `openai/responses` |                                                                    |
-| `databricks-gpt-5-1-codex-max`  | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-1-codex-mini` | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `databricks-gpt-5-1`            | `chat/completions` · `openai/responses` | Instant + Thinking modes                                           |
-| `databricks-gpt-5`              | `chat/completions` · `openai/responses` |                                                                    |
-| `databricks-gpt-5-mini`         | `chat/completions` · `openai/responses` |                                                                    |
-| `databricks-gpt-5-nano`         | `chat/completions` · `openai/responses` |                                                                    |
+| Model ID             | Endpoints                               | Notes                                                              |
+| -------------------- | --------------------------------------- | ------------------------------------------------------------------ |
+| `gpt-5-4`            | `chat/completions` · `openai/responses` |                                                                    |
+| `gpt-5-4-mini`       | `chat/completions` · `openai/responses` |                                                                    |
+| `gpt-5-4-nano`       | `chat/completions` · `openai/responses` |                                                                    |
+| `gpt-5-3-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `gpt-5-2-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `gpt-5-2`            | `chat/completions` · `openai/responses` |                                                                    |
+| `gpt-5-1-codex-max`  | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `gpt-5-1-codex-mini` | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
+| `gpt-5-1`            | `chat/completions` · `openai/responses` | Instant + Thinking modes                                           |
+| `gpt-5`              | `chat/completions` · `openai/responses` |                                                                    |
+| `gpt-5-mini`         | `chat/completions` · `openai/responses` |                                                                    |
+| `gpt-5-nano`         | `chat/completions` · `openai/responses` |                                                                    |
 
 ### Databricks
 

--- a/content/docs/ai-gateway/openai-responses.md
+++ b/content/docs/ai-gateway/openai-responses.md
@@ -6,7 +6,7 @@ summary: >-
   AI Gateway. Required for codex model variants, which do not work with the
   chat completions endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T18:57:11.444Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -16,24 +16,24 @@ The OpenAI Responses endpoint exposes the [OpenAI Responses API](https://platfor
 **Base URL:** `https://<branch-host>/ai-gateway/openai/v1`
 
 <Admonition type="warning">
-All codex model variants (`databricks-gpt-5-3-codex`, `databricks-gpt-5-2-codex`, `databricks-gpt-5-1-codex-max`, `databricks-gpt-5-1-codex-mini`) **require this endpoint**. They do not work with the [chat completions endpoint](/docs/ai-gateway/chat-completions).
+All codex model variants (`gpt-5-3-codex`, `gpt-5-2-codex`, `gpt-5-1-codex-max`, `gpt-5-1-codex-mini`) **require this endpoint**. They do not work with the [chat completions endpoint](/docs/ai-gateway/chat-completions).
 </Admonition>
 
 ## Supported models
 
 This endpoint accepts OpenAI models only:
 
-| Model ID                        | Notes                  |
-| ------------------------------- | ---------------------- |
-| `databricks-gpt-5-4`            |                        |
-| `databricks-gpt-5-4-mini`       |                        |
-| `databricks-gpt-5-4-nano`       |                        |
-| `databricks-gpt-5-3-codex`      | Requires this endpoint |
-| `databricks-gpt-5-2-codex`      | Requires this endpoint |
-| `databricks-gpt-5-2`            |                        |
-| `databricks-gpt-5-1-codex-max`  | Requires this endpoint |
-| `databricks-gpt-5-1-codex-mini` | Requires this endpoint |
-| `databricks-gpt-5-1`            |                        |
+| Model ID             | Notes                  |
+| -------------------- | ---------------------- |
+| `gpt-5-4`            |                        |
+| `gpt-5-4-mini`       |                        |
+| `gpt-5-4-nano`       |                        |
+| `gpt-5-3-codex`      | Requires this endpoint |
+| `gpt-5-2-codex`      | Requires this endpoint |
+| `gpt-5-2`            |                        |
+| `gpt-5-1-codex-max`  | Requires this endpoint |
+| `gpt-5-1-codex-mini` | Requires this endpoint |
+| `gpt-5-1`            |                        |
 
 Sending a non-OpenAI model ID returns `400 model is not available on this endpoint`.
 
@@ -45,12 +45,12 @@ Sending a non-OpenAI model ID returns `400 model is not available on this endpoi
 import OpenAI from 'openai';
 
 const client = new OpenAI({
-  apiKey: process.env.NEON_AI_GATEWAY_KEY,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
   baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1`,
 });
 
 const response = await client.responses.create({
-  model: 'databricks-gpt-5-4',
+  model: 'gpt-5-4',
   input: [{ role: 'user', content: 'What is Neon?' }],
 });
 
@@ -62,12 +62,12 @@ from openai import OpenAI
 import os
 
 client = OpenAI(
-    api_key=os.environ['NEON_AI_GATEWAY_KEY'],
+    api_key=os.environ['NEON_AI_GATEWAY_TOKEN'],
     base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/openai/v1",
 )
 
 response = client.responses.create(
-    model='databricks-gpt-5-4',
+    model='gpt-5-4',
     input=[{'role': 'user', 'content': 'What is Neon?'}],
 )
 
@@ -76,10 +76,10 @@ print(response.output_text)
 
 ```bash shouldWrap
 curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/openai/v1/responses" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "databricks-gpt-5-4",
+    "model": "gpt-5-4",
     "input": [{"role": "user", "content": "What is Neon?"}]
   }'
 ```
@@ -92,7 +92,7 @@ curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/openai/v1/responses" \
 
 ```typescript shouldWrap
 const stream = await client.responses.create({
-  model: 'databricks-gpt-5-4',
+  model: 'gpt-5-4',
   input: [{ role: 'user', content: 'Explain database branching.' }],
   stream: true,
 });
@@ -106,7 +106,7 @@ for await (const event of stream) {
 
 ```python shouldWrap
 with client.responses.stream(
-    model='databricks-gpt-5-4',
+    model='gpt-5-4',
     input=[{'role': 'user', 'content': 'Explain database branching.'}],
 ) as stream:
     for event in stream:
@@ -116,10 +116,10 @@ with client.responses.stream(
 
 ```bash shouldWrap
 curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/openai/v1/responses" \
-  -H "Authorization: Bearer $NEON_AI_GATEWAY_KEY" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "databricks-gpt-5-4",
+    "model": "gpt-5-4",
     "input": [{"role": "user", "content": "Explain database branching."}],
     "stream": true
   }'

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -3,10 +3,10 @@ title: Neon AI Gateway
 subtitle: One API for all frontier & open-source models. At-cost rates.
 summary: >-
   Neon AI Gateway is the LLM inference layer built into the Neon backend. One
-  Neon credential gives you access to 39 models across 7 providers. Standard AI
+  Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T19:07:32.151Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <RequestForm type="backend-platform" title="Get early access to Neon AI Gateway" description="Neon AI Gateway is in private preview. Drop your email and we'll reach out with access." />
@@ -19,7 +19,7 @@ During the private preview, AI Gateway is available for **new projects** in the 
 Participation in this Private Preview is subject to our Private Preview Terms. Access is not available to users, organizations, or entities located in or operating from regions restricted by Anthropic's [Supported Regions Policy](https://www.anthropic.com/supported-countries). This restriction also applies to entities that are majority owned, directly or indirectly, by companies headquartered in unsupported regions.
 </Admonition>
 
-- **One credential for all providers.** A single Neon credential gives you access to 39 models across Anthropic, OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. No separate provider accounts needed.
+- **One credential for all providers.** A single Neon credential gives you access to models from Anthropic, OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. No separate provider accounts needed.
 - **Standard SDKs, one URL change.** OpenAI SDK, Anthropic SDK, and google-genai all work out of the box.
 - **AI follows your branches.** Each branch has its own gateway endpoint. If you use Neon branches for preview deployments, AI requests from a feature branch are scoped to that branch. It's the same isolation your database already gets.
 - **Streaming support.** Server-sent events work on all endpoints with no extra configuration.

--- a/content/docs/ai-gateway/troubleshooting.md
+++ b/content/docs/ai-gateway/troubleshooting.md
@@ -5,7 +5,7 @@ summary: >-
   Solutions for common errors when using Neon AI Gateway, including
   authentication failures, model errors, quota limits, and upstream issues.
 enableTableOfContents: true
-updatedOn: '2026-06-15T18:57:11.444Z'
+updatedOn: '2026-06-15T19:57:08.490Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -16,7 +16,7 @@ updatedOn: '2026-06-15T18:57:11.444Z'
 
 The bearer token is missing, malformed, or has been revoked.
 
-**Fix:** Check that `NEON_AI_GATEWAY_KEY` is set and contains the full `nt_live_...` token returned when you created the credential. If the credential was revoked, create a new one. See [Authentication](/docs/ai-gateway/authentication#creating-a-credential).
+**Fix:** Check that `NEON_AI_GATEWAY_TOKEN` is set and contains the full `nt_live_...` token returned when you created the credential. If the credential was revoked, create a new one. See [Authentication](/docs/ai-gateway/authentication#creating-a-credential).
 
 ### `403 credential not authorized for ai gateway`
 
@@ -44,7 +44,7 @@ The credential store or branch resolver is temporarily unavailable.
 
 The `model` field in the request body does not match any entry in the AI Gateway catalog.
 
-**Fix:** Check the model ID. All model IDs use the `databricks-` prefix (e.g., `databricks-claude-sonnet-4-6`). See the [full model catalog](/docs/ai-gateway/models) for valid IDs.
+**Fix:** Check the model ID against the [full model catalog](/docs/ai-gateway/models). Use the short form (e.g., `claude-sonnet-4-6`) or the `databricks-` prefixed form (`databricks-claude-sonnet-4-6`) — both are accepted.
 
 ### `400 model is not available on this endpoint`
 
@@ -52,7 +52,7 @@ The model exists in the catalog but doesn't work with the endpoint you're callin
 
 **Fix:** Check which endpoint the model requires:
 
-- Anthropic models (`databricks-claude-*`) on `/openai/v1/responses` → use `/anthropic/v1/messages` or `/mlflow/v1/chat/completions`
+- Anthropic models (`claude-*`) on `/openai/v1/responses` → use `/anthropic/v1/messages` or `/mlflow/v1/chat/completions`
 - OpenAI codex models on `/mlflow/v1/chat/completions` → use `/openai/v1/responses`
 - Google models on `/anthropic/v1/messages` → use `/gemini/v1beta/...` or `/mlflow/v1/chat/completions`
 
@@ -78,7 +78,7 @@ The action in the Gemini endpoint URL is not `generateContent`.
 
 The `{modelAction}` segment in the Gemini URL path is malformed. It must follow the format `<model>:<action>` where both parts are non-empty.
 
-**Fix:** Ensure the URL path contains exactly one colon separating the model ID and action, e.g. `databricks-gemini-2-5-flash:generateContent`.
+**Fix:** Ensure the URL path contains exactly one colon separating the model ID and action, e.g. `gemini-2-5-flash:generateContent`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Corrects `NEON_AI_GATEWAY_KEY` → `NEON_AI_GATEWAY_TOKEN` across all AI Gateway docs (the old name was wrong)
- Switches model IDs to short form (`claude-sonnet-4-6`, `gpt-5-4`, `gemini-2-5-flash`) — both forms work, short form is what the Console shows
- Adds an env var reference table and route mapping to `authentication.md`
- Restores Console-first credential creation flow in `get-started.md`, with API curl as an alternative
- Removes hardcoded model/provider counts from `overview.md`

All changes validated against a live AI Gateway branch. Both dialects tested (chat completions, Anthropic Messages, Gemini native, OpenAI Responses).

## Test plan

- [ ] Spot-check env var names in Console match `NEON_AI_GATEWAY_TOKEN`
- [ ] Try a request with a short model ID from the quickstart

This pull request and its description were written by Isaac.