### PR TITLE
docs: use <cell> placeholder in Functions invocation URL templates

### DIFF
--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -150,7 +150,7 @@ GET /projects/{project_id}/branches/{branch_id}/functions/{slug}
 The response includes `invocation_url`, the public URL for your function:
 
 ```
-https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech
+https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech
 ```
 
 ### List functions

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -138,13 +138,13 @@ neonctl functions get hello
 The `invocation_url` field contains the public URL for your function:
 
 ```
-https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech
+https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech
 ```
 
 Call it with curl:
 
 ```bash shouldWrap
-curl https://<branch_id>-hello.compute.c-1.us-east-2.aws.neon.tech
+curl https://<branch_id>-hello.compute.<cell>.us-east-2.aws.neon.tech
 ```
 
 The response is a JSON object with your branch's Postgres version:


### PR DESCRIPTION
The invocation URL templates in get-started and deploy showed a hardcoded `c-1` cell component. The cell is platform-assigned and varies — confirmed `c-3` on us-east-2 during testing, but it's not a fixed value. Changed to `<cell>` placeholder to match the existing `<branch_id>` / `<slug>` convention.

This pull request and its description were written by Isaac.