### PR TITLE
chore(bootstrap): sync fallback manifest with examples/bootstrap.yaml

### DIFF
--- a/src/app/bootstrap/templates.yaml/route.js
+++ b/src/app/bootstrap/templates.yaml/route.js
@@ -53,6 +53,40 @@ const FALLBACK_MANIFEST = `templates:
       repo: examples
       ref: main
       subdir: with-mastra
+  - id: mcp
+    title: "MCP server (Model Context Protocol SDK, Hono, Drizzle) on Neon Functions"
+    description: "An MCP server on Neon Functions exposing CRUD tools (create, update, delete, search) over a contact-management database. Built with the Anthropic MCP TypeScript SDK and Hono's streamable HTTP transport, backed by Neon Postgres via Drizzle."
+    services:
+      - Postgres
+      - Functions
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-mcp
+  - id: realtime-chat
+    title: "Realtime chat (Next.js, Neon Auth, WebSockets) on Neon Functions"
+    description: "A full-stack realtime chat: a Next.js app with Neon Auth talking over WebSockets to a Hono server on Neon Functions. Messages are stored in Neon Postgres via Drizzle and fanned out to all clients across isolates with Postgres LISTEN/NOTIFY."
+    services:
+      - Postgres
+      - Functions
+      - Neon Auth
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-realtime-chat
+  - id: realtime-sse
+    title: "Realtime counter (TanStack Router, SSE) on Neon Functions"
+    description: "A realtime shared counter: a client-only TanStack Router SPA talking over server-sent events to a Hono server on Neon Functions. The count is stored in Neon Postgres via Drizzle and pushed to all clients across isolates with Postgres LISTEN/NOTIFY."
+    services:
+      - Postgres
+      - Functions
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-realtime-sse
 `;
 
 // Cheap structural guard so a 200 that returns an error page / truncated body


### PR DESCRIPTION
## Summary

The `/bootstrap/templates.yaml` route serves the bootstrap manifest read-through from `neondatabase/examples/bootstrap.yaml@main` (cached ~1h), with a hardcoded `FALLBACK_MANIFEST` used only when the upstream GitHub fetch fails.

That fallback had drifted to 3 templates (`hono`, `ai-sdk`, `mastra`). This re-syncs it with the full set of 6 currently in the examples repo, adding:

- `mcp` (newly added MCP server example)
- `realtime-chat`
- `realtime-sse`

No behavior change on the happy path — the live endpoint already read-throughs the examples repo and will pick up `mcp` automatically within ~1h. This just keeps the failure-mode safety net accurate.

## Test plan

- [x] Lint clean.
- [ ] `GET /bootstrap/templates.yaml` returns a valid manifest (happy path unchanged; fallback now lists all 6 templates).