### PR TITLE
Fix 404 crashes on deleted branching pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -235,6 +235,62 @@ const defaultConfig = {
         destination: '/?ref=tbm-p',
         permanent: true,
       },
+      // Branching page redirects — old slugs deleted in PR #4374 (Jan 2026)
+      {
+        source: '/branching/identifying-use-case',
+        destination: '/branching/introduction',
+        permanent: true,
+      },
+      {
+        source: '/branching/production-on-neon',
+        destination: '/branching/production-staging-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/branch-per-developer',
+        destination: '/branching/branching-workflows-for-development',
+        permanent: true,
+      },
+      {
+        source: '/branching/branch-per-preview',
+        destination: '/branching/ci-preview-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/branch-per-test-run',
+        destination: '/branching/ci-preview-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/branches',
+        destination: '/branching/foundational-concepts',
+        permanent: true,
+      },
+      {
+        source: '/branching/hierarchies',
+        destination: '/branching/foundational-concepts',
+        permanent: true,
+      },
+      {
+        source: '/branching/projects',
+        destination: '/branching/foundational-concepts',
+        permanent: true,
+      },
+      {
+        source: '/branching/ephemeral-environments',
+        destination: '/branching/ci-preview-workflows',
+        permanent: true,
+      },
+      {
+        source: '/branching/neon-for-dev-test',
+        destination: '/branching/branching-workflows-for-development',
+        permanent: true,
+      },
+      {
+        source: '/branching/resources-and-next-steps',
+        destination: '/branching/introduction',
+        permanent: true,
+      },
       {
         source: '/yc-startups',
         destination: '/startups',

--- a/src/app/branching/[slug]/page.jsx
+++ b/src/app/branching/[slug]/page.jsx
@@ -16,6 +16,8 @@ import { getAllPosts, getNavigationLinks } from 'utils/api-branching';
 import { getPostBySlug } from 'utils/api-content';
 import getMetadata from 'utils/get-metadata';
 
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
   const posts = await getAllPosts();
   if (!posts) return notFound();


### PR DESCRIPTION
## Summary

Branching pages deleted in #4374 (Jan 2026) had no redirects, causing `TypeError` crashes when bots or bookmarks hit the old URLs. Adds `dynamicParams = false` to return clean 404s for any unknown slug, and adds permanent redirects for all 11 deleted pages to their closest current equivalents.

## Changes

- `src/app/branching/[slug]/page.jsx` — add `dynamicParams = false`
- `next.config.js` — 11 permanent redirects for deleted branching slugs