### PR TITLE
docs: fix llms.txt 404 for curl and AI agents

### DIFF
--- a/scripts/check-agent-endpoints.js
+++ b/scripts/check-agent-endpoints.js
@@ -181,6 +181,35 @@ const CHECKS = [
     },
   },
   {
+    name: '/docs/llms.txt — docs index served to curl (no browser UA)',
+    path: '/docs/llms.txt',
+    requestHeaders: { 'User-Agent': 'curl/8.4.0', Accept: '*/*' },
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      if (body.includes('Page Not Found')) return 'got agent 404 page instead of llms.txt content';
+      if (!body.includes('Neon')) return 'response does not look like llms.txt';
+      return null;
+    },
+    summarize(body) {
+      return body.split('\n')[0]?.slice(0, 80) ?? '';
+    },
+  },
+  {
+    name: '/docs/llms-full.txt — full docs served to curl (no browser UA)',
+    path: '/docs/llms-full.txt',
+    requestHeaders: { 'User-Agent': 'curl/8.4.0', Accept: '*/*' },
+    validate(status, body) {
+      if (status !== 200) return `expected 200, got ${status}`;
+      if (body.includes('Page Not Found'))
+        return 'got agent 404 page instead of llms-full.txt content';
+      if (!body.includes('Neon')) return 'response does not look like llms-full.txt';
+      return null;
+    },
+    summarize(body) {
+      return body.split('\n')[0]?.slice(0, 80) ?? '';
+    },
+  },
+  {
     name: '/docs/.well-known/agent-skills/index.json — skills discovery at /docs/ path',
     path: '/docs/.well-known/agent-skills/index.json',
     validate(status, body) {

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -65,7 +65,7 @@ const CUSTOM_MARKDOWN_PATHS = {
 // - Route handlers that accept non-GET requests (docs/mcp), where the middleware
 //   would otherwise detect the non-HTML Accept header, try to serve /md/docs/mcp.md,
 //   fail with 404, and return a markdown error before the route handler fires.
-const STATIC_DOC_PREFIXES = ['docs/ai/skills/', 'docs/.well-known/', 'docs/mcp'];
+const STATIC_DOC_PREFIXES = ['docs/ai/skills/', 'docs/.well-known/', 'docs/mcp', 'docs/llms'];
 
 // Convert URL path to markdown file path
 // Example: /docs/introduction -> /md/docs/introduction.md (maps to public/md/)


### PR DESCRIPTION
curl's UA matched `aiAgentPatterns` in middleware, causing it to build
the path `/md/docs/llms.txt.md`, fetch it, get 404, and return an agent
error page instead of the static file.

Fix: add `'docs/llms'` to `STATIC_DOC_PREFIXES` in `ai-agent-detection.js`
so `getMarkdownPath` returns null and Next.js serves the static file directly.
Covers `docs/llms.txt`, `docs/llms-full.txt`, and section-level llms.txt files.

Also adds two `check-agent-endpoints.js` checks to catch regressions.