### PR TITLE
chore: point topbar at the latest changelog highlights

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: "New in Neon: vector (ANN) and text (BM25) search extensions optimized for Neon's lakebase architecture. Read the docs."
+text: 'New in Neon: Refer a friend and earn credits, Neon backend private preview, and more. Read the changelog.'
 link:
-  url: 'https://neon.com/docs/ai/lakebase-search'
+  url: 'https://neon.com/docs/changelog/2026-06-19'
   target: '_blank'


### PR DESCRIPTION
## What

Updates the site-wide topbar announcement to promote the latest changelog highlights.

- **Text:** "New in Neon: Refer a friend and earn credits, Neon backend private preview, and more. Read the changelog."
- **Link:** https://neon.com/docs/changelog/2026-06-19

Config-only change to `content/config/topbar.yaml`. No component or frontend code touched.

## Note

The pre-push unit-test hook flags 2 pre-existing, unrelated failures in `scripts/docs-checks/neonctl/__tests__` (two blog posts use neonctl options that no longer exist in neonctl 2.26.6: `--timestamp` on `branches create` and `--branch` on `connection-string`). These exist on `main` and are unrelated to this change, so the push bypassed the hook.