### PR TITLE
docs(cli): repoint neonctl repo links to neon-pkgs

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -47,4 +47,4 @@ More about global options:
 
 ## GitHub repository
 
-The Neon CLI is open source. See the [neondatabase/neonctl](https://github.com/neondatabase/neonctl) repository.
+The Neon CLI is open source. See the [neondatabase/neon-pkgs](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli) repository.

--- a/content/docs/cli/install.md
+++ b/content/docs/cli/install.md
@@ -45,7 +45,7 @@ bun install -g neonctl
 Download the binary. No installation required.
 
 ```bash shouldWrap
-curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-macos-x64 -o neonctl
+curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-macos-x64 -o neonctl
 ```
 
 Run the CLI from the download directory:
@@ -77,7 +77,7 @@ bun install -g neonctl
 Download the binary. No installation required.
 
 ```bash shouldWrap
-curl -sL -O https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-win-x64.exe
+curl -sL -O https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-win-x64.exe
 ```
 
 Run the CLI from the download directory:
@@ -109,13 +109,13 @@ Download the x64 or ARM64 binary, depending on your processor type. No installat
 x64:
 
 ```bash shouldWrap
-curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-x64 -o neonctl
+curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-linux-x64 -o neonctl
 ```
 
 ARM64:
 
 ```bash shouldWrap
-curl -sL https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-arm64 -o neonctl
+curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-linux-arm64 -o neonctl
 ```
 
 Run the CLI from the download directory:
@@ -143,7 +143,7 @@ bunx neonctl <command>
 
 ### Upgrade
 
-Upgrade using the method that matches how you installed the CLI. To check for the latest version, see the **Releases** page on the [Neon CLI GitHub repository](https://github.com/neondatabase/neonctl). To check your installed version, run:
+Upgrade using the method that matches how you installed the CLI. To check for the latest version, see the [Neon CLI **Releases** page](https://github.com/neondatabase/neon-pkgs/releases). To check your installed version, run:
 
 ```bash
 neonctl --version
@@ -169,7 +169,7 @@ brew upgrade neonctl
 
 <TabItem>
 
-To upgrade a [binary](https://github.com/neondatabase/neonctl/releases) version, download the `latest` binary as described in the install instructions above, and replace your old binary with the new one.
+To upgrade a [binary](https://github.com/neondatabase/neon-pkgs/releases) version, download the `latest` binary as described in the install instructions above, and replace your old binary with the new one.
 
 </TabItem>
 
@@ -203,12 +203,12 @@ Homebrew automatically fetches the latest version when running the `install` or 
 
 <TabItem>
 
-If you're downloading a binary, reference the latest release from the [Releases page](https://github.com/neondatabase/neonctl/releases) using `curl` or `wget` in your workflow:
+If you're downloading a binary, reference the latest release from the [Releases page](https://github.com/neondatabase/neon-pkgs/releases) using `curl` or `wget` in your workflow:
 
 ```yaml
 - name: Install Neon CLI
   run: |
-    curl -L https://github.com/neondatabase/neonctl/releases/latest/download/neonctl-linux-x64 -o /usr/local/bin/neonctl
+    curl -L https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-linux-x64 -o /usr/local/bin/neonctl
     chmod +x /usr/local/bin/neonctl
 ```
 

--- a/content/docs/cli/quickstart.md
+++ b/content/docs/cli/quickstart.md
@@ -88,7 +88,7 @@ Verify the installation by checking the CLI version:
 neonctl --version
 ```
 
-For the latest version, refer to the [Neon CLI GitHub repository](https://github.com/neondatabase/neonctl).
+For the latest version, refer to the [Neon CLI GitHub repository](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli).
 
 ## Authenticate
 

--- a/src/components/pages/cli/features/features.jsx
+++ b/src/components/pages/cli/features/features.jsx
@@ -26,7 +26,7 @@ const items = [
     title: 'Contribute',
     description: 'Neon CLI is open source. Contribute&nbsp;to our GitHub&nbsp;repo.',
     linkText: 'Contribute to Neon CLI',
-    url: 'https://github.com/neondatabase/neonctl',
+    url: 'https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli',
   },
 ];
 


### PR DESCRIPTION
## Summary

The Neon CLI source has moved into the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo (`packages/cli`), and its release **binaries are now published to neon-pkgs releases** (the standalone `neonctl` repo no longer cuts releases). This repoints the website's links accordingly.

### Changed
- **`content/docs/cli.md`** — "GitHub repository" link → `neon-pkgs/tree/main/packages/cli`
- **`content/docs/cli/quickstart.md`** — "Neon CLI GitHub repository" link → `neon-pkgs/tree/main/packages/cli`
- **`src/components/pages/cli/features/features.jsx`** — source link → `neon-pkgs/tree/main/packages/cli`
- **`content/docs/cli/install.md`** — all binary download URLs and Releases-page links → `neon-pkgs/releases` (asset names unchanged: `neonctl-{linux-x64,linux-arm64,macos-x64,win-x64.exe}`)

### Unchanged (intentionally)
- The **`neonctl` npm package** is unchanged, so all `npm i -g neonctl` / `bunx neonctl` / `brew install neonctl` commands stay as-is.
- A **historical changelog entry** (`content/changelog/2024-03-22.md`) and a **source permalink to an immutable commit** (`content/docs/guides/oauth-integration.md`) — both still resolve, left as-is.
- Internal tooling (`scripts/docs-checks/neonctl/generate-schema.js`, `.claude/agents/extract-analyze-cli.md`) — separate follow-up.

### Verified
- `https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-linux-x64` returns `302` → the `neonctl@2.27.1` asset (the current Latest release on neon-pkgs).

## Test plan
- [ ] Links resolve on the rendered CLI docs + `/cli` page