### PR TITLE
docs: serve blog posts as markdown and add to llms.txt

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2532,6 +2532,7 @@ const defaultConfig = {
         // /docs.md serves the canonical, curated docs index (llms.txt) instead of a
         // generated page-listing. beforeFiles so the [slug] catch-all doesn't intercept it.
         { source: '/docs.md', destination: '/docs/llms.txt' },
+        { source: '/blog.md', destination: '/blog/llms.txt' },
         // Index .md files (e.g. /faqs.md, /programs.md) must be beforeFiles so the
         // top-level [slug] catch-all doesn't intercept them before the rewrite fires.
         ...indexRewrites,

--- a/scripts/test-markdown-urls.js
+++ b/scripts/test-markdown-urls.js
@@ -607,7 +607,7 @@ function buildTests() {
     { note: 'homepage is not a CONTENT_ROUTE' }
   );
 
-  const nonContentRoutes = ['/about', '/blog'];
+  const nonContentRoutes = ['/about'];
 
   for (const path of nonContentRoutes) {
     add(
@@ -638,6 +638,203 @@ function buildTests() {
       { note: 'should not serve markdown' }
     );
   }
+
+  // ── 9b-blog. Blog markdown serving ──────────────────────────────────────────
+  // /blog is content-negotiated: agents get blog/llms.txt index; browsers get HTML.
+  // /blog/[slug].md is served from CDN for all requesters (no agent detection needed).
+  // /blog/[slug] without .md always serves HTML — the middleware matcher does NOT catch
+  // bare blog slugs even with Accept: text/markdown. This is intentional; adding the
+  // matcher would add overhead to every blog page load.
+
+  // blog index: agent UA gets markdown
+  add(
+    'Blog index (agent UA)',
+    '/blog',
+    'agent-ua',
+    [
+      (r) => expectStatus(r.status, 200),
+      (r) => expectContentType(r.contentType, 'text/markdown'),
+      (r) => {
+        if (!r.body.includes('# Neon Blog')) return 'body missing "# Neon Blog" heading';
+        return null;
+      },
+    ],
+    { note: 'agent UA should get blog/llms.txt content' }
+  );
+
+  // blog index: Accept: text/markdown gets markdown
+  add(
+    'Blog index (Accept: markdown)',
+    '/blog',
+    'accept-md',
+    [
+      (r) => expectStatus(r.status, 200),
+      (r) => expectContentType(r.contentType, 'text/markdown'),
+      (r) => {
+        if (!r.body.includes('# Neon Blog')) return 'body missing "# Neon Blog" heading';
+        return null;
+      },
+    ],
+    { note: 'Accept: text/markdown should get blog index markdown' }
+  );
+
+  // blog index: browser gets HTML
+  add(
+    'Blog index (browser)',
+    '/blog',
+    'browser',
+    [
+      (r) => expectStatus(r.status, 200),
+      (r) => expectContentType(r.contentType, 'text/html'),
+      (r) => expectHtmlBody(r.body),
+    ],
+    { note: 'browser must get HTML, not blog markdown index' }
+  );
+
+  // blog/llms.txt: static route handler serves text/plain index
+  add(
+    'Blog llms.txt',
+    '/blog/llms.txt',
+    'browser',
+    [
+      (r) => expectStatus(r.status, 200),
+      (r) => expectContentType(r.contentType, 'text/plain'),
+      (r) => {
+        if (!r.body.includes('# Neon Blog')) return 'body missing "# Neon Blog" heading';
+        return null;
+      },
+      (r) => {
+        if (!r.body.includes('](') || !r.body.includes('/blog/'))
+          return 'body missing blog post links';
+        return null;
+      },
+    ],
+    { note: 'static route handler serves blog post index as text/plain' }
+  );
+
+  // blog.md rewrite → blog/llms.txt
+  add(
+    'Blog .md rewrite',
+    '/blog.md',
+    'browser',
+    [
+      (r) => expectStatus(r.status, 200),
+      (r) => {
+        if (r.contentType.includes('text/html'))
+          return `expected non-HTML content type, got ${r.contentType}`;
+        return null;
+      },
+      (r) => {
+        if (!r.body.includes('# Neon Blog')) return 'body missing "# Neon Blog" heading';
+        return null;
+      },
+    ],
+    { note: '/blog.md must rewrite to /blog/llms.txt content, not HTML' }
+  );
+
+  // individual post .md: served from CDN
+  add(
+    'Blog post .md (exists)',
+    '/blog/slop-fork-neon.md',
+    'browser',
+    [
+      (r) => expectStatus(r.status, 200),
+      (r) => expectContentType(r.contentType, 'text/markdown'),
+      (r) => {
+        const src = r.headers.get('x-content-source');
+        if (src !== 'markdown') return `expected x-content-source: markdown, got ${src}`;
+        return null;
+      },
+      (r) => {
+        if (!r.body.includes('Slop Fork') && !r.body.includes('slop-fork-neon'))
+          return 'body does not appear to be the expected blog post';
+        return null;
+      },
+    ],
+    { note: 'CDN-fetched blog post markdown with content verification' }
+  );
+
+  // individual post .md: 404 for nonexistent slug
+  add(
+    'Blog post .md (404)',
+    '/blog/nonexistent-slug-xyz-does-not-exist.md',
+    'browser',
+    [
+      (r) => expectStatus(r.status, 404),
+      (r) => expectContentType(r.contentType, 'text/markdown'),
+      (r) => {
+        if (!r.body.includes('# Page Not Found')) return 'body missing "# Page Not Found" heading';
+        return null;
+      },
+      (r) => {
+        if (!r.body.includes('/blog/llms.txt')) return 'body missing link to /blog/llms.txt';
+        return null;
+      },
+      (r) => {
+        if (!r.body.includes('Neon Blog')) return 'body missing "Neon Blog" context';
+        return null;
+      },
+    ],
+    { note: 'missing blog .md must return 404 text/markdown with blog index link' }
+  );
+
+  // PITFALL: bare slug with Accept: text/markdown → HTML (or 404), NOT markdown.
+  // The middleware matcher only covers /blog/:slug.md (literal .md suffix).
+  // /blog/[slug] never hits the blog .md handler regardless of Accept header.
+  // (Blog pages 404 locally since blog is hosted separately; on Vercel they return 200 HTML.)
+  add(
+    'Blog post bare slug (Accept: markdown) — pitfall',
+    '/blog/slop-fork-neon',
+    'accept-md',
+    [
+      (r) => {
+        if (r.status !== 200 && r.status !== 404)
+          return `unexpected status ${r.status} — expected 200 (HTML) or 404`;
+        return null;
+      },
+      (r) => {
+        const src = r.headers.get('x-content-source');
+        if (src === 'markdown')
+          return 'bare blog slug must not return markdown — use /blog/[slug].md';
+        return null;
+      },
+      (r) => {
+        if (r.contentType.includes('text/markdown'))
+          return 'bare blog slug must not serve text/markdown — use .md suffix';
+        return null;
+      },
+    ],
+    {
+      note: 'pitfall: Accept: text/markdown on bare slug gets HTML/404; use /blog/[slug].md instead',
+    }
+  );
+
+  // PITFALL: agent UA on bare slug → HTML (or 404), NOT markdown.
+  // Same reason: /blog/[slug] not in matcher, so middleware blog handler never fires.
+  add(
+    'Blog post bare slug (agent UA) — pitfall',
+    '/blog/slop-fork-neon',
+    'agent-ua',
+    [
+      (r) => {
+        if (r.status !== 200 && r.status !== 404)
+          return `unexpected status ${r.status} — expected 200 (HTML) or 404`;
+        return null;
+      },
+      (r) => {
+        const src = r.headers.get('x-content-source');
+        if (src === 'markdown')
+          return 'bare blog slug must not return markdown — agent should use /blog/[slug].md';
+        return null;
+      },
+      (r) => {
+        if (r.contentType.includes('text/markdown'))
+          return 'bare blog slug must not serve text/markdown — use .md suffix';
+        return null;
+      },
+    ],
+    { note: 'pitfall: agent UA on bare slug gets HTML/404; agents must request /blog/[slug].md' }
+  );
 
   // ── 9b. Non-docs marketing page (stays HTML for agents / Accept: markdown)
   // Tests that middleware does not serve markdown for pages outside CONTENT_ROUTES.

--- a/src/app/(blog)/blog/llms.txt/route.js
+++ b/src/app/(blog)/blog/llms.txt/route.js
@@ -1,0 +1,46 @@
+export const revalidate = 3600;
+
+const CDN_BASE = process.env.BLOG_CDN_URL || 'https://blog.neonapi.io/blog';
+const SITE_URL = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.com';
+
+// Only list categories whose labels can't be derived by title-casing the slug.
+// New categories from the CDN fall back to title case automatically.
+const CATEGORY_LABEL_OVERRIDES = {
+  ai: 'AI',
+  'case-study': 'Case Studies',
+};
+
+function categoryLabel(key) {
+  if (CATEGORY_LABEL_OVERRIDES[key]) return CATEGORY_LABEL_OVERRIDES[key];
+  return key.replace(/-./g, (m) => ' ' + m[1].toUpperCase()).replace(/^./, (m) => m.toUpperCase());
+}
+
+export async function GET() {
+  const res = await fetch(`${CDN_BASE}/titles.json`, { next: { revalidate: 3600 } });
+
+  if (!res.ok) {
+    return new Response('Failed to load blog index', { status: 502 });
+  }
+
+  const byCategory = await res.json();
+  const lines = [];
+
+  lines.push('# Neon Blog');
+  lines.push('');
+  lines.push('Engineering, product, and community posts from the Neon team.');
+  lines.push('');
+
+  for (const [key, posts] of Object.entries(byCategory)) {
+    if (!posts.length) continue;
+    lines.push(`## ${categoryLabel(key)}`);
+    lines.push('');
+    for (const { slug, title, date } of posts) {
+      lines.push(`- [${title}](${SITE_URL}/blog/${slug}.md) — ${date}`);
+    }
+    lines.push('');
+  }
+
+  return new Response(lines.join('\n').trimEnd() + '\n', {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -61,9 +61,63 @@ function trackLLMPageview(req, { is404 = false } = {}) {
   }).catch(() => {});
 }
 
+const BLOG_CDN_BASE = process.env.BLOG_CDN_URL || 'https://blog.neonapi.io/blog';
+
 export async function proxy(req) {
   try {
     const { pathname } = req.nextUrl;
+
+    // /blog/[slug].md — serve raw markdown from CDN for any requester
+    if (pathname.startsWith('/blog/') && pathname.endsWith('.md')) {
+      const slug = pathname.slice('/blog/'.length, -'.md'.length);
+      try {
+        const res = await fetch(`${BLOG_CDN_BASE}/posts/${slug}.md`);
+        if (res.ok) {
+          trackLLMPageview(req);
+          const markdown = await res.text();
+          return new NextResponse(markdown, {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/markdown; charset=utf-8',
+              'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+              'X-Content-Source': 'markdown',
+              'X-Robots-Tag': 'noindex',
+              'X-LLMs-Txt': '/blog/llms.txt',
+            },
+          });
+        }
+        if (res.status === 404) {
+          return new NextResponse(
+            buildAgent404Response(pathname, {
+              context: 'Neon Blog',
+              extraLinks: [
+                { label: 'Blog index', href: '/blog/llms.txt', description: 'All Neon blog posts' },
+              ],
+            }),
+            {
+              status: 404,
+              headers: {
+                'Content-Type': 'text/markdown; charset=utf-8',
+                'Cache-Control': 'public, max-age=60, s-maxage=300',
+                'X-Content-Source': 'agent-404',
+                'X-LLMs-Txt': '/blog/llms.txt',
+              },
+            }
+          );
+        }
+        // Non-200/404 from CDN (5xx, etc.) — fall through to 502
+        return new NextResponse(`# Service Unavailable\n\nCould not fetch /blog/${slug}.md.\n`, {
+          status: 502,
+          headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+        });
+      } catch (error) {
+        console.error('[blog .md] Error fetching from CDN', { slug, error: error.message });
+        return new NextResponse(`# Service Unavailable\n\nCould not fetch /blog/${slug}.md.\n`, {
+          status: 502,
+          headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+        });
+      }
+    }
 
     if (isAIAgentRequest(req)) {
       let agentHit404 = false;
@@ -229,6 +283,8 @@ export const config = {
     '/home', // Check if the user is logged in
     '/pricing', // Agent-friendly pricing page
     '/docs', // Bare docs root: serve llms.txt for agents; browsers fall through to the /docs→/docs/introduction redirect
+    '/blog', // Bare blog root: serve blog/llms.txt for agents; browsers fall through normally
+    '/blog/:slug.md', // Individual blog post markdown
     '/(docs|postgresql|guides|branching|programs|use-cases|faqs)/:path*', // All markdown routes
     '/:path(docs|postgresql|guides|branching|programs|use-cases).md', // Top-level .md index URLs
   ],

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -300,6 +300,11 @@ module.exports = {
       url: 'https://neon.com/docs/reference/glossary.md',
       sourcePath: 'reference/glossary.md',
     },
+    {
+      title: 'Blog',
+      url: 'https://neon.com/blog.md',
+      description: 'Engineering, product, and community posts from the Neon team',
+    },
   ],
 
   // Configuration for llms-full.txt (single file with all doc content).

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -51,6 +51,10 @@ const CUSTOM_MARKDOWN_PATHS = {
   //   2. next.config.js beforeFiles rewrite: /docs.md → /docs/llms.txt (static/browser)
   //   3. process-md-for-llms.js ROUTES_ALIASED_TO_LLMS (skips generating public/md/docs.md)
   docs: '/docs/llms.txt',
+  // Blog root aliases to the blog index. Two places enforce this alias — keep in sync:
+  //   1. Here (getMarkdownPath — agent requests to /blog and /blog.md)
+  //   2. next.config.js beforeFiles rewrite: /blog.md → /blog/llms.txt (static/browser)
+  blog: '/blog/llms.txt',
   'docs/changelog': '/md/docs/changelog.md',
   'docs/skill.md': '/docs/ai/skills/neon-postgres/SKILL.md', // primary skill alias — update alongside next.config.js if primary changes (see config/skills.json)
 };
@@ -102,15 +106,37 @@ export function getMarkdownPath(pathname) {
   return slug ? `${publicPath}/${mdSlug}` : `${publicPath}.md`;
 }
 
-export function buildAgent404Response(pathname) {
+const DEFAULT_404_LINKS = [
+  {
+    label: 'All Neon documentation',
+    href: '/docs/llms.txt',
+    description: 'Table of contents for all Neon docs',
+  },
+  {
+    label: 'Full documentation text',
+    href: '/docs/llms-full.txt',
+    description: 'Complete Neon docs in one file',
+  },
+  {
+    label: 'Neon API reference',
+    href: '/docs/reference/api-reference.md',
+    description: 'API endpoints and usage',
+  },
+];
+
+export function buildAgent404Response(
+  pathname,
+  { extraLinks = [], context = 'Neon documentation' } = {}
+) {
+  const linkLines = [...extraLinks, ...DEFAULT_404_LINKS]
+    .map(({ label, href, description }) => `- [${label}](${href}): ${description}`)
+    .join('\n');
   return `# Page Not Found
 
-\`${pathname}\` does not exist in Neon documentation.
+\`${pathname}\` does not exist in ${context}.
 
 Find what you need:
 
-- [All Neon documentation](/docs/llms.txt): Table of contents for all Neon docs
-- [Full documentation text](/docs/llms-full.txt): Complete Neon docs in one file
-- [Neon API reference](/docs/reference/api-reference.md): API endpoints and usage
+${linkLines}
 `;
 }


### PR DESCRIPTION
## Summary

- Adds `/blog/llms.txt` — categorized blog index fetched from CDN at runtime (ISR, 1h)
- Adds `/blog.md` rewrite alias pointing to the index
- Serves individual posts at `/blog/[slug].md` via middleware, proxied from `blog.neonapi.io`
- Agents requesting `/blog` get the markdown index; browsers get the normal blog page
- Adds `blog.md` to the Additional Resources section of `/docs/llms.txt`
- Refactors `buildAgent404Response` to accept `extraLinks` + `context` params; blog 404s link to `/blog/llms.txt` first, then default docs links
- 9 new QA tests covering index, rewrite, individual posts, 404 behavior, and bare-slug pitfalls

## Test plan

- [ ] Run `node scripts/test-markdown-urls.js http://localhost:3000 --filter Blog` — 9/9 pass
- [ ] Push to Vercel preview and confirm `/blog/slop-fork-neon` still renders as HTML
- [ ] Confirm `/blog/slop-fork-neon.md` returns markdown with frontmatter on preview
- [ ] Confirm `/blog` with agent UA returns `# Neon Blog` index on preview

This pull request and its description were written by Isaac.