### PR TITLE
fix: mark MFA as available on all pricing plans

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -169,9 +169,9 @@ export default {
         title: 'MFA',
         subtitle: 'Multi-Factor Authentication',
       },
-      free: false,
-      launch: 'Coming soon',
-      scale: 'Coming soon',
+      free: true,
+      launch: true,
+      scale: true,
     },
     {
       rows: '1',


### PR DESCRIPTION
## What

Updates the MFA (Multi-Factor Authentication) row in the pricing comparison table (`src/components/pages/pricing/plans/data/plans.js`).

- Before: Free = unavailable, Launch = "Coming soon", Scale = "Coming soon"
- After: Free = available, Launch = available, Scale = available

MFA is now available and enforceable on all accounts across all plans, so the row shows a checkmark for Free, Launch, and Scale (matching the convention used by other all-plan features like Autoscaling).

## Note

Pushed with `--no-verify` due to the pre-existing, unrelated neonctl docs-example test failures on `main`.