### PR TITLE
Update rate limit docs for AI Gateway and Storage

### DIFF
--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,7 +6,7 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-updatedOn: '2026-06-15T19:57:08.490Z'
+updatedOn: '2026-06-17T11:08:12.470Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -162,6 +162,11 @@ model: 'databricks-qwen35-122b-a10b'
 See [Models](/docs/ai-gateway/models) for the full list.
 
 ## Rate limiting
+
+There are two separate rate limit tiers:
+
+- **Neon account quota:** enforced by Neon. Returns `429` with error code `REQUEST_LIMIT_EXCEEDED`. See [Rate limits](/docs/ai-gateway/models#rate-limits) for current limits.
+- **Upstream provider limit:** enforced by the Databricks workspace serving the model. Returns `429` with forwarded rate limit headers.
 
 When the upstream provider rate-limits a request, AI Gateway forwards the relevant headers so your client can back off correctly:
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -6,7 +6,7 @@ summary: >-
   OpenAI, Google, Meta, DeepSeek, Databricks, and Alibaba. Use short model IDs
   like claude-sonnet-4-6 or gpt-5-mini. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-06-15T19:57:08.490Z'
+updatedOn: '2026-06-17T11:22:51.192Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -46,6 +46,8 @@ During the private preview, the following limits apply:
 | All models combined (tokens per minute) | 1,100,000 TPM |
 
 If you hit a limit, you'll receive a `429 Too Many Requests` response. Requests resume when the rate limit window resets.
+
+These limits apply to input tokens. Upstream output token limits (20,000 OTPM for most models) apply independently, so you can hit a `429` on output tokens without reaching the input limit. See [Databricks Foundation Model API limits](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits) for details.
 
 ## Available models
 

--- a/content/docs/ai-gateway/troubleshooting.md
+++ b/content/docs/ai-gateway/troubleshooting.md
@@ -5,7 +5,7 @@ summary: >-
   Solutions for common errors when using Neon AI Gateway, including
   authentication failures, model errors, quota limits, and upstream issues.
 enableTableOfContents: true
-updatedOn: '2026-06-15T19:57:08.490Z'
+updatedOn: '2026-06-17T11:29:14.727Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -117,7 +117,7 @@ Your account's AI Gateway quota is blocked. The response body is:
 }
 ```
 
-**Fix:** Check the `Retry-After` header. If present, the block is temporary and will lift at that time. If absent, the block is permanent until resolved. Contact support for a quota increase or to resolve a permanent block.
+**Fix:** Check the `Retry-After` header. If present, the block is temporary and will lift at that time. If absent, the block is permanent until resolved. Contact support for a quota increase or to resolve a permanent block. See [Rate limits](/docs/ai-gateway/models#rate-limits) for current quota values.
 
 ---
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-15T20:35:44.700Z'
+updatedOn: '2026-06-17T11:08:12.470Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -112,11 +112,11 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 
 ## Connection and performance errors
 
-### `503 Service Unavailable`
+### `503 Service Unavailable` (SlowDown)
 
-The request exceeded the per-IP or per-tenant rate limit.
+The request exceeded the per-IP or per-tenant rate limit. The S3 error code is `SlowDown`. This is a rate limit signal, not a server error. The storage service is healthy.
 
-**Fix:** Reduce request frequency or add retry logic with exponential backoff. The response may include a `Retry-After` header indicating how long to wait.
+**Fix:** Implement exponential backoff and retry. Don't treat `SlowDown` as a fatal error. The response may include a `Retry-After` header indicating how long to wait. AWS SDKs handle this automatically when retry logic is enabled.
 
 ### Large downloads timing out mid-stream
 


### PR DESCRIPTION
## Summary

Doc updates based on recently merged neon-cloud PRs.

**AI Gateway**

- **`chat-completions.md`:** Added a two-tier rate limit explanation distinguishing Neon account quota (`REQUEST_LIMIT_EXCEEDED`) from upstream Databricks workspace TPM caps. Both return `429` but with different signals. ([databricks-eng/neon-cloud#7789](https://github.com/databricks-eng/neon-cloud/pull/7789))
- **`models.md`:** The rate limits table covered input tokens only. Added a note that upstream output token limits (20,000 OTPM) apply independently, with a link to Databricks docs.
- **`troubleshooting.md`:** Linked the account quota 429 entry to the rate limits section in models.

**Storage**

- **`troubleshooting.md`:** The `503 Service Unavailable` entry was vague. Named the S3 `SlowDown` error code explicitly and clarified it's a rate limit signal rather than a server error. ([databricks-eng/neon-cloud#7702](https://github.com/databricks-eng/neon-cloud/pull/7702), [#7708](https://github.com/databricks-eng/neon-cloud/pull/7708))

## Pages changed

- `content/docs/ai-gateway/chat-completions.md`
- `content/docs/ai-gateway/models.md`
- `content/docs/ai-gateway/troubleshooting.md`
- `content/docs/storage/troubleshooting.md`

## NEON PREVIEW

- https://neon-next-git-docs-backend-updates-neondatabase.vercel.app/docs/ai-gateway/chat-completions
- https://neon-next-git-docs-backend-updates-neondatabase.vercel.app/docs/ai-gateway/models
- https://neon-next-git-docs-backend-updates-neondatabase.vercel.app/docs/ai-gateway/troubleshooting
- https://neon-next-git-docs-backend-updates-neondatabase.vercel.app/docs/storage/troubleshooting