### PR TITLE
Tighten MCP docs and add access control documentation

### DIFF
--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -10,12 +10,12 @@ summary: >-
   per-client setup instructions for `npx neonctl@latest init`, OAuth, or local
   API key authentication with `@neondatabase/mcp-server-neon`. Also covers
   troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache)
-  and the deprecated SSE endpoint for clients that do not support Streamable
+  and the deprecated SSE endpoint for clients that don't support Streamable
   HTTP.
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
 This guide covers connecting MCP clients to the Neon MCP Server for natural language interaction with your Neon Postgres databases.
@@ -68,14 +68,6 @@ This adds the MCP config to your editor's configuration files. Add `-g` for glob
 | Zed                       | `zed`                |
 
 **Aliases:** `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`. Config paths differ by agent and by project vs global (`-g`); see the [add-mcp README](https://github.com/neondatabase/add-mcp#supported-agents).
-
-## Setup options
-
-- **Quick setup:** `npx neonctl@latest init` (MCP with API key auth, extension where supported, agent skills, and many assistants via the wizard)
-- **OAuth:** Connect to Neon's remote MCP server (no local installation needed)
-- **Local:** Run the MCP server locally with your API key (requires Node.js >= v18)
-
-For Local setup, you'll need a [Neon API key](/docs/manage/api-keys#creating-api-keys).
 
 ## Kiro
 
@@ -461,13 +453,13 @@ This tool auto-detects supported clients and configures them. Use `-a <agent>` t
 }
 ```
 
-For Windows-specific configurations, see [Local MCP Server](/docs/ai/neon-mcp-server#other-setup-options).
+For Windows-specific configurations, see [Other MCP clients](/docs/ai/connect-mcp-clients-to-neon#other-mcp-clients).
 
 ## Troubleshooting
 
 ### Configuration Issues
 
-If your client does not use `JSON` for configuration of MCP servers (such as older versions of Cursor), you can use the following command when prompted:
+If your client doesn't support JSON config (such as older Cursor versions), run:
 
 ```bash
 # For OAuth (remote server)
@@ -498,11 +490,9 @@ This typically occurs when there are issues with cached OAuth credentials. To re
 2. Restart your MCP client application
 3. The OAuth flow will start fresh, allowing you to properly authenticate
 
-This error is most common when using OAuth authentication and can occur after OAuth configuration changes or when cached credentials become invalid.
-
 ## Next steps
 
-Once connected, explore the [available MCP tools](/docs/ai/neon-mcp-server#supported-actions-tools) to see what you can do with natural language.
+Once connected, explore the [available tools](/docs/ai/neon-mcp-server#available-tools) to see what you can do with natural language.
 
 ## Resources
 

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -1,107 +1,78 @@
 ---
 title: Neon MCP Server overview
-subtitle: Learn about managing your Neon projects using natural language with Neon MCP
-  Server
+subtitle: Connect your AI assistant to Neon to manage projects, run queries, and make schema changes
 summary: >-
-  Neon MCP Server is an open-source bridge between natural language requests and
-  the Neon API, letting AI assistants create projects, run SQL, manage branches,
-  and perform schema migrations without manual API calls or code. Use it when
-  you want to control Neon Postgres databases through conversational commands in
-  editors like Cursor, VS Code, or Claude Code instead of the Neon Console. Set
-  up with a single command (`npx neonctl@latest init` or `npx add-mcp
-  https://mcp.neon.tech/mcp`); supports OAuth and API key auth.
+  The Neon MCP Server implements the Model Context Protocol (MCP), letting AI
+  assistants interact with your Neon projects on your behalf. Set up with
+  `npx neonctl@latest init` or use the config generator. Supports OAuth and
+  API key auth.
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-The **Neon MCP Server** is an open-source tool that lets you interact with your Neon Postgres databases in **natural language**:
+The Neon MCP Server implements the Model Context Protocol (MCP), letting AI assistants interact with your Neon projects on your behalf. Your AI agent can interact with Neon via MCP tools or by running [Neon CLI](/docs/reference/neon-cli) commands directly.
 
-- Manage projects, branches, and databases with conversational commands
-- Run SQL queries and make schema changes without writing code
-- Use branch-based migrations for safer schema modifications
+<Admonition type="important" title="Security">
+The Neon MCP Server grants broad database management capabilities. **Always review and authorize actions requested by the LLM before execution.** Restrict access to trusted users only. See [MCP security guidance](#mcp-security-guidance).
+</Admonition>
 
 ## Quick setup
-
-The fastest way to set up Neon's MCP Server is with one command:
 
 ```bash
 npx neonctl@latest init
 ```
 
-This configures the Neon MCP Server for compatible MCP clients in your workspace using API key authentication, including Cursor, VS Code, Claude Code, and other assistants [add-mcp can target](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp). See the [neonctl init documentation](/docs/cli/init).
+Runs `neonctl init` via npx to configure MCP and other integrations for your editor. If you only want the MCP server, use the config generator below.
 
-**If you only want the MCP server and nothing else**, use:
+## Config generator
 
-```bash
-npx add-mcp https://mcp.neon.tech/mcp
-```
-
-This command adds the required configuration to your editor's MCP config files; it does not open a browser by itself. Add `-g` for global (user-level) setup instead of project-level. Restart your editor (or enable the MCP server in your editor's settings). When you use the MCP connection, an OAuth window will open in your browser to authorize access to your Neon account. For more options (for example, global vs project-level), see the [add-mcp repository](https://github.com/neondatabase/add-mcp).
-
-**Other setup options:**
-
-- **API key authentication (remote agents):** For remote agents or when OAuth isn't available:
-
-  ```bash
-  npx add-mcp https://mcp.neon.tech/mcp --header 'Authorization: Bearer ${NEON_API_KEY}'
-  ```
-
-- **Manual configuration:** See [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon) for step-by-step instructions for any editor, including Windsurf, ChatGPT, Zed, and others.
-
-After setup, restart your editor and ask your AI assistant to **"Get started with Neon"** to launch the interactive onboarding guide.
-
----
-
-Imagine you want to create a new database. Instead of using the Neon Console or API, you could just type a request like, "Create a database named 'my-new-database'". Or, to see your projects, you might ask, "List all my Neon projects". The Neon MCP Server makes this possible.
-
-It works by acting as a bridge between natural language requests and the [Neon API](https://api-docs.neon.tech/reference/getting-started-with-neon-api). Built upon the [Model Context Protocol (MCP)](https://modelcontextprotocol.org), it translates your requests into the necessary Neon API calls, allowing you to manage everything from creating projects and branches to running queries and performing database migrations.
-
-<Admonition type="important" title="Neon MCP Server Security Considerations">
-The Neon MCP Server grants powerful database management capabilities through natural language requests. **Always review and authorize actions requested by the LLM before execution.** Ensure that only authorized users and applications have access to the Neon MCP Server.
-</Admonition>
-
-## Other setup options
-
-### MCP Server Config Generator
-
-Use this generator to build valid Neon hosted MCP config snippets with supported auth modes, transport, and headers:
+Use the generator to build an MCP config for your editor, auth method, and transport, including the `Authorization` header for API key or remote agent setups.
 
 <McpSetupConfigurator />
 
-<MCPTools />
+## Access control
 
-### Troubleshooting
+The Neon MCP Server supports URL parameters to restrict scope and permissions. Append them to the MCP URL (`https://mcp.neon.tech/mcp`).
 
-If your client does not use JSON for configuration of MCP servers (such as older versions of Cursor), use this command when prompted:
+### Read-only mode
 
-```bash
-npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
+Append `?readonly=true` to restrict the server to read operations:
+
+```
+https://mcp.neon.tech/mcp?readonly=true
 ```
 
-<Admonition type="note">
-For clients that don't support Streamable HTTP, you can use the deprecated SSE endpoint: `https://mcp.neon.tech/sse`. SSE is not supported with API key authentication.
-</Admonition>
+`SELECT` queries and schema inspection remain available. Write operations (creating branches, running migrations, modifying auth config) are disabled.
 
-## Usage examples
+With OAuth, you can also choose read-only scope during the authorization flow instead of using the URL parameter.
 
-After setup, interact with your Neon databases using natural language:
+### Project-scoped mode
 
-- `"Get started with Neon"`: Launch the interactive onboarding guide
-- `"List my Neon projects"`
-- `"Create a project named 'my-app'"`
-- `"Show tables in database 'main'"`
-- `"Search for 'production' across my Neon resources"`
-- `"SELECT * FROM users LIMIT 10"`
+Scope all operations to a single project:
 
-<Video  
-sources={[{src: "/videos/pages/doc/neon-mcp.mp4",type: "video/mp4",}]}
-width={960}
-height={1080}
-/>
+```
+https://mcp.neon.tech/mcp?projectId=<your-project-id>
+```
+
+Cross-project search and navigation are disabled in this mode.
+
+### Category filtering
+
+Restrict active tools to specific categories using `?category=<name>` (repeatable):
+
+```
+https://mcp.neon.tech/mcp?category=querying&category=schema
+```
+
+See [Available tools](#available-tools) for the full category list. To verify which tools are active for a given config without authenticating:
+
+```bash
+curl "https://mcp.neon.tech/api/list-tools?readonly=true&category=querying"
+```
 
 ## MCP security guidance
 
-The Neon MCP server provides powerful database tools. We recommend MCP for **development and testing only**, not production environments.
+We recommend MCP for **development and testing only**, not production environments.
 
 - Use MCP only for local development or IDE-based workflows
 - Never connect MCP agents to production databases
@@ -117,6 +88,22 @@ The hosted Neon MCP Server (`mcp.neon.tech`) connects to your Neon databases fro
 - `23.22.233.166`
 
 If [IP Allow](/docs/introduction/ip-allow) is enabled on your project, add these addresses to your allowlist so the MCP server can connect.
+
+<MCPTools />
+
+## Troubleshooting
+
+If your client doesn't support JSON for MCP server configuration (such as older versions of Cursor), use this command when prompted:
+
+```bash
+npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
+```
+
+For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon).
+
+<Admonition type="note">
+For clients that don't support Streamable HTTP, you can use the deprecated SSE endpoint: `https://mcp.neon.tech/sse`. SSE is not supported with API key authentication.
+</Admonition>
 
 ## Resources
 

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -1,69 +1,19 @@
 ---
-updatedOn: '2026-05-22T11:06:11.144Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-## Supported actions (tools)
+## Available tools
 
-The Neon MCP Server provides the following actions, which are exposed as "tools" to MCP clients. You can use these tools to interact with your Neon projects and databases using natural language commands.
+Tools are grouped into categories. Use the `?category=` URL parameter to restrict which categories are active. You can pass it more than once to enable multiple categories.
 
-**Project management:**
+| Category                        | What it enables                                                                     |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| Project management (`projects`) | List, create, describe, and delete projects and organizations                       |
+| Branch management (`branches`)  | Create branches, compare schemas, reset branches to parent state                    |
+| Schema (`schema`)               | Inspect tables and columns; run schema changes via a safe temporary branch workflow |
+| SQL (`querying`)                | Execute queries and transactions; inspect database structure                        |
+| Neon Auth (`neon_auth`)         | Set up and configure app authentication for a branch                                |
+| Neon Data API (`data_api`)      | Enable HTTP-based Data API access for a branch                                      |
+| Documentation (`docs`)          | Look up Neon documentation from within your assistant (no OAuth required)           |
 
-- `list_projects`: Lists the first 10 Neon projects in your account, providing a summary of each project. If you can't find a specific project, increase the limit by passing a higher value to the limit parameter.
-- `list_shared_projects`: Lists Neon projects shared with the current user. Supports a search parameter and limiting the number of projects returned (default: 10).
-- `describe_project`: Fetches detailed information about a specific Neon project, including its ID, name, and associated branches and databases.
-- `create_project`: Creates a new Neon project in your Neon account. A project acts as a container for branches, databases, roles, and computes.
-- `delete_project`: Deletes an existing Neon project and all its associated resources.
-- `list_organizations`: Lists all organizations that the current user has access to. Optionally filter by organization name or ID using the search parameter.
-
-**Branch management:**
-
-- `create_branch`: Creates a new branch within a specified Neon project. By default the branch is created from the project's default branch; pass optional `parentId` (a branch ID such as `br-...`) to fork from an existing non-default branch instead. Leverages [Neon's branching](/docs/introduction/branching) feature for development, testing, or migrations.
-- `delete_branch`: Deletes an existing branch from a Neon project.
-- `describe_branch`: Retrieves details about a specific branch, such as its name, ID, and parent branch.
-- `list_branch_computes`: Lists compute endpoints for a project or specific branch, including compute ID, type, size, last active time, and autoscaling information.
-- `compare_database_schema`: Shows the schema diff between the child branch and its parent.
-- `reset_from_parent`: Resets the current branch to its parent's state, discarding local changes. Automatically preserves to backup if branch has children, or optionally preserve on request with a custom name.
-
-**SQL query execution:**
-
-- `get_connection_string`: Returns your database connection string.
-- `run_sql`: Executes a single SQL query against a specified Neon database. Supports both read and write operations.
-- `run_sql_transaction`: Executes a series of SQL queries within a single transaction against a Neon database.
-- `get_database_tables`: Lists all tables within a specified Neon database.
-- `describe_table_schema`: Retrieves the schema definition of a specific table, detailing columns, data types, and constraints.
-
-**Database migrations (schema changes):**
-
-- `prepare_database_migration`: Initiates a database migration process. Critically, it creates a temporary branch to apply and test the migration safely before affecting the main branch.
-- `complete_database_migration`: Finalizes and applies a prepared database migration to the main branch. This action merges changes from the temporary migration branch and cleans up temporary resources.
-
-**SQL querying and optimization:**
-
-- `list_slow_queries`: Identifies performance bottlenecks by finding the slowest queries in a database. Requires the pg_stat_statements extension.
-- `explain_sql_statement`: Provides detailed execution plans for SQL queries to help identify performance bottlenecks.
-- `prepare_query_tuning`: Analyzes query performance and suggests optimizations, like index creation. Creates a temporary branch for safely testing these optimizations.
-- `complete_query_tuning`: Finalizes query tuning by either applying optimizations to the main branch or discarding them. Cleans up the temporary tuning branch.
-
-**Neon Auth:**
-
-To set up Neon Auth in your application code, use [Agent Skills](/docs/ai/agent-skills) after running `npx neonctl@latest init`. See [Set up Neon Auth with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor).
-
-- `provision_neon_auth`: Provisions [Neon Auth](/docs/auth/overview) for a project's branch so you can add authentication to your app without standing up a separate auth service. If Neon Auth is already provisioned, this returns the existing configuration instead of erroring.
-- `get_neon_auth_config`: Returns the Neon Auth configuration for a branch, including the auth `base_url`, `jwks_url`, trusted origins, allowed auth methods (for example email and password), configured OAuth providers, and email provider settings. Secrets such as OAuth client secrets and SMTP passwords are redacted.
-- `configure_neon_auth`: Updates the Neon Auth configuration for a branch. Use it to manage trusted origins, toggle localhost, enable or tune email and password sign-in, add or update OAuth providers, configure the email provider, and send a test email.
-
-**Neon Data API:**
-
-- `provision_neon_data_api`: Provisions the Neon Data API for a branch, enabling HTTP-based Data API access with optional JWT authentication.
-
-**Search and discovery:**
-
-- `search`: Searches across organizations, projects, and branches matching a query. Returns IDs, titles, and direct links to the Neon Console.
-- `fetch`: Fetches detailed information about a specific organization, project, or branch using an ID (typically from the search tool).
-
-In project-scoped mode, `search` and `fetch` are not available.
-
-**Documentation and resources:**
-
-- `list_docs_resources`: Lists all available Neon documentation pages by fetching the docs index. Returns page URLs and titles that can be fetched individually using the `get_doc_resource` tool.
-- `get_doc_resource`: Fetches a specific Neon documentation page as markdown content. Use the `list_docs_resources` tool first to discover available page slugs, then pass the slug to this tool.
+Search and navigation tools (search across projects, fetch resource details by ID) are available by default but disabled in [project-scoped mode](/docs/ai/neon-mcp-server#project-scoped-mode).

--- a/content/guides/claude-code-mcp-neon.md
+++ b/content/guides/claude-code-mcp-neon.md
@@ -4,44 +4,20 @@ subtitle: 'Interact with Neon APIs using Claude Code through natural language'
 author: pedro-figueiredo
 enableTableOfContents: true
 createdAt: '2025-08-27T00:00:00.000Z'
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-Imagine adjusting your database schema simply by describing the change in plain English. This is possible by combining [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon).
+This guide shows how to use [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
 
-This guide demonstrates how to use Claude Code's command-line interface and Neon's MCP server to perform database migrations in your Neon project.
-
-<Admonition type="important" title="Neon MCP Server Security Considerations">
-The Neon MCP Server grants powerful database management capabilities through natural language requests. **Always review and authorize actions requested by the LLM before execution.** Ensure that only authorized users and applications have access to the Neon MCP Server.
-
-The Neon MCP Server is intended for local development and IDE integrations only. **We do not recommend using the Neon MCP Server in production environments.** It can execute powerful operations that may lead to accidental or unauthorized changes.
-
-For more information, see [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
+<Admonition type="important" title="Security">
+The Neon MCP Server grants broad database management capabilities. Always review and authorize actions requested by the LLM before execution. See [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
 </Admonition>
-
-## Key components
-
-Let's break down the key components in this setup:
-
-- **Claude Code**: Claude Code is Anthropic's official CLI tool that supports Model Context Protocol (MCP) for interfacing with external tools (APIs, databases, etc.)
-
-- **Neon MCP Server**: Neon's MCP server acts as a bridge between MCP clients like Claude Code and [Neon's API](https://api-docs.neon.tech/reference/getting-started-with-neon-api), letting you work with Neon databases using natural language commands.
-
-- **Model Context Protocol (MCP)**: MCP is a lightweight communication standard that allows Claude Code and Neon MCP Server to work together.
 
 ## Setting up Neon MCP Server in Claude Code
 
-You have three options for connecting Claude Code to the Neon MCP Server:
-
-1. **Quick Setup (Recommended):** Use the `neonctl init` command to automatically configure Claude Code with OAuth authentication and API key creation.
-
-2. **Remote MCP Server (OAuth):** Manually connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Claude Code. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
-
-3. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
-
 ### Prerequisites
 
-Before you begin, ensure you have the following:
+Make sure you have:
 
 1. **Claude Code:** Ensure you have Claude Code installed. Visit [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code) for installation instructions.
 2. **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
@@ -65,10 +41,8 @@ This command authenticates via OAuth, creates an API key, and configures Claude 
 ### Option 1: Setting up the Remote Hosted Neon MCP Server (OAuth)
 
 <Admonition type="note">
-By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#api-key-based-authentication).
+By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#config-generator).
 </Admonition>
-
-This method uses Neon's managed server and OAuth authentication.
 
 1. Open your terminal.
 2. Add the Neon MCP server to Claude Code with the following command:
@@ -105,18 +79,14 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
    claude mcp add neon -- npx -y @neondatabase/mcp-server-neon start "<YOUR_NEON_API_KEY>"
    ```
 
-   > Replace `<YOUR_NEON_API_KEY>` with your actual Neon API key which you obtained from the [prerequisites](#prerequisites) section.
-
 3. Start a new Claude Code session with the `claude` command and start using the Neon MCP server:
    ```sh
    claude
    ```
 
-You've now configured the Neon MCP Server in Claude Code and can manage your Neon Postgres databases using AI.
-
 ### Verification
 
-Now that you have the Neon MCP server set up either remotely or locally, you can verify the connection and test the available tools.
+Verify the connection:
 
 1. Start Claude Code:
 
@@ -128,21 +98,11 @@ Now that you have the Neon MCP server set up either remotely or locally, you can
 
 3. Try out a Neon MCP Server tool by typing a query like `List my Neon projects` to see your projects and verify the connection.
 
-<MCPTools />
-
-These actions enable any MCP client like Claude Code to interact with various functionalities of the **Neon platform via the Neon API.** Certain tools, especially database migration ones, are tailored for AI agent and LLM usage, leveraging Neon's branching for safe preview and commit.
+For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.
 
 ## Development Workflow: Adding a Column with Claude Code and Neon MCP
 
-Let's walk through a typical development scenario: Quickly adding a column for prototyping using natural language within Claude Code. The following chat log demonstrates a real interaction with Claude Code and the Neon MCP server.
-
-**Scenario:** During development, you decide to track timestamps for entries in your `playing_with_neon` table. You want to quickly add a `created_at` column.
-
-<Admonition type="tip" title="Security Reminder">
-For your security, review the tool's purpose before permitting the operation to proceed. Remember that LLMs can sometimes produce unexpected results, so careful monitoring is always recommended.
-</Admonition>
-
-Here's the conversation log between the user and Claude Code:
+Here's an example interaction adding a `created_at` column to a table:
 
 ```text shouldWrap
 User: In my neon project id: round-salad-44063611 list all the tables
@@ -180,58 +140,11 @@ Claude Code: I'll complete the migration and apply the changes to the production
 > The migration has been successfully completed! The created_at column has been added to your table in the production branch, and the temporary branch has been cleaned up.
 ```
 
-**Key takeaways:**
-
-- **Natural language interaction:** You can use simple, conversational English to interact with your database.
-- **Step-by-step guidance:** Claude Code confirms each step and provides details like branch names and migration IDs.
-- **MCP Tools in Action:** The underlying MCP tools (`get_database_tables`, `run_sql`, `prepare_database_migration`, `complete_database_migration`) illustrate the automated process.
-- **Branching for safety:** The agent automatically creates a temporary branch for schema changes. The user will be prompted to confirm the migration before applying it to the production branch.
-
 You can verify the changes in your Neon Console or by querying the database directly.
 
 <Admonition type="note">
-While the Neon MCP server allows you to utilize all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
+While the Neon MCP server allows you to use all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
 </Admonition>
-
-## Bonus: Creating a project and branch
-
-Beyond schema changes, you can also manage your Neon projects and branches directly within Claude Code using natural language commands. This can be useful for quickly setting up a new development or test environment.
-
-### Creating a new project
-
-Let's say you want to create a new Neon project named "my-new-project". You can simply tell Claude Code:
-
-```text shouldWrap
-User: Create a Neon project named "my-new-project"
-Claude Code: I'll help you create a new Neon project with the specified name.
-> Called MCP Tool (create_project)
-> Great! I've created a new Neon project for you with the name "my-new-project". Here are the important details:
-> Project ID: orange-dawn-33739962
-> Default branch: main
-> Default database: neondb
-> The project is ready to use. You can start creating tables and working with your database right away.
-```
-
-Claude Code will then use the `create_project` MCP tool to initiate the project creation. It will provide you with a project ID and name.
-
-### Creating a New Branch
-
-Once you have a project, you can easily create new branches for development or experimentation. For example, to create a branch named "feature-x" in your "my-new-project" project:
-
-```text shouldWrap
-User: Create a branch named "feature-x"
-Claude Code: Perfect! I've created a new branch named "feature-x". Here are the details:
-> Branch ID: br-cold-mountain-a523ka2w
-> Branch name: feature-x
-> Parent branch ID: br-odd-pine-a5y53krm
-> The branch has been created successfully and is ready for use.
-```
-
-Claude Code will use the `create_branch` MCP tool to create the branch and provide you with the branch name and ID. Notice how we don't need to specify the project ID, as Claude Code remembers the active project context.
-
-## Conclusion
-
-Claude Code combined with the Neon MCP Server, whether using the **Remote Hosted** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing database ideas and making schema changes during development.
 
 ## Resources
 

--- a/content/guides/cline-mcp-neon.md
+++ b/content/guides/cline-mcp-neon.md
@@ -4,42 +4,20 @@ subtitle: 'Make schema changes with natural language using Cline and Neon MCP Se
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-22T00:00:00.000Z'
-updatedOn: '2026-03-04T15:50:25.000Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-Imagine adjusting your database schema simply by describing the change in plain English. This is possible by combining [Cline](https://cline.bot) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon).
+This guide shows how to use [Cline](https://cline.bot) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
 
-This guide demonstrates how to use [Cline](https://docs.cline.bot/mcp-servers/mcp) and Neon's MCP server to perform database migrations in your Neon project.
-
-<Admonition type="important" title="Neon MCP Server Security Considerations">
-The Neon MCP Server grants powerful database management capabilities through natural language requests. **Always review and authorize actions requested by the LLM before execution.** Ensure that only authorized users and applications have access to the Neon MCP Server.
-
-The Neon MCP Server is intended for local development and IDE integrations only. **We do not recommend using the Neon MCP Server in production environments.** It can execute powerful operations that may lead to accidental or unauthorized changes.
-
-For more information, see [MCP security guidance →](/docs/ai/neon-mcp-server#mcp-security-guidance).
+<Admonition type="important" title="Security">
+The Neon MCP Server grants broad database management capabilities. Always review and authorize actions requested by the LLM before execution. See [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
 </Admonition>
-
-## Key components
-
-Let's break down the key components in this setup:
-
-- **Cline**: Cline is an autonomous coding agent streamlining your development process within your IDE. It offers powerful features for creating, editing, executing, and even browsing, all under your guidance. Cline has support for the Model Context Protocol (MCP), facilitating seamless interaction with external tools.
-
-- **Neon MCP Server**: Neon's MCP server acts as a bridge between MCP clients like Cline and [Neon's API](https://api-docs.neon.tech/reference/getting-started-with-neon-api), letting you work with Neon databases using natural language commands.
-
-- **Model Context Protocol (MCP)**: MCP is a lightweight communication standard that allows Cline and Neon MCP Server to work together.
 
 ## Setting up Neon MCP Server in Cline
 
-You have two options for connecting Cline to the Neon MCP Server:
-
-1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Cline. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
-
-2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
-
 ### Prerequisites
 
-Before you begin, ensure you have the following:
+Make sure you have:
 
 1.  **Cline extension and Setup:**
     - Download and install the Cline VS Code extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev).
@@ -53,12 +31,8 @@ Before you begin, ensure you have the following:
 
 ### Option 1: Setting up the remote hosted Neon MCP Server
 
-This method uses Neon's managed server and OAuth authentication.
-
-### Installation and configuration
-
 <Admonition type="note">
-By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#api-key-based-authentication).
+By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#config-generator).
 </Admonition>
 
 1. Open Cline by clicking the **Cline** icon in the VS Code sidebar.
@@ -87,9 +61,8 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
    ![Cline MCP Servers Icon](/docs/guides/cline-mcp-servers-icon.png)
 3. Click **Configure** to open the MCP server settings.
    ![Cline MCP Server Configure](/docs/guides/cline-mcp-server-configure.png)
-4. This will open the `cline_mcp_settings.json` file.
-5. In the `cline_mcp_settings.json` file, you need to specify a list of MCP servers.
-6. Paste the following JSON configuration into it. Replace `<YOUR_NEON_API_KEY>` with your actual Neon API key which you obtained from the [prerequisites](#prerequisites) section:
+4. This opens `cline_mcp_settings.json`.
+5. Paste the following JSON configuration into it. Replace `<YOUR_NEON_API_KEY>` with your Neon API key:
    <CodeTabs labels={["MacOS/Linux", "Windows", "Windows (WSL)"]}>
 
    ```json
@@ -134,34 +107,22 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
 
    </CodeTabs>
 
-7. **Save** the `cline_mcp_settings.json` file.
-8. You should see a notification in VS Code that says: "MCP servers updated".
+6. **Save** the `cline_mcp_settings.json` file.
+7. You should see a notification in VS Code that says: "MCP servers updated".
    ![Cline MCP Server Updated](/docs/guides/cline-mcp-config-update.png)
-9. Cline is now configured to use the local Neon MCP server. You should see **neon** listed under available MCP servers.
+8. Cline is now configured to use the local Neon MCP server. You should see **neon** listed under available MCP servers.
 
 ### Verifying the Integration
 
-Now that you have the Neon MCP server set up either remotely or locally, you can verify the connection and test the available tools. If the integration is successful, you should see the Neon MCP server listed in the Cline MCP Servers Installed section.
+The Neon MCP server will appear in the Cline MCP Servers Installed section.
 
 ![Cline Available MCP Tools](/docs/guides/cline-available-mcp-tools.png)
 
-You've now configured Neon MCP Server in Cline and can manage your Neon Postgres databases using AI.
-
-<MCPTools />
-
-These actions enable any MCP client like Cline to interact with various functionalities of the **Neon platform via the Neon API.** Certain tools, especially database migration ones, are tailored for AI agent and LLM usage, leveraging Neon's branching for safe preview and commit.
+For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.
 
 ## Development Workflow: Adding a Column with Cline and Neon MCP
 
-Let's walk through a typical development scenario: Quickly adding a column for prototyping using natural language within Cline. The following chat log demonstrates a real interaction with Cline and the Neon MCP server.
-
-**Scenario:** During development, you decide to track timestamps for entries in your `playing_with_neon` table. You want to quickly add a `created_at` column.
-
-<Admonition type="tip" title="Security Reminder">
-For your security, review the tool's purpose before permitting the operation to proceed. Remember that LLMs can sometimes produce unexpected results, so careful monitoring is always recommended.
-</Admonition>
-
-Following is a sample interaction with Cline where you can see how it uses the Neon MCP server to add a column to your table:
+Here's an example interaction adding a `created_at` column to a table:
 
 ```text shouldWrap
 User: in my neon project id: fancy-bush-59303206, list all my tables
@@ -199,66 +160,13 @@ Cline: I'll use the prepare_database_migration tool to add a created_at column t
 > The migration has been successfully completed. The created_at column has been added to the table and is populated with timestamps.
 ```
 
-**Key takeaways:**
-
-- **Natural language interaction:** You can use simple, conversational English to interact with your database through Cline.
-- **Step-by-step guidance:** Cline confirms each step and provides details like branch names and migration IDs.
-- **MCP Tools in Action:** The underlying MCP tools (`get_database_tables`, `run_sql`, `prepare_database_migration`, `complete_database_migration`) illustrate the automated process.
-- **Branching for safety:** The agent automatically creates a temporary branch for schema changes. The user will be prompted to confirm the migration before applying it to the production branch.
-
 You can verify the changes in your Neon Console or by querying the database directly.
 
 ![Neon Console with added column](/docs/guides/neon-cursor-mcp-added-column.png)
 
 <Admonition type="note">
-While the Neon MCP server allows you to utilize all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
+While the Neon MCP server allows you to use all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
 </Admonition>
-
-## Bonus: Creating a project and branch
-
-Beyond schema changes, you can also manage your Neon projects and branches directly within Cline using natural language commands. This can be useful for quickly setting up a new development or test environment.
-
-### Creating a new project
-
-Let's say you want to create a new Neon project named "my-new-project". You can simply tell Cline:
-
-```text shouldWrap
-User: Create a Neon project named "my-new-project"
-Cline: I see that I have access to the Neon MCP server which provides tools for interacting with Neon's API. Looking at the available tools, I can use the create_project tool to create a new Neon project with the specified name "my-new-project".
-> Cline wants to use a tool on the neon MCP server:
-> create_project ARGUMENTS: { "name": "my-new-project" }
-> I've created a new Neon project named "my-new-project". Here are the project details:
-> Project ID: muddy-bar-98083629
-> Default branch: main
-> Default database: neondb
-```
-
-![Cline creating a new Neon project](/docs/guides/cline-mcp-create-new-project.png)
-
-Cline will then use the `create_project` MCP tool to initiate the project creation. It will provide you with a project ID and name.
-
-### Creating a New Branch
-
-Once you have a project, you can easily create new branches for development or experimentation. For example, to create a branch named "feature-x" in your "my-new-project" project:
-
-```text shouldWrap
-User: Create a branch named "feature-x"
-Cline: I'll use the create_branch tool from the Neon MCP server to create a new branch named "feature-x" in the project we just created (project ID: muddy-bar-98083629).
-> Cline wants to use a tool on the neon MCP server:
-> create_branch ARGUMENTS: { "project_id": "muddy-bar-98083629", branchName": "feature-x" }
-> I've created a new branch named "feature-x" in your Neon project. Here are the branch details:
-> Branch ID: br-broad-base-a5kh7wyi
-> Branch name: feature-x
-> Parent branch: br-lively-cherry-a5kz48n6
-```
-
-![Cline creating a new Neon branch](/docs/guides/cline-mcp-create-new-branch.png)
-
-Cline will use the `create_branch` MCP tool to create the branch and provide you with the branch name and ID. Notice how we don't need to specify the project ID, as Cline remembers the active project context.
-
-## Conclusion
-
-Cline with Neon MCP Server lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing database ideas and making schema changes during development.
 
 ## Resources
 

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -4,42 +4,20 @@ subtitle: 'Make schema changes with natural language using Cursor and Neon MCP S
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-20T00:00:00.000Z'
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-Imagine adjusting your database schema simply by describing the change in plain English. This is possible by combining [Cursor](https://cursor.com) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon).
+This guide shows how to use [Cursor](https://cursor.com) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
 
-This guide demonstrates how to use [Cursor's Composer](https://docs.cursor.com/composer) and Neon's MCP server to perform database migrations in your Neon project.
-
-<Admonition type="important" title="Neon MCP Server Security Considerations">
-The Neon MCP Server grants powerful database management capabilities through natural language requests. **Always review and authorize actions requested by the LLM before execution.** Ensure that only authorized users and applications have access to the Neon MCP Server.
-
-The Neon MCP Server is intended for local development and IDE integrations only. **We do not recommend using the Neon MCP Server in production environments.** It can execute powerful operations that may lead to accidental or unauthorized changes.
-
-For more information, see [MCP security guidance →](/docs/ai/neon-mcp-server#mcp-security-guidance).
+<Admonition type="important" title="Security">
+The Neon MCP Server grants broad database management capabilities. Always review and authorize actions requested by the LLM before execution. See [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
 </Admonition>
-
-## Key components
-
-Let's break down the key components in this setup:
-
-- **Cursor**: Cursor is an AI-first code editor that supports Model Context Protocol (MCP) for interfacing with external tools (APIs, databases, etc.)
-
-- **Neon MCP Server**: Neon's MCP server acts as a bridge between MCP clients like Cursor and [Neon's API](https://api-docs.neon.tech/reference/getting-started-with-neon-api), letting you work with Neon databases using natural language commands.
-
-- **Model Context Protocol (MCP)**: MCP is a lightweight communication standard that allows Cursor and Neon MCP Server to work together.
 
 ## Setting up Neon MCP Server in Cursor
 
-You have two options for connecting Cursor to the Neon MCP Server:
-
-1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Cursor. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
-
-2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
-
 ### Prerequisites
 
-Before you begin, ensure you have the following:
+Make sure you have:
 
 1. **Cursor Editor:** Download and install Cursor from [cursor.com](https://cursor.com).
 2. **A Neon Account and Project:** You'll need a Neon account and a project. You can create a new Neon project in the [Neon Console](https://console.neon.tech)
@@ -72,10 +50,8 @@ Note: This uses OAuth (not API key), so you'll need to approve each MCP action. 
 ### Option 1: Setting up the Remote Hosted Neon MCP Server (OAuth)
 
 <Admonition type="note">
-By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#api-key-based-authentication).
+By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#config-generator).
 </Admonition>
-
-This method uses Neon's managed server and OAuth authentication.
 
 1. Open Cursor.
 2. Create a `.cursor` directory in your project's root directory. This is where Cursor will look for the MCP server configuration.
@@ -104,8 +80,6 @@ This method uses Neon's managed server and OAuth authentication.
 
 6. You can verify that the connection is successful by checking the **Tools & MCP** section in Cursor settings.
    ![Cursor with Neon MCP Tools](/docs/guides/cursor-with-neon-mcp-tools.png)
-
-7. Cursor is now connected to Neon's remote MCP server.
 
 ### Option 2: Setting up the Local Neon MCP Server
 
@@ -167,15 +141,13 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
 
 5. **Restart Cursor** or reload the window (`Developer: Reload Window` from the Command Palette).
 
-6. Cursor is now connected to Neon's MCP server. You can verify that the connection is successful by checking the **MCP Servers** section in Cursor settings.
+6. Check the **MCP Servers** section in Cursor settings to verify the connection.
 
    ![Cursor with Neon MCP Tools](/docs/guides/cursor-with-neon-mcp-tools.png)
 
-You've now configured Neon MCP Server in Cursor and can manage your Neon Postgres databases using AI.
-
 ### Verification
 
-Now that you have the Neon MCP server set up either remotely or locally, you can verify the connection and test the available tools.
+Verify the connection:
 
 1. Open a Cursor **Chat** using the keyboard shortcut **Command + I** (on Mac) or **Control + I** (on Windows) and select the **Agent** option from the drop-down menu.
 
@@ -183,7 +155,7 @@ Now that you have the Neon MCP server set up either remotely or locally, you can
 
 2. Type `List your available MCP tools` in the Composer text field, select the **agent** option in the corner of the field, and click **Submit**.
 
-   **_Note: The agent option here is tiny and easy to miss!_**
+   <Admonition type="tip">The agent option is small and easy to miss.</Admonition>
 
    ![Cursor list available tools](/docs/guides/cursor_list_tools.png)
 
@@ -195,7 +167,7 @@ Now that you have the Neon MCP server set up either remotely or locally, you can
 
 ### Global MCP Server in Cursor
 
-You can also set up a global MCP server in Cursor. This allows you to use the same MCP server configuration across all your projects. To do this, follow these steps:
+You can also set up a global MCP server in Cursor. To set this up:
 
 1. Open Cursor.
 2. Go to the **Settings**.
@@ -203,7 +175,6 @@ You can also set up a global MCP server in Cursor. This allows you to use the sa
 4. Paste the same JSON configuration either for the **Remote Hosted** or **Local MCP Server** (as shown in the previous sections) into the configuration field.
 5. Save the configuration.
 6. Restart Cursor or reload the window (`Developer: Reload Window` from the Command Palette).
-7. You now have Neon MCP Server set up globally in Cursor. You can use it in any project without needing to configure it again for each project.
 
 ### Troubleshooting
 
@@ -213,25 +184,15 @@ If you are on a version of Cursor that does not support JSON configuration for M
 npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 ```
 
-<MCPTools />
-
-These actions enable any MCP client like Cursor to interact with various functionalities of the **Neon platform via the Neon API.** Certain tools, especially database migration ones, are tailored for AI agent and LLM usage, leveraging Neon’s branching for safe preview and commit.
+For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.
 
 ## Development Workflow: Adding a Column with Cursor and Neon MCP
-
-Let's walk through a typical development scenario: Quickly adding a column for prototyping using natural language within Cursor. The following chat log demonstrates a real interaction with Cursor and the Neon MCP server.
-
-**Scenario:** During development, you decide to track timestamps for entries in your `playing_with_neon` table. You want to quickly add a `created_at` column.
 
 <Admonition type="tip">
 Use `⌘I` to open Cursor's Composer and `⌘N` to create a new Composer.
 </Admonition>
 
-<Admonition type="tip" title="Security Reminder">
-For your security, review the tool's purpose before permitting the operation to proceed. Remember that LLMs can sometimes produce unexpected results, so careful monitoring is always recommended.
-</Admonition>
-
-Here's the conversation log between the user and Cursor:
+Here's an example interaction adding a `created_at` column to a table:
 
 ```text shouldWrap
 User: In my neon project id: round-salad-44063611 list all the tables
@@ -269,65 +230,13 @@ Cursor: I'll complete the migration and apply the changes to the production bran
 > The migration has been successfully completed! The created_at column has been added to your table in the production branch, and the temporary branch has been cleaned up.
 ```
 
-**Key takeaways:**
-
-- **Natural language interaction:** You can use simple, conversational English to interact with your database.
-- **Step-by-step guidance:** Cursor (Claude) confirms each step and provides details like branch names and migration IDs.
-- **MCP Tools in Action:** The underlying MCP tools (`get_database_tables`, `run_sql`, `prepare_database_migration`, `complete_database_migration`) illustrate the automated process.
-- **Branching for safety:** The agent automatically creates a temporary branch for schema changes. The user will be prompted to confirm the migration before applying it to the production branch.
-
 You can verify the changes in your Neon Console or by querying the database directly.
 
 ![Neon Console with added column](/docs/guides/neon-cursor-mcp-added-column.png)
 
 <Admonition type="note">
-While the Neon MCP server allows you to utilize all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
+While the Neon MCP server gives you access to all of Neon's features, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
 </Admonition>
-
-## Bonus: Creating a project and branch
-
-Beyond schema changes, you can also manage your Neon projects and branches directly within Cursor using natural language commands. This can be useful for quickly setting up a new development or test environment.
-
-### Creating a new project
-
-Let's say you want to create a new Neon project named "my-new-project". You can simply tell Cursor:
-
-```text shouldWrap
-User: Create a Neon project named "my-new-project"
-Cursor: I'll help you create a new Neon project with the specified name.
-> Called MCP Tool (create_project)
-> Great! I've created a new Neon project for you with the name "my-new-project". Here are the important details:
-> Project ID: orange-dawn-33739962
-> Default branch: main
-> Default database: neondb
-> The project is ready to use. You can start creating tables and working with your database right away.
-```
-
-![Cursor creating a new Neon project](/docs/guides/cursor-mcp-create-new-project.png)
-
-Cursor will then use the `create_project` MCP tool to initiate the project creation. It will provide you with a project ID and name.
-
-### Creating a New Branch
-
-Once you have a project, you can easily create new branches for development or experimentation. For example, to create a branch named "feature-x" in your "my-new-project" project:
-
-```text shouldWrap
-User: Create a branch named "feature-x"
-Cursor: Perfect! I've created a new branch named "feature-x". Here are the details:
-> Branch ID: br-cold-mountain-a523ka2w
-> Branch name: feature-x
-> Parent branch ID: br-odd-pine-a5y53krm
-> The branch has been created successfully and is ready for use.
-```
-
-![Cursor creating a new Neon branch](/docs/guides/cursor-mcp-create-new-branch.png)
-
-Cursor will use the `create_branch` MCP tool to create the branch and provide you with the branch name and ID. Notice how we don't need to specify the project ID, as Cursor remembers the active project context.
-
-## Conclusion
-
-Cursor combined with the Neon MCP Server, whether using the **Remote Hosted** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing
-database ideas and making schema changes during development.
 
 ## Resources
 

--- a/content/guides/neon-mcp-server.md
+++ b/content/guides/neon-mcp-server.md
@@ -1,89 +1,31 @@
 ---
 title: 'Get started with Claude Desktop and Neon MCP Server'
-subtitle: 'Enable natural language interaction with your Neon Postgres databases using LLMs'
+subtitle: 'Connect Claude Desktop to Neon to manage projects, run queries, and make schema changes'
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-06T00:00:00.000Z'
-updatedOn: '2026-01-31T14:05:11.000Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-Imagine managing your database with natural language. Instead of complex SQL, you can simply ask your AI assistant to "create a new table for customer orders" or "show me last quarter's sales figures." This is the power of the [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol), an open standard for AI interaction with external systems.
+This guide shows how to connect Claude Desktop to the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) so you can manage your Neon Postgres databases.
 
-This guide will introduce you to [Neon's MCP server](https://github.com/neondatabase/mcp-server-neon), which allows you to use Large Language Models (LLMs) for intuitive database management. At its core, Neon MCP server allows tools like Claude to easily communicate with the [Neon API](https://api-docs.neon.tech/reference/getting-started-with-neon-api).
-
-With Neon's MCP server and an LLM like Claude, you can simplify workflows, improve productivity, and manage your Postgres databases more naturally. Let's explore how this approach can make database management easier and more efficient.
-
-<Admonition type="important" title="Neon MCP Server Security Considerations">
-The Neon MCP Server grants powerful database management capabilities through natural language requests. **Always review and authorize actions requested by the LLM before execution.** Ensure that only authorized users and applications have access to the Neon MCP Server.
-
-The Neon MCP Server is intended for local development and IDE integrations only. **We do not recommend using the Neon MCP Server in production environments.** It can execute powerful operations that may lead to accidental or unauthorized changes.
-
-For more information, see [MCP security guidance →](/docs/ai/neon-mcp-server#mcp-security-guidance).
+<Admonition type="important" title="Security">
+The Neon MCP Server grants broad database management capabilities. Always review and authorize actions requested by the LLM before execution. See [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
 </Admonition>
-
-## Understanding MCP
-
-The **Model Context Protocol (MCP)** is a standard that helps LLMs communicate with external tools, like databases and APIs. It's like a translator, making it easier to connect LLMs to services and data. For the Neon MCP server, it's the protocol that lets Claude (and other LLMs) understand and control your Neon databases through the Neon API.
-
-MCP follows a client-server architecture, where a host application can connect to multiple servers. The key components include:
-
-- **Host**: These are LLM applications, such as Claude Desktop or integrated development environments (IDEs), that initiate connections to MCP servers
-- **Client**: These reside within the host application and maintain one-to-one connections with individual servers
-- **Server**: These programs provide context, tools, and prompts to clients, enabling access to external data and functionalities
-
-### Why use MCP?
-
-Traditionally, connecting AI models to different data sources required developers to create custom code for each integration. This fragmented approach led to increased development time, maintenance burdens, and limited interoperability between AI models and tools. MCP tackles this challenge by providing a standardized protocol that simplifies integration, accelerates development, and enhances the capabilities of AI assistants.
-
-### What is Neon MCP server?
-
-**Neon's MCP server** is an open-source tool that lets LLMs like **Claude manage your Neon databases using natural language by interacting with the Neon API.** It translates your simple English instructions into **Neon API calls**.
-
-Examples of natural language commands that are converted to **Neon API actions**:
-
-- **Create a Postgres database called `my-database`**: Calls the Neon API to create a database
-- **Add a column `created_at` to the 'users' table in project `my-project`**: Uses the Neon API to run an SQL command
-- **List all my Neon projects**: Calls the Neon API to fetch a project list
-
-### Why use Neon MCP server?
-
-Neon MCP server, combined with Neon, offers:
-
-- **Simple Setup:** Easily connect LLMs to **Neon API**.
-- **Natural Language:** Manage databases without direct **Neon API** coding.
-- **Empowering Non-Developers**: Intuitive database interaction for everyone.
-
-<Admonition type="important">
-The Neon MCP server's ability to execute arbitrary commands from natural language requests requires careful attention to security.  Always review and approve actions before they are committed.  Grant access only to authorized users and applications.
-</Admonition>
-
-<MCPTools />
-
-These actions enable any MCP Host to interact with various functionalities of the **Neon platform via the Neon API.** Certain tools, especially database migration ones, are tailored for AI agent and LLM usage, leveraging Neon’s branching for safe preview and commit.
 
 ## Setting up Neon MCP server
-
-We'll use Claude Desktop to interact with Neon MCP server. Here's how to set it up:
 
 ### Prerequisites
 
 - **Node.js (>= v18):** Install from [nodejs.org](https://nodejs.org/).
 - **Claude Desktop:** Install Anthropic's [Claude Desktop](https://claude.ai/download).
 - **Neon Account:** Sign up for a free Neon account at [neon.tech](https://neon.tech).
-- **Neon API Key (for Local MCP server)::** Get your [Neon API Key](/docs/manage/api-keys#creating-api-keys).
-
-### Setting up Neon MCP Server in Claude
-
-You have two options for connecting Claude to the Neon MCP Server:
-
-1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Claude. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
-
-2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
+- **Neon API Key (for Local MCP server):** Get your [Neon API Key](/docs/manage/api-keys#creating-api-keys).
 
 ### Option 1: Setting up the remote hosted Neon MCP Server
 
 <Admonition type="note">
-By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#api-key-based-authentication). Claude connectors currently do not support API key authentication.
+By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#config-generator). Claude connectors currently don't support API key authentication.
 </Admonition>
 
 Choose one of the following methods to set up the Remote Neon MCP server in Claude Desktop:
@@ -145,7 +87,7 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
 
     > Make sure to replace `$NEON_API_KEY` with your actual Neon API key. You can generate one through the Neon Console by following the instructions in [Creating API keys](/docs/manage/api-keys#creating-api-keys).
 
-    You will be prompted to install the required dependencies. Type `y` to proceed. You should see output similar to this:
+    You'll be prompted to install the required dependencies. Type `y` to proceed. You should see output similar to this:
 
     ```bash
     npx @neondatabase/mcp-server-neon init napi_xxxx
@@ -157,83 +99,19 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
     The Neon MCP server will start automatically the next time you open Claude.
     ```
 
-3.  Restart Claude Desktop. You can do so by quitting the Claude Desktop and opening it again.
+3.  Restart Claude Desktop.
 
 ### Verifying the connection
 
-You can verify that the connection to the Neon MCP server either remote or local is successful by following these steps:
+Verify the connection:
 
 1. In Claude click on the search and tools icon to see the available tools.
    ![Claude available tools](/guides/images/claude_mcp/claude_available_tools.png)
 2. You should see the Neon MCP server's tools listed. Click on the **neon** tool to see the available tools in detail.
    ![Claude list available tools](/guides/images/claude_mcp/claude_list_available_tools.png)
-3. Claude is now connected to Neon's remote MCP server.
-
-Ask Claude `"List my Neon projects"`. If it works, you'll see your projects listed by Claude, fetched using the **Neon API**. For example, you might see output similar to this:
+   Ask Claude `"List my Neon projects"` to verify the connection. For example, you might see output similar to this:
 
 ![Claude output](/guides/images/claude_mcp/claude_list_project.png)
-
-## Using Neon MCP server
-
-Neon MCP server lets you manage Neon via **Neon API calls**
-
-### Neon platform operations
-
-- **List databases:** `"What databases do I have in my Neon project?"`
-- **Create a new Neon project**: `"Create a new Neon named my-project"`
-- **Create a new database**: `"Create a new database called my-database in the Neon project named my-project"`
-
-### Simple SQL queries
-
-- **Insert records"** `"Create a table named posts with 20 records."`
-- **Query a table:** `"Show me 10 posts from 'posts' table in database 'my-database' of project 'my-project'"` (Triggers `run_sql` action to execute query)
-
-### Schema exploration
-
-- **List tables:** `"What tables are in database 'my-database' of project 'my-project'?"` (Triggers `get_database_tables` action to get table list)
-- **Table schema:** `"Show schema of 'posts' table in database 'my-database' of project 'my-project'"` (Triggers `describe_table_schema` action to describe schema)
-
-### Quick example: Neon MCP server in action
-
-Imagine you want to add a column to a table in your Neon project. Instead of writing SQL migrations and directly calling the Neon API, with Neon MCP server and Claude, you can say: `"In my social network Neon project, edit the posts table and add a deleted_at column."`
-
-<Video  
-sources={[{src: "/videos/pages/doc/neon-mcp.mp4",type: "video/mp4",}]}
-width={960}
-height={1080}
-/>
-
-Using Neon MCP server, Claude will:
-
-1. **Confirm project:** Check which project you are referring to.
-2. **Check schema:** Look at the `posts` table structure.
-3. **Make migration:** Create the SQL to add the column
-4. **Preview changes:** Show you the changes in a safe, temporary branch leveraging Neon's branching feature.
-5. **Apply changes:** After you approve, apply the change to your database.
-6. **Confirm success:** Tell you the column is added and prompt you to commit the migration.
-
-This shows how Neon MCP server simplifies and makes database management safer with natural language, all powered by the **Neon API** under the hood.
-
-## Real-world use cases
-
-Neon MCP server can be used in various scenarios. Here are just a few possibilities:
-
-- **SaaS apps:** Faster development with natural language database management
-- **Dev/Test:** Quick database setup for testing
-- **AI agents:** Simple database backend for AI using natural language
-- **Internal tools:** Data access for non-technical teams via natural language interaction
-
-## Security considerations
-
-When Claude uses the Neon MCP tool, you'll see an authorization prompt: "Allow tool from "neon"?"
-
-![Claude output](/guides/images/claude_mcp/claude_allow_tool.png)
-
-For your security, review the tool's purpose before permitting the operation to proceed. Remember that LLMs can sometimes produce unexpected results, so careful monitoring is always recommended.
-
-## Conclusion
-
-Neon MCP server makes database management conversational and easier by enabling natural language interaction with the Neon API. It simplifies tasks, automates processes, and opens new ways to use AI with databases.
 
 ## Resources
 

--- a/content/guides/windsurf-mcp-neon.md
+++ b/content/guides/windsurf-mcp-neon.md
@@ -4,42 +4,20 @@ subtitle: 'Make schema changes with natural language using Codeium Windsurf and 
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-22T00:00:00.000Z'
-updatedOn: '2026-03-04T15:50:25.000Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-Imagine adjusting your database schema simply by describing the change in plain English. This is possible by combining [Codeium Windsurf](https://codeium.com/windsurf) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon).
+This guide shows how to use [Windsurf](https://codeium.com/windsurf) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
 
-This guide demonstrates how to use [Windsurf's Cascade](https://docs.codeium.com/windsurf/cascade) and Neon's MCP server to perform database migrations in your Neon project.
-
-<Admonition type="important" title="Neon MCP Server Security Considerations">
-The Neon MCP Server grants powerful database management capabilities through natural language requests. **Always review and authorize actions requested by the LLM before execution.** Ensure that only authorized users and applications have access to the Neon MCP Server.
-
-The Neon MCP Server is intended for local development and IDE integrations only. **We do not recommend using the Neon MCP Server in production environments.** It can execute powerful operations that may lead to accidental or unauthorized changes.
-
-For more information, see [MCP security guidance →](/docs/ai/neon-mcp-server#mcp-security-guidance).
+<Admonition type="important" title="Security">
+The Neon MCP Server grants broad database management capabilities. Always review and authorize actions requested by the LLM before execution. See [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
 </Admonition>
-
-## Key components
-
-Let's break down the key components in this setup:
-
-- **Codeium Windsurf**: Windsurf is Codeium's next-generation AI IDE, featuring Cascade, an agentic chatbot that supports Model Context Protocol (MCP) for interfacing with external tools.
-
-- **Neon MCP Server**: Neon's MCP server acts as a bridge between MCP clients like Windsurf and [Neon's API](https://api-docs.neon.tech/reference/getting-started-with-neon-api), letting you work with Neon databases using natural language commands.
-
-- **Model Context Protocol (MCP)**: MCP is a lightweight communication standard that allows Windsurf and Neon MCP Server to work together.
 
 ## Setting up Neon MCP Server in Windsurf
 
-You have two options for connecting Windsurf to the Neon MCP Server:
-
-1. **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Windsurf. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
-
-2. **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
-
 ### Prerequisites
 
-Before you begin, ensure you have the following:
+Make sure you have:
 
 1.  **Codeium Windsurf Editor:** Download and install Windsurf from [codeium.com/windsurf](https://codeium.com/windsurf).
 2.  **A Neon Account and Project:** You'll need a Neon account and a project. You can create a new Neon project in the [Neon Console](https://console.neon.tech)
@@ -53,8 +31,6 @@ Before you begin, ensure you have the following:
 
 ### Option 1: Setting up the Remote Hosted Neon MCP Server
 
-This method uses Neon's managed server and OAuth authentication.
-
 You can either watch the video below or follow the steps to set up the Neon MCP server in Windsurf.
 
 <video controls playsInline loop width="800" height="600">
@@ -62,14 +38,14 @@ You can either watch the video below or follow the steps to set up the Neon MCP 
 </video>
 
 <Admonition type="note">
-By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#api-key-based-authentication).
+By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#config-generator).
 </Admonition>
 
 1. Open Windsurf.
 2. Open Cascade by using `⌘L` on MacOS or `Ctrl+L` on Windows/Linux.
 3. Click on the plug icon (🔌), then click the **"Configure"** button.
    ![Windsurf Configure MCP](/docs/guides/windsurf-configure-mcp.png)
-4. This will open up the MCP configuration file in Windsurf.
+4. This opens the MCP configuration file.
 5. Add the "Neon" server entry within the `mcpServers` object:
 
    ```json
@@ -87,11 +63,9 @@ By default, the Remote MCP Server connects to your personal Neon account. To con
 6. **Save** the MCP configuration file.
 7. An OAuth window will open in your browser. Follow the prompts to authorize Windsurf to access your Neon account.
    ![Neon OAuth window](/docs/guides/neon-oauth-window.png)
-8. You can verify that the connection is successful by checking the available MCP servers. The toolbar should indicate that you have Neon MCP server available.
+8. Check the toolbar to confirm Neon appears in your MCP servers.
 
    ![Windsurf MCP Toolbar](/docs/guides/windsurf-mcp-server-available.png)
-
-9. Windsurf is now connected to the Neon MCP server.
 
 <Admonition type="tip" title="Troubleshooting OAuth Errors">
 If you encounter an error message like `{"code":"invalid_request","error":"invalid redirect uri"}` when starting Windsurf with the remote MCP server, this is typically due to cached OAuth credentials. To fix this issue:
@@ -112,8 +86,8 @@ key for authentication.
 2. Open Cascade by using `⌘L` on MacOS or `Ctrl+L` on Windows/Linux.
 3. Click on the hammer icon (🔨), then click the **"Configure"** button.
    ![Windsurf Configure MCP](/docs/guides/windsurf-configure-mcp.png)
-4. This will open up the MCP configuration file in Windsurf.
-5. Click on "View raw config" to open the Windsurf's MCP configuration file.
+4. This opens the Cascade MCP settings panel.
+5. Click **View raw config** to edit the JSON directly.
 6. Add the "Neon" server entry within the `mcpServers` object:
 
    <CodeTabs labels={["MacOS/Linux", "Windows", "Windows (WSL)"]}>
@@ -165,26 +139,14 @@ key for authentication.
    If you have other MCP servers configured, you can copy just the `Neon` part.
 
 7. **Save** the MCP configuration file.
-8. You can verify that the connection is successful by checking the available MCP servers. The toolbar should indicate that you have Neon MCP server available.
+8. Check the toolbar to confirm Neon appears in your MCP servers.
    ![Windsurf MCP Toolbar with Server Available](/docs/guides/windsurf-mcp-server-available.png)
 
-   You've now configured Neon MCP Server in Windsurf and can manage your Neon Postgres databases using AI.
-
-<MCPTools />
-
-These actions enable any MCP client like Windsurf to interact with various functionalities of the **Neon platform via the Neon API.** Certain tools, especially database migration ones, are tailored for AI agent and LLM usage, leveraging Neon's branching for safe preview and commit.
+For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.
 
 ## Development Workflow: Adding a Column with Windsurf and Neon MCP
 
-Let's walk through a typical development scenario: Quickly adding a column for prototyping using natural language within Windsurf's Cascade. The following chat log demonstrates a real interaction with Windsurf and the Neon MCP server.
-
-**Scenario:** During development, you decide to track timestamps for entries in your `playing_with_neon` table. You want to quickly add a `created_at` column.
-
-<Admonition type="tip" title="Security Reminder">
-Be aware that Cascade currently executes commands directly from your prompts without confirmation unlike other IDE's and apps like [Cursor](/guides/cursor-mcp-neon) and [Claude](/guides/neon-mcp-server).  Review your requests thoroughly to avoid unintended or unwanted actions.
-</Admonition>
-
-Following is a sample interaction with Cascade where you can see how it uses the Neon MCP server to add a new column to your database table:
+Here's an example interaction adding a `created_at` column to a table:
 
 ```text shouldWrap
 User: in my neon project id: fancy-bush-59303206, list all the tables
@@ -212,68 +174,13 @@ Cascade: I'll help you add a created_at column to the playing_with_neon table. I
 > Perfect! The created_at column has been successfully added and populated with timestamps. For existing rows, it was set to the time when the column was added. Any new rows added to the table will automatically get their creation timestamp.
 ```
 
-**Key takeaways:**
-
-- **Natural language interaction:** You can use simple, conversational English to interact with your database through Windsurf's Cascade.
-- **MCP Tools in Action:** The underlying MCP tools (`get_database_tables`, `run_sql`, `prepare_database_migration`, `complete_database_migration`) illustrate the automated process.
-- **Branching for safety:** The agent automatically creates a temporary branch for schema changes and tests them before committing to the production branch.
-
 You can verify the changes in your Neon Console or by querying the database directly.
 
 ![Neon Console with added column](/docs/guides/neon-cursor-mcp-added-column.png)
 
 <Admonition type="note">
-While the Neon MCP server allows you to utilize all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
+While the Neon MCP server allows you to use all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
 </Admonition>
-
-## Bonus: Creating a project and branch
-
-Beyond schema changes, you can also manage your Neon projects and branches directly within Windsurf using natural language commands. This can be useful for quickly setting up a new development or test environment.
-
-### Creating a new project
-
-Let's say you want to create a new Neon project named "my-new-project". You can simply tell Cascade:
-
-```text shouldWrap
-User: Create a Neon project named "my-new-project"
-Cascade: I'll help you create a new Neon project with the specified name.
-> MCP Tool: neon / create_project
-> Tool Arguments: { "name": "my-new-project" }
-> Great! I've created a new Neon project for you with the following details:
-> Project Name: `my-new-project`
-> Project ID: `restless-butterfly-08800888`
-> Default Branch: `main`
-> Default Database: `neondb`
-> The project is now ready for use. You can start creating tables, running queries, or creating additional databases as needed. Would you like to do anything specific with your new project?
-```
-
-![Windsurf creating a new Neon project](/docs/guides/windsurf-mcp-create-new-project.png)
-
-Cascade will then use the `create_project` MCP tool to initiate the project creation. It will provide you with a project ID and name.
-
-### Creating a New Branch
-
-Once you have a project, you can easily create new branches for development or experimentation. For example, to create a branch named "feature-x" in your "my-new-project" project:
-
-```text shouldWrap
-User: Create a branch named "feature-x"
-Cascade: I'll create a new branch named "feature-x" in your Neon project.
-> MCP Tool: neon / create_branch
-> Tool Arguments: { "projectId": "restless-butterfly-08800888", "branchName": "feature-x" }
-> Perfect! I've created a new branch with the following details:
-> Branch Name: `feature-x`
-> Branch ID: `br-aged-sun-a5woam3c`
-> Project ID: `restless-butterfly-08800888`
-> The branch has been created successfully and is ready for use. You can now make changes to this branch without affecting the production branch. Would you like to do anything with this new branch?
-```
-
-![Windsurf creating a new Neon branch](/docs/guides/windsurf-mcp-create-new-branch.png)
-
-Cascade will use the `create_branch` MCP tool to create the branch and provide you with the branch name and ID. Notice how we don't need to specify the project ID, as Cascade remembers the active project context.
-
-## Conclusion
-
-Windsurf with Neon MCP Server lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing database ideas and making schema changes during development.
 
 ## Resources
 

--- a/content/guides/zed-mcp-neon.md
+++ b/content/guides/zed-mcp-neon.md
@@ -4,32 +4,20 @@ subtitle: 'Make schema changes with natural language using Zed and Neon MCP Serv
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-04-10T00:00:00.000Z'
-updatedOn: '2026-03-04T15:50:25.000Z'
+updatedOn: '2026-06-19T23:17:10.824Z'
 ---
 
-Imagine you could interact with your database using plain English, whether you're asking for specific data or changing its schema. That's what the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) allows you to do. It lets you manage your Neon Postgres databases using everyday language, simplifying tasks like running queries and performing database migrations.
+This guide shows how to use [Zed](https://zed.dev) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
 
-In this guide, we'll explore how to set up the Neon MCP Server within [Zed](https://zed.dev), a next-generation AI-powered code editor, to handle various database operations. These include creating projects, managing database branches, running SQL queries, and performing safe database migrations.
-
-<Admonition type="important" title="Neon MCP Server Security Considerations">
-The Neon MCP Server grants powerful database management capabilities through natural language requests. **Always review and authorize actions requested by the LLM before execution.** Ensure that only authorized users and applications have access to the Neon MCP Server.
-
-The Neon MCP Server is intended for local development and IDE integrations only. **We do not recommend using the Neon MCP Server in production environments.** It can execute powerful operations that may lead to accidental or unauthorized changes.
-
-For more information, see [MCP security guidance →](/docs/ai/neon-mcp-server#mcp-security-guidance).
+<Admonition type="important" title="Security">
+The Neon MCP Server grants broad database management capabilities. Always review and authorize actions requested by the LLM before execution. See [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
 </Admonition>
 
 ## Setting up Neon MCP Server in Zed
 
-You have two options for connecting Zed to the Neon MCP Server:
-
-1.  **Remote MCP Server:** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys in Zed. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
-
-2.  **Local MCP Server:** Run the Neon MCP server locally on your machine, authenticating with a Neon API key.
-
 ### Prerequisites
 
-Before you begin, ensure you have the following:
+Make sure you have:
 
 1.  **Zed editor:** Download and install Zed from [zed.dev](https://zed.dev/download).
 2.  **A Neon account and project:** You'll need a Neon account and a project. You can create a new Neon project in the [Neon Console](https://console.neon.tech)
@@ -44,10 +32,8 @@ Before you begin, ensure you have the following:
 ### Option 1: Setting up the Remote Hosted Neon MCP Server
 
 <Admonition type="note">
-By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#api-key-based-authentication).
+By default, the Remote MCP Server connects to your personal Neon account. To connect to an organization's account, you must authenticate with an API key. For more information, see [API key-based authentication](/docs/ai/neon-mcp-server#config-generator).
 </Admonition>
-
-This method uses Neon's managed server and OAuth authentication.
 
 1.  Open Zed.
 2.  Click the Assistant (✨) icon in the bottom right corner of Zed.
@@ -72,8 +58,6 @@ This method uses Neon's managed server and OAuth authentication.
 7.  Check the **Model Context Protocol (MCP) Servers** section in Zed **Settings** to ensure the connection is successful. Neon should be listed as an MCP server.
     ![Zed with Neon MCP](/docs/guides/zed/with-neon-mcp.png)
 
-8.  Zed is now connected to Neon's remote MCP server.
-
 ### Option 2: Setting up the Local Neon MCP Server
 
 This method runs the Neon MCP server locally on your machine, using a Neon API key for authentication.
@@ -97,11 +81,10 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
 5.  Click **Add Server**.
 6.  Check the **Model Context Protocol (MCP) Servers** section in Zed **Settings** to ensure the connection is successful. Neon should be listed as an MCP server.
     ![Zed with Neon MCP](/docs/guides/zed/with-neon-mcp.png)
-7.  Zed is now connected to Neon's local MCP server.
 
 ### Verification
 
-With the Neon MCP server set up either remotely or locally, you can now verify the connection and test the available tools.
+Verify the connection:
 
 1.  Open Zed Assistant.
 
@@ -113,8 +96,6 @@ With the Neon MCP server set up either remotely or locally, you can now verify t
 
 4.  Zed will use the `list_projects` MCP tool to retrieve and display your Neon projects, including project ID, name, and other details.
     ![Zed list projects](/docs/guides/zed/list_projects.png)
-
-5.  Try other commands such as listing all tables, creating a new branch, creating a new project, or running SQL queries.
 
 ### Troubleshooting
 
@@ -185,21 +166,11 @@ If you are using Windows, and you encounter issues with the command line, you ma
 
 </CodeTabs>
 
-<MCPTools />
-
-These actions enable any MCP client like Zed to interact with various functionalities of the **Neon platform via the Neon API.** Certain tools, especially database migration ones, are tailored for AI agent and LLM usage, leveraging Neon's branching for safe preview and commit.
+For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.
 
 ## Development Workflow: Adding a Column with Zed and Neon MCP
 
-Let's walk through a typical development scenario: Quickly adding a column for prototyping using natural language within Zed. The following chat log demonstrates a real interaction with Zed and the Neon MCP server.
-
-**Scenario:** During development, you decide to track timestamps for entries in your `playing_with_neon` table. You want to quickly add a `created_at` column.
-
-<Admonition type="tip" title="Security Reminder">
-For your security, review the tool's purpose before permitting the operation to proceed. Remember that LLMs can sometimes produce unexpected results, so careful monitoring is always recommended.
-</Admonition>
-
-Here's the conversation log between the user and Zed:
+Here's an example interaction adding a `created_at` column to a table:
 
 ![Zed listing projects](/docs/guides/zed/mcp-neon-adding-column-1.png)
 
@@ -259,67 +230,13 @@ Zed: I'll complete the migration using the provided migration ID:
 
 ![Zed completing migration](/docs/guides/zed/mcp-neon-adding-column-3.png)
 
-**Key takeaways:**
-
-- **Natural language interaction:** You can use simple, conversational English to interact with your database.
-- **Step-by-step guidance:** Zed (Claude) confirms each step and provides details like branch names and migration IDs.
-- **MCP Tools in action:** The underlying MCP tools (`get_database_tables`, `run_sql`, `prepare_database_migration`, `complete_database_migration`) illustrate the automated process.
-- **Branching for safety:** The agent automatically creates a temporary branch for schema changes. The user will be prompted to confirm the migration before applying it to the production branch.
-
 You can verify the changes in your Neon Console or by querying the database directly.
 
 ![Neon Console with added column](/docs/guides/neon-cursor-mcp-added-column.png)
 
 <Admonition type="note">
-While the Neon MCP server allows you to utilize all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
+While the Neon MCP server allows you to use all of Neon's functionalities, you can also use a [generic Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to Neon.
 </Admonition>
-
-## Bonus: Creating a project and branch
-
-Beyond schema changes, you can also manage your Neon projects and branches directly within Zed using natural language commands. This can be useful for quickly setting up a new development or test environment.
-
-### Creating a new project
-
-Let's say you want to create a new Neon project named "my-new-project". You can simply tell Zed:
-
-```text shouldWrap
-User: Create a Neon project named "my-new-project"
-Zed: I'll create a new Neon project with the specified name.
-> Run MCP tool `create_project`
-> I've successfully created a new Neon project named "my-new-project". Here are the key details:
-> - Project ID: red-frog-93550744
-> - Default Branch: main (ID: br-shiny-water-a5us05x3)
-> - Default Database: neondb
-> The project is ready to use. You can now create tables, add data, or perform other database operations. Would you like to perform any specific operations with your new project?
-```
-
-![Zed creating a new Neon project](/docs/guides/zed/mcp-create-new-project.png)
-
-Zed will then use the `create_project` MCP tool to initiate the project creation. It will provide you with a project ID, default branch, and database details. You can then proceed to create tables or perform other operations within this project.
-
-### Creating a New Branch
-
-Once you have a project, you can easily create new branches for development or experimentation. For example, to create a branch named "feature-x" in your "my-new-project" project:
-
-```text shouldWrap
-User: Create a branch named "feature-x"
-Zed: I'll create a new branch named "feature-x" in your project.
-> Run MCP tool `create_branch`
-> I've successfully created a new branch named "feature-x" in your project. Here are the details:
-> - Branch Name: feature-x
-> - Branch ID: br-gentle-dream-a5u9fmm4
-> - Parent Branch: br-shiny-water-a5us05x3
-> The branch is ready for use. Would you like to perform any specific operations in this branch?
-```
-
-![Zed creating a new Neon branch](/docs/guides/zed/mcp-create-new-branch.png)
-
-Zed will use the `create_branch` MCP tool to create the branch and provide you with the branch name and ID. Notice how we don't need to specify the project ID, as Zed remembers the active project context.
-
-## Conclusion
-
-Zed combined with the Neon MCP Server, whether using the **Remote Hosted** option or the **Local Server** setup, lets you use natural language to interact with your database and take advantage of Neon's branching capabilities for fast iteration. This approach is ideal for quickly testing
-database ideas and making schema changes during development.
 
 ## Resources
 

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -19,6 +19,67 @@ The API endpoint has been deprecated.
 "
 `;
 
+exports[`MDX to Markdown Conversion > Component conversion test page (snapshot) > should convert every component without raw MDX leaks > Available tools 1`] = `
+"## Available tools
+
+Tools are grouped into categories. Use the \`?category=\` URL parameter to restrict which categories are active. You can pass it more than once to enable multiple categories.
+
+| Category                        | What it enables                                                                     |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| Project management (\`projects\`) | List, create, describe, and delete projects and organizations                       |
+| Branch management (\`branches\`)  | Create branches, compare schemas, reset branches to parent state                    |
+| Schema (\`schema\`)               | Inspect tables and columns; run schema changes via a safe temporary branch workflow |
+| SQL (\`querying\`)                | Execute queries and transactions; inspect database structure                        |
+| Neon Auth (\`neon_auth\`)         | Set up and configure app authentication for a branch                                |
+| Neon Data API (\`data_api\`)      | Enable HTTP-based Data API access for a branch                                      |
+| Documentation (\`docs\`)          | Look up Neon documentation from within your assistant (no OAuth required)           |
+
+Search and navigation tools (search across projects, fetch resource details by ID) are available by default but disabled in [project-scoped mode](https://neon.com/docs/ai/neon-mcp-server#project-scoped-mode).
+
+### LinkAPIKey
+
+**Note:** To learn more about the types of API keys you can create — personal, organization, or project-scoped — see [Manage API Keys](https://neon.com/docs/manage/api-keys).
+
+### LRNotice
+
+**Important: Enrollment Pause for Logical Replication Beta**
+
+We have temporarily paused new enrollments in our Logical Replication Beta program. This pause is aimed at evaluating the feature's performance and incorporating feedback from our early adopters. Please stay tuned for updates, and thank you for your interest. We plan to reopen enrollment again soon.
+
+### PrivatePreview
+
+**Coming Soon: Private Preview**
+
+This feature is currently accessible in Private Preview only.
+
+### PrivatePreviewEnquire
+
+**Coming Soon: Private Preview**
+
+This feature is in private preview: it's not ready for production use, and it may be briefly unavailable as we deploy updates. To get access, [sign up here](https://neon.com/blog/were-building-backends#access).
+
+### PublicPreview
+
+**Note: Public Preview**
+
+This feature is in Public Preview. Please provide [Feedback](https://console.neon.tech/app/projects?modal=feedback) from the Neon Console or by connecting with us on [Discord](https://discord.gg/92vNTzKDGp).
+
+### LRBeta
+
+**Note: Beta**
+
+Replicating data to Neon, where Neon is configured as a subscriber in a Postgres logical replication setup, is currently in Beta. We welcome your feedback to help improve this feature. You can provide feedback via the [Feedback](https://console.neon.tech/app/projects?modal=feedback) form in the Neon Console or by reaching out to us on [Discord](https://discord.gg/92vNTzKDGp).
+
+### MigrationAssistant
+
+**Note: New feature**
+
+If you are looking to migrate your database to Neon, you may want to try our new **Migration Assistant**, which can help. Read the [guide](https://neon.com/docs/import/migration-assistant) to learn more.
+
+### NextSteps
+"
+`;
+
 exports[`MDX to Markdown Conversion > Component conversion test page (snapshot) > should convert every component without raw MDX leaks > CTA 1`] = `
 "## CTA
 


### PR DESCRIPTION
## Summary

- Restructured `neon-mcp-server.md`: moved config generator up, added new Access control section documenting `?readonly`, `?projectId`, `?category` URL params and `/api/list-tools` debug endpoint
- Rewrote `mcp-tools.md` as a category-level table with filter param values inline
- Tightened all 6 per-client guides (Claude Desktop, Cursor, Claude Code, Cline, Windsurf, Zed): cut verbose intros, redundant security admonitions, Key takeaways sections, Bonus sections, and usage example lists
- Fixed stale anchors across all guides (`#api-key-based-authentication` → `#config-generator`)
- Removed `<MCPTools />` duplication from guides (now only on overview page)
- Applied Neon voice throughout: contractions, active voice, no em dashes, no filler

[Preview](https://neon-next-git-docs-mcp-server-doc-refactor-neondatabase.vercel.app/docs/ai/neon-mcp-server)

This pull request and its description were written by Claude Code.