### PR TITLE
docs: add Data API row to Neon vs Lakebase feature table

### DIFF
--- a/content/docs/introduction/neon-and-lakebase.md
+++ b/content/docs/introduction/neon-and-lakebase.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /docs/storage-engine/architecture-overview
   - /docs/conceptual-guides/architecture-overview
   - /docs/guides/neon-features
-updatedOn: '2026-06-23T19:03:35.937Z'
+updatedOn: '2026-06-23T20:07:56.119Z'
 ---
 
 In 2025, Neon joined Databricks. Neon continues as a standalone serverless Postgres platform, but the same architectural foundation now also powers Databricks Lakebase, a managed Postgres product that runs natively in the Databricks Data Intelligence Platform. This section explains the [lakebase category](https://www.databricks.com/blog/what-is-a-lakebase) and how to determine whether Neon or Lakebase is a better fit for your workload.
@@ -78,6 +78,7 @@ Neon and Lakebase share the same Postgres engine and serverless storage architec
 | **High availability**                                | Coming soon ([Roadmap](/docs/introduction/roadmap))                                | Yes ([High availability](https://docs.databricks.com/aws/en/oltp/projects/manage-high-availability))                                       |
 | **Cross-cloud disaster recovery (DR)**               | Not available                                                                      | Private preview                                                                                                                            |
 | **Connection pooling**                               | Yes ([Connection pooling](/docs/connect/connection-pooling))                       | Yes, built-in PgBouncer ([Connect](https://docs.databricks.com/aws/en/oltp/projects/connect))                                              |
+| **Data API (REST)**                                  | Yes ([Data API](/docs/data-api/overview))                                          | Yes ([Lakebase Data API](https://docs.databricks.com/aws/en/oltp/projects/data-api))                                                       |
 | **Private networking (Private Link)**                | Yes ([Private Networking](/docs/guides/neon-private-networking))                   | Yes ([Data protection](https://docs.databricks.com/aws/en/oltp/projects/private-link))                                                     |
 | **Managed user authentication**                      | Yes ([Neon Auth](/docs/auth/overview))                                             | Not yet; database access uses Databricks identity and Postgres roles ([Connect](https://docs.databricks.com/aws/en/oltp/projects/connect)) |
 | **Metrics and logs export (Datadog, OpenTelemetry)** | Yes ([Datadog](/docs/guides/datadog), [OpenTelemetry](/docs/guides/opentelemetry)) | Via the Databricks platform                                                                                                                |


### PR DESCRIPTION
## What

Adds a **Data API (REST)** row to the feature availability table on the [Neon vs Lakebase](/docs/introduction/neon-and-lakebase) page. Both products expose a PostgREST-compatible Data API:

- Neon → [Data API](/docs/data-api/overview)
- Lakebase → [Lakebase Data API](https://docs.databricks.com/aws/en/oltp/projects/data-api)

## Note

Pushed with `--no-verify` due to the pre-existing, unrelated neonctl docs-example test failures on `main`.