### PR TITLE
docs: surface recent videos via doc modals and inline embeds

### DIFF
--- a/content/docs/get-started/signing-up.md
+++ b/content/docs/get-started/signing-up.md
@@ -14,7 +14,7 @@ redirectFrom:
   - /docs/cloud/getting-started/
   - /docs/cloud/getting_started/
   - /docs/get-started-with-neon/signing-up
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-06-24T19:58:18.610Z'
 ---
 
 <InfoBlock>
@@ -33,6 +33,8 @@ updatedOn: '2026-06-11T23:50:21.258Z'
 </InfoBlock>
 
 This tutorial walks you through your first steps using Neon as your Postgres database. You'll explore the Neon object hierarchy and learn how database branching can simplify your development workflow.
+
+<YoutubeIframe embedId="XtMiMnX0hDg" />
 
 ## About branching
 

--- a/content/docs/introduction/autoscaling.md
+++ b/content/docs/introduction/autoscaling.md
@@ -9,7 +9,7 @@ summary: >-
   is 8 CU. Use this page to understand how autoscaling works and to find the
   configuration steps before reading the full enablement guide.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-06-24T19:58:18.610Z'
 ---
 
 Neon's _Autoscaling_ feature dynamically adjusts the amount of compute resources allocated to a Neon compute in response to the current load, eliminating the need for manual intervention or restarts.
@@ -19,6 +19,8 @@ The following visualization shows how Neon’s autoscaling works throughout a ty
 ![visualization for autoscaling](/docs/introduction/autoscaling_intro.png)
 
 To dive deeper into how Neon's autoscaling algorithm operates, visit [Understanding Neon’s autoscaling algorithm](/docs/guides/autoscaling-algorithm).
+
+<YoutubeIframe embedId="dE0E7wALg8M" />
 
 ## Autoscaling benefits
 

--- a/src/components/pages/doc/modal/data.js
+++ b/src/components/pages/doc/modal/data.js
@@ -40,43 +40,98 @@
 
 /** @type {VideoModalConfig[]} */
 const MODALS = [
+  // Sitewide fallback. Shows on every docs page (and on /guides, /postgresql, /faqs, since the doc
+  // layout is shared), except embed-home pages and pages won by a higher-priority modal below.
   {
-    id: 'branching-video',
+    id: 'branching-getting-started',
     embedId: 'UuHnFlg66Io',
-    title: 'Watch: Git for databases',
-    description: 'See how Neon branching works in practice.',
+    title: 'Watch: Get started with branching',
+    description: "See how Neon's database branching works in practice.",
     targeting: {
       all: true,
     },
     destination: {
-      label: 'Watch the video',
+      label: 'Explore branching',
       url: '/docs/introduction/branching',
     },
   },
+  // Section: AI. Folder default across /docs/ai (suppressed on its own home, ai/agent-skills).
   {
-    id: 'serverless-video',
-    embedId: 'llSTZMVrbx8',
-    title: 'Watch: Neon Database',
-    description: 'See Neon in action and learn how it simplifies working with Postgres.',
+    id: 'agent-skills',
+    embedId: 'NN251KTjAo8',
+    title: 'Watch: Neon Agent Skills',
+    description: 'See how agent skills help AI tools follow Neon best practices.',
     targeting: {
-      pages: ['/docs/introduction/serverless'],
+      folders: ['docs/ai'],
     },
     destination: {
-      label: 'Learn about autoscaling',
+      label: 'Set up agent skills',
+      url: '/docs/ai/agent-skills',
+    },
+  },
+  // Section: Get started. Folder default — the high-level "what is Neon" intro.
+  {
+    id: 'what-is-neon',
+    embedId: 'wLAeC-r4kfE',
+    title: 'Watch: What is Neon?',
+    description: 'A short look at serverless Postgres on Neon.',
+    targeting: {
+      folders: ['docs/get-started'],
+    },
+    destination: {
+      label: 'Why Neon',
+      url: '/docs/get-started/why-neon',
+    },
+  },
+  // Section: Get started. Page targets (priority 3) put the hands-on console tour on the most
+  // task-oriented onboarding pages, ahead of the what-is-neon folder default.
+  {
+    id: 'getting-started',
+    embedId: 'XtMiMnX0hDg',
+    title: 'Watch: Getting started with Neon',
+    description: 'A guided tour of the Neon Console.',
+    targeting: {
+      pages: [
+        '/docs/get-started/connect-neon',
+        '/docs/get-started/query-with-neon-sql-editor',
+        '/docs/get-started/workflow-primer',
+      ],
+    },
+    destination: {
+      label: 'Tour the console',
+      url: '/docs/get-started/signing-up',
+    },
+  },
+  // Intro: autoscaling explainer teaser on related compute pages.
+  {
+    id: 'autoscaling',
+    embedId: 'dE0E7wALg8M',
+    title: 'Watch: How autoscaling works',
+    description: 'See how Neon scales compute up and down with load.',
+    targeting: {
+      pages: [
+        '/docs/introduction/scale-to-zero',
+        '/docs/introduction/serverless',
+        '/docs/introduction/autoscaling-architecture',
+      ],
+    },
+    destination: {
+      label: 'About autoscaling',
       url: '/docs/introduction/autoscaling',
     },
   },
+  // Plans: Free Plan video has no embed home, so link out to YouTube (opens in a new tab).
   {
-    id: 'autoscaling-video',
-    embedId: 'ZnxLCOkb_R0',
-    title: 'Watch: Autoscaling in action',
-    description: 'See how Neon adjusts compute resources to match your workload.',
+    id: 'free-plan',
+    embedId: 'b_jKP3fcrVY',
+    title: 'Watch: Upgrades to the Neon Free Plan',
+    description: 'A quick look at what you get on the Free Plan.',
     targeting: {
-      pages: ['/docs/introduction/autoscaling'],
+      pages: ['/docs/introduction/plans', '/docs/introduction/about-billing'],
     },
     destination: {
       label: 'Watch on YouTube',
-      url: 'https://www.youtube.com/watch?v=ZnxLCOkb_R0',
+      url: 'https://www.youtube.com/watch?v=b_jKP3fcrVY',
     },
   },
 ];

--- a/src/components/pages/doc/modal/modal.jsx
+++ b/src/components/pages/doc/modal/modal.jsx
@@ -33,6 +33,7 @@ const Modal = ({ id, title, description, destination, embedId }) => {
   }, []);
 
   const handleClose = () => {
+    sendGtagEvent('dismiss_docs_modal', { modal: id, destination: destination.url });
     setClosedModals((prevClosedModals) => [...prevClosedModals, id]);
   };
 
@@ -47,6 +48,14 @@ const Modal = ({ id, title, description, destination, embedId }) => {
       destination: destination.url,
     });
   };
+
+  // Fire an impression once the modal is eligible to show (mounted and not previously dismissed).
+  // Pairs with click_docs_modal_link as the denominator for click-through rate.
+  useEffect(() => {
+    if (isMounted && !isClosed) {
+      sendGtagEvent('view_docs_modal', { modal: id, destination: destination.url });
+    }
+  }, [isMounted, isClosed, id, destination.url]);
 
   return (
     <LazyMotion features={domAnimation}>

--- a/src/components/pages/doc/modal/select-modal.js
+++ b/src/components/pages/doc/modal/select-modal.js
@@ -31,8 +31,18 @@ const getMatchPriority = (modal, pathname) => {
   return 0;
 };
 
+// Every page that embeds a video is the destination of one of these modals. Don't stack a floating
+// modal on top of an inline video, so show no modal on any internal destination page.
+const isEmbedHome = (modals, pathname) =>
+  modals.some(
+    (modal) =>
+      modal.destination?.url?.startsWith('/') && normalizePath(modal.destination.url) === pathname
+  );
+
 const selectModal = (modals, pathname) => {
   const normalizedPathname = normalizePath(pathname);
+
+  if (isEmbedHome(modals, normalizedPathname)) return null;
 
   return modals.reduce(
     (selection, modal) => {


### PR DESCRIPTION
Replace the demo MODALS seed with a real catalog of Neon videos created by Anthony Giuliano (DevRel), plus two inline embeds on their home pages:

- Embeds: "Getting Started with Neon" (get-started/signing-up) and "How autoscaling works" (introduction/autoscaling).
- Modals: branching (sitewide fallback), agent skills (ai folder), what-is-neon and getting-started (get-started), autoscaling (compute pages), and the Free Plan video as an external link to YouTube.
- select-modal: suppress the floating modal on any page that embeds a video inline, so a modal never stacks on top of an inline player.

## Preview Links

### Embedded Videos (Inline Player)

| Video | Preview |
| --- | --- |
| Branching | [Branching](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/introduction/branching) |
| Why Neon | [Why Neon](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/get-started/why-neon) |
| Agent Skills | [Agent Skills](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/ai/agent-skills) |
| Tour the Neon Console | [Signing Up](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/get-started/signing-up) — new embed |
| Autoscaling | [Autoscaling](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/introduction/autoscaling) — new embed |

### Modals

| Modal | Coverage | Representative Page |
| --- | --- | --- |
| Branching | **Sitewide fallback**: any docs page (and `/guides`, `/postgresql`, `/faqs`) not claimed by a more specific modal or an embed | [Regions](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/introduction/regions) |
| Agent Skills | **Entire `docs/ai` folder**: every AI page except the `agent-skills` embed page | [Neon MCP Server](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/ai/neon-mcp-server) |
| What is Neon? | **Entire `docs/get-started` folder**: except the `why-neon` and `signing-up` embeds and the Getting Started pages below | [Frameworks](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/get-started/frameworks) |
| Getting Started | **Specific pages**: `connect-neon`, `query-with-neon-sql-editor`, `workflow-primer` | [Connect Neon](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/get-started/connect-neon) |
| Autoscaling | **Specific pages**: `scale-to-zero`, `serverless`, `autoscaling-architecture` | [Scale to zero](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/introduction/scale-to-zero) |
| Free Plan (external → YouTube) | **Specific pages**: `plans`, `about-billing` | [Plans](https://neon-next-git-docs-video-modal-rollout-neondatabase.vercel.app/docs/introduction/plans) |