### PR TITLE
docs: fix storage env var names and add neon.ts setup

### DIFF
--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-15T20:35:44.700Z'
+updatedOn: '2026-06-15T20:45:19.947Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -52,11 +52,11 @@ The response includes these fields. Both secrets are returned once only, so stor
 
 ```json
 {
-  "token_id": "550e8400-e29b-41d4-a716-446655440000",
-  "token_id_short": "550e8400e29b",
+  "token_id": "nak_live_...",
+  "token_id_short": "9043e374b584...",
   "name": "my-app-credential",
-  "api_token": "nt_live_550e8400e29b_...",
-  "s3_secret_access_key": "a665a459...",
+  "api_token": "nt_live_...",
+  "s3_secret_access_key": "nsk_live_...",
   "scopes": ["storage:read", "storage:write"],
   "branch_id": "br-winter-pond-aptw82ef",
   "created_at": "2026-06-08T00:00:00Z",

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:06.925Z'
+updatedOn: '2026-06-15T20:35:44.700Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -87,11 +87,11 @@ Configure your S3 client using these values:
 import { S3Client } from '@aws-sdk/client-s3';
 
 const client = new S3Client({
-  region: 'us-east-2',
-  endpoint: process.env.NEON_STORAGE_ENDPOINT,
+  region: process.env.AWS_REGION,
+  endpoint: process.env.AWS_ENDPOINT_URL_S3,
   credentials: {
-    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID,   // token_id
-    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY, // s3_secret_access_key
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,   // token_id
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!, // s3_secret_access_key
   },
   forcePathStyle: true,
 });
@@ -102,17 +102,18 @@ import boto3, os
 
 client = boto3.client(
     's3',
-    region_name='us-east-2',
-    endpoint_url=os.environ['NEON_STORAGE_ENDPOINT'],
-    aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],      # token_id
-    aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],  # s3_secret_access_key
+    region_name=os.environ['AWS_REGION'],
+    endpoint_url=os.environ['AWS_ENDPOINT_URL_S3'],
+    aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],         # token_id
+    aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'], # s3_secret_access_key
 )
 ```
 
 ```bash
-export AWS_ACCESS_KEY_ID=$NEON_STORAGE_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY=$NEON_STORAGE_SECRET_ACCESS_KEY
-export AWS_DEFAULT_REGION=us-east-2
+# These env vars are already in AWS-standard form; no remapping needed.
+export AWS_ACCESS_KEY_ID=nak_live_...
+export AWS_SECRET_ACCESS_KEY=nsk_live_...
+export AWS_REGION=us-east-2
 ```
 
 </CodeTabs>
@@ -126,10 +127,10 @@ export AWS_DEFAULT_REGION=us-east-2
 For local development, `neonctl env pull` writes storage credentials to your `.env` file automatically — no manual copy-paste from the API response:
 
 ```bash
-neonctl env pull .env
+neonctl env pull --file .env.local
 ```
 
-This populates `NEON_STORAGE_ENDPOINT`, `NEON_STORAGE_ACCESS_KEY_ID`, and `NEON_STORAGE_SECRET_ACCESS_KEY` for the current branch alongside your database connection string. To check the current credential status:
+This populates `AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` for the current branch alongside your database connection string. To check the current credential status:
 
 ```bash
 neonctl config status
@@ -151,25 +152,26 @@ The S3 data plane enforces scope on every request. A credential without a storag
 
 When your code runs inside Neon Functions, Neon injects storage credentials automatically. You don't need to create a credential:
 
-| Variable                         | Value                             |
-| -------------------------------- | --------------------------------- |
-| `NEON_STORAGE_ENDPOINT`          | Branch S3 endpoint URL            |
-| `NEON_STORAGE_REGION`            | Storage region (e.g. `us-east-2`) |
-| `NEON_STORAGE_ACCESS_KEY_ID`     | S3 Access Key ID                  |
-| `NEON_STORAGE_SECRET_ACCESS_KEY` | S3 Secret Access Key              |
-| `NEON_STORAGE_FORCE_PATH_STYLE`  | Always `"true"`                   |
+| Variable                        | Value                                                     |
+| ------------------------------- | --------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`             | S3 Access Key ID                                          |
+| `AWS_SECRET_ACCESS_KEY`         | S3 Secret Access Key                                      |
+| `AWS_ENDPOINT_URL_S3`           | Branch S3 endpoint URL                                    |
+| `AWS_REGION`                    | Storage region (e.g. `us-east-2`)                         |
+| `NEON_STORAGE_REGION`           | Region, e.g. `us-east-2` (also available as `AWS_REGION`) |
+| `NEON_STORAGE_FORCE_PATH_STYLE` | Always `"true"` — path-style addressing is required       |
 
-Credentials are branch-scoped and tied to the function's serving branch. User-supplied environment variables with the same name can't override the injected values (the injected secret access key always wins). Use them directly with your S3 client:
+Credentials are branch-scoped and tied to the function's serving branch. User-supplied environment variables with the same name can't override the injected values (the injected secret access key always wins). Because the credentials use AWS-standard names, the AWS SDK picks them up automatically. Only `forcePathStyle` needs explicit configuration:
 
 ```typescript
 import { S3Client } from '@aws-sdk/client-s3';
 
 const client = new S3Client({
-  region: process.env.NEON_STORAGE_REGION,
-  endpoint: process.env.NEON_STORAGE_ENDPOINT,
+  region: process.env.AWS_REGION,
+  endpoint: process.env.AWS_ENDPOINT_URL_S3,
   credentials: {
-    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY!,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
   forcePathStyle: true,
 });
@@ -215,11 +217,11 @@ To rotate a credential, create a new one, update your environment variables, the
 
 ## Common errors
 
-| Error                       | Cause                               | Fix                                                                                      |
-| --------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------- |
-| `403 InvalidAccessKeyId`    | `token_id` is wrong or revoked      | Check `NEON_STORAGE_ACCESS_KEY_ID` is set to the full UUID                               |
-| `403 SignatureDoesNotMatch` | Wrong secret access key             | Check `NEON_STORAGE_SECRET_ACCESS_KEY` is the 64-char hex value from credential creation |
-| `403 AccessDenied`          | Credential lacks the required scope | Recreate with `storage:write` for uploads/deletes                                        |
-| `403 AccessDenied`          | Branch not in credential lineage    | Use a credential created on this branch or an ancestor                                   |
+| Error                       | Cause                               | Fix                                                                                                                           |
+| --------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `403 InvalidAccessKeyId`    | `token_id` is wrong or revoked      | Check `AWS_ACCESS_KEY_ID` is set correctly. If you rotated the credential, update the value.                                  |
+| `403 SignatureDoesNotMatch` | Wrong secret access key             | Check `AWS_SECRET_ACCESS_KEY` is the value from credential creation. Secrets can't be retrieved. Revoke and recreate if lost. |
+| `403 AccessDenied`          | Credential lacks the required scope | Recreate with `storage:write` for uploads/deletes                                                                             |
+| `403 AccessDenied`          | Branch not in credential lineage    | Use a credential created on this branch or an ancestor                                                                        |
 
 <NeedHelp/>

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,7 +6,7 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:06.925Z'
+updatedOn: '2026-06-15T20:35:44.700Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -38,11 +38,11 @@ curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{b
 import { S3Client, CreateBucketCommand } from '@aws-sdk/client-s3';
 
 const client = new S3Client({
-  region: 'us-east-2',
-  endpoint: process.env.NEON_STORAGE_ENDPOINT,
+  region: process.env.AWS_REGION,
+  endpoint: process.env.AWS_ENDPOINT_URL_S3,
   credentials: {
-    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID,
-    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
   forcePathStyle: true,
 });
@@ -55,10 +55,10 @@ import boto3, os
 
 client = boto3.client(
     's3',
-    region_name='us-east-2',
-    endpoint_url=os.environ['NEON_STORAGE_ENDPOINT'],
-    aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],
-    aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],
+    region_name=os.environ['AWS_REGION'],
+    endpoint_url=os.environ['AWS_ENDPOINT_URL_S3'],
+    aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+    aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
 )
 
 client.create_bucket(Bucket='my-bucket')
@@ -68,7 +68,7 @@ client.create_bucket(Bucket='my-bucket')
 aws s3api create-bucket \
   --bucket my-bucket \
   --region us-east-2 \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>
@@ -80,7 +80,7 @@ neonctl bucket create my-public-bucket --access-level public_read
 ```
 
 <Admonition type="note">
-`NEON_STORAGE_ENDPOINT` is your branch's storage endpoint. See [Get started](/docs/storage/get-started) for how to obtain it.
+`AWS_ENDPOINT_URL_S3` is your branch's storage endpoint. See [Get started](/docs/storage/get-started) for how to obtain it.
 </Admonition>
 
 ## Access levels
@@ -127,7 +127,7 @@ print(response['Buckets'])
 ```
 
 ```bash
-aws s3api list-buckets --endpoint-url "$NEON_STORAGE_ENDPOINT"
+aws s3api list-buckets --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>
@@ -155,7 +155,7 @@ client.delete_bucket(Bucket='my-bucket')
 ```bash
 aws s3api delete-bucket \
   --bucket my-bucket \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,12 +6,39 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:06.925Z'
+updatedOn: '2026-06-15T20:35:44.700Z'
 ---
 
 <PrivatePreviewEnquire/>
 
 To follow this guide, you need a new project in the AWS us-east-2 region.
+
+## Recommended: enable storage with neon.ts
+
+The recommended way to enable storage and get credentials is via `neon.ts`, Neon's infrastructure-as-code config file. Declare buckets under `preview.buckets`, then run `neonctl deploy` to provision them on the linked branch and pull credentials into `.env.local` automatically:
+
+```typescript filename="neon.ts"
+import { defineConfig } from '@neondatabase/config/v1';
+
+export default defineConfig({
+  preview: {
+    buckets: {
+      'my-bucket': {},                          // private (default)
+      'public-assets': { access: 'public_read' },
+    },
+  },
+});
+```
+
+```bash
+neonctl deploy          # provisions buckets and writes AWS_* vars to .env.local
+```
+
+After deploy, your `.env.local` contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, and `NEON_STORAGE_FORCE_PATH_STYLE`. Skip to [Configure your S3 client](#configure-your-s3-client) below.
+
+---
+
+If you prefer to manage credentials manually (for example, for CI or production deployments), follow the steps below.
 
 <Steps>
 
@@ -39,8 +66,8 @@ The response includes your S3 credentials. Store them immediately. You'll only g
 Set these as environment variables:
 
 ```bash
-export NEON_STORAGE_ACCESS_KEY_ID=550e8400-e29b-41d4-a716-446655440000   # token_id
-export NEON_STORAGE_SECRET_ACCESS_KEY=a665a45920422f9d...                 # s3_secret_access_key
+export AWS_ACCESS_KEY_ID=550e8400-e29b-41d4-a716-446655440000   # token_id
+export AWS_SECRET_ACCESS_KEY=a665a459...                         # s3_secret_access_key
 ```
 
 Your project ID and branch ID are available in the Neon Console URL or via `neonctl projects list` and `neonctl branches list`.
@@ -66,8 +93,8 @@ curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id
 Set these as environment variables:
 
 ```bash
-export NEON_STORAGE_ENDPOINT=https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech
-export NEON_STORAGE_REGION=us-east-2
+export AWS_ENDPOINT_URL_S3=https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech
+export AWS_REGION=us-east-2
 ```
 
 A `404` response means Storage is not yet enabled for that branch. Make sure you're using a project in the AWS us-east-2 region.
@@ -103,11 +130,11 @@ import { S3Client } from '@aws-sdk/client-s3';
 import 'dotenv/config';
 
 export const client = new S3Client({
-  region: 'us-east-2',
-  endpoint: process.env.NEON_STORAGE_ENDPOINT,
+  region: process.env.AWS_REGION,
+  endpoint: process.env.AWS_ENDPOINT_URL_S3,
   credentials: {
-    accessKeyId: process.env.NEON_STORAGE_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.NEON_STORAGE_SECRET_ACCESS_KEY!,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
   forcePathStyle: true,
 });
@@ -122,18 +149,17 @@ load_dotenv()
 
 client = boto3.client(
     's3',
-    region_name='us-east-2',
-    endpoint_url=os.environ['NEON_STORAGE_ENDPOINT'],
-    aws_access_key_id=os.environ['NEON_STORAGE_ACCESS_KEY_ID'],
-    aws_secret_access_key=os.environ['NEON_STORAGE_SECRET_ACCESS_KEY'],
+    region_name=os.environ['AWS_REGION'],
+    endpoint_url=os.environ['AWS_ENDPOINT_URL_S3'],
+    aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+    aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
 )
 ```
 
-```bash
-# Add to ~/.aws/credentials or export as env vars
-export AWS_ACCESS_KEY_ID=$NEON_STORAGE_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY=$NEON_STORAGE_SECRET_ACCESS_KEY
-export AWS_DEFAULT_REGION=us-east-2
+```bash shouldWrap
+# The AWS CLI reads AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION
+# from the environment automatically. Set the endpoint explicitly:
+aws configure set endpoint_url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>
@@ -179,11 +205,11 @@ print('Uploaded!')
 # Create a bucket
 aws s3api create-bucket \
   --bucket my-bucket \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 
 # Upload a file
 aws s3 cp hello.txt s3://my-bucket/hello.txt \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>
@@ -212,7 +238,7 @@ print(response['Body'].read().decode('utf-8'))  # Hello from Neon Storage!
 
 ```bash shouldWrap
 aws s3 cp s3://my-bucket/hello.txt ./downloaded.txt \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   your S3 client, creating a bucket, and uploading and downloading your first
   file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T20:35:44.700Z'
+updatedOn: '2026-06-15T20:45:19.947Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -57,8 +57,8 @@ The response includes your S3 credentials. Store them immediately. You'll only g
 
 ```json
 {
-  "token_id": "550e8400-e29b-41d4-a716-446655440000",
-  "s3_secret_access_key": "a665a459...",
+  "token_id": "nak_live_...",
+  "s3_secret_access_key": "nsk_live_...",
   ...
 }
 ```
@@ -66,8 +66,8 @@ The response includes your S3 credentials. Store them immediately. You'll only g
 Set these as environment variables:
 
 ```bash
-export AWS_ACCESS_KEY_ID=550e8400-e29b-41d4-a716-446655440000   # token_id
-export AWS_SECRET_ACCESS_KEY=a665a459...                         # s3_secret_access_key
+export AWS_ACCESS_KEY_ID=nak_live_...   # token_id
+export AWS_SECRET_ACCESS_KEY=nsk_live_...   # s3_secret_access_key
 ```
 
 Your project ID and branch ID are available in the Neon Console URL or via `neonctl projects list` and `neonctl branches list`.

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   Supports single-part and multipart uploads, range requests, batch deletes,
   and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:06.925Z'
+updatedOn: '2026-06-15T20:35:44.700Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -52,7 +52,7 @@ client.put_object(
 ```bash shouldWrap
 aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
   --content-type image/jpeg \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>
@@ -134,7 +134,7 @@ with open('./photo.jpg', 'wb') as f:
 
 ```bash shouldWrap
 aws s3 cp s3://my-bucket/images/photo.jpg ./photo.jpg \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>
@@ -199,7 +199,7 @@ print(response.get('CommonPrefixes', []))
 
 ```bash shouldWrap
 aws s3 ls s3://my-bucket/images/ \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>
@@ -245,7 +245,7 @@ client.delete_object(Bucket='my-bucket', Key='images/photo.jpg')
 
 ```bash shouldWrap
 aws s3 rm s3://my-bucket/images/photo.jpg \
-  --endpoint-url "$NEON_STORAGE_ENDPOINT"
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
 
 </CodeTabs>

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-15T14:48:06.925Z'
+updatedOn: '2026-06-15T20:35:44.700Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -17,13 +17,13 @@ updatedOn: '2026-06-15T14:48:06.925Z'
 
 The Access Key ID is wrong, missing, or the credential has been revoked.
 
-**Fix:** Check that `NEON_STORAGE_ACCESS_KEY_ID` is set to the full `token_id` UUID from the credential response (e.g. `550e8400-e29b-41d4-a716-446655440000`). This is not the same as the `token_id_short`. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for the correct field mapping.
+**Fix:** Check that `AWS_ACCESS_KEY_ID` is set to the `token_id` from the credential response, not `token_id_short`. See [Authentication](/docs/storage/authentication#mapping-to-your-s3-sdk) for the correct field mapping. If you no longer have it, revoke the credential and create a new one.
 
 ### `403 SignatureDoesNotMatch`
 
 The Secret Access Key is wrong.
 
-**Fix:** Check that `NEON_STORAGE_SECRET_ACCESS_KEY` is set to the `s3_secret_access_key` field from the credential response. This is the 64-character hex string, not the `api_token`. Both are returned only once at creation. If you no longer have the `s3_secret_access_key`, revoke the credential and create a new one.
+**Fix:** Check that `AWS_SECRET_ACCESS_KEY` is set to the `s3_secret_access_key` field from the credential response. This is the 64-character hex string, not the `api_token`. Both are returned only once at creation. If you no longer have the `s3_secret_access_key`, revoke the credential and create a new one.
 
 ### `403 AccessDenied`: missing scope
 
@@ -52,7 +52,7 @@ If you forget to set the custom endpoint, the SDK will route requests to AWS S3 
 
 ```typescript
 const client = new S3Client({
-  endpoint: process.env.NEON_STORAGE_ENDPOINT,
+  endpoint: process.env.AWS_ENDPOINT_URL_S3,
   // ...
 });
 ```


### PR DESCRIPTION
## Summary

- Replace `NEON_STORAGE_ACCESS_KEY_ID`, `NEON_STORAGE_SECRET_ACCESS_KEY`, and `NEON_STORAGE_ENDPOINT` with the correct AWS-standard names (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`) across all storage docs — the old names don't exist
- Add `neon.ts` + `neonctl deploy` as the recommended provisioning path in get-started.md; manual API steps remain for CI/production use
- Minor fixes: `neonctl env pull` syntax, credential format, hardcoded region replaced with `AWS_REGION`

Env var names confirmed against a live project via `neonctl deploy` and tested with `@aws-sdk/client-s3`.

This pull request and its description were written by Isaac.