### PR TITLE
fix: extend llms.txt static bypass to all subdirectory paths

### DIFF
--- a/src/constants/content.js
+++ b/src/constants/content.js
@@ -31,7 +31,7 @@ const EXCLUDED_ROUTES = [
 
 const EXCLUDED_DIRS = ['shared-content', 'unused'];
 
-const EXCLUDED_FILES = ['rss.xml', 'context7.json'];
+const EXCLUDED_FILES = ['rss.xml', 'context7.json', 'llms.txt', 'llms-full.txt'];
 
 const isUnusedOrSharedContent = (slug) =>
   slug.includes('unused/') ||

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -65,7 +65,7 @@ const CUSTOM_MARKDOWN_PATHS = {
 // - Route handlers that accept non-GET requests (docs/mcp), where the middleware
 //   would otherwise detect the non-HTML Accept header, try to serve /md/docs/mcp.md,
 //   fail with 404, and return a markdown error before the route handler fires.
-const STATIC_DOC_PREFIXES = ['docs/ai/skills/', 'docs/.well-known/', 'docs/mcp', 'docs/llms'];
+const STATIC_DOC_PREFIXES = ['docs/ai/skills/', 'docs/.well-known/', 'docs/mcp'];
 
 // Convert URL path to markdown file path
 // Example: /docs/introduction -> /md/docs/introduction.md (maps to public/md/)


### PR DESCRIPTION
Follow-up to #5177, which added `'docs/llms'` to `STATIC_DOC_PREFIXES`
to prevent the middleware from building `/md/docs/llms.txt.md` and 404ing.
That prefix only matched root-level `docs/llms.txt` and `docs/llms-full.txt`.

Subdirectory paths like `docs/introduction/llms.txt` (linked from the index)
were still intercepted and 404'd.

Fix: add `'llms.txt'` and `'llms-full.txt'` to `EXCLUDED_FILES` in
`constants/content.js`, which uses `pathname.endsWith()` — covers all depths.
Removes the now-redundant `STATIC_DOC_PREFIXES` entry.