### PR TITLE
docs: add files sdk examples to storage docs

### DIFF
--- a/content/docs/compute/functions/agents.md
+++ b/content/docs/compute/functions/agents.md
@@ -6,7 +6,7 @@ summary: >-
   stream a response for minutes while the agent calls models and tools, with
   the Neon AI Gateway wired in automatically and Postgres next to your code.
 enableTableOfContents: true
-updatedOn: '2026-06-24T23:12:20.545Z'
+updatedOn: '2026-06-25T15:31:37.545Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -109,7 +109,16 @@ Call the function directly from the browser, not through your web app's backend.
 
 ## Persist what matters
 
-Module memory is wiped when an isolate is evicted, and several isolates can run in parallel, so keep anything that must last in Postgres: conversation history, run metadata, results. For generated assets like images, declare a bucket in `neon.ts` (`buckets: { images: {} }`) and write them to [Object Storage](/docs/storage/overview), which branches with your database. The storage credentials are injected the same way the gateway's are.
+Module memory is wiped when an isolate is evicted, and several isolates can run in parallel, so keep anything that must last in Postgres: conversation history, run metadata, results. For generated assets like images, declare a bucket in `neon.ts` (`buckets: { images: {} }`) and write them to [Object Storage](/docs/storage/objects), which branches with your database. When a bucket is declared, `neon deploy` injects `AWS_*` credentials automatically. For example, using the [Files SDK](https://files-sdk.dev):
+
+```typescript
+import { Files } from 'files-sdk';
+import { neon as neonStorage } from 'files-sdk/neon';
+
+const files = new Files({ adapter: neonStorage({ bucket: 'images' }) });
+await files.upload('outputs/result.png', imageBuffer, { contentType: 'image/png' });
+const url = await files.url('outputs/result.png', { expiresIn: 3600 });
+```
 
 ## Examples
 

--- a/content/docs/compute/functions/agents.md
+++ b/content/docs/compute/functions/agents.md
@@ -6,7 +6,7 @@ summary: >-
   stream a response for minutes while the agent calls models and tools, with
   the Neon AI Gateway wired in automatically and Postgres next to your code.
 enableTableOfContents: true
-updatedOn: '2026-06-25T15:31:37.545Z'
+updatedOn: '2026-06-25T15:54:38.441Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -113,9 +113,9 @@ Module memory is wiped when an isolate is evicted, and several isolates can run 
 
 ```typescript
 import { Files } from 'files-sdk';
-import { neon as neonStorage } from 'files-sdk/neon';
+import { neon } from 'files-sdk/neon';
 
-const files = new Files({ adapter: neonStorage({ bucket: 'images' }) });
+const files = new Files({ adapter: neon({ bucket: 'images' }) });
 await files.upload('outputs/result.png', imageBuffer, { contentType: 'image/png' });
 const url = await files.url('outputs/result.png', { expiresIn: 3600 });
 ```

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-06-15T20:45:19.947Z'
+updatedOn: '2026-06-25T15:54:38.441Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -152,14 +152,12 @@ The S3 data plane enforces scope on every request. A credential without a storag
 
 When your code runs inside Neon Functions, Neon injects storage credentials automatically. You don't need to create a credential:
 
-| Variable                        | Value                                                     |
-| ------------------------------- | --------------------------------------------------------- |
-| `AWS_ACCESS_KEY_ID`             | S3 Access Key ID                                          |
-| `AWS_SECRET_ACCESS_KEY`         | S3 Secret Access Key                                      |
-| `AWS_ENDPOINT_URL_S3`           | Branch S3 endpoint URL                                    |
-| `AWS_REGION`                    | Storage region (e.g. `us-east-2`)                         |
-| `NEON_STORAGE_REGION`           | Region, e.g. `us-east-2` (also available as `AWS_REGION`) |
-| `NEON_STORAGE_FORCE_PATH_STYLE` | Always `"true"` — path-style addressing is required       |
+| Variable                | Value                             |
+| ----------------------- | --------------------------------- |
+| `AWS_ACCESS_KEY_ID`     | S3 Access Key ID                  |
+| `AWS_SECRET_ACCESS_KEY` | S3 Secret Access Key              |
+| `AWS_ENDPOINT_URL_S3`   | Branch S3 endpoint URL            |
+| `AWS_REGION`            | Storage region (e.g. `us-east-2`) |
 
 Credentials are branch-scoped and tied to the function's serving branch. User-supplied environment variables with the same name can't override the injected values (the injected secret access key always wins). Because the credentials use AWS-standard names, the AWS SDK picks them up automatically. Only `forcePathStyle` needs explicit configuration:
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -3,10 +3,10 @@ title: Get started with Neon Storage
 subtitle: Upload your first file in minutes
 summary: >-
   This quickstart walks you through creating a storage credential, configuring
-  your S3 client, creating a bucket, and uploading and downloading your first
-  file. Any AWS S3-compatible SDK works. Just point it at your branch endpoint.
+  a client, creating a bucket, and uploading and downloading your first file.
+  Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-15T20:45:19.947Z'
+updatedOn: '2026-06-25T15:31:37.545Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -34,7 +34,7 @@ export default defineConfig({
 neonctl deploy          # provisions buckets and writes AWS_* vars to .env.local
 ```
 
-After deploy, your `.env.local` contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, and `NEON_STORAGE_FORCE_PATH_STYLE`. Skip to [Configure your S3 client](#configure-your-s3-client) below.
+After deploy, your `.env.local` contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, and `NEON_STORAGE_FORCE_PATH_STYLE`. Skip to [Configure your client](#configure-your-client) below.
 
 ---
 
@@ -101,18 +101,15 @@ A `404` response means Storage is not yet enabled for that branch. Make sure you
 
 ## Install dependencies
 
-<CodeTabs labels={["npm", "yarn", "pnpm", "pip"]}>
+<CodeTabs labels={["Files SDK", "S3 Client", "Python"]}>
+
+```bash shouldWrap
+# files-sdk uses @aws-sdk/* packages as peer dependencies; install them alongside it
+npm install files-sdk @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/s3-presigned-post dotenv
+```
 
 ```bash
 npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner dotenv
-```
-
-```bash
-yarn add @aws-sdk/client-s3 @aws-sdk/s3-request-presigner dotenv
-```
-
-```bash
-pnpm add @aws-sdk/client-s3 @aws-sdk/s3-request-presigner dotenv
 ```
 
 ```bash
@@ -121,9 +118,18 @@ pip install boto3 python-dotenv
 
 </CodeTabs>
 
-## Configure your S3 client
+## Configure your client
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+The `neon` adapter is a subpath export (`files-sdk/neon`) that reads `AWS_*` environment variables and configures the Files SDK for Neon's S3-compatible endpoint automatically.
+
+<CodeTabs labels={["Files SDK", "S3 Client", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { Files } from 'files-sdk';
+import { neon } from 'files-sdk/neon';
+
+export const files = new Files({ adapter: neon({ bucket: 'my-bucket' }) });
+```
 
 ```typescript shouldWrap
 import { S3Client } from '@aws-sdk/client-s3';
@@ -164,18 +170,30 @@ aws configure set endpoint_url "$AWS_ENDPOINT_URL_S3"
 
 </CodeTabs>
 
-## Create a bucket and upload a file
+<Admonition type="note">
+If you're using [Neon Functions](/docs/compute/functions/overview), the `AWS_*` credentials are injected automatically when a bucket is declared in `neon.ts`. No `.env` setup is needed inside a function.
+</Admonition>
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+## Upload a file
+
+You need an existing bucket before uploading. [Create one](/docs/storage/buckets#create-a-bucket), or declare it in `neon.ts` and run `neonctl deploy`.
+
+<CodeTabs labels={["Files SDK", "S3 Client", "Python", "AWS CLI"]}>
 
 ```typescript shouldWrap
-import { CreateBucketCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { files } from './client';
+
+await files.upload('hello.txt', 'Hello from Neon Storage!', {
+  contentType: 'text/plain',
+});
+
+console.log('Uploaded!');
+```
+
+```typescript shouldWrap
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { client } from './client';
 
-// Create a bucket
-await client.send(new CreateBucketCommand({ Bucket: 'my-bucket' }));
-
-// Upload a file
 await client.send(new PutObjectCommand({
   Bucket: 'my-bucket',
   Key: 'hello.txt',
@@ -187,10 +205,6 @@ console.log('Uploaded!');
 ```
 
 ```python shouldWrap
-# Create a bucket
-client.create_bucket(Bucket='my-bucket')
-
-# Upload a file
 client.put_object(
     Bucket='my-bucket',
     Key='hello.txt',
@@ -202,12 +216,6 @@ print('Uploaded!')
 ```
 
 ```bash shouldWrap
-# Create a bucket
-aws s3api create-bucket \
-  --bucket my-bucket \
-  --endpoint-url "$AWS_ENDPOINT_URL_S3"
-
-# Upload a file
 aws s3 cp hello.txt s3://my-bucket/hello.txt \
   --endpoint-url "$AWS_ENDPOINT_URL_S3"
 ```
@@ -216,7 +224,15 @@ aws s3 cp hello.txt s3://my-bucket/hello.txt \
 
 ## Download a file
 
-<CodeTabs labels={["TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["Files SDK", "S3 Client", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+const result = await files.download('hello.txt');
+const text = await result.text();
+console.log(text); // Hello from Neon Storage!
+```
 
 ```typescript shouldWrap
 import { GetObjectCommand } from '@aws-sdk/client-s3';
@@ -250,5 +266,6 @@ aws s3 cp s3://my-bucket/hello.txt ./downloaded.txt \
 - [Buckets](/docs/storage/buckets): access levels, bucket branching, and the Console UI
 - [Objects](/docs/storage/objects): list, delete, multipart uploads, and presigned URLs
 - [Authentication](/docs/storage/authentication): credential scopes, branch binding, and rotation
+- [with-files-sdk](https://github.com/neondatabase/examples/tree/main/with-files-sdk): working example showing how to upload files to a branch-scoped bucket using the Files SDK and its `neon` adapter
 
 <NeedHelp/>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-25T15:54:38.441Z'
+updatedOn: '2026-06-25T16:13:46.346Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -35,6 +35,12 @@ neonctl deploy          # provisions buckets and writes AWS_* vars to .env.local
 ```
 
 After deploy, your `.env.local` contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, and `AWS_REGION`. Skip to [Configure your client](#configure-your-client) below.
+
+Already deployed? Pull the vars again with:
+
+```bash
+neonctl env pull
+```
 
 ---
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,10 +6,16 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-25T16:13:46.346Z'
+updatedOn: '2026-06-25T17:41:39.717Z'
 ---
 
 <PrivatePreviewEnquire/>
+
+To set up Neon Storage with an AI coding assistant, install the Neon Platform (`neon`) and Neon Storage skills:
+
+```bash
+npx skills add neondatabase/agent-skills -s neon -s neon-object-storage
+```
 
 To follow this guide, you need a new project in the AWS us-east-2 region.
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-25T15:31:37.545Z'
+updatedOn: '2026-06-25T15:54:38.441Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -34,7 +34,7 @@ export default defineConfig({
 neonctl deploy          # provisions buckets and writes AWS_* vars to .env.local
 ```
 
-After deploy, your `.env.local` contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, and `NEON_STORAGE_FORCE_PATH_STYLE`. Skip to [Configure your client](#configure-your-client) below.
+After deploy, your `.env.local` contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, and `AWS_REGION`. Skip to [Configure your client](#configure-your-client) below.
 
 ---
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -2,22 +2,31 @@
 title: Objects
 subtitle: Upload, download, list, and delete files
 summary: >-
-  Work with objects in Neon Storage using any S3-compatible SDK or the AWS CLI.
-  Supports single-part and multipart uploads, range requests, batch deletes,
-  and presigned URLs for browser-side access.
+  Work with objects in Neon Storage using the Files SDK, any S3-compatible SDK,
+  or the AWS CLI. Supports single-part and multipart uploads, range requests,
+  batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-06-15T20:35:44.700Z'
+updatedOn: '2026-06-25T15:31:37.545Z'
 ---
 
 <PrivatePreviewEnquire/>
 
 Objects in Neon Storage are files stored inside a bucket. Every object has a key (its path within the bucket), a body, a content type, and optional metadata. Objects branch with your database. Each branch inherits the parent's objects at the moment of forking without copying any data.
 
-The examples below use an S3 client configured with your branch endpoint and credentials. See [Get started](/docs/storage/get-started) to set that up, or [Authentication](/docs/storage/authentication) if you need to create a credential.
+The examples below show both the [Files SDK](https://files-sdk.dev) and the AWS S3 client. See [Get started](/docs/storage/get-started) to configure either client, or [Authentication](/docs/storage/authentication) if you need to create a credential.
 
 ## Upload
 
-<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["Files SDK", "neonctl", "S3 Client", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+await files.upload('images/photo.jpg', fileBuffer, {
+  contentType: 'image/jpeg',
+  metadata: { 'uploaded-by': 'user-123' },
+});
+```
 
 ```bash
 neonctl bucket object put my-bucket/images/photo.jpg --file ./photo.jpg
@@ -104,7 +113,14 @@ client.upload_file(
 
 ## Download
 
-<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["Files SDK", "neonctl", "S3 Client", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+const result = await files.download('images/photo.jpg');
+const buffer = await result.arrayBuffer();
+```
 
 ```bash
 # Downloads to ./photo.jpg by default; use --file to specify a different path
@@ -151,9 +167,18 @@ const response = await client.send(new GetObjectCommand({
 
 ## List objects
 
-Use a prefix and delimiter to simulate a folder structure.
+Use a prefix to filter results. The Files SDK returns a flat array of items; the S3 client supports a delimiter to simulate folder structure.
 
-<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["Files SDK", "neonctl", "S3 Client", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+const { items } = await files.list({ prefix: 'images/' });
+for (const item of items) {
+  console.log(item.key, item.size);
+}
+```
 
 ```bash
 # Folder-collapsed view by default (same as aws s3 ls)
@@ -224,7 +249,13 @@ do {
 
 **Single object:**
 
-<CodeTabs labels={["neonctl", "TypeScript", "Python", "AWS CLI"]}>
+<CodeTabs labels={["Files SDK", "neonctl", "S3 Client", "Python", "AWS CLI"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+await files.delete('images/photo.jpg');
+```
 
 ```bash
 neonctl bucket object delete my-bucket/images/photo.jpg
@@ -252,7 +283,13 @@ aws s3 rm s3://my-bucket/images/photo.jpg \
 
 **Batch delete (up to 1,000 objects per request):**
 
-<CodeTabs labels={["TypeScript", "Python"]}>
+<CodeTabs labels={["Files SDK", "S3 Client", "Python"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+await files.delete(['images/photo1.jpg', 'images/photo2.jpg']);
+```
 
 ```typescript shouldWrap
 import { DeleteObjectsCommand } from '@aws-sdk/client-s3';
@@ -305,7 +342,14 @@ Generate a time-limited URL that allows a browser or unauthenticated client to u
 
 **Presigned GET (download):**
 
-<CodeTabs labels={["TypeScript", "Python"]}>
+<CodeTabs labels={["Files SDK", "S3 Client", "Python"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+const url = await files.url('report.pdf', { expiresIn: 3600 }); // 1 hour
+console.log(url); // share this URL — no credentials needed
+```
 
 ```typescript shouldWrap
 import { GetObjectCommand } from '@aws-sdk/client-s3';
@@ -334,7 +378,20 @@ print(url)
 
 **Presigned PUT (upload from browser):**
 
-<CodeTabs labels={["TypeScript", "Python"]}>
+<CodeTabs labels={["Files SDK", "S3 Client", "Python"]}>
+
+```typescript shouldWrap
+import { files } from './client';
+
+// Returns { url, method, headers } — pass all three to fetch on the client side
+const { url, method, headers } = await files.signedUploadUrl('uploads/user-avatar.png', {
+  contentType: 'image/png',
+  expiresIn: 300, // 5 minutes
+});
+
+// On the client side:
+// await fetch(url, { method, headers, body: file });
+```
 
 ```typescript shouldWrap
 import { PutObjectCommand } from '@aws-sdk/client-s3';

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-06-24T13:43:35.494Z'
+updatedOn: '2026-06-25T15:31:37.545Z'
 ---
 
 <RequestForm type="backend-platform" title="Get early access to Neon Storage" description="Neon Storage is in private preview. Drop your email and we'll reach out with access." />
@@ -17,7 +17,7 @@ Neon Storage is S3-compatible object storage built into the Neon backend for app
 > During the private preview, Storage is available for **new projects** in the **AWS us-east-2** region only.
 
 - **Branches with your database.** Each branch has its own view of storage. Test file uploads and deletions in preview branches without touching production data.
-- **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, and any other S3-compatible tool works out of the box.
+- **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, the [Files SDK](https://files-sdk.dev), and any other S3-compatible tool works out of the box.
 - **Two access modes.** `private` buckets require authentication for all operations. `public_read` buckets allow anonymous reads with authenticated writes.
 - **One credential system.** The same Neon credential system used by AI Gateway and Functions.
 
@@ -25,7 +25,7 @@ Neon Storage is S3-compatible object storage built into the Neon backend for app
 
 <DetailIconCards>
 
-<a href="/docs/storage/get-started" description="Create a credential, configure your S3 client, and upload your first file." icon="todo">Quickstart</a>
+<a href="/docs/storage/get-started" description="Create a credential, configure a client, and upload your first file." icon="todo">Quickstart</a>
 
 <a href="/docs/storage/buckets" description="Create and manage buckets, set access levels, and understand how buckets branch." icon="database">Buckets</a>
 
@@ -42,5 +42,7 @@ Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.verc
 ```bash
 neonctl bootstrap --template ai-sdk
 ```
+
+The [with-files-sdk](https://github.com/neondatabase/examples/tree/main/with-files-sdk) example shows a minimal script that uploads local files to a branch-scoped bucket using the Files SDK and its `neon` adapter.
 
 <NeedHelp/>


### PR DESCRIPTION
Add **Files SDK** tabs (upload, download, list, delete, presigned URLs) to `get-started.md` and objects.md alongside existing S3 client examples. 

Update `overview.md` and `agents.md` to reference `files-sdk/neon` adapter and the `with-files-sdk` example repo. 

All new code samples verified against a live branch endpoint.