### PR TITLE
docs: Fix foreign key syntax in delete-cascade.md

### DIFF
--- a/content/postgresql/tutorial/delete-cascade.md
+++ b/content/postgresql/tutorial/delete-cascade.md
@@ -40,7 +40,7 @@ CREATE TABLE parent_table(
 CREATE TABLE child_table(
     id SERIAL PRIMARY KEY,
     parent_id INT,
-    FOREIGN_KEY(parent_id)
+    FOREIGN KEY(parent_id)
        REFERENCES parent_table(id)
        ON DELETE CASCADE
 );


### PR DESCRIPTION
removing the underscore in the example code