### PR TITLE
Fix real bugs found in TS error audit (#5155)

### DIFF
--- a/src/app/templates/[slug]/page.jsx
+++ b/src/app/templates/[slug]/page.jsx
@@ -44,7 +44,7 @@ const TemplatePage = async (props) => {
   const template = templates.find((template) => template.slug === slug);
   if (!template) return notFound();
 
-  const { name, description, framework, type, css, cms, publisher, gitHubUrl } = template;
+  const { name, description, framework, type, css, cms, publisher, githubUrl } = template;
   const items = [
     {
       label: 'Framework',
@@ -114,7 +114,7 @@ const TemplatePage = async (props) => {
                   theme="black"
                   target="_blank"
                   rel="noopener noreferrer"
-                  to={template.gitHubUrl}
+                  to={template.githubUrl}
                 >
                   <GitHubIcon /> View Repo
                 </Link>
@@ -123,7 +123,7 @@ const TemplatePage = async (props) => {
                   theme="black"
                   target="_blank"
                   rel="noopener noreferrer"
-                  to={`https://app.netlify.com/start/deploy?repository=${gitHubUrl}#DATABASE_URL`}
+                  to={`https://app.netlify.com/start/deploy?repository=${githubUrl}#DATABASE_URL`}
                 >
                   <NetlifyIcon /> Deploy to Netlify
                 </Link>
@@ -134,7 +134,7 @@ const TemplatePage = async (props) => {
                   theme="black"
                   target="_blank"
                   rel="noopener noreferrer"
-                  to={`https://vercel.com/new/clone?repository-url=${gitHubUrl}&env=DATABASE_URL`}
+                  to={`https://vercel.com/new/clone?repository-url=${githubUrl}&env=DATABASE_URL`}
                 >
                   <VercelIcon /> Deploy to Vercel
                 </Link>
@@ -143,7 +143,7 @@ const TemplatePage = async (props) => {
                   theme="black"
                   target="_blank"
                   rel="noopener noreferrer"
-                  to={`https://render.com/deploy?repo=${gitHubUrl}#DATABASE_URL`}
+                  to={`https://render.com/deploy?repo=${githubUrl}#DATABASE_URL`}
                 >
                   <RenderIcon /> Deploy to Render
                 </Link>

--- a/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/contact-sales/hero/contact-form/contact-form.jsx
@@ -137,7 +137,7 @@ const ContactForm = () => {
     } catch (error) {
       if (error.name !== 'AbortError') {
         doNowOrAfterSomeTime(() => {
-          setFormState(FORM_STATES.BROKEN);
+          setFormState(FORM_STATES.ERROR);
           setIsBroken(true);
         }, 2000);
       }

--- a/src/components/pages/startups/hero/contact-form/contact-form.jsx
+++ b/src/components/pages/startups/hero/contact-form/contact-form.jsx
@@ -122,7 +122,7 @@ const ContactForm = () => {
     } catch (error) {
       if (error.name !== 'AbortError') {
         doNowOrAfterSomeTime(() => {
-          setFormState(FORM_STATES.BROKEN);
+          setFormState(FORM_STATES.ERROR);
           setIsBroken(true);
         }, 2000);
       }

--- a/src/components/pages/templates/templates-list/templates-list.jsx
+++ b/src/components/pages/templates/templates-list/templates-list.jsx
@@ -5,8 +5,8 @@ import { cn } from 'utils/cn';
 
 const TemplatesList = ({ className, templates }) => (
   <ul className={cn('divide-y divide-gray-new-80/80 dark:divide-gray-new-15/80', className)}>
-    {templates.map(({ name, description, slug, gitHubUrl }) => (
-      <li className="pt-6 pb-6 first:pt-0 last:pb-0" key={gitHubUrl}>
+    {templates.map(({ name, description, slug, githubUrl }) => (
+      <li className="pt-6 pb-6 first:pt-0 last:pb-0" key={githubUrl}>
         <Link
           className="group flex items-center justify-between md:flex-col md:items-start md:gap-y-3"
           to={`/templates/${slug}`}

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -20,6 +20,7 @@ export default {
   partners: '/docs/guides/platform-integration-overview',
   postgresqltutorial: '/postgresql/tutorial',
   pricing: '/pricing',
+  programs: '/programs',
   programsAgents: '/programs/agents',
   scaleTrial: '/scale-trial',
   security: '/security',

--- a/src/hooks/use-is-touch-device.js
+++ b/src/hooks/use-is-touch-device.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 function isTouchDevice() {
-  return 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 }
 
 export default function useIsTouchDevice() {


### PR DESCRIPTION
## Summary

Fixes four real bugs surfaced while triaging the TypeScript errors in #5155.
The remaining ~248 errors are false positives (useRef/never inference,
third-party globals, PropTypes destructuring).

## Changes

- **contact-sales + startups forms**: `FORM_STATES.BROKEN` doesn't exist —
  form got stuck in undefined state on network error. Fixed to `FORM_STATES.ERROR`.
- **templates page + list**: `gitHubUrl` → `githubUrl` — deploy links and
  repo link rendered `undefined` for all templates. List item `key` was also
  always `undefined` (same wrong field), causing React key collisions.
- **links.js**: Added missing `LINKS.programs` — used in `programs/[slug]/page.jsx`
  metadata, was a silent undefined reference.
- **use-is-touch-device**: Removed dead `navigator.msMaxTouchPoints` (IE10,
  circa 2012). `maxTouchPoints` covers all modern browsers.

Refs #5155

This pull request and its description were written by Isaac.