### PR TITLE
docs: apply lakebase-search review corrections to extension pages

### DIFF
--- a/content/docs/extensions/lakebase-text.md
+++ b/content/docs/extensions/lakebase-text.md
@@ -6,16 +6,16 @@ summary: >-
   for BM25 full-text search. It requires no migration from PostgreSQL's built-in
   full-text search — standard tsvector types and tsquery operators work unchanged.
   Use this page to enable the extension, create a lakebase_bm25 index, query
-  with the <&> operator and to_bm25query function, configure the default_limit
+  with the <@> operator and to_bm25query function, configure the default_limit
   and prefilter GUCs, set fallback parameters at the index level, and reference
   all types, operators, functions, and index parameters.
 enableTableOfContents: true
-updatedOn: '2026-06-09T20:13:02.957Z'
+updatedOn: '2026-06-16T12:11:52.162Z'
 ---
 
 <EarlyAccessProps feature_name="lakebase_text" />
 
-The `lakebase_text` extension adds a `lakebase_bm25` index type to Postgres for [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) full-text search. It is a native upgrade to PostgreSQL's built-in full-text search: standard `tsvector` types and query operators work unchanged; only the index type changes.
+The `lakebase_text` extension adds a `lakebase_bm25` index type to Postgres for [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) full-text search. It is a native upgrade to PostgreSQL's built-in full-text search: standard `tsvector` type and query operators work unchanged; only the index type changes.
 
 Lakebase Search is in private preview. To request access or learn about its architecture advantages, see [Lakebase Search](/docs/ai/lakebase-search).
 
@@ -23,7 +23,7 @@ Lakebase Search is in private preview. To request access or learn about its arch
 
 PostgreSQL's built-in full-text search uses GIN indexes with `tsvector`. GIN works well for boolean filtering, but it has two limitations for search relevance:
 
-- **No BM25 ranking.** GIN uses `ts_rank`, a TF-IDF variant that scores documents by fetching `tsvector` values from the heap at query time. BM25 is more accurate, accounting for term frequency, document length, and corpus-wide statistics together.
+- **No BM25 ranking.** GIN uses `ts_rank`, which does not use global corpus statistics, so scores degrade as data grows. BM25 is more accurate, accounting for term frequency, document length, and corpus-wide statistics together.
 - **No top-K pushdown.** GIN must score all matching documents even when you only need the top 10. For large tables, this means significant unnecessary work on every query.
 
 `lakebase_bm25` adds a first-class BM25 index with Block-Max WAND top-K pushdown: the index returns only the K most relevant results directly, without scoring the entire match set. It fully preserves standard `tsvector` types and existing query operators. No application logic changes are required.
@@ -40,31 +40,31 @@ CREATE EXTENSION IF NOT EXISTS lakebase_text;
 
 ## Quick start
 
-Create a table with a `tsvector` column generated from a text column:
+Create a table with a `tsvector` column and insert data:
 
 ```sql
 CREATE TABLE documents (
     id serial PRIMARY KEY,
     passage text,
-    vector tsvector GENERATED ALWAYS AS (to_tsvector('english', passage)) STORED
+    vector tsvector
 );
 
-INSERT INTO documents (passage) VALUES
-('PostgreSQL is a powerful, open-source object-relational database system.'),
-('Full-text search is a technique for searching in plain-text documents.'),
-('BM25 is a ranking function used by search engines to estimate document relevance.'),
-('PostgreSQL provides advanced features like full-text search and window functions.'),
-('Effective ranking algorithms like BM25 improve information retrieval results.');
+INSERT INTO documents (passage, vector) VALUES
+('PostgreSQL is a powerful, open-source object-relational database system.', to_tsvector('english', 'PostgreSQL is a powerful, open-source object-relational database system.')),
+('Full-text search is a technique for searching in plain-text documents.', to_tsvector('english', 'Full-text search is a technique for searching in plain-text documents.')),
+('BM25 is a ranking function used by search engines to estimate document relevance.', to_tsvector('english', 'BM25 is a ranking function used by search engines to estimate document relevance.')),
+('PostgreSQL provides advanced features like full-text search and window functions.', to_tsvector('english', 'PostgreSQL provides advanced features like full-text search and window functions.')),
+('Effective ranking algorithms like BM25 improve information retrieval results.', to_tsvector('english', 'Effective ranking algorithms like BM25 improve information retrieval results.'));
 ```
 
 Create a `lakebase_bm25` index on the `tsvector` column:
 
 ```sql
-CREATE INDEX documents_passage_bm25 ON documents USING lakebase_bm25 (vector bm25_ops);
+CREATE INDEX documents_passage_bm25 ON documents USING lakebase_bm25 (vector);
 ```
 
 <Admonition type="important" title="Create the index after inserting data">
-`lakebase_bm25` computes corpus-wide statistics (document count, term frequencies, IDF values) at index build time, not incrementally. Create the index after your initial data load. If you insert a large number of new documents later, drop and recreate the index to keep BM25 scores accurate.
+`lakebase_bm25` computes corpus-wide statistics (document count, term frequencies) at index build time and updates them at VACUUM time. Create the index after your initial data load. After bulk-loading a large amount of new data, run `VACUUM` manually to keep BM25 scores accurate.
 </Admonition>
 
 Set how many results the index returns and run a BM25 search:
@@ -74,13 +74,13 @@ SET lakebase_bm25.default_limit TO 5;
 
 SELECT
   id,
-  vector <&> to_bm25query(to_tsvector('english', 'PostgreSQL'), 'documents_passage_bm25') AS score
+  vector <@> to_bm25query(to_tsvector('english', 'PostgreSQL'), 'documents_passage_bm25') AS score
 FROM documents
 ORDER BY score
 LIMIT 5;
 ```
 
-The `<&>` operator calculates the negative BM25 score of a document against a query. Ordering by score ascending returns the most relevant documents first (lower negative score = higher relevance).
+The `<@>` operator calculates the negative BM25 score of a document against a query. Ordering by score ascending returns the most relevant documents first (lower negative score = higher relevance).
 
 `to_bm25query` constructs a `bm25query_tsvector` value by combining the query `tsvector` with the object identifier of the BM25 index. The index identifier is required because BM25 scoring depends on corpus-wide statistics stored in the index.
 
@@ -102,7 +102,7 @@ You can store search parameters directly in an index as storage parameters, rath
 Set `default_limit` at index creation:
 
 ```sql
-CREATE INDEX documents_passage_bm25 ON documents USING lakebase_bm25 (vector bm25_ops)
+CREATE INDEX documents_passage_bm25 ON documents USING lakebase_bm25 (vector)
 WITH (default_limit = 5);
 ```
 
@@ -111,7 +111,7 @@ Queries against this index use `default_limit = 5` without requiring a `SET` com
 ```sql
 SELECT
   id,
-  vector <&> to_bm25query(to_tsvector('english', 'PostgreSQL'), 'documents_passage_bm25') AS score
+  vector <@> to_bm25query(to_tsvector('english', 'PostgreSQL'), 'documents_passage_bm25') AS score
 FROM documents
 ORDER BY score
 LIMIT 5;
@@ -137,7 +137,7 @@ SET lakebase_bm25.prefilter = on;
 
 SELECT
   id,
-  vector <&> to_bm25query(to_tsvector('english', 'PostgreSQL'), 'documents_passage_bm25') AS score
+  vector <@> to_bm25query(to_tsvector('english', 'PostgreSQL'), 'documents_passage_bm25') AS score
 FROM documents
 WHERE id % 1000 = 0
 ORDER BY score
@@ -152,19 +152,19 @@ Prefilter is recommended when the filter is **strict** (eliminates many rows) or
 
 | Type                 | Description                                                                                                   |
 | :------------------- | :------------------------------------------------------------------------------------------------------------ |
-| `bm25query_tsvector` | Combines a query `tsvector` with the object identifier of a BM25 index. Passed as the right operand to `<&>`. |
+| `bm25query_tsvector` | Combines a query `tsvector` with the object identifier of a BM25 index. Passed as the right operand to `<@>`. |
 
 ### Operators
 
 | Operator | Arguments                        | Result   | Description                                                                                                                               |
 | :------- | :------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `<&>`    | `tsvector`, `bm25query_tsvector` | `double` | Returns the negative BM25 score of a document against a query, in the context of the BM25 index. Order ascending for most-relevant-first. |
+| `<@>`    | `tsvector`, `bm25query_tsvector` | `double` | Returns the negative BM25 score of a document against a query, in the context of the BM25 index. Order ascending for most-relevant-first. |
 
 ### Operator classes
 
-| Operator class | Default | Operator                            |
-| :------------- | :------ | :---------------------------------- |
-| `bm25_ops`     | Yes     | `<&>(tsvector, bm25query_tsvector)` |
+| Operator class      | Default | Operator                            |
+| :------------------ | :------ | :---------------------------------- |
+| `tsvector_bm25_ops` | Yes     | `<@>(tsvector, bm25query_tsvector)` |
 
 ### Functions
 
@@ -174,12 +174,12 @@ Prefilter is recommended when the filter is **strict** (eliminates many rows) or
 
 ### Index storage parameters
 
-| Parameter       | Type    | Default | Domain        | Description                                                                      |
-| :-------------- | :------ | :------ | :------------ | :------------------------------------------------------------------------------- |
-| `k1`            | real    | `1.2`   | `[1.2, 2.0]`  | BM25 `k1` parameter. Controls term frequency saturation.                         |
-| `b`             | real    | `0.75`  | `[0.0, 1.0]`  | BM25 `b` parameter. Controls document length normalization.                      |
-| `default_limit` | integer | `1000`  | `[-1, 65535]` | Fallback value for `lakebase_bm25.default_limit`. GUCs take precedence when set. |
-| `prefilter`     | boolean | `false` | —             | Fallback value for `lakebase_bm25.prefilter`. GUCs take precedence when set.     |
+| Parameter       | Type    | Default | Domain       | Description                                                                      |
+| :-------------- | :------ | :------ | :----------- | :------------------------------------------------------------------------------- |
+| `k1`            | real    | `1.2`   | `[1.2, 2.0]` | BM25 `k1` parameter. Controls term frequency saturation.                         |
+| `b`             | real    | `0.75`  | `[0.0, 1.0]` | BM25 `b` parameter. Controls document length normalization.                      |
+| `default_limit` | integer | `1000`  | `[1, 65535]` | Fallback value for `lakebase_bm25.default_limit`. GUCs take precedence when set. |
+| `prefilter`     | boolean | `false` | —            | Fallback value for `lakebase_bm25.prefilter`. GUCs take precedence when set.     |
 
 ### Search parameters (GUCs)
 

--- a/content/docs/extensions/lakebase-text.md
+++ b/content/docs/extensions/lakebase-text.md
@@ -10,7 +10,7 @@ summary: >-
   and prefilter GUCs, set fallback parameters at the index level, and reference
   all types, operators, functions, and index parameters.
 enableTableOfContents: true
-updatedOn: '2026-06-16T12:11:52.162Z'
+updatedOn: '2026-06-16T18:44:07.041Z'
 ---
 
 <EarlyAccessProps feature_name="lakebase_text" />
@@ -30,7 +30,7 @@ PostgreSQL's built-in full-text search uses GIN indexes with `tsvector`. GIN wor
 
 ## Enable the lakebase_text extension
 
-Run the following statement in the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or from a client such as [psql](/docs/connect/query-with-psql-editor):
+[Lakebase Search](/docs/ai/lakebase-search) must be enabled on your Neon project before you can install this extension. Once it's enabled, run the following statement in the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or from a client such as [psql](/docs/connect/query-with-psql-editor):
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS lakebase_text;

--- a/content/docs/extensions/lakebase-vector.md
+++ b/content/docs/extensions/lakebase-vector.md
@@ -6,11 +6,10 @@ summary: >-
   for fast approximate nearest-neighbor vector search. It requires no migration
   from pgvector — the same vector types, distance operators, and query syntax
   work unchanged. Use this page to enable the extension, create a lakebase_ann
-  index, tune build parameters (lists, residual_quantization, build.pin), configure
-  search with the lakebase_ann.probes GUC, and reference all operator classes and
-  index options.
+  index, configure build_mode, tune search with the lakebase_ann.probes GUC, and
+  reference all operator classes and index options.
 enableTableOfContents: true
-updatedOn: '2026-06-09T20:13:02.957Z'
+updatedOn: '2026-06-16T12:11:52.162Z'
 ---
 
 <EarlyAccessProps feature_name="lakebase_vector" />
@@ -61,77 +60,31 @@ SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 5;
 
 ## Index tuning
 
-For tables with fewer than 100,000 rows, no tuning is required.
+Set `build_mode` at index creation to control the accuracy/speed tradeoff:
 
-As your dataset grows, configure the `build.internal.lists` option to partition the vector space into an appropriate number of lists. Pass options as a [TOML](https://toml.io/) string:
+- `standard` (default): optimizes for recall. Use for most workloads.
+- `fast`: builds faster at lower recall. Use when build time matters more than search quality.
 
 ```sql
-CREATE INDEX ON items USING lakebase_ann (embedding vector_l2_ops) WITH (options = $$
-build.internal.lists = [1000]
-$$);
+CREATE INDEX ON items USING lakebase_ann (embedding vector_l2_ops) WITH (build_mode = 'fast');
 ```
 
-Use the `lakebase_ann.probes` GUC to control how many lists are searched at query time. More probes improves recall at the cost of speed. This GUC only applies when the index has `build.internal.lists` configured; no probes setting is needed for the default (no-lists) configuration.
+Before tuning search, call `lakebase_ann_index_info(index_name)` to get the index's `lists`, `default_probes`, and `default_epsilon` values.
+
+Use the `lakebase_ann.probes` GUC to control how many lists are searched at query time. Higher values improve recall at the cost of speed.
 
 ```sql
 SET lakebase_ann.probes TO '10';
 SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 10;
 ```
 
-Use the following guidelines when choosing `lists` based on your row count:
-
-| Rows                   | Recommended lists | Example   |
-| :--------------------- | :---------------- | :-------- |
-| Fewer than 100,000     | Not needed        | `[]`      |
-| 100,000 – 2,000,000    | N / 500           | `[2000]`  |
-| 2,000,000 – 50,000,000 | 4√N – 8√N         | `[10000]` |
-| 50,000,000+            | 8√N – 16√N        | `[80000]` |
-
-### Cosine similarity with residual quantization
-
-For most datasets using cosine similarity, enabling `residual_quantization` and `spherical_centroids` improves both queries per second and recall:
-
-```sql
-CREATE INDEX ON items USING lakebase_ann (embedding vector_cosine_ops) WITH (options = $$
-residual_quantization = true
-build.internal.spherical_centroids = true
-build.internal.lists = [1000]
-$$);
-```
-
-### Faster index builds
-
-To speed up index builds on large tables, set `build.pin = 2` to use more shared memory during the build process:
-
-```sql
-CREATE INDEX ON items USING lakebase_ann (embedding vector_l2_ops) WITH (options = $$
-residual_quantization = true
-build.internal.spherical_centroids = true
-build.internal.lists = [1000]
-build.pin = 2
-$$);
-```
-
 ### Concurrent index updates
 
-For large, frequently changing datasets, use `CREATE INDEX CONCURRENTLY` to build or rebuild an index without blocking reads and writes. You can then update the index options and rebuild with `REINDEX INDEX CONCURRENTLY`:
+For large, frequently changing datasets, use `CREATE INDEX CONCURRENTLY` to build or rebuild an index without blocking reads and writes:
 
 ```sql
 CREATE INDEX CONCURRENTLY items_embedding_ann ON items
-USING lakebase_ann (embedding vector_l2_ops) WITH (options = $$
-residual_quantization = true
-build.internal.spherical_centroids = true
-build.internal.lists = [1024]
-build.pin = 2
-$$);
-
--- Update options and rebuild without downtime
-ALTER INDEX items_embedding_ann SET (options = $$
-residual_quantization = true
-build.internal.spherical_centroids = true
-build.internal.lists = [4096]
-build.pin = 2
-$$);
+  USING lakebase_ann (embedding vector_l2_ops);
 
 REINDEX INDEX CONCURRENTLY items_embedding_ann;
 ```
@@ -161,21 +114,15 @@ The `rabitq8` and `rabitq4` types are quantization types defined by `lakebase_ve
 
 ### Index options
 
-Options are passed as a TOML string to the `WITH (options = $$ ... $$)` clause.
-
-| Option                               | Type               | Default | Description                                                                                                                                                  |
-| :----------------------------------- | :----------------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `build.internal.lists`               | array              | `[]`    | Number of partitions for the vector space. Set based on dataset size. See [Index tuning](#index-tuning).                                                     |
-| `residual_quantization`              | boolean            | `false` | Enables residual quantization to improve recall. Recommended for cosine similarity workloads. Not supported with `rabitq8` or `rabitq4` operator classes.    |
-| `build.internal.spherical_centroids` | boolean            | `false` | Enables spherical centroids. Recommended alongside `residual_quantization` for cosine similarity.                                                            |
-| `build.pin`                          | integer or boolean | `-1`    | Controls shared memory usage during index builds. `-1` disables pinning (default). Set to `2` to use more shared memory and speed up builds on large tables. |
-| `degree_of_parallelism`              | integer            | `32`    | Hint for the number of concurrent processes accessing the index. Increase only if you have more than 32 CPU threads and want to use more for index builds.   |
+| Option       | Type   | Default      | Description                                                                                                                            |
+| :----------- | :----- | :----------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `build_mode` | string | `'standard'` | Controls the accuracy/speed tradeoff at index build time. `'standard'` optimizes for recall; `'fast'` builds faster with lower recall. |
 
 ### Search parameters
 
-| GUC                        | Type    | Default | Description                                                                                                                                                                    |
-| :------------------------- | :------ | :------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lakebase_ann.probes`      | integer | not set | Number of lists to search at query time. Must be set explicitly when using an index with `build.internal.lists` configured. Higher values improve recall at the cost of speed. |
-| `lakebase_ann.enable_scan` | boolean | `on`    | Enables or disables `lakebase_ann` index scans. Set to `off` for testing to force a sequential scan.                                                                           |
+| GUC                        | Type    | Default | Description                                                                                          |
+| :------------------------- | :------ | :------ | :--------------------------------------------------------------------------------------------------- |
+| `lakebase_ann.probes`      | integer | not set | Number of lists to search at query time. Higher values improve recall at the cost of speed.          |
+| `lakebase_ann.enable_scan` | boolean | `on`    | Enables or disables `lakebase_ann` index scans. Set to `off` for testing to force a sequential scan. |
 
 <NeedHelp />

--- a/content/docs/extensions/lakebase-vector.md
+++ b/content/docs/extensions/lakebase-vector.md
@@ -6,10 +6,10 @@ summary: >-
   for fast approximate nearest-neighbor vector search. It requires no migration
   from pgvector — the same vector types, distance operators, and query syntax
   work unchanged. Use this page to enable the extension, create a lakebase_ann
-  index, configure build_mode, tune search with the lakebase_ann.probes GUC, and
-  reference all operator classes and index options.
+  index, configure build_mode, tune search with the lakebase_ann.probes and
+  lakebase_ann.epsilon GUCs, and reference all operator classes and index options.
 enableTableOfContents: true
-updatedOn: '2026-06-16T12:11:52.162Z'
+updatedOn: '2026-06-16T18:44:07.041Z'
 ---
 
 <EarlyAccessProps feature_name="lakebase_vector" />
@@ -26,7 +26,7 @@ There is no migration involved. `lakebase_vector` inherits all `pgvector` data t
 
 ## Enable the lakebase_vector extension
 
-Run the following statement in the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or from a client such as [psql](/docs/connect/query-with-psql-editor):
+[Lakebase Search](/docs/ai/lakebase-search) must be enabled on your Neon project before you can install this extension. Once it's enabled, run the following statement in the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or from a client such as [psql](/docs/connect/query-with-psql-editor):
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS lakebase_vector CASCADE;
@@ -71,11 +71,17 @@ CREATE INDEX ON items USING lakebase_ann (embedding vector_l2_ops) WITH (build_m
 
 Before tuning search, call `lakebase_ann_index_info(index_name)` to get the index's `lists`, `default_probes`, and `default_epsilon` values.
 
-Use the `lakebase_ann.probes` GUC to control how many lists are searched at query time. Higher values improve recall at the cost of speed.
+Use the `lakebase_ann.probes` GUC to control how many IVF partitions are searched at query time. Higher values improve recall at the cost of speed.
 
 ```sql
 SET lakebase_ann.probes TO '10';
 SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 10;
+```
+
+`lakebase_ann.epsilon` controls the re-ranking margin. The default value of `1.9` works well for most workloads.
+
+```sql
+SET lakebase_ann.epsilon TO '1.5';
 ```
 
 ### Concurrent index updates
@@ -120,9 +126,9 @@ The `rabitq8` and `rabitq4` types are quantization types defined by `lakebase_ve
 
 ### Search parameters
 
-| GUC                        | Type    | Default | Description                                                                                          |
-| :------------------------- | :------ | :------ | :--------------------------------------------------------------------------------------------------- |
-| `lakebase_ann.probes`      | integer | not set | Number of lists to search at query time. Higher values improve recall at the cost of speed.          |
-| `lakebase_ann.enable_scan` | boolean | `on`    | Enables or disables `lakebase_ann` index scans. Set to `off` for testing to force a sequential scan. |
+| GUC                    | Type    | Default | Description                                                                                              |
+| :--------------------- | :------ | :------ | :------------------------------------------------------------------------------------------------------- |
+| `lakebase_ann.probes`  | integer | not set | Number of IVF partitions to scan at query time. Higher values improve recall at the cost of query speed. |
+| `lakebase_ann.epsilon` | float   | `1.9`   | Re-ranking margin. Valid range: `0.0` to `4.0`.                                                          |
 
 <NeedHelp />


### PR DESCRIPTION
Apply corrections from the Lakebase Search engineering review to the Neon extension reference pages.

**lakebase-text:**
- Change BM25 operator `<&>` to `<@>` throughout
- Drop `bm25_ops` opclass from `CREATE INDEX`; rename to `tsvector_bm25_ops` in reference table
- Fix `ts_rank` description: does not use global corpus statistics
- Update index accuracy note: VACUUM updates BM25 stats, no need to drop/recreate
- Remove `-1` from `default_limit` domain (errors, not no-limit)
- Replace generated tsvector column with explicit INSERT for Postgres compatibility
- Fix `tsvector types` → `tsvector type`

**lakebase-vector:**
- Replace TOML options API with `build_mode = 'standard' | 'fast'`
- Add `lakebase_ann_index_info` guidance before probes/epsilon tuning
- Update `lakebase_ann.probes` GUC description
- Update summary frontmatter

## NEON PREVIEW

- https://neon-next-git-lakebase-search-review-fixes-neondatabase.vercel.app/docs/extensions/lakebase-text
- https://neon-next-git-lakebase-search-review-fixes-neondatabase.vercel.app/docs/extensions/lakebase-vector