### PR TITLE
docs: surface OSS models and add pricing statement to AI Gateway docs

### DIFF
--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -6,7 +6,7 @@ summary: >-
   OpenAI, Google, Meta, Databricks, and Alibaba. Use short model IDs
   like claude-sonnet-4-6 or gpt-5-mini. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-06-18T09:59:52.874Z'
+updatedOn: '2026-06-26T16:05:44.229Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -25,16 +25,15 @@ Model availability may vary by region. The catalog expands over time, so check b
 
 Not sure which model to use? Start here.
 
-| I want to...                            | Recommended model                         |
-| --------------------------------------- | ----------------------------------------- |
-| Build a general chat or reasoning app   | `claude-sonnet-4-6`                       |
-| Understand images                       | `claude-sonnet-4-6` or `gemini-2-5-flash` |
-| Process audio or video                  | `gemini-3-5-flash`                        |
-| Generate or review code                 | `gpt-5-3-codex`                           |
-| Run extended or deep reasoning          | `claude-opus-4-7` or `gpt-5-1`            |
-| Handle very long documents (1M+ tokens) | `gemini-3-1-pro` or `claude-opus-4-7`     |
-| Keep costs low for lightweight tasks    | `claude-haiku-4-5` or `gpt-5-4-nano`      |
-| Use an open-weight model                | `gpt-oss-120b`                            |
+| I want to...                            | Recommended model                         | Open-weight alternative       |
+| --------------------------------------- | ----------------------------------------- | ----------------------------- |
+| Build a general chat or reasoning app   | `claude-sonnet-4-6`                       | `llama-4-maverick`            |
+| Understand images                       | `claude-sonnet-4-6` or `gemini-2-5-flash` | `llama-4-maverick`            |
+| Process audio or video                  | `gemini-3-5-flash`                        | —                             |
+| Generate or review code                 | `gpt-5-3-codex`                           | `gpt-oss-120b`                |
+| Run extended or deep reasoning          | `claude-opus-4-7` or `gpt-5-1`            | `qwen3-next-80b-a3b-instruct` |
+| Handle very long documents (1M+ tokens) | `gemini-3-1-pro` or `claude-opus-4-7`     | `qwen35-122b-a10b`            |
+| Keep costs low for lightweight tasks    | `claude-haiku-4-5` or `gpt-5-4-nano`      | `meta-llama-3-1-8b-instruct`  |
 
 ## Rate limits
 
@@ -48,6 +47,10 @@ During the private preview, the following limits apply:
 If you hit a limit, you'll receive a `429 Too Many Requests` response. Requests resume when the rate limit window resets.
 
 These limits apply to input tokens. Upstream output token limits (20,000 OTPM for most models) apply independently, so you can hit a `429` on output tokens without reaching the input limit. See [Databricks Foundation Model API limits](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits) for details.
+
+## Pricing
+
+Inference is free during the private preview. When billing begins, prices will match each provider's published list prices.
 
 ## Available models
 
@@ -80,6 +83,32 @@ Endpoints are shown in short form. See [Which endpoint to use](#which-endpoint-t
 | `gemini-2-5-flash`      | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
 | `gemma-3-12b`           | text, image               | 128K    | `chat/completions`            | Chat completions only |
 
+### Databricks
+
+Open-weight models hosted by Databricks. Text input only. Chat completions only.
+
+| Model ID                  | Context | Endpoints          | Notes                                    |
+| ------------------------- | ------- | ------------------ | ---------------------------------------- |
+| `databricks-gpt-oss-120b` | 128K    | `chat/completions` | Recommended. Adjustable reasoning effort |
+| `databricks-gpt-oss-20b`  | 128K    | `chat/completions` |                                          |
+
+### Meta
+
+| Model ID                                 | Inputs      | Context | Endpoints          | Notes                                                                                                                                                                                                              |
+| ---------------------------------------- | ----------- | ------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `databricks-llama-4-maverick`            | text, image | —       | `chat/completions` | Recommended. [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                         |
+| `databricks-meta-llama-3-3-70b-instruct` | text        | 128K    | `chat/completions` | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
+| `databricks-meta-llama-3-1-8b-instruct`  | text        | 128K    | `chat/completions` | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
+
+### Alibaba
+
+Text input only. Chat completions only.
+
+| Model ID                                 | Context | Endpoints          | Notes                            |
+| ---------------------------------------- | ------- | ------------------ | -------------------------------- |
+| `databricks-qwen3-next-80b-a3b-instruct` | —       | `chat/completions` |                                  |
+| `databricks-qwen35-122b-a10b`            | 256K    | `chat/completions` | Always reasons before responding |
+
 ### OpenAI
 
 All OpenAI models have a 400K token context window and accept text and image inputs.
@@ -98,32 +127,6 @@ All OpenAI models have a 400K token context window and accept text and image inp
 | `gpt-5`              | `chat/completions` · `openai/responses` |                                                                    |
 | `gpt-5-mini`         | `chat/completions` · `openai/responses` |                                                                    |
 | `gpt-5-nano`         | `chat/completions` · `openai/responses` |                                                                    |
-
-### Databricks
-
-Open-weight models hosted by Databricks. Text input only. Chat completions only.
-
-| Model ID                  | Context | Endpoints          | Notes                       |
-| ------------------------- | ------- | ------------------ | --------------------------- |
-| `databricks-gpt-oss-120b` | 128K    | `chat/completions` | Adjustable reasoning effort |
-| `databricks-gpt-oss-20b`  | 128K    | `chat/completions` |                             |
-
-### Meta
-
-| Model ID                                 | Inputs      | Context | Endpoints          | Notes                                                                                                                                                                                                              |
-| ---------------------------------------- | ----------- | ------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `databricks-llama-4-maverick`            | text, image | —       | `chat/completions` | [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                                      |
-| `databricks-meta-llama-3-3-70b-instruct` | text        | 128K    | `chat/completions` | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
-| `databricks-meta-llama-3-1-8b-instruct`  | text        | 128K    | `chat/completions` | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
-
-### Alibaba
-
-Text input only. Chat completions only.
-
-| Model ID                                 | Context | Endpoints          | Notes                            |
-| ---------------------------------------- | ------- | ------------------ | -------------------------------- |
-| `databricks-qwen3-next-80b-a3b-instruct` | —       | `chat/completions` |                                  |
-| `databricks-qwen35-122b-a10b`            | 256K    | `chat/completions` | Always reasons before responding |
 
 ## Which endpoint to use
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,14 +6,14 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-24T13:43:35.494Z'
+updatedOn: '2026-06-26T16:05:44.229Z'
 ---
 
 <RequestForm type="backend-platform" title="Get early access to Neon AI Gateway" description="Neon AI Gateway is in private preview. Drop your email and we'll reach out with access." />
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
 
-> During the private preview, AI Gateway is available for **new projects** in the **AWS us-east-2** region only, and foundation model access requires a paid Neon plan.
+> During the private preview, AI Gateway is available for **new projects** in the **AWS us-east-2** region only, and requires a paid Neon plan. Inference is free during the preview. When billing begins, prices will match each provider's published list prices.
 
 <Admonition type="important">
 Participation in this Private Preview is subject to our Private Preview Terms. Access is not available to users, organizations, or entities located in or operating from regions restricted by Anthropic's [Supported Regions Policy](https://www.anthropic.com/supported-countries). This restriction also applies to entities that are majority owned, directly or indirectly, by companies headquartered in unsupported regions.

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -22,7 +22,7 @@ redirectFrom:
   - /docs/reference/billing-sample
   - /docs/introduction/legacy-plans
   - /docs/introduction/extra-usage
-updatedOn: '2026-06-19T14:28:23.449Z'
+updatedOn: '2026-06-26T16:05:44.229Z'
 ---
 
 Neon offers plans to support you at every stage, from your first prototype to production at scale.
@@ -57,6 +57,7 @@ For AI agent platforms that provision thousands of databases, Neon offers an **A
 | [History window](#history-window)                     | 6 hours, up to 1 GB-month                  | Up to 7 days                         | Up to 30 days                                                                                     |
 | [Snapshots](#snapshots)                               | 1 manual snapshot                          | 100 manual snapshots                 | 100 manual snapshots                                                                              |
 | [Auth](#auth) (Beta)                                  | Up to 60k MAU                              | Up to 1M MAU                         | Up to 1M MAU                                                                                      |
+| [AI Gateway](#ai-gateway) (Private Preview)           | —                                          | Free during preview                  | Free during preview                                                                               |
 | [Private network transfer](#private-network-transfer) | —                                          | —                                    | $0.01/GB                                                                                          |
 | [Compliance and security](#compliance-and-security)   | —                                          | Protected branches                   | SOC 2, ISO, GDPR, [HIPAA](/docs/security/hipaa), Protected branches, IP Allow, Private Networking |
 | [Uptime SLA](#uptime-sla)                             | —                                          | —                                    | ✅                                                                                                |
@@ -318,6 +319,14 @@ Monthly Active User (MAU) limits per plan:
 > An MAU (Monthly Active User) is a unique user who authenticates at least once during a monthly billing period.
 
 See [Neon Auth](/docs/auth/overview) for more information.
+
+### AI Gateway
+
+Neon AI Gateway provides access to foundation models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba through a single Neon credential. It is available on paid plans during the private preview.
+
+Inference is free during the preview. When billing begins, prices will match each provider's published list prices.
+
+See [AI Gateway models](/docs/ai-gateway/models#pricing) for details.
 
 ### Private network transfer
 


### PR DESCRIPTION
## Summary

- **Quick picks table:** Added an "Open-weight alternative" column to every use case row, so users see OSS options alongside frontier model recommendations without having to go looking for them. The standalone "Use an open-weight model" row has been removed since OSS options are now surfaced throughout.
- **Model catalog order:** Moved Databricks, Meta, and Alibaba sections before OpenAI. OSS providers were previously buried at the bottom after three frontier model sections; they now appear immediately after Anthropic and Google.
- **OSS recommendations:** Added "Recommended" notes to `databricks-gpt-oss-120b` and `databricks-llama-4-maverick`, matching the existing pattern used for `claude-sonnet-4-6`.
- **Pricing statement:** Added a new "Pricing" section to `models.md` stating that inference is free during the private preview and that prices will match each provider's published list prices when billing begins. The same language is added to the private preview note in `overview.md`.
- **Plans page:** Added an AI Gateway row to the plan overview table and a corresponding section in Plan features, so users looking at plan pricing can see AI Gateway availability and the pricing commitment in one place.

## Addresses

- Make OSS models the visible default where possible, and make model choice more obvious. The Quick picks OSS column and the reordered catalog sections directly address this without requiring frontend changes.
- State that Neon matches foundation model list prices. The pricing section in `models.md`, the note in `overview.md`, and the Plans page entry all carry this statement, scoped correctly to the private preview period.

## Test plan

- [ ] Verify Quick picks table renders correctly with three columns
- [ ] Verify model section ordering in the catalog (Databricks, Meta, Alibaba now appear before OpenAI)
- [ ] Verify Pricing section anchor (`#pricing`) works from the Plans page link
- [ ] Verify AI Gateway row in the Plans overview table links correctly to the `#ai-gateway` section

This pull request and its description were written by Isaac.