### PR TITLE
Fix hijacked appdotbuild org links → neondatabase (SEC-16797)

### DIFF
--- a/content/changelog/2025-06-06.md
+++ b/content/changelog/2025-06-06.md
@@ -27,7 +27,7 @@ With this single command, you can create and deploy a complete application with 
 
 The agent decomposes app creation into validated tasks, running checks at each step to ensure everything works. This divide-and-conquer approach enables reliable generation of complex applications beyond simple code snippets.
 
-**Join us:** [GitHub](https://github.com/appdotbuild) - Built in the open for developers exploring AI-powered development.
+**Join us:** [GitHub](https://github.com/neondatabase) - Built in the open for developers exploring AI-powered development.
 
 ## Instagres (formerly Neon Launchpad)
 

--- a/content/docs/unused/ai-app-build.md
+++ b/content/docs/unused/ai-app-build.md
@@ -135,8 +135,8 @@ As a reference implementation, we've made specific choices to keep the codebase 
 ## Contributing
 
 - Repositories:
-  - [github.com/appdotbuild/agent](https://github.com/appdotbuild/agent) (agent logic and generation)
-  - [github.com/appdotbuild/platform](https://github.com/appdotbuild/platform) (backend infrastructure)
+  - [github.com/neondatabase/appdotbuild-agent](https://github.com/neondatabase/appdotbuild-agent) (agent logic and generation)
+  - [github.com/neondatabase/appdotbuild-agent](https://github.com/neondatabase/appdotbuild-agent) (backend infrastructure)
 - Issues: Bug reports, feature requests, and discussions
 - PRs: Code contributions, documentation, templates
 


### PR DESCRIPTION
## What

Repoint two docs/content files away from the **hijacked `appdotbuild` GitHub org** to the canonical `neondatabase` repos.

- `content/docs/unused/ai-app-build.md` — the two "Repositories" links:
  - `github.com/appdotbuild/agent` → `github.com/neondatabase/appdotbuild-agent`
  - `github.com/appdotbuild/platform` → `github.com/neondatabase/appdotbuild-agent`
- `content/changelog/2025-06-06.md` — the "Join us: GitHub" link: `github.com/appdotbuild` → `github.com/neondatabase`

## Why

The `appdotbuild` GitHub org was abandoned and **re-registered by a third party on 2026-03-18** (attacker-controlled). Any link pointing there is a live supply-chain / phishing risk. `appdotbuild/platform` has no public `neondatabase` counterpart, so it is pointed at the agent repo (the canonical open-source home).

Follow-up to SEC-16797 — these website references were not covered by the original fix (which cleaned `neondatabase/appdotbuild-agent@main`).

Ref: SEC-16797

This pull request and its description were written by Isaac.
