### PR TITLE
docs: fix BM25 operator and operator class in lakebase-search get-started

### DIFF
--- a/content/docs/ai/lakebase-search-get-started.md
+++ b/content/docs/ai/lakebase-search-get-started.md
@@ -7,7 +7,7 @@ summary: >-
   BM25 full-text index, and running vector and keyword searches from a
   TypeScript application using @neondatabase/serverless and OpenAI.
 enableTableOfContents: true
-updatedOn: '2026-06-09T17:17:42.901Z'
+updatedOn: '2026-06-17T09:53:50.753Z'
 ---
 
 <EarlyAccessProps feature_name="Lakebase Search" />
@@ -134,7 +134,7 @@ async function vectorSearch(query: string, limit = 5) {
 async function textSearch(query: string, limit = 5) {
   return sql`
     SELECT id, title,
-           body_tsv <&> to_bm25query(
+           body_tsv <@> to_bm25query(
              to_tsvector('english', ${query}),
              'documents_bm25'
            ) AS score
@@ -151,7 +151,7 @@ async function main() {
   console.log('Building BM25 index...');
   await sql`
     CREATE INDEX IF NOT EXISTS documents_bm25 ON documents
-    USING lakebase_bm25 (body_tsv bm25_ops)
+    USING lakebase_bm25 (body_tsv)
     WITH (default_limit = 10)
   `;
 


### PR DESCRIPTION
## Summary

- Changes `<&>` to `<@>` in the `textSearch` function — `<&>` was the old operator name, `<@>` is what the extension registers as of the June 12 compute release (hadron PR #7073)
- Removes `bm25_ops` from `CREATE INDEX ... USING lakebase_bm25 (body_tsv)` — `bm25_ops` was renamed to `tsvector_bm25_ops` and is now the default operator class for `tsvector`, so it no longer needs to be specified

## How this was verified

Tested live against a Neon project after dropping and recreating `lakebase_text` to pick up the June 12 compute release (`release-compute-13259`, hadron PR #7293). Queried `pg_operator`, `pg_type`, and `pg_opclass` directly to confirm names. The `lakebase_text` reference page already uses the correct names.

## Test plan

- [ ] `CREATE INDEX ... USING lakebase_bm25 (body_tsv)` succeeds without specifying an operator class on a Lakebase Search-enabled project
- [ ] BM25 query with `<@>` operator returns results

This pull request and its description were written by Isaac.