### PR TITLE
fix: docs aside position

### DIFF
--- a/src/components/pages/doc/post/post.jsx
+++ b/src/components/pages/doc/post/post.jsx
@@ -175,7 +175,7 @@ const Post = ({
       {/* Regular pages: Show standard right sidebar (hide for docs index, wide layout, and changelog) */}
       {!isDocsIndex && !isWideLayout && !isChangelog && (
         <Aside
-          className="-left-20 ml-0! w-[312px] shrink-0 3xl:left-auto xl:hidden"
+          className="ml-0! w-78 shrink-0 xl:hidden"
           isDocsIndex={isDocsIndex}
           isChangelog={isChangelog}
           enableTableOfContents={enableTableOfContents}


### PR DESCRIPTION
This fixes the docs aside positioning.

<details>
<summary>Screenshots</summary>

Before:
<img width="1695" height="878" alt="image" src="https://github.com/user-attachments/assets/45c71778-ebd8-4511-ae58-5a41c70e0d7d" />

After:
<img width="1460" height="809" alt="image" src="https://github.com/user-attachments/assets/c74a002a-023e-4ac2-a4d8-6ae77bdb16ec" />

</details>

[Preview](https://neon-next-git-fix-aside-position-pixelpoint.vercel.app/docs/get-started/built-to-scale)