### PR TITLE
docs: adjust API reference UI

### DIFF
--- a/src/components/pages/doc/annotated-field/annotated-field.jsx
+++ b/src/components/pages/doc/annotated-field/annotated-field.jsx
@@ -45,7 +45,7 @@ const TypeBadge = ({ type }) => {
   return (
     <span
       className={cn(
-        'px-1.5 py-0.5 font-mono text-sm leading-normal font-medium',
+        'rounded px-1.5 py-0.5 font-mono text-sm leading-normal font-medium',
         TYPE_STYLES[type] ?? TYPE_STYLES.string
       )}
     >
@@ -62,7 +62,7 @@ const DetailCard = ({ node, onClose }) => {
   const d = node.details;
   if (!d) return null;
   return (
-    <div className="relative my-1 mr-5 ml-8 border border-gray-new-80 bg-white p-5 shadow-lg dark:border-gray-new-20 dark:bg-gray-new-8">
+    <div className="relative my-1 mr-5 ml-8 border border-gray-new-80 bg-white p-5 dark:border-gray-new-20 dark:bg-gray-new-8">
       <button
         type="button"
         onClick={onClose}
@@ -71,7 +71,7 @@ const DetailCard = ({ node, onClose }) => {
       >
         ×
       </button>
-      <div className="mb-3 flex flex-wrap items-baseline gap-2 pr-8">
+      <div className="flex flex-wrap items-baseline gap-2 pr-8">
         <code className="font-mono text-sm leading-relaxed font-semibold text-[var(--shiki-token-string-expression)]">
           {node.key}
         </code>
@@ -86,7 +86,7 @@ const DetailCard = ({ node, onClose }) => {
       {(d.descriptionHtml || d.description) &&
         (() => {
           const descClass =
-            'mb-3 text-base leading-relaxed text-gray-new-20 dark:text-gray-new-80 [&_a]:underline';
+            'mt-3 text-sm leading-normal text-gray-new-20 dark:text-gray-new-80 [&_a]:underline';
           return d.descriptionHtml ? (
             <p
               className={cn(descClass, INLINE_CODE_STYLES)}
@@ -97,7 +97,7 @@ const DetailCard = ({ node, onClose }) => {
           );
         })()}
       {d.example && (
-        <div className="mb-3">
+        <div className="mt-3">
           <span className="mb-1 block text-sm font-semibold tracking-wide text-gray-new-50 uppercase dark:text-gray-new-60">
             Example
           </span>
@@ -107,7 +107,7 @@ const DetailCard = ({ node, onClose }) => {
         </div>
       )}
       {d.values && d.values.length > 0 && (
-        <div className="mb-3">
+        <div className="mt-3">
           <span className="mb-1 block text-sm font-semibold tracking-wide text-gray-new-50 uppercase dark:text-gray-new-60">
             Valid values
           </span>
@@ -174,7 +174,7 @@ const FieldRow = ({
       'flex items-baseline justify-between gap-4 border-l-2 px-5 py-1.5 transition-all duration-100',
       isInteractive && 'cursor-pointer',
       isHovered
-        ? 'border-l-green-45/50 bg-[rgba(0,229,153,0.04)] dark:bg-[rgba(0,229,153,0.03)]'
+        ? 'border-l-green-45/70 bg-[rgba(0,229,153,0.04)] dark:bg-[rgba(0,229,153,0.03)]'
         : 'border-l-transparent'
     )}
     style={{ paddingLeft: `${20 + indent * 18}px` }}
@@ -363,7 +363,7 @@ export const AnnotatedField = ({ node, indent = 0, parentPath = '', isOpen, onTo
             </span>
           )}
           {node.deprecated && (
-            <span className="ml-1.5 border border-[#F0B375]/40 bg-transparent px-1 py-0.5 text-sm font-semibold text-[#F0B375]">
+            <span className="ml-1.5 rounded border border-[#F0B375]/40 bg-transparent px-1 py-0.5 text-sm font-semibold text-[#F0B375]">
               deprecated{node.sunset ? ` · sunset ${node.sunset}` : ''}
             </span>
           )}
@@ -389,7 +389,7 @@ export const AnnotatedField = ({ node, indent = 0, parentPath = '', isOpen, onTo
             aria-hidden="true"
             className={cn(
               'ml-auto shrink-0 text-sm leading-none transition-colors',
-              pinned ? 'text-green-45' : 'text-gray-new-50 dark:text-gray-new-60',
+              pinned ? 'text-green-44' : 'text-gray-new-50 dark:text-gray-new-60',
               hovered && !pinned && 'text-gray-new-30 dark:text-gray-new-80'
             )}
           >

--- a/src/components/pages/doc/annotated-field/annotated-field.jsx
+++ b/src/components/pages/doc/annotated-field/annotated-field.jsx
@@ -3,7 +3,7 @@
 import PropTypes from 'prop-types';
 import { useEffect, useRef, useState } from 'react';
 
-import { TYPE_STYLES, getTypeColor } from 'utils/api-style';
+import { INLINE_CODE_STYLES, TYPE_STYLES, getTypeColor } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
 // ── Field validation ─────────────────────────────────────────────────────────
@@ -45,7 +45,7 @@ const TypeBadge = ({ type }) => {
   return (
     <span
       className={cn(
-        'rounded px-1.5 py-0.5 font-mono text-[10px] leading-normal font-medium',
+        'px-1.5 py-0.5 font-mono text-sm leading-normal font-medium',
         TYPE_STYLES[type] ?? TYPE_STYLES.string
       )}
     >
@@ -62,54 +62,56 @@ const DetailCard = ({ node, onClose }) => {
   const d = node.details;
   if (!d) return null;
   return (
-    <div className="relative my-1 mr-3 ml-8 rounded-lg border border-gray-new-90 bg-gray-new-98 p-3.5 shadow-lg dark:border-gray-new-20 dark:bg-gray-new-10">
+    <div className="relative my-1 mr-5 ml-8 border border-gray-new-80 bg-white p-5 shadow-lg dark:border-gray-new-20 dark:bg-gray-new-8">
       <button
         type="button"
         onClick={onClose}
-        className="absolute top-2 right-2 rounded px-1.5 py-0.5 text-sm text-gray-new-50 hover:text-gray-new-20 dark:text-gray-new-60 dark:hover:text-gray-new-80"
+        className="absolute top-3 right-3 px-1.5 py-0.5 text-xl leading-none text-gray-new-50 transition-colors hover:text-gray-new-20 dark:text-gray-new-60 dark:hover:text-gray-new-80"
+        aria-label="Close field details"
       >
         ×
       </button>
-      <div className="mb-2 flex flex-wrap items-baseline gap-2">
-        <code className="font-mono text-[13px] font-semibold text-[#426CE0]">{node.key}</code>
+      <div className="mb-3 flex flex-wrap items-baseline gap-2 pr-8">
+        <code className="font-mono text-sm leading-relaxed font-semibold text-[var(--shiki-token-string-expression)]">
+          {node.key}
+        </code>
         <TypeBadge type={node.type} />
         {node.required && (
-          <span className="text-red-600 text-[9px] font-semibold dark:text-[#FF5645]">
-            required
-          </span>
+          <span className="text-red-600 text-sm font-semibold dark:text-[#FF5645]">required</span>
         )}
         {node.constraints && (
-          <span className="text-[10px] text-gray-new-50 dark:text-gray-new-60">
-            {node.constraints}
-          </span>
+          <span className="text-sm text-gray-new-50 dark:text-gray-new-60">{node.constraints}</span>
         )}
       </div>
       {(d.descriptionHtml || d.description) &&
         (() => {
           const descClass =
-            'mb-2 text-[13px] leading-relaxed text-gray-new-20 dark:text-gray-new-80 [&_a]:underline [&_code]:rounded [&_code]:bg-gray-new-94 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[11px] dark:[&_code]:bg-gray-new-15';
+            'mb-3 text-base leading-relaxed text-gray-new-20 dark:text-gray-new-80 [&_a]:underline';
           return d.descriptionHtml ? (
-            <p className={descClass} dangerouslySetInnerHTML={{ __html: d.descriptionHtml }} />
+            <p
+              className={cn(descClass, INLINE_CODE_STYLES)}
+              dangerouslySetInnerHTML={{ __html: d.descriptionHtml }}
+            />
           ) : (
             <p className={descClass}>{d.description}</p>
           );
         })()}
       {d.example && (
-        <div className="mb-2">
-          <span className="mb-1 block text-[10px] font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
+        <div className="mb-3">
+          <span className="mb-1 block text-sm font-semibold tracking-wide text-gray-new-50 uppercase dark:text-gray-new-60">
             Example
           </span>
-          <code className="block rounded border border-gray-new-90 bg-gray-new-95 px-2.5 py-1.5 font-mono text-[12px] text-[#EC6F09] dark:border-gray-new-20 dark:bg-gray-new-15">
+          <code className="block border border-gray-new-70 bg-transparent px-2.5 py-1.5 font-mono text-sm text-[var(--shiki-token-string)] dark:border-gray-new-30">
             {d.example}
           </code>
         </div>
       )}
       {d.values && d.values.length > 0 && (
-        <div className="mb-2">
-          <span className="mb-1 block text-[10px] font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
+        <div className="mb-3">
+          <span className="mb-1 block text-sm font-semibold tracking-wide text-gray-new-50 uppercase dark:text-gray-new-60">
             Valid values
           </span>
-          <ul className="space-y-0.5 text-[12px] text-gray-new-30 dark:text-gray-new-70">
+          <ul className="space-y-0.5 text-sm text-gray-new-30 dark:text-gray-new-70">
             {d.values.map((v) => (
               <li key={v}>
                 <code className="font-mono">{v}</code>
@@ -119,7 +121,7 @@ const DetailCard = ({ node, onClose }) => {
         </div>
       )}
       {d.link && (
-        <a href={d.link.href} className="mt-1 text-[12px] text-green-45 hover:underline">
+        <a href={d.link.href} className="mt-1 text-sm text-green-45 hover:underline">
           {d.link.text} →
         </a>
       )}
@@ -146,10 +148,31 @@ DetailCard.propTypes = {
 
 // ── Shared row wrapper ──────────────────────────────────────────────────────
 
-const FieldRow = ({ indent, isHovered, children }) => (
+const FieldRow = ({
+  indent,
+  isHovered,
+  isInteractive,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  children,
+}) => (
   <div
+    role={isInteractive ? 'button' : undefined}
+    tabIndex={isInteractive ? 0 : undefined}
+    onClick={onClick}
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+    onKeyDown={(e) => {
+      if (!isInteractive) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick?.(e);
+      }
+    }}
     className={cn(
-      'flex items-baseline justify-between gap-4 border-l-2 px-5 py-1 transition-all duration-100',
+      'flex items-baseline justify-between gap-4 border-l-2 px-5 py-1.5 transition-all duration-100',
+      isInteractive && 'cursor-pointer',
       isHovered
         ? 'border-l-green-45/50 bg-[rgba(0,229,153,0.04)] dark:bg-[rgba(0,229,153,0.03)]'
         : 'border-l-transparent'
@@ -163,6 +186,10 @@ const FieldRow = ({ indent, isHovered, children }) => (
 FieldRow.propTypes = {
   indent: PropTypes.number.isRequired,
   isHovered: PropTypes.bool,
+  isInteractive: PropTypes.bool,
+  onClick: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
   children: PropTypes.node.isRequired,
 };
 
@@ -207,15 +234,15 @@ const EnumDropdown = ({ options, selected, isEdited, onChange }) => {
         type="button"
         onClick={handleOpen}
         className={cn(
-          'inline-flex items-center gap-1 rounded px-0.5 font-mono text-[12px] transition-colors',
-          isEdited ? 'text-[#EC6F09]' : getTypeColor(typeGuess),
+          'inline-flex items-center gap-1 rounded px-0.5 font-mono text-sm transition-colors',
+          isEdited ? 'text-[var(--shiki-token-string)]' : getTypeColor(typeGuess),
           'hover:opacity-80'
         )}
       >
         {selected !== null && selected !== undefined && selected !== ''
           ? String(selected)
           : '(select)'}
-        <span className="text-[9px] text-gray-new-50 dark:text-gray-new-60">▼</span>
+        <span className="text-sm text-gray-new-50 dark:text-gray-new-60">▼</span>
       </button>
 
       {open && (
@@ -234,14 +261,14 @@ const EnumDropdown = ({ options, selected, isEdited, onChange }) => {
                   setOpen(false);
                 }}
                 className={cn(
-                  'flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left font-mono text-[13px] transition-colors',
+                  'flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left font-mono text-sm transition-colors',
                   isSelected
-                    ? 'bg-[#d8d8d8] text-[#00B87B] dark:bg-[#242427]'
+                    ? 'bg-transparent text-[#00B87B] dark:text-green-45'
                     : 'text-gray-new-50 hover:bg-gray-new-20/40 hover:text-gray-new-20 dark:text-gray-new-60 dark:hover:text-gray-new-80'
                 )}
               >
                 {String(opt)}
-                {isSelected && <span className="text-[11px] text-[#00B87B]">✓</span>}
+                {isSelected && <span className="text-sm text-[#00B87B]">✓</span>}
               </button>
             );
           })}
@@ -269,23 +296,32 @@ export const AnnotatedField = ({ node, indent = 0, parentPath = '', isOpen, onTo
   const open = isOpen(path);
   const bracket = hasKids ? (node.type === 'array' ? '[' : '{') : null;
   const closeBracket = node.type === 'array' ? ']' : '}';
+  const hasDetails = Boolean(node.details);
 
   return (
     <>
-      <FieldRow indent={indent} isHovered={hovered}>
+      <FieldRow
+        indent={indent}
+        isHovered={hovered || pinned}
+        isInteractive={hasDetails}
+        onClick={() => hasDetails && setPinned((p) => !p)}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
         <div
           className={cn(
             'flex min-w-0 flex-wrap items-baseline gap-0',
             node.deprecated && 'opacity-50'
           )}
-          onMouseEnter={() => setHovered(true)}
-          onMouseLeave={() => setHovered(false)}
         >
           {hasKids && (
             <button
               type="button"
-              onClick={() => onToggle(path)}
-              className="mr-1 p-0 text-[9px] text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggle(path);
+              }}
+              className="mr-1 p-0 text-sm text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
               style={{ transform: open ? 'rotate(90deg)' : 'none' }}
             >
               ▶
@@ -293,93 +329,72 @@ export const AnnotatedField = ({ node, indent = 0, parentPath = '', isOpen, onTo
           )}
           <span
             className={cn(
-              'font-mono text-[13px]',
+              'font-mono text-sm',
               node.deprecated
                 ? 'text-gray-new-50 line-through dark:text-gray-new-60'
-                : 'text-[#426CE0]'
+                : 'text-[var(--shiki-token-string-expression)]'
             )}
           >
             &quot;{node.key}&quot;
           </span>
-          <span className="font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60">: </span>
+          <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">: </span>
           {bracket && !open ? (
-            <span className="font-mono text-[12px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
               {bracket}…{closeBracket}
-              <span className="ml-1.5 text-[10px]">
+              <span className="ml-1.5 text-sm">
                 {node.children.length} {node.type === 'array' ? 'items' : 'fields'}
               </span>
             </span>
           ) : bracket ? (
-            <span className="font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
               {bracket}
             </span>
           ) : (
             <>
-              <span className={cn('font-mono text-[13px]', getTypeColor(node.type))}>
+              <span className={cn('font-mono text-sm', getTypeColor(node.type))}>
                 {node.value ?? `(${node.type})`}
               </span>
-              <span className="font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60">
-                ,
-              </span>
+              <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">,</span>
             </>
           )}
           {node.required && (
-            <span className="text-red-600 ml-1.5 font-mono text-[9px] font-semibold tracking-wider dark:text-[#FF5645]">
+            <span className="text-red-600 ml-1.5 font-mono text-sm font-semibold tracking-wider dark:text-[#FF5645]">
               req
             </span>
           )}
           {node.deprecated && (
-            <span className="ml-1.5 rounded bg-[#F0B375]/10 px-1 py-0.5 text-[9px] font-semibold text-[#F0B375]">
+            <span className="ml-1.5 border border-[#F0B375]/40 bg-transparent px-1 py-0.5 text-sm font-semibold text-[#F0B375]">
               deprecated{node.sunset ? ` · sunset ${node.sunset}` : ''}
             </span>
           )}
           {node.enum && (
-            <span className="ml-1.5 font-mono text-[10px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="ml-1.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
               {node.enum.join(' | ')}
             </span>
           )}
           {node.format && (
-            <span className="ml-1.5 font-mono text-[10px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="ml-1.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
               {node.format}
             </span>
           )}
           {node.constraints && (
-            <span className="ml-1.5 text-[10px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="ml-1.5 text-sm text-gray-new-50 dark:text-gray-new-60">
               {node.constraints}
             </span>
           )}
         </div>
 
-        {/* Annotation — click to pin if details exist */}
-        {node.annotation && (
-          <button
-            type="button"
-            onClick={() => node.details && setPinned((p) => !p)}
+        {hasDetails && (
+          <span
+            aria-hidden="true"
             className={cn(
-              'flex max-w-[280px] shrink-0 items-baseline text-right text-[12px] transition-colors duration-100',
-              node.details
-                ? 'cursor-pointer underline-offset-2 hover:text-gray-new-20 dark:hover:text-gray-new-80'
-                : 'cursor-default',
-              hovered || pinned
-                ? 'text-gray-new-30 dark:text-gray-new-70'
-                : 'text-gray-new-60 dark:text-gray-new-50',
-              node.details && (hovered || pinned) && 'underline decoration-dashed'
+              'ml-auto shrink-0 text-sm leading-none transition-colors',
+              pinned ? 'text-green-45' : 'text-gray-new-50 dark:text-gray-new-60',
+              hovered && !pinned && 'text-gray-new-30 dark:text-gray-new-80'
             )}
           >
-            <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-              {node.annotation}
-            </span>
-            {node.details && (
-              <span
-                className={cn(
-                  'ml-1 shrink-0 text-[10px]',
-                  pinned ? 'text-green-45' : 'text-gray-new-50'
-                )}
-              >
-                ⓘ
-              </span>
-            )}
-          </button>
+            ⓘ
+          </span>
         )}
       </FieldRow>
 
@@ -398,7 +413,7 @@ export const AnnotatedField = ({ node, indent = 0, parentPath = '', isOpen, onTo
             />
           ))}
           <div
-            className="px-5 py-0.5 font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60"
+            className="px-5 py-0.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60"
             style={{ paddingLeft: `${20 + indent * 18}px` }}
           >
             {closeBracket},
@@ -474,7 +489,7 @@ export const EditableField = ({
   const renderValue = () => {
     if (node.deprecated) {
       return (
-        <span className={cn('font-mono text-[13px]', getTypeColor(node.type))}>
+        <span className={cn('font-mono text-sm', getTypeColor(node.type))}>
           {node.value ?? `(${node.type})`}
         </span>
       );
@@ -487,8 +502,10 @@ export const EditableField = ({
           type="button"
           onClick={() => handleEdit(active ? 'false' : 'true')}
           className={cn(
-            'font-mono text-[12px] transition-colors',
-            edited ? 'text-[#2D8665]' : 'text-[#426CE0]'
+            'font-mono text-sm transition-colors',
+            edited
+              ? 'text-[var(--shiki-token-keyword)]'
+              : 'text-[var(--shiki-token-string-expression)]'
           )}
         >
           {active ? 'true' : 'false'}
@@ -535,7 +552,7 @@ export const EditableField = ({
             }
           }}
           aria-label={`Edit ${node.key} value`}
-          className="rounded border border-green-45/40 bg-green-45/5 px-1 font-mono text-[12px] text-[#CE9178] outline-none"
+          className="rounded border border-green-45/40 bg-green-45/5 px-1 font-mono text-sm text-[var(--shiki-token-string)] outline-none"
           style={{ width: `${Math.max(80, String(currentVal).length * 7.5)}px`, maxWidth: '200px' }}
         />
       );
@@ -559,9 +576,9 @@ export const EditableField = ({
         aria-label={`Edit ${node.key} value`}
         aria-disabled={node.deprecated || undefined}
         className={cn(
-          'cursor-text rounded border-b border-dashed border-transparent px-0.5 font-mono text-[12px] transition-all outline-none',
+          'cursor-text rounded border-b border-dashed border-transparent px-0.5 font-mono text-sm transition-all outline-none',
           edited
-            ? 'border-[#00B87B] bg-green-45/5 text-[#EC6F09]'
+            ? 'border-[#00B87B] bg-green-45/5 text-[var(--shiki-token-string)]'
             : 'text-gray-new-50 hover:border-gray-new-50 dark:text-gray-new-60',
           node.deprecated && 'cursor-default'
         )}
@@ -623,7 +640,7 @@ export const EditableField = ({
             <button
               type="button"
               onClick={() => onToggle(path)}
-              className="mr-1 p-0 text-[9px] text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
+              className="mr-1 p-0 text-sm text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
               style={{ transform: open ? 'rotate(90deg)' : 'none' }}
             >
               ▶
@@ -632,44 +649,42 @@ export const EditableField = ({
 
           <span
             className={cn(
-              'font-mono text-[13px]',
+              'font-mono text-sm',
               node.deprecated
                 ? 'text-gray-new-50 line-through dark:text-gray-new-60'
-                : 'text-[#426CE0]'
+                : 'text-[var(--shiki-token-string-expression)]'
             )}
           >
             &quot;{node.key}&quot;
           </span>
-          <span className="font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60">: </span>
+          <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">: </span>
 
           {bracket && !open ? (
-            <span className="font-mono text-[12px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
               {bracket}…{closeBracket}
-              <span className="ml-1.5 text-[10px]">
+              <span className="ml-1.5 text-sm">
                 {node.children.length} {node.type === 'array' ? 'items' : 'fields'}
               </span>
             </span>
           ) : bracket ? (
-            <span className="font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
               {bracket}
             </span>
           ) : (
             <>
               {renderValue()}
-              <span className="font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60">
-                ,
-              </span>
+              <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">,</span>
             </>
           )}
 
           {node.deprecated && (
-            <span className="ml-1.5 rounded bg-[#F0B375]/10 px-1 py-0.5 text-[9px] font-semibold text-[#F0B375]">
+            <span className="ml-1.5 border border-[#F0B375]/40 bg-transparent px-1 py-0.5 text-sm font-semibold text-[#F0B375]">
               deprecated{node.sunset ? ` · sunset ${node.sunset}` : ''}
             </span>
           )}
 
           {node.constraints && !node.enum && (
-            <span className="ml-1.5 text-[10px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="ml-1.5 text-sm text-gray-new-50 dark:text-gray-new-60">
               {node.constraints}
             </span>
           )}
@@ -677,16 +692,14 @@ export const EditableField = ({
 
         {/* Annotation — show validation error or click-to-pin annotation */}
         {error ? (
-          <span className="text-amber-400 shrink-0 text-right text-[11px] font-medium">
-            ⚠ {error}
-          </span>
+          <span className="text-amber-400 shrink-0 text-right text-sm font-medium">⚠ {error}</span>
         ) : (
           node.annotation && (
             <button
               type="button"
               onClick={() => node.details && onPin(isPinned ? null : path)}
               className={cn(
-                'flex max-w-[260px] shrink-0 items-baseline text-right text-[12px] transition-colors duration-100',
+                'flex max-w-[260px] shrink-0 items-baseline text-right text-sm transition-colors duration-100',
                 node.details ? 'cursor-pointer' : 'cursor-default',
                 hovered || isPinned
                   ? 'text-gray-new-30 dark:text-gray-new-70'
@@ -702,7 +715,7 @@ export const EditableField = ({
               {node.details && (
                 <span
                   className={cn(
-                    'ml-1 shrink-0 text-[10px]',
+                    'ml-1 shrink-0 text-sm',
                     isPinned
                       ? 'text-gray-new-30 dark:text-gray-new-70'
                       : 'text-gray-new-60 dark:text-gray-new-50'
@@ -739,7 +752,7 @@ export const EditableField = ({
             />
           ))}
           <div
-            className="px-5 py-0.5 font-mono text-[13px] text-gray-new-50 dark:text-gray-new-60"
+            className="px-5 py-0.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60"
             style={{ paddingLeft: `${20 + indent * 18}px` }}
           >
             {closeBracket},

--- a/src/components/pages/doc/annotated-field/annotated-field.jsx
+++ b/src/components/pages/doc/annotated-field/annotated-field.jsx
@@ -148,31 +148,12 @@ DetailCard.propTypes = {
 
 // ── Shared row wrapper ──────────────────────────────────────────────────────
 
-const FieldRow = ({
-  indent,
-  isHovered,
-  isInteractive,
-  onClick,
-  onMouseEnter,
-  onMouseLeave,
-  children,
-}) => (
+const FieldRow = ({ indent, isHovered, onMouseEnter, onMouseLeave, children }) => (
   <div
-    role={isInteractive ? 'button' : undefined}
-    tabIndex={isInteractive ? 0 : undefined}
-    onClick={onClick}
     onMouseEnter={onMouseEnter}
     onMouseLeave={onMouseLeave}
-    onKeyDown={(e) => {
-      if (!isInteractive) return;
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        onClick?.(e);
-      }
-    }}
     className={cn(
       'flex items-baseline justify-between gap-4 border-l-2 px-5 py-1.5 transition-all duration-100',
-      isInteractive && 'cursor-pointer',
       isHovered
         ? 'border-l-green-45/70 bg-[rgba(0,229,153,0.04)] dark:bg-[rgba(0,229,153,0.03)]'
         : 'border-l-transparent'
@@ -186,8 +167,6 @@ const FieldRow = ({
 FieldRow.propTypes = {
   indent: PropTypes.number.isRequired,
   isHovered: PropTypes.bool,
-  isInteractive: PropTypes.bool,
-  onClick: PropTypes.func,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   children: PropTypes.node.isRequired,
@@ -297,104 +276,113 @@ export const AnnotatedField = ({ node, indent = 0, parentPath = '', isOpen, onTo
   const bracket = hasKids ? (node.type === 'array' ? '[' : '{') : null;
   const closeBracket = node.type === 'array' ? ']' : '}';
   const hasDetails = Boolean(node.details);
+  const leftContentClassName = cn(
+    'flex min-w-0 flex-wrap items-baseline gap-0 text-left',
+    hasKids && 'cursor-pointer',
+    node.deprecated && 'opacity-50'
+  );
+  const fieldContent = (
+    <>
+      {hasKids && (
+        <span
+          className="mr-1 p-0 text-sm text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
+          style={{ transform: open ? 'rotate(90deg)' : 'none' }}
+          aria-hidden="true"
+        >
+          ▶
+        </span>
+      )}
+      <span
+        className={cn(
+          'font-mono text-sm',
+          node.deprecated
+            ? 'text-gray-new-50 line-through dark:text-gray-new-60'
+            : 'text-[var(--shiki-token-string-expression)]'
+        )}
+      >
+        &quot;{node.key}&quot;
+      </span>
+      <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">: </span>
+      {bracket && !open ? (
+        <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
+          {bracket}…{closeBracket}
+          <span className="ml-1.5 text-sm">
+            {node.children.length} {node.type === 'array' ? 'items' : 'fields'}
+          </span>
+        </span>
+      ) : bracket ? (
+        <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">{bracket}</span>
+      ) : (
+        <>
+          <span className={cn('font-mono text-sm', getTypeColor(node.type))}>
+            {node.value ?? `(${node.type})`}
+          </span>
+          <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">,</span>
+        </>
+      )}
+      {node.required && (
+        <span className="text-red-600 ml-1.5 font-mono text-sm font-semibold tracking-wider dark:text-[#FF5645]">
+          req
+        </span>
+      )}
+      {node.deprecated && (
+        <span className="ml-1.5 rounded border border-[#F0B375]/40 bg-transparent px-1 py-0.5 text-sm font-semibold text-[#F0B375]">
+          deprecated{node.sunset ? ` · sunset ${node.sunset}` : ''}
+        </span>
+      )}
+      {node.enum && (
+        <span className="ml-1.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
+          {node.enum.join(' | ')}
+        </span>
+      )}
+      {node.format && (
+        <span className="ml-1.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
+          {node.format}
+        </span>
+      )}
+      {node.constraints && (
+        <span className="ml-1.5 text-sm text-gray-new-50 dark:text-gray-new-60">
+          {node.constraints}
+        </span>
+      )}
+    </>
+  );
 
   return (
     <>
       <FieldRow
         indent={indent}
         isHovered={hovered || pinned}
-        isInteractive={hasDetails}
-        onClick={() => hasDetails && setPinned((p) => !p)}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
-        <div
-          className={cn(
-            'flex min-w-0 flex-wrap items-baseline gap-0',
-            node.deprecated && 'opacity-50'
-          )}
-        >
-          {hasKids && (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggle(path);
-              }}
-              className="mr-1 p-0 text-sm text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
-              style={{ transform: open ? 'rotate(90deg)' : 'none' }}
-            >
-              ▶
-            </button>
-          )}
-          <span
-            className={cn(
-              'font-mono text-sm',
-              node.deprecated
-                ? 'text-gray-new-50 line-through dark:text-gray-new-60'
-                : 'text-[var(--shiki-token-string-expression)]'
-            )}
+        {hasKids ? (
+          <button
+            type="button"
+            onClick={() => onToggle(path)}
+            aria-expanded={open}
+            aria-label={`${open ? 'Collapse' : 'Expand'} ${node.key}`}
+            className={leftContentClassName}
           >
-            &quot;{node.key}&quot;
-          </span>
-          <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">: </span>
-          {bracket && !open ? (
-            <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
-              {bracket}…{closeBracket}
-              <span className="ml-1.5 text-sm">
-                {node.children.length} {node.type === 'array' ? 'items' : 'fields'}
-              </span>
-            </span>
-          ) : bracket ? (
-            <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
-              {bracket}
-            </span>
-          ) : (
-            <>
-              <span className={cn('font-mono text-sm', getTypeColor(node.type))}>
-                {node.value ?? `(${node.type})`}
-              </span>
-              <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">,</span>
-            </>
-          )}
-          {node.required && (
-            <span className="text-red-600 ml-1.5 font-mono text-sm font-semibold tracking-wider dark:text-[#FF5645]">
-              req
-            </span>
-          )}
-          {node.deprecated && (
-            <span className="ml-1.5 rounded border border-[#F0B375]/40 bg-transparent px-1 py-0.5 text-sm font-semibold text-[#F0B375]">
-              deprecated{node.sunset ? ` · sunset ${node.sunset}` : ''}
-            </span>
-          )}
-          {node.enum && (
-            <span className="ml-1.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
-              {node.enum.join(' | ')}
-            </span>
-          )}
-          {node.format && (
-            <span className="ml-1.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
-              {node.format}
-            </span>
-          )}
-          {node.constraints && (
-            <span className="ml-1.5 text-sm text-gray-new-50 dark:text-gray-new-60">
-              {node.constraints}
-            </span>
-          )}
-        </div>
+            {fieldContent}
+          </button>
+        ) : (
+          <div className={leftContentClassName}>{fieldContent}</div>
+        )}
 
         {hasDetails && (
-          <span
-            aria-hidden="true"
+          <button
+            type="button"
+            onClick={() => setPinned((p) => !p)}
+            aria-label={`${pinned ? 'Hide' : 'Show'} ${node.key} details`}
             className={cn(
-              'ml-auto shrink-0 text-sm leading-none transition-colors',
+              'ml-auto shrink-0 cursor-pointer text-sm leading-none transition-colors',
               pinned ? 'text-green-44' : 'text-gray-new-50 dark:text-gray-new-60',
               hovered && !pinned && 'text-gray-new-30 dark:text-gray-new-80'
             )}
           >
             ⓘ
-          </span>
+          </button>
         )}
       </FieldRow>
 

--- a/src/components/pages/doc/api-endpoints-table/api-endpoints-table.jsx
+++ b/src/components/pages/doc/api-endpoints-table/api-endpoints-table.jsx
@@ -5,41 +5,34 @@ import PropTypes from 'prop-types';
 import { useState } from 'react';
 
 import { DOCS_BASE_PATH } from 'constants/docs';
+import { METHOD_TEXT_FALLBACK_STYLE, METHOD_TEXT_STYLES } from 'utils/api-style';
 import { cn } from 'utils/cn';
-
-const METHOD_COLOR = {
-  GET: 'text-[#00B87B] dark:text-green-45',
-  POST: 'text-[#426CE0] dark:text-blue-70',
-  PUT: 'text-[#BE8A3C] dark:text-brown-70',
-  PATCH: 'text-[#E9943E] dark:text-yellow-70',
-  DELETE: 'text-[#E2301D] dark:text-[#FF5645]',
-};
 
 const ApiEndpointsTable = ({ operations, tagDisplay }) => {
   const [open, setOpen] = useState(true);
 
   return (
-    <div className="mt-7 rounded-[10px] border border-gray-new-90 dark:border-gray-new-20">
+    <div className="mt-7 overflow-hidden border border-gray-new-90 dark:border-gray-new-20">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 px-4 py-3 text-left"
+        className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors duration-200 hover:bg-gray-new-98 dark:hover:bg-gray-new-10"
       >
         <span
           className={cn(
-            'text-[11px] transition-transform duration-200',
+            'text-xs transition-transform duration-200',
             open ? 'rotate-90' : 'rotate-0'
           )}
         >
           ▶
         </span>
-        <span className="flex-1 text-[13px] font-semibold text-black-pure dark:text-white">
+        <span className="flex-1 text-sm font-semibold text-black-pure dark:text-white">
           All {tagDisplay} endpoints
         </span>
-        <span className="font-mono text-[11px] text-gray-new-50 dark:text-gray-new-60">
+        <span className="font-mono text-xs text-gray-new-50 dark:text-gray-new-60">
           {operations.length}
         </span>
-        <span className="text-[11px] text-gray-new-50 dark:text-gray-new-60">
+        <span className="text-xs text-gray-new-50 dark:text-gray-new-60">
           {open ? 'Hide' : 'Show'}
         </span>
       </button>
@@ -66,16 +59,16 @@ const ApiEndpointsTable = ({ operations, tagDisplay }) => {
                 >
                   <span
                     className={cn(
-                      'w-[46px] shrink-0 font-mono text-[11px] font-semibold uppercase',
-                      METHOD_COLOR[method] ?? 'text-gray-new-50 dark:text-gray-new-60'
+                      'w-12 shrink-0 font-mono text-xs font-semibold uppercase',
+                      METHOD_TEXT_STYLES[method] ?? METHOD_TEXT_FALLBACK_STYLE
                     )}
                   >
                     {method}
                   </span>
-                  <code className="flex-1 overflow-hidden font-mono text-[12px] text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
+                  <code className="flex-1 overflow-hidden font-mono text-xs text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
                     {op.path}
                   </code>
-                  <span className="shrink-0 text-right text-[12px] text-gray-new-50 group-hover:text-gray-new-40 dark:text-gray-new-60 dark:group-hover:text-gray-new-50">
+                  <span className="shrink-0 text-right text-xs text-gray-new-50 group-hover:text-gray-new-40 dark:text-gray-new-60 dark:group-hover:text-gray-new-50 md:hidden">
                     {op.summary}
                   </span>
                 </a>

--- a/src/components/pages/doc/api-operation/__tests__/components.test.jsx
+++ b/src/components/pages/doc/api-operation/__tests__/components.test.jsx
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { AnnotatedField } from 'components/pages/doc/annotated-field';
+
 import { CliSection } from '../operation-cli';
 import { CliFlagRow, CliPositionalRow } from '../operation-shared';
 
@@ -11,6 +13,31 @@ import { CliFlagRow, CliPositionalRow } from '../operation-shared';
 
 beforeEach(() => {
   sessionStorage.clear();
+});
+
+// ── AnnotatedField ──────────────────────────────────────────────────────────
+
+describe('AnnotatedField', () => {
+  const node = {
+    key: 'project',
+    type: 'object',
+    details: {
+      description: 'Project details',
+    },
+    children: [{ key: 'name', type: 'string', value: '(string)' }],
+  };
+
+  it('uses the field name area to expand objects and the info control for details', () => {
+    const onToggle = vi.fn();
+    render(<AnnotatedField node={node} isOpen={() => false} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand project' }));
+    expect(onToggle).toHaveBeenCalledWith('project');
+    expect(screen.queryByText('Project details')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show project details' }));
+    expect(screen.getByText('Project details')).toBeInTheDocument();
+  });
 });
 
 // ── CliFlagRow ──────────────────────────────────────────────────────────────

--- a/src/components/pages/doc/api-operation/__tests__/doc-quick-start.test.jsx
+++ b/src/components/pages/doc/api-operation/__tests__/doc-quick-start.test.jsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { CodeTabsProvider } from 'contexts/code-tabs-context';
 
 import DocQuickStart from '../doc-quick-start';
 
@@ -44,18 +46,28 @@ const operation = {
   console: { breadcrumb: 'Projects > New project' },
 };
 
+const renderQuickStart = (props) =>
+  render(
+    <CodeTabsProvider>
+      <DocQuickStart {...props} />
+    </CodeTabsProvider>
+  );
+
 describe('DocQuickStart', () => {
-  it('keeps REST curl in Quick start and swaps a separate non-REST example card', () => {
-    render(<DocQuickStart operation={operation} />);
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('keeps REST curl in Quick start and renders non-REST examples as code tabs', () => {
+    renderQuickStart({ operation });
 
     expect(screen.getByRole('heading', { name: 'Quick start' })).toHaveClass('sr-only');
     expect(screen.getByText(/REST API/)).toBeInTheDocument();
     expect(screen.getAllByText(/my-production-db/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Also available in')).toBeInTheDocument();
 
     expect(screen.getByRole('button', { name: 'CLI' })).toBeInTheDocument();
     expect(screen.getAllByText('CLI').length).toBeGreaterThan(0);
-
-    fireEvent.click(screen.getByRole('button', { name: 'CLI' }));
 
     expect(screen.getByText(/neon projects create/)).toBeInTheDocument();
     expect(screen.getByText(/--region-id aws-us-east-2/)).toBeInTheDocument();
@@ -73,44 +85,42 @@ describe('DocQuickStart', () => {
   });
 
   it('only says an empty body works when the request body itself is optional', () => {
-    const { rerender } = render(<DocQuickStart operation={operation} requiredLeafCount={0} />);
+    const { rerender } = renderQuickStart({ operation, requiredLeafCount: 0 });
 
     expect(screen.queryByText(/An empty body works/)).not.toBeInTheDocument();
 
     rerender(
-      <DocQuickStart
-        operation={{ ...operation, requestBody: { ...operation.requestBody, required: false } }}
-        requiredLeafCount={0}
-      />
+      <CodeTabsProvider>
+        <DocQuickStart
+          operation={{ ...operation, requestBody: { ...operation.requestBody, required: false } }}
+          requiredLeafCount={0}
+        />
+      </CodeTabsProvider>
     );
 
     expect(screen.getByText(/An empty body works/)).toBeInTheDocument();
   });
 
   it('renders every CLI command for multi-command coverage entries', () => {
-    render(
-      <DocQuickStart
-        operation={{
-          ...operation,
-          cli: {
-            commands: [
-              {
-                command: 'neon neon-auth domain allow-localhost enable',
-                flags: [],
-                positionals: [],
-              },
-              {
-                command: 'neon neon-auth domain allow-localhost disable',
-                flags: [],
-                positionals: [],
-              },
-            ],
-          },
-        }}
-      />
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'CLI' }));
+    renderQuickStart({
+      operation: {
+        ...operation,
+        cli: {
+          commands: [
+            {
+              command: 'neon neon-auth domain allow-localhost enable',
+              flags: [],
+              positionals: [],
+            },
+            {
+              command: 'neon neon-auth domain allow-localhost disable',
+              flags: [],
+              positionals: [],
+            },
+          ],
+        },
+      },
+    });
 
     expect(screen.getByText(/# enable/)).toBeInTheDocument();
     expect(screen.getByText(/neon neon-auth domain allow-localhost enable/)).toBeInTheDocument();

--- a/src/components/pages/doc/api-operation/api-code-block.jsx
+++ b/src/components/pages/doc/api-operation/api-code-block.jsx
@@ -27,6 +27,7 @@ const ApiCodeBlock = ({
   preClassName = '',
   copyCode = null,
   wrap = true,
+  showFilename = true,
 }) => {
   const filename = descriptor ? `${label} - ${descriptor}` : label;
   const language =
@@ -58,7 +59,7 @@ const ApiCodeBlock = ({
         'rounded-none border border-gray-new-80 dark:border-gray-new-20 [&_.line]:text-sm [&_code]:text-sm [&_pre]:text-sm [&_pre]:leading-relaxed [&>pre]:my-0 [&>pre]:rounded-none [&>pre]:bg-white! [&>pre]:py-4 [&>pre]:dark:bg-black-pure!',
         className
       )}
-      filename={filename}
+      filename={showFilename ? filename : null}
       language={language}
       copyCode={copyCode ?? code}
     >
@@ -90,6 +91,7 @@ ApiCodeBlock.propTypes = {
   preClassName: PropTypes.string,
   copyCode: PropTypes.string,
   wrap: PropTypes.bool,
+  showFilename: PropTypes.bool,
 };
 
 export default ApiCodeBlock;

--- a/src/components/pages/doc/api-operation/api-code-block.jsx
+++ b/src/components/pages/doc/api-operation/api-code-block.jsx
@@ -1,0 +1,95 @@
+'use client';
+
+import parse from 'html-react-parser';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+
+import CodeBlockWrapper from 'components/shared/code-block-wrapper';
+import highlight from 'lib/shiki';
+import { cn } from 'utils/cn';
+
+const LANGUAGE_BY_LABEL = {
+  'REST API': 'bash',
+  CLI: 'bash',
+  curl: 'bash',
+  SDK: 'typescript',
+  MCP: 'json',
+  JSON: 'json',
+};
+
+const ApiCodeBlock = ({
+  label,
+  descriptor = null,
+  code = null,
+  children = null,
+  className = '',
+  language: languageProp = null,
+  preClassName = '',
+  copyCode = null,
+  wrap = true,
+}) => {
+  const filename = descriptor ? `${label} - ${descriptor}` : label;
+  const language =
+    languageProp ?? LANGUAGE_BY_LABEL[descriptor] ?? LANGUAGE_BY_LABEL[label] ?? 'text';
+  const [highlightedHtml, setHighlightedHtml] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!code || children) {
+      setHighlightedHtml('');
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    highlight(code, language).then((result) => {
+      if (!cancelled) setHighlightedHtml(result);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [children, code, language]);
+
+  return (
+    <CodeBlockWrapper
+      className={cn(
+        'rounded-none border border-gray-new-80 dark:border-gray-new-20 [&_.line]:text-sm [&_code]:text-sm [&_pre]:text-sm [&_pre]:leading-relaxed [&>pre]:my-0 [&>pre]:rounded-none [&>pre]:bg-white! [&>pre]:py-4 [&>pre]:dark:bg-black-pure!',
+        className
+      )}
+      filename={filename}
+      language={language}
+      copyCode={copyCode ?? code}
+    >
+      {highlightedHtml ? (
+        parse(highlightedHtml)
+      ) : (
+        <pre
+          className={cn(
+            'overflow-x-auto bg-white p-4 font-mono text-sm leading-relaxed text-gray-new-20 dark:bg-black-pure dark:text-gray-new-80',
+            wrap ? 'whitespace-pre-wrap' : 'whitespace-pre',
+            preClassName
+          )}
+          data-language={language}
+        >
+          <code>{children ?? code}</code>
+        </pre>
+      )}
+    </CodeBlockWrapper>
+  );
+};
+
+ApiCodeBlock.propTypes = {
+  label: PropTypes.string.isRequired,
+  descriptor: PropTypes.string,
+  code: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  language: PropTypes.string,
+  preClassName: PropTypes.string,
+  copyCode: PropTypes.string,
+  wrap: PropTypes.bool,
+};
+
+export default ApiCodeBlock;

--- a/src/components/pages/doc/api-operation/api-operation.jsx
+++ b/src/components/pages/doc/api-operation/api-operation.jsx
@@ -8,6 +8,8 @@ import Tag from 'components/pages/doc/tag';
 import DocFooter from 'components/shared/doc-footer';
 import NavigationLinks from 'components/shared/navigation-links';
 import { DOCS_BASE_PATH } from 'constants/docs';
+import { INLINE_CODE_STYLES } from 'utils/api-style';
+import { cn } from 'utils/cn';
 
 import OperationDoc from './operation-doc';
 import { buildOperationToc } from './operation-toc';
@@ -144,7 +146,7 @@ const ApiOperation = ({ operation, breadcrumbs, navigationLinks, currentSlug }) 
 
   return (
     <>
-      <div className="min-w-0 flex-1 pb-32 lg:pb-24 md:pb-20">
+      <div className="max-w-208 min-w-0 flex-1 pb-32 lg:max-w-none lg:pb-24 md:pb-20">
         {breadcrumbs?.length > 0 && (
           <Breadcrumbs className="mb-7!" breadcrumbs={breadcrumbs} baseUrl={DOCS_BASE_PATH} />
         )}
@@ -152,7 +154,7 @@ const ApiOperation = ({ operation, breadcrumbs, navigationLinks, currentSlug }) 
         <article>
           <div className="flex flex-wrap items-center gap-2">
             <ApiMethodBadge method={operation.method} />
-            <code className="font-mono text-base font-medium text-gray-new-20 dark:text-gray-new-80">
+            <code className="font-mono text-sm font-medium text-gray-new-20 dark:text-gray-new-80">
               {operation.path}
             </code>
             {operation.stability && <Tag label={operation.stability} size="sm" className="ml-1" />}
@@ -175,7 +177,10 @@ const ApiOperation = ({ operation, breadcrumbs, navigationLinks, currentSlug }) 
 
           {operation.descriptionHtml && (
             <div
-              className="mt-3 text-[15px] leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_code]:rounded [&_code]:bg-gray-new-95 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:dark:bg-gray-new-15 [&_p+p]:mt-3"
+              className={cn(
+                'mt-3 text-[15px] leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_p+p]:mt-3',
+                INLINE_CODE_STYLES
+              )}
               dangerouslySetInnerHTML={{ __html: operation.descriptionHtml }}
             />
           )}
@@ -197,7 +202,7 @@ const ApiOperation = ({ operation, breadcrumbs, navigationLinks, currentSlug }) 
         />
       </div>
       <Aside
-        className="-left-20 ml-0! w-[312px] shrink-0 3xl:left-auto xl:hidden"
+        className="ml-0! w-78 shrink-0 xl:hidden"
         enableTableOfContents
         tableOfContents={tableOfContents}
         gitHubPath={gitHubPath}

--- a/src/components/pages/doc/api-operation/api-operation.jsx
+++ b/src/components/pages/doc/api-operation/api-operation.jsx
@@ -162,11 +162,15 @@ const ApiOperation = ({ operation, breadcrumbs, navigationLinks, currentSlug }) 
                 <Tag
                   label={operation.stability}
                   size="sm"
-                  className="ml-1 inline-flex tabular-nums"
+                  className="ml-2 inline-flex px-2 py-1 text-[0.6875rem]/none font-normal -tracking-tight tabular-nums"
                 />
               )}
               {operation.deprecated && (
-                <Tag label="deprecated" size="sm" className="ml-1 inline-flex tabular-nums" />
+                <Tag
+                  label="deprecated"
+                  size="sm"
+                  className="ml-2 inline-flex px-2 py-1 text-[0.6875rem]/none font-normal -tracking-tight tabular-nums"
+                />
               )}
             </span>
           </div>

--- a/src/components/pages/doc/api-operation/api-operation.jsx
+++ b/src/components/pages/doc/api-operation/api-operation.jsx
@@ -152,13 +152,23 @@ const ApiOperation = ({ operation, breadcrumbs, navigationLinks, currentSlug }) 
         )}
 
         <article>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <ApiMethodBadge method={operation.method} />
-            <code className="font-mono text-sm font-medium text-gray-new-20 dark:text-gray-new-80">
-              {operation.path}
-            </code>
-            {operation.stability && <Tag label={operation.stability} size="sm" className="ml-1" />}
-            {operation.deprecated && <Tag label="deprecated" size="sm" className="ml-1" />}
+            <span className="text-pretty">
+              <code className="max-w-full min-w-0 font-mono text-sm font-medium text-wrap wrap-anywhere text-gray-new-20 dark:text-gray-new-80">
+                {operation.path}
+              </code>
+              {operation.stability && (
+                <Tag
+                  label={operation.stability}
+                  size="sm"
+                  className="ml-1 inline-flex tabular-nums"
+                />
+              )}
+              {operation.deprecated && (
+                <Tag label="deprecated" size="sm" className="ml-1 inline-flex tabular-nums" />
+              )}
+            </span>
           </div>
 
           {operation.deprecated && (
@@ -168,7 +178,7 @@ const ApiOperation = ({ operation, breadcrumbs, navigationLinks, currentSlug }) 
             </p>
           )}
 
-          <div className="mt-4 flex items-start justify-between gap-4">
+          <div className="mt-4 mb-8 flex items-start justify-between gap-x-4 gap-y-3 sm:flex-col">
             <h1 className="text-[36px] leading-tight font-medium tracking-tighter text-balance md:text-[28px]">
               {operation.summary}
             </h1>

--- a/src/components/pages/doc/api-operation/doc-body.jsx
+++ b/src/components/pages/doc/api-operation/doc-body.jsx
@@ -3,6 +3,7 @@
 import PropTypes from 'prop-types';
 import { useId, useState } from 'react';
 
+import { INLINE_CODE_STYLES } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
 import { fieldDefaultLabel, fieldTitle } from './field-label';
@@ -30,7 +31,7 @@ function descriptionText(node) {
 function TypeBadge({ type }) {
   if (!type) return null;
   return (
-    <span className="rounded bg-gray-new-90 px-1.5 py-0.5 font-mono text-[10px] leading-normal font-medium text-gray-new-40 dark:bg-gray-new-20 dark:text-gray-new-70">
+    <span className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-gray-new-40 dark:border-gray-new-30 dark:text-gray-new-70">
       {type}
     </span>
   );
@@ -44,17 +45,17 @@ function MetadataBadges({ node, row }) {
   return (
     <>
       {row?.common && (
-        <span className="rounded bg-[#00B87B]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[#00B87B] dark:text-green-45">
+        <span className="border border-[#00B87B]/40 bg-transparent px-1.5 py-0.5 text-sm font-semibold text-[#00B87B] dark:border-green-45/40 dark:text-green-45">
           common
         </span>
       )}
       {row?.outOfObject && (
-        <span className="rounded bg-gray-new-90 px-1.5 py-0.5 text-[10px] font-medium text-gray-new-50 dark:bg-gray-new-20 dark:text-gray-new-60">
+        <span className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 text-sm font-medium text-gray-new-50 dark:border-gray-new-30 dark:text-gray-new-60">
           top-level field
         </span>
       )}
       {node?.deprecated && (
-        <span className="rounded bg-[#E2301D]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#E2301D] dark:bg-[#FF5645]/10 dark:text-[#FF5645]">
+        <span className="border border-[#E2301D]/40 bg-transparent px-1.5 py-0.5 text-sm font-medium text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]">
           deprecated
         </span>
       )}
@@ -82,10 +83,10 @@ function EnumPills({ node }) {
           <span
             key={String(value)}
             className={cn(
-              'rounded px-1.5 py-0.5 font-mono text-[11px]',
+              'rounded-sm px-1.5 py-0.5 font-mono text-sm',
               isActive
-                ? 'bg-green-45/15 font-semibold text-[#00B87B] dark:text-green-45'
-                : 'bg-gray-new-90/70 text-gray-new-50 dark:bg-gray-new-20 dark:text-gray-new-60'
+                ? 'border border-[#00B87B]/40 bg-transparent font-semibold text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
+                : 'border border-gray-new-70 bg-transparent text-gray-new-50 dark:border-gray-new-30 dark:text-gray-new-60'
             )}
           >
             {String(value)}
@@ -109,7 +110,7 @@ EnumPills.propTypes = {
 function ConstraintText({ node }) {
   if (!node?.constraints) return null;
   return (
-    <p className="mt-2 font-mono text-[11px] text-gray-new-50 dark:text-gray-new-60">
+    <p className="mt-2 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
       {node.constraints}
     </p>
   );
@@ -141,24 +142,22 @@ export function DocField({ node, path, labels, row, depth = 0, defaultOpen = dep
                 aria-label={`Toggle ${title} field`}
                 aria-expanded={open}
                 aria-controls={childrenId}
-                className="mr-0.5 flex size-6 items-center justify-center text-[11px] text-gray-new-50 transition-transform dark:text-gray-new-60"
+                className="mr-0.5 flex size-6 items-center justify-center text-sm text-gray-new-50 transition-transform dark:text-gray-new-60"
                 style={{ transform: open ? 'rotate(90deg)' : 'none' }}
               >
                 {'>'}
               </button>
             )}
-            <span className="text-[13px] font-semibold text-black-pure dark:text-white">
-              {title}
-            </span>
+            <span className="text-sm font-semibold text-black-pure dark:text-white">{title}</span>
             <MetadataBadges node={node} row={row} />
           </div>
-          <code className="mt-1 block font-mono text-[12px] text-gray-new-50 dark:text-gray-new-60">
+          <code className="mt-1 block font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
             {node.key}
           </code>
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
             <TypeBadge type={node.type} />
             {defaultLabel && (
-              <span className="bg-gray-new-96 rounded px-1.5 py-0.5 font-mono text-[10px] text-gray-new-50 dark:bg-gray-new-15 dark:text-gray-new-60">
+              <span className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm text-gray-new-50 dark:border-gray-new-30 dark:text-gray-new-60">
                 default {defaultLabel}
               </span>
             )}
@@ -167,11 +166,14 @@ export function DocField({ node, path, labels, row, depth = 0, defaultOpen = dep
         <div>
           {descriptionHtml(node) ? (
             <div
-              className="text-[12px] leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_a]:underline [&_code]:rounded [&_code]:bg-gray-new-94 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[11px] dark:[&_code]:bg-gray-new-15 [&_p+p]:mt-2"
+              className={cn(
+                'text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_a]:underline [&_p+p]:mt-2',
+                INLINE_CODE_STYLES
+              )}
               dangerouslySetInnerHTML={{ __html: descriptionHtml(node) }}
             />
           ) : (
-            <p className="text-[12px] leading-relaxed text-gray-new-30 dark:text-gray-new-70">
+            <p className="text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70">
               {descriptionText(node)}
             </p>
           )}
@@ -241,7 +243,7 @@ function SectionCard({ section, bodyTree, labels, isFirst }) {
     .filter(Boolean);
 
   return (
-    <section className="overflow-hidden rounded-xl border border-gray-new-90 bg-white dark:border-gray-new-20 dark:bg-gray-new-10">
+    <section className="overflow-hidden border border-gray-new-90 bg-white dark:border-gray-new-20 dark:bg-gray-new-10">
       <div className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-gray-new-98 dark:hover:bg-gray-new-15">
         <button
           type="button"
@@ -249,7 +251,7 @@ function SectionCard({ section, bodyTree, labels, isFirst }) {
           aria-label={`Toggle ${section.label} section`}
           aria-expanded={open}
           aria-controls={fieldsId}
-          className="mt-0.5 flex size-7 shrink-0 items-center justify-center text-[11px] text-gray-new-50 transition-transform dark:text-gray-new-60"
+          className="mt-0.5 flex size-7 shrink-0 items-center justify-center text-sm text-gray-new-50 transition-transform dark:text-gray-new-60"
           style={{ transform: open ? 'rotate(90deg)' : 'none' }}
         >
           {'>'}
@@ -258,28 +260,28 @@ function SectionCard({ section, bodyTree, labels, isFirst }) {
           <div className="flex flex-wrap items-center gap-2">
             <h3
               id={`body-${section.id}`}
-              className="scroll-mt-20 text-[14px] leading-tight font-semibold text-black-pure dark:text-white"
+              className="scroll-mt-20 text-sm leading-tight font-semibold text-black-pure dark:text-white"
             >
               {section.label}
             </h3>
             {section.common && (
-              <span className="rounded bg-[#00B87B]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[#00B87B] dark:text-green-45">
+              <span className="border border-[#00B87B]/40 bg-transparent px-1.5 py-0.5 text-sm font-semibold text-[#00B87B] dark:border-green-45/40 dark:text-green-45">
                 commonly set
               </span>
             )}
             {section.schemaPath && (
-              <code className="font-mono text-[11px] text-gray-new-50 dark:text-gray-new-60">
+              <code className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
                 {section.schemaPath}
               </code>
             )}
           </div>
           {section.blurb && (
-            <p className="mt-1 text-[12px] leading-relaxed text-gray-new-50 dark:text-gray-new-60">
+            <p className="mt-1 text-sm leading-relaxed text-gray-new-50 dark:text-gray-new-60">
               {section.blurb}
             </p>
           )}
         </div>
-        <span className="shrink-0 font-mono text-[11px] text-gray-new-50 dark:text-gray-new-60">
+        <span className="shrink-0 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
           {rows.length} {rows.length === 1 ? 'field' : 'fields'}
         </span>
       </div>
@@ -338,8 +340,8 @@ export function getRequiredLeafPaths(nodes, prefix = '', ancestorsRequired = tru
 function RequiredSummary({ requiredFields, bodyRequired }) {
   const count = requiredFields.length;
   return (
-    <div className="mb-4 rounded-lg border-l-2 border-[#00B87B] bg-[#00B87B]/5 px-4 py-3 dark:bg-green-45/5">
-      <p className="text-[13px] leading-relaxed text-gray-new-40 dark:text-gray-new-70">
+    <div className="mb-4 border-l-2 border-[#00B87B] bg-[#00B87B]/5 px-4 py-3 dark:bg-green-45/5">
+      <p className="text-sm leading-relaxed text-gray-new-40 dark:text-gray-new-70">
         <strong className="font-semibold text-black-pure dark:text-white">{count} required</strong>{' '}
         {count === 0 ? (
           <>
@@ -351,7 +353,7 @@ function RequiredSummary({ requiredFields, bodyRequired }) {
             Required:{' '}
             {requiredFields.map((field, index) => (
               <span key={field}>
-                <code className="rounded bg-gray-new-95 px-1 py-0.5 font-mono text-[12px] dark:bg-gray-new-15">
+                <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
                   {field}
                 </code>
                 {index < requiredFields.length - 1 ? ', ' : ''}
@@ -403,7 +405,7 @@ export function DocBodySection({ bodyTree, requestBody }) {
           ))}
         </div>
       ) : (
-        <div className="rounded-xl border border-gray-new-90 px-4 dark:border-gray-new-20">
+        <div className="border border-gray-new-90 px-4 dark:border-gray-new-20">
           {bodyTree.map((node) => (
             <DocField
               key={node.key}

--- a/src/components/pages/doc/api-operation/doc-body.jsx
+++ b/src/components/pages/doc/api-operation/doc-body.jsx
@@ -3,6 +3,7 @@
 import PropTypes from 'prop-types';
 import { useId, useState } from 'react';
 
+import Chevron from 'icons/chevron-right-lg.inline.svg';
 import { INLINE_CODE_STYLES } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
@@ -31,7 +32,7 @@ function descriptionText(node) {
 function TypeBadge({ type }) {
   if (!type) return null;
   return (
-    <span className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-gray-new-40 dark:border-gray-new-30 dark:text-gray-new-70">
+    <span className="rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-black-pure dark:border-gray-new-30 dark:text-white">
       {type}
     </span>
   );
@@ -55,7 +56,7 @@ function MetadataBadges({ node, row }) {
         </span>
       )}
       {node?.deprecated && (
-        <span className="border border-[#E2301D]/40 bg-transparent px-1.5 py-0.5 text-sm font-medium text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]">
+        <span className="rounded border border-[#E2301D]/40 bg-transparent px-1.5 py-0.5 text-sm font-medium text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]">
           deprecated
         </span>
       )}
@@ -142,10 +143,9 @@ export function DocField({ node, path, labels, row, depth = 0, defaultOpen = dep
                 aria-label={`Toggle ${title} field`}
                 aria-expanded={open}
                 aria-controls={childrenId}
-                className="mr-0.5 flex size-6 items-center justify-center text-sm text-gray-new-50 transition-transform dark:text-gray-new-60"
-                style={{ transform: open ? 'rotate(90deg)' : 'none' }}
+                className="mr-0.5 flex size-6 items-center justify-center text-gray-new-50 dark:text-gray-new-60"
               >
-                {'>'}
+                <Chevron className={cn('w-1.5', open && 'rotate-90')} />
               </button>
             )}
             <span className="text-sm font-semibold text-black-pure dark:text-white">{title}</span>
@@ -156,11 +156,7 @@ export function DocField({ node, path, labels, row, depth = 0, defaultOpen = dep
           </code>
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
             <TypeBadge type={node.type} />
-            {defaultLabel && (
-              <span className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm text-gray-new-50 dark:border-gray-new-30 dark:text-gray-new-60">
-                default {defaultLabel}
-              </span>
-            )}
+            {defaultLabel && <TypeBadge type={`default ${defaultLabel}`} />}
           </div>
         </div>
         <div>
@@ -251,10 +247,9 @@ function SectionCard({ section, bodyTree, labels, isFirst }) {
           aria-label={`Toggle ${section.label} section`}
           aria-expanded={open}
           aria-controls={fieldsId}
-          className="mt-0.5 flex size-7 shrink-0 items-center justify-center text-sm text-gray-new-50 transition-transform dark:text-gray-new-60"
-          style={{ transform: open ? 'rotate(90deg)' : 'none' }}
+          className="mt-0.5 flex size-7 shrink-0 items-center justify-center text-gray-new-50 dark:text-gray-new-60"
         >
-          {'>'}
+          <Chevron className={cn('w-1.5', open && 'rotate-90')} />
         </button>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
@@ -353,7 +348,7 @@ function RequiredSummary({ requiredFields, bodyRequired }) {
             Required:{' '}
             {requiredFields.map((field, index) => (
               <span key={field}>
-                <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
+                <code className="rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-black-pure dark:border-gray-new-30 dark:text-white">
                   {field}
                 </code>
                 {index < requiredFields.length - 1 ? ', ' : ''}

--- a/src/components/pages/doc/api-operation/doc-body.jsx
+++ b/src/components/pages/doc/api-operation/doc-body.jsx
@@ -29,17 +29,24 @@ function descriptionText(node) {
   return node?.details?.description ?? node?.description ?? '';
 }
 
-function TypeBadge({ type }) {
-  if (!type) return null;
+function TypeBadge({ label, variant }) {
+  if (!label) return null;
   return (
-    <span className="rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-black-pure dark:border-gray-new-30 dark:text-white">
-      {type}
+    <span
+      className={cn(
+        'rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-black-pure dark:border-gray-new-30 dark:text-white',
+        variant === 'value' &&
+          'bg-gray-new-98 px-1.5 py-0.5 text-gray-new-40 dark:border-gray-new-20 dark:bg-white/10 dark:text-gray-new-70'
+      )}
+    >
+      {label}
     </span>
   );
 }
 
 TypeBadge.propTypes = {
-  type: PropTypes.string,
+  label: PropTypes.string,
+  variant: PropTypes.oneOf(['type', 'value']),
 };
 
 function MetadataBadges({ node, row }) {
@@ -155,8 +162,8 @@ export function DocField({ node, path, labels, row, depth = 0, defaultOpen = dep
             {node.key}
           </code>
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            <TypeBadge type={node.type} />
-            {defaultLabel && <TypeBadge type={`default ${defaultLabel}`} />}
+            <TypeBadge label={node.type} />
+            {defaultLabel && <TypeBadge label={`default: ${defaultLabel}`} variant="value" />}
           </div>
         </div>
         <div>
@@ -337,7 +344,6 @@ function RequiredSummary({ requiredFields, bodyRequired }) {
   return (
     <div className="mb-4 border-l-2 border-[#00B87B] bg-[#00B87B]/5 px-4 py-3 dark:bg-green-45/5">
       <p className="text-sm leading-relaxed text-gray-new-40 dark:text-gray-new-70">
-        <strong className="font-semibold text-black-pure dark:text-white">{count} required</strong>{' '}
         {count === 0 ? (
           <>
             No field is required.
@@ -345,6 +351,9 @@ function RequiredSummary({ requiredFields, bodyRequired }) {
           </>
         ) : (
           <>
+            <strong className="font-semibold text-black-pure dark:text-white">
+              {count} required
+            </strong>{' '}
             Required:{' '}
             {requiredFields.map((field, index) => (
               <span key={field}>

--- a/src/components/pages/doc/api-operation/doc-quick-start.jsx
+++ b/src/components/pages/doc/api-operation/doc-quick-start.jsx
@@ -1,10 +1,10 @@
 'use client';
 
 import PropTypes from 'prop-types';
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo } from 'react';
 
+import CodeTabs from 'components/pages/doc/code-tabs';
 import { buildCliCommand } from 'utils/api-ref.mjs';
-import { cn } from 'utils/cn';
 
 import ApiCodeBlock from './api-code-block';
 
@@ -105,20 +105,13 @@ function availableExamples(operation) {
 
 const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
   const examples = useMemo(() => availableExamples(operation), [operation]);
-  const [selectedId, setSelectedId] = useState(null);
-
-  useEffect(() => {
-    if (examples.length === 0) {
-      setSelectedId(null);
-      return;
-    }
-    if (selectedId && !examples.some((example) => example.id === selectedId)) {
-      setSelectedId(null);
-    }
-  }, [examples, selectedId]);
+  const exampleLabels = examples.map((example) =>
+    example.descriptor
+      ? `${LABELS[example.id] ?? example.label} ${example.descriptor}`
+      : (LABELS[example.id] ?? example.label)
+  );
 
   const restCode = operation.examples?.representative?.curl ?? operation.examples?.curl ?? '';
-  const selected = examples.find((example) => example.id === selectedId) ?? null;
   const noRequired =
     requiredLeafCount === null
       ? (operation.requestBody?.requiredFields ?? []).length === 0
@@ -142,47 +135,20 @@ const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
 
       {examples.length > 0 && (
         <div className="mt-6">
-          <div className="mb-3 flex flex-wrap items-center gap-2">
-            <span className="mr-1 text-sm text-gray-new-50 dark:text-gray-new-60">
-              Also available in
-            </span>
-            {examples.map((example) => {
-              const selectedPill = selected?.id === example.id;
-              return (
-                <button
-                  key={example.id}
-                  type="button"
-                  onClick={() =>
-                    setSelectedId((currentId) => (currentId === example.id ? null : example.id))
-                  }
-                  aria-pressed={selectedPill}
-                  aria-label={
-                    example.descriptor ? `${example.label} ${example.descriptor}` : example.label
-                  }
-                  className={cn(
-                    'flex items-center gap-1 rounded-sm border px-3 py-1.5 text-sm font-medium transition-colors',
-                    selectedPill
-                      ? 'border-[#00B87B]/30 bg-[#00B87B]/10 text-[#00B87B] dark:text-white'
-                      : 'border-gray-new-90 text-gray-new-40 hover:border-gray-new-70 dark:border-gray-new-20 dark:text-gray-new-70'
-                  )}
-                >
-                  <span>{LABELS[example.id] ?? example.label}</span>
-                  {example.descriptor && (
-                    <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
-                      {example.descriptor}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-          {selected && (
-            <ApiCodeBlock
-              label={selected.label}
-              descriptor={selected.descriptor}
-              code={selected.code}
-            />
-          )}
+          <span className="mb-4 block scroll-mt-20 text-base leading-tight font-semibold tracking-tight">
+            Also available in
+          </span>
+          <CodeTabs labels={exampleLabels}>
+            {examples.map((example) => (
+              <ApiCodeBlock
+                key={example.id}
+                label={LABELS[example.id] ?? example.label}
+                descriptor={example.descriptor}
+                code={example.code}
+                showFilename={false}
+              />
+            ))}
+          </CodeTabs>
         </div>
       )}
     </section>

--- a/src/components/pages/doc/api-operation/doc-quick-start.jsx
+++ b/src/components/pages/doc/api-operation/doc-quick-start.jsx
@@ -1,11 +1,12 @@
 'use client';
 
 import PropTypes from 'prop-types';
-import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 
-import useCopyToClipboard from 'hooks/use-copy-to-clipboard';
 import { buildCliCommand } from 'utils/api-ref.mjs';
 import { cn } from 'utils/cn';
+
+import ApiCodeBlock from './api-code-block';
 
 const LABELS = {
   cli: 'CLI',
@@ -102,48 +103,9 @@ function availableExamples(operation) {
   return examples;
 }
 
-function CodeCard({ label, descriptor, code, copied, onCopy }) {
-  const title = descriptor ? `${label} · ${descriptor}` : label;
-  return (
-    <div className="overflow-hidden rounded-xl border border-gray-new-90 bg-gray-new-98 dark:border-gray-new-20 dark:bg-gray-new-10">
-      <div className="flex items-center justify-between border-b border-gray-new-90 px-4 py-2.5 dark:border-gray-new-20">
-        <span className="font-mono text-[12px] text-gray-new-50 dark:text-gray-new-60">
-          {title}
-        </span>
-        <button
-          type="button"
-          onClick={onCopy}
-          className={cn(
-            'rounded border px-2 py-0.5 font-mono text-[11px] transition-all',
-            copied
-              ? 'border-green-45/40 text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
-              : 'border-gray-new-90 text-gray-new-50 hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60'
-          )}
-        >
-          {copied ? 'Copied' : 'Copy'}
-        </button>
-      </div>
-      <pre className="overflow-x-auto p-5 font-mono text-[13px] leading-relaxed whitespace-pre-wrap text-gray-new-20 dark:text-gray-new-80">
-        {code}
-      </pre>
-    </div>
-  );
-}
-
-CodeCard.propTypes = {
-  label: PropTypes.string.isRequired,
-  descriptor: PropTypes.string,
-  code: PropTypes.string.isRequired,
-  copied: PropTypes.bool,
-  onCopy: PropTypes.func.isRequired,
-};
-
 const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
   const examples = useMemo(() => availableExamples(operation), [operation]);
   const [selectedId, setSelectedId] = useState(null);
-  const { handleCopy } = useCopyToClipboard(1800);
-  const [copiedId, setCopiedId] = useState(null);
-  const clearCopiedTimer = useRef(null);
 
   useEffect(() => {
     if (examples.length === 0) {
@@ -154,23 +116,6 @@ const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
       setSelectedId(null);
     }
   }, [examples, selectedId]);
-
-  useEffect(
-    () => () => {
-      if (clearCopiedTimer.current) clearTimeout(clearCopiedTimer.current);
-    },
-    []
-  );
-
-  const copy = useCallback(
-    (id, text) => {
-      handleCopy(text);
-      setCopiedId(id);
-      if (clearCopiedTimer.current) clearTimeout(clearCopiedTimer.current);
-      clearCopiedTimer.current = setTimeout(() => setCopiedId(null), 1800);
-    },
-    [handleCopy]
-  );
 
   const restCode = operation.examples?.representative?.curl ?? operation.examples?.curl ?? '';
   const selected = examples.find((example) => example.id === selectedId) ?? null;
@@ -186,16 +131,10 @@ const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
         Quick start
       </h2>
 
-      <CodeCard
-        label="REST API"
-        descriptor="curl"
-        code={restCode}
-        copied={copiedId === 'rest'}
-        onCopy={() => copy('rest', restCode)}
-      />
+      <ApiCodeBlock label="REST API" descriptor="curl" code={restCode} />
 
       {operation.examples?.representative && (
-        <p className="mt-3 text-[12px] leading-relaxed text-gray-new-50 dark:text-gray-new-60">
+        <p className="mt-3 text-sm leading-relaxed text-gray-new-50 dark:text-gray-new-60">
           A representative request with common fields prefilled.
           {emptyBodyAllowed ? ' An empty body works too; every field below is optional.' : ''}
         </p>
@@ -204,7 +143,7 @@ const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
       {examples.length > 0 && (
         <div className="mt-6">
           <div className="mb-3 flex flex-wrap items-center gap-2">
-            <span className="mr-1 text-[13px] text-gray-new-50 dark:text-gray-new-60">
+            <span className="mr-1 text-sm text-gray-new-50 dark:text-gray-new-60">
               Also available in
             </span>
             {examples.map((example) => {
@@ -221,7 +160,7 @@ const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
                     example.descriptor ? `${example.label} ${example.descriptor}` : example.label
                   }
                   className={cn(
-                    'flex items-center gap-1 rounded-full border px-4 py-1.5 text-[13px] font-medium transition-colors',
+                    'flex items-center gap-1 rounded-sm border px-3 py-1.5 text-sm font-medium transition-colors',
                     selectedPill
                       ? 'border-[#00B87B]/30 bg-[#00B87B]/10 text-[#00B87B] dark:text-white'
                       : 'border-gray-new-90 text-gray-new-40 hover:border-gray-new-70 dark:border-gray-new-20 dark:text-gray-new-70'
@@ -229,7 +168,7 @@ const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
                 >
                   <span>{LABELS[example.id] ?? example.label}</span>
                   {example.descriptor && (
-                    <span className="font-mono text-[10px] text-gray-new-50 dark:text-gray-new-60">
+                    <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
                       {example.descriptor}
                     </span>
                   )}
@@ -238,12 +177,10 @@ const DocQuickStart = ({ operation, requiredLeafCount = null }) => {
             })}
           </div>
           {selected && (
-            <CodeCard
+            <ApiCodeBlock
               label={selected.label}
               descriptor={selected.descriptor}
               code={selected.code}
-              copied={copiedId === selected.id}
-              onCopy={() => copy(selected.id, selected.code)}
             />
           )}
         </div>

--- a/src/components/pages/doc/api-operation/operation-body.jsx
+++ b/src/components/pages/doc/api-operation/operation-body.jsx
@@ -386,7 +386,7 @@ export const BodySection = ({ operation, bodyTree, state, copy, copiedId }) => (
               type="button"
               onClick={() => copy('body', JSON.stringify(state.json, null, 2))}
               className={cn(
-                'rounded border px-2 py-0.5 font-mono text-[11px] transition-all',
+                'rounded border px-2 py-0.5 font-mono text-sm transition-all',
                 copiedId === 'body'
                   ? 'border-green-45/40 text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
                   : Object.keys(state.errors).length > 0
@@ -410,14 +410,14 @@ export const BodySection = ({ operation, bodyTree, state, copy, copiedId }) => (
       <div className="overflow-hidden border border-gray-new-90 dark:border-gray-new-20">
         <div className="border-b border-gray-new-90 bg-gray-new-98 px-3.5 py-2 dark:border-gray-new-20 dark:bg-gray-new-10">
           <div className="flex items-center justify-between">
-            <span className="text-[11px] text-gray-new-60 italic dark:text-gray-new-50">
+            <span className="text-sm text-gray-new-60 italic dark:text-gray-new-50">
               Click values to edit · ☑ to include
             </span>
             {state.editCount > 0 && (
               <button
                 type="button"
                 onClick={state.reset}
-                className="rounded border border-gray-new-90 px-1.5 py-0.5 text-[10px] text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
+                className="border border-gray-new-90 px-1.5 py-0.5 text-sm text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
               >
                 Reset
               </button>

--- a/src/components/pages/doc/api-operation/operation-cli-multi.jsx
+++ b/src/components/pages/doc/api-operation/operation-cli-multi.jsx
@@ -81,7 +81,7 @@ const MultiCmdSection = ({ operation, state, paramValues, copy, copiedId }) => {
               {cmd.covers.map((c) => (
                 <code
                   key={c}
-                  className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm text-gray-new-20 dark:border-gray-new-30 dark:text-gray-new-80"
+                  className="rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm text-gray-new-20 dark:border-gray-new-30 dark:text-gray-new-80"
                 >
                   {c}
                 </code>

--- a/src/components/pages/doc/api-operation/operation-cli-multi.jsx
+++ b/src/components/pages/doc/api-operation/operation-cli-multi.jsx
@@ -37,17 +37,17 @@ const MultiCmdSection = ({ operation, state, paramValues, copy, copiedId }) => {
             <button
               type="button"
               onClick={state.reset}
-              className="rounded border border-gray-new-90 px-1.5 py-0.5 text-[10px] text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
+              className="border border-gray-new-90 px-1.5 py-0.5 text-sm text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
             >
               Reset
             </button>
           )
         }
       />
-      <p className="mb-1 text-[13px] text-gray-new-50 dark:text-gray-new-60">
+      <p className="mb-1 text-sm text-gray-new-50 dark:text-gray-new-60">
         This operation maps to separate CLI commands depending on what you want to update.
       </p>
-      <p className="mb-4 text-[11px] text-gray-new-60 italic dark:text-gray-new-50">
+      <p className="mb-4 text-sm text-gray-new-60 italic dark:text-gray-new-50">
         Click values to edit · ☑ to include in command
       </p>
       {cliCommands.map((cmd, cmdIdx) => {
@@ -77,11 +77,11 @@ const MultiCmdSection = ({ operation, state, paramValues, copy, copiedId }) => {
             }
           >
             <div className="mb-2 flex items-center gap-1.5">
-              <span className="text-[11px] text-gray-new-50 dark:text-gray-new-60">Covers</span>
+              <span className="text-sm text-gray-new-50 dark:text-gray-new-60">Covers</span>
               {cmd.covers.map((c) => (
                 <code
                   key={c}
-                  className="rounded bg-gray-new-94 px-1.5 py-0.5 font-mono text-[11px] text-gray-new-20 dark:bg-gray-new-15 dark:text-gray-new-80"
+                  className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm text-gray-new-20 dark:border-gray-new-30 dark:text-gray-new-80"
                 >
                   {c}
                 </code>

--- a/src/components/pages/doc/api-operation/operation-cli.jsx
+++ b/src/components/pages/doc/api-operation/operation-cli.jsx
@@ -244,14 +244,14 @@ const SingleCmdSection = ({ operation, state }) => {
             <button
               type="button"
               onClick={state.reset}
-              className="rounded border border-gray-new-90 px-1.5 py-0.5 text-[10px] text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
+              className="border border-gray-new-90 px-1.5 py-0.5 text-sm text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
             >
               Reset
             </button>
           )
         }
       />
-      <p className="mb-2 text-[11px] text-gray-new-60 italic dark:text-gray-new-50">
+      <p className="mb-2 text-sm text-gray-new-60 italic dark:text-gray-new-50">
         Click values to edit · ☑ to include in command
       </p>
       <div>

--- a/src/components/pages/doc/api-operation/operation-client.jsx
+++ b/src/components/pages/doc/api-operation/operation-client.jsx
@@ -12,6 +12,7 @@ import useCopyToClipboard from 'hooks/use-copy-to-clipboard';
 import { buildCurl, buildCliCommand, buildTs } from 'utils/api-ref.mjs';
 import { cn } from 'utils/cn';
 
+import ApiCodeBlock from './api-code-block';
 import { useBodyState, BodySection } from './operation-body';
 import { useCliState, CliSection } from './operation-cli';
 import { McpDescription } from './operation-mcp';
@@ -172,10 +173,10 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
       {/* ── Unavailable fallback card ── */}
       {!currentAvailable && (
         <div className="mt-8 rounded-xl border border-gray-new-90 bg-gray-new-98 p-6 dark:border-gray-new-20 dark:bg-gray-new-10">
-          <p className="text-[13px] font-semibold text-black-pure dark:text-white">
+          <p className="text-sm font-semibold text-black-pure dark:text-white">
             Not available via {LABELS[current] ?? current}
           </p>
-          <p className="mt-2 text-[13px] leading-relaxed text-gray-new-40 dark:text-gray-new-60">
+          <p className="mt-2 text-sm leading-relaxed text-gray-new-40 dark:text-gray-new-60">
             {current === 'mcp'
               ? "The Neon MCP server doesn't expose a tool for this operation. You can call it directly from your agent using the REST API:"
               : current === 'console'
@@ -183,14 +184,12 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
                 : `This operation is not available via ${LABELS[current] ?? current}.`}
           </p>
           {current !== 'console' && (
-            <div className="mt-4 overflow-hidden rounded-lg border border-gray-new-90 dark:border-gray-new-20">
-              <div className="border-b border-gray-new-90 bg-gray-new-94 px-3.5 py-2 text-[12px] text-gray-new-50 dark:border-gray-new-20 dark:bg-gray-new-15 dark:text-gray-new-60">
-                {current === 'mcp' ? 'curl — use from agent via shell tool' : 'curl equivalent'}
-              </div>
-              <pre className="overflow-x-auto bg-gray-new-98 p-4 font-mono text-[12px] leading-relaxed whitespace-pre-wrap text-gray-new-50 dark:bg-gray-new-10 dark:text-gray-new-60">
-                {curlCode}
-              </pre>
-            </div>
+            <ApiCodeBlock
+              className="mt-4"
+              label={current === 'mcp' ? 'curl - use from agent via shell tool' : 'curl equivalent'}
+              code={curlCode}
+              preClassName="text-sm"
+            />
           )}
           <div className="mt-4 flex flex-wrap items-center gap-4">
             {availableIds
@@ -200,7 +199,7 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
                   key={id}
                   type="button"
                   onClick={() => setActiveIface(id)}
-                  className="text-[13px] text-[#00B87B] hover:underline dark:text-green-45"
+                  className="text-sm text-[#00B87B] hover:underline dark:text-green-45"
                 >
                   Use {LABELS[id] ?? id} →
                 </button>
@@ -210,7 +209,7 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
                 href="https://github.com/neondatabase/neon/issues"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ml-auto text-[12px] text-gray-new-50 hover:underline dark:text-gray-new-60"
+                className="ml-auto text-sm text-gray-new-50 hover:underline dark:text-gray-new-60"
               >
                 Request {LABELS[current] ?? current} support →
               </a>
@@ -233,7 +232,7 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
             href="https://console.neon.tech"
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-2.5 inline-block text-[13px] text-[#00B87B] hover:underline dark:text-green-45"
+            className="mt-2.5 inline-block text-sm text-[#00B87B] hover:underline dark:text-green-45"
           >
             Open Neon Console →
           </a>
@@ -244,14 +243,14 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
       {current === 'mcp' && operation.mcp?.tool && (
         <div className="mt-8 overflow-hidden border border-gray-new-90 dark:border-gray-new-20">
           <div className="flex items-center justify-between border-b border-gray-new-90 bg-gray-new-98 px-3.5 py-2.5 dark:border-gray-new-20 dark:bg-gray-new-10">
-            <span className="text-[10px] font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
+            <span className="text-sm font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
               MCP Tool
             </span>
             <button
               type="button"
               onClick={() => copy('mcp-tool', operation.mcp.tool)}
               className={cn(
-                'rounded border px-2 py-0.5 font-mono text-[11px] transition-all',
+                'rounded border px-2 py-0.5 font-mono text-sm transition-all',
                 copiedId === 'mcp-tool'
                   ? 'border-green-45/40 text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
                   : 'border-gray-new-90 text-gray-new-50 hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60'
@@ -261,7 +260,7 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
             </button>
           </div>
           <div className="bg-gray-new-98 px-4.5 py-4 dark:bg-gray-new-10">
-            <code className="font-mono text-lg font-semibold text-black-pure dark:text-white">
+            <code className="font-mono text-sm font-semibold text-black-pure dark:text-white">
               {operation.mcp.tool}
             </code>
             {operation.mcp.description && (
@@ -328,7 +327,7 @@ const OperationClient = ({ operation, interfaces, bodyTree, respTree }) => {
               </ApiParam>
             ))}
           </div>
-          <p className="mt-3 text-[12px] leading-relaxed text-gray-new-50 dark:text-gray-new-60">
+          <p className="mt-3 text-sm leading-relaxed text-gray-new-50 dark:text-gray-new-60">
             Works with Cursor, Claude Desktop, Windsurf, and any MCP client.{' '}
             <Link
               href="/docs/ai/neon-mcp-server"

--- a/src/components/pages/doc/api-operation/operation-doc.jsx
+++ b/src/components/pages/doc/api-operation/operation-doc.jsx
@@ -35,7 +35,7 @@ const ParametersSection = ({ parameters }) => (
     >
       Parameters
     </h2>
-    <div className="rounded-xl border border-gray-new-90 px-4 dark:border-gray-new-20">
+    <div className="border border-gray-new-90 px-4 dark:border-gray-new-20">
       {parameters.map((param) => (
         <DocField key={param.name} node={parameterToNode(param)} path={param.name} />
       ))}
@@ -52,9 +52,9 @@ function isGeneralError(err) {
 }
 
 const GeneralErrorCard = () => (
-  <div className="api-response my-4 rounded-xl border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
+  <div className="api-response my-4 border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
     <div className="mb-3 flex items-start gap-3">
-      <span className="mt-0.5 shrink-0 rounded border border-gray-new-80 bg-gray-new-95 px-2 py-0.5 font-mono text-[11px] leading-normal font-semibold text-gray-new-40 dark:border-gray-new-20 dark:bg-gray-new-15 dark:text-gray-new-70">
+      <span className="mt-0.5 shrink-0 border border-gray-new-70 bg-transparent px-2 py-0.5 font-mono text-sm leading-normal font-semibold text-gray-new-40 dark:border-gray-new-30 dark:text-gray-new-70">
         default
       </span>
       <div>
@@ -65,28 +65,28 @@ const GeneralErrorCard = () => (
       </div>
     </div>
 
-    <div className="grid gap-3 text-[13px] leading-relaxed text-gray-new-40 dark:text-gray-new-70">
+    <div className="grid gap-3 text-sm leading-relaxed text-gray-new-40 dark:text-gray-new-70">
       <div>
         <p className="font-semibold text-black-pure dark:text-white">Response fields</p>
         <ul className="mt-1 list-disc space-y-1 pl-4">
           <li>
-            <code className="rounded bg-gray-new-90 px-1 py-0.5 font-mono text-[11px] dark:bg-gray-new-20">
+            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
               message
             </code>{' '}
             Required. Human-readable error message.
           </li>
           <li>
-            <code className="rounded bg-gray-new-90 px-1 py-0.5 font-mono text-[11px] dark:bg-gray-new-20">
+            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
               code
             </code>{' '}
             Required. Machine-readable error code.
           </li>
           <li>
-            <code className="rounded bg-gray-new-90 px-1 py-0.5 font-mono text-[11px] dark:bg-gray-new-20">
+            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
               request_id
             </code>{' '}
             Optional. Request identifier for debugging. You can provide one with the{' '}
-            <code className="rounded bg-gray-new-90 px-1 py-0.5 font-mono text-[11px] dark:bg-gray-new-20">
+            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
               X-Request-ID
             </code>{' '}
             header.

--- a/src/components/pages/doc/api-operation/operation-doc.jsx
+++ b/src/components/pages/doc/api-operation/operation-doc.jsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import ApiResponse from 'components/pages/doc/api-response';
 import useCopyToClipboard from 'hooks/use-copy-to-clipboard';
+import cn from 'utils/cn';
 
 import { DocBodySection, DocField, getRequiredLeafPaths } from './doc-body';
 import DocQuickStart from './doc-quick-start';
@@ -51,12 +52,13 @@ function isGeneralError(err) {
   );
 }
 
+const codeClassName =
+  'rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-black-pure dark:border-gray-new-30 dark:text-white';
+
 const GeneralErrorCard = () => (
   <div className="api-response my-4 border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
     <div className="mb-3 flex items-start gap-3">
-      <span className="mt-0.5 shrink-0 border border-gray-new-70 bg-transparent px-2 py-0.5 font-mono text-sm leading-normal font-semibold text-gray-new-40 dark:border-gray-new-30 dark:text-gray-new-70">
-        default
-      </span>
+      <span className={cn('mt-0.5 shrink-0', codeClassName)}>default</span>
       <div>
         <p className="text-sm font-semibold text-black-pure dark:text-white">General error</p>
         <p className="mt-1 text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70">
@@ -70,26 +72,15 @@ const GeneralErrorCard = () => (
         <p className="font-semibold text-black-pure dark:text-white">Response fields</p>
         <ul className="mt-1 list-disc space-y-1 pl-4">
           <li>
-            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
-              message
-            </code>{' '}
-            Required. Human-readable error message.
+            <code className={codeClassName}>message</code> Required. Human-readable error message.
           </li>
           <li>
-            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
-              code
-            </code>{' '}
-            Required. Machine-readable error code.
+            <code className={codeClassName}>code</code> Required. Machine-readable error code.
           </li>
           <li>
-            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
-              request_id
-            </code>{' '}
-            Optional. Request identifier for debugging. You can provide one with the{' '}
-            <code className="border border-gray-new-70 bg-transparent px-1 py-0.5 font-mono text-sm dark:border-gray-new-30">
-              X-Request-ID
-            </code>{' '}
-            header.
+            <code className={codeClassName}>request_id</code> Optional. Request identifier for
+            debugging. You can provide one with the{' '}
+            <code className={codeClassName}>X-Request-ID</code> header.
           </li>
         </ul>
       </div>

--- a/src/components/pages/doc/api-operation/operation-mcp.jsx
+++ b/src/components/pages/doc/api-operation/operation-mcp.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 
 import { cn } from 'utils/cn';
 
+import ApiCodeBlock from './api-code-block';
+
 // MCP description rendering — parses the XML-like blocks Neon's MCP server
 // emits (workflow, important_notes, returns, etc.) and renders each as a
 // labeled section. Falls back to plain text when no recognized blocks are
@@ -143,7 +145,7 @@ export const McpDescription = ({ description }) => {
 
   if (!segments) {
     return (
-      <p className="mt-2 text-[13px] leading-relaxed text-gray-new-30 dark:text-gray-new-70">
+      <p className="mt-2 text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70">
         {description}
       </p>
     );
@@ -154,10 +156,7 @@ export const McpDescription = ({ description }) => {
       {segments.map((seg, i) => {
         if (seg.type === 'text') {
           return (
-            <p
-              key={i}
-              className="text-[13px] leading-relaxed text-gray-new-30 dark:text-gray-new-70"
-            >
+            <p key={i} className="text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70">
               {seg.content}
             </p>
           );
@@ -169,7 +168,7 @@ export const McpDescription = ({ description }) => {
             className={cn(seg.label && 'border-t border-gray-new-90 pt-3 dark:border-gray-new-20')}
           >
             {seg.label && (
-              <p className="mb-1.5 text-[10px] font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
+              <p className="mb-1.5 text-sm font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
                 {seg.label}
               </p>
             )}
@@ -177,8 +176,8 @@ export const McpDescription = ({ description }) => {
               {seg.items.map((item, j) => {
                 if (item.type === 'numbered') {
                   return (
-                    <div key={j} className="flex gap-2 py-0.5 text-[13px] leading-relaxed">
-                      <span className="mt-0.5 w-5 flex-none text-right font-mono text-[11px] font-semibold text-green-45">
+                    <div key={j} className="flex gap-2 py-0.5 text-sm leading-relaxed">
+                      <span className="mt-0.5 w-5 flex-none text-right font-mono text-sm font-semibold text-green-45">
                         {item.n}.
                       </span>
                       <span className="text-gray-new-30 dark:text-gray-new-70">{item.text}</span>
@@ -190,7 +189,7 @@ export const McpDescription = ({ description }) => {
                     <div
                       key={j}
                       className={cn(
-                        'flex items-baseline gap-2 py-0.5 text-[13px] leading-relaxed',
+                        'flex items-baseline gap-2 py-0.5 text-sm leading-relaxed',
                         item.type === 'sub' && 'ml-7'
                       )}
                     >
@@ -202,7 +201,7 @@ export const McpDescription = ({ description }) => {
                 return (
                   <p
                     key={j}
-                    className="py-0.5 text-[13px] leading-relaxed text-gray-new-30 dark:text-gray-new-70"
+                    className="py-0.5 text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70"
                   >
                     {item.text}
                   </p>
@@ -210,9 +209,12 @@ export const McpDescription = ({ description }) => {
               })}
             </div>
             {seg.code && (
-              <pre className="mt-2 overflow-x-auto rounded-lg bg-gray-new-94 p-3 font-mono text-[11px] leading-relaxed text-gray-new-50 dark:bg-gray-new-15 dark:text-gray-new-60">
-                {seg.code}
-              </pre>
+              <ApiCodeBlock
+                label="Example"
+                code={seg.code}
+                className="mt-2"
+                preClassName="text-sm"
+              />
             )}
           </div>
         );

--- a/src/components/pages/doc/api-operation/operation-params.jsx
+++ b/src/components/pages/doc/api-operation/operation-params.jsx
@@ -132,14 +132,14 @@ export const ParamsSection = ({ operation, state }) => (
           <button
             type="button"
             onClick={state.reset}
-            className="rounded border border-gray-new-90 px-1.5 py-0.5 text-[10px] text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
+            className="border border-gray-new-90 px-1.5 py-0.5 text-sm text-gray-new-50 transition-all hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60"
           >
             Reset
           </button>
         )
       }
     />
-    <p className="mb-2 text-[11px] text-gray-new-60 italic dark:text-gray-new-50">
+    <p className="mb-2 text-sm text-gray-new-60 italic dark:text-gray-new-50">
       Click values to edit · ☑ to include in request
     </p>
     <div>

--- a/src/components/pages/doc/api-operation/operation-response.jsx
+++ b/src/components/pages/doc/api-operation/operation-response.jsx
@@ -119,10 +119,10 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
         {respTree.length === 0 && operation.response?.example == null ? (
           <p className="text-sm text-gray-new-50 dark:text-gray-new-60">No example available.</p>
         ) : (
-          <div className="overflow-hidden border border-gray-new-80 bg-white dark:border-gray-new-20 dark:bg-black-pure">
+          <div className="max-w-full overflow-hidden border border-gray-new-80 bg-white dark:border-gray-new-20 dark:bg-black-pure">
             {/* Header bar: tabs left, controls right */}
-            <div className="flex min-h-11 items-stretch justify-between border-b border-gray-new-80 bg-gray-new-98 dark:border-gray-new-20 dark:bg-gray-new-8">
-              <div className="flex">
+            <div className="relative flex min-h-11 w-full items-stretch justify-between bg-gray-new-98 after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-gray-new-80 dark:bg-gray-new-8 dark:after:bg-gray-new-20">
+              <div className="relative z-10 no-scrollbars flex flex-nowrap gap-5 overflow-auto pl-5">
                 {['schema', ...(operation.response?.example != null ? ['example'] : [])].map(
                   (v) => (
                     <button
@@ -130,10 +130,10 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
                       type="button"
                       onClick={() => state.setView(v)}
                       className={cn(
-                        'px-4 text-sm leading-none font-medium capitalize transition-colors',
+                        'relative z-10 cursor-pointer border-b pt-2.5 pb-3.5 text-sm leading-none font-medium tracking-extra-tight whitespace-nowrap capitalize transition-colors duration-200 hover:text-black-pure dark:hover:text-white',
                         state.view === v
-                          ? 'border-b-2 border-b-[#00B87B] bg-[rgba(0,229,153,0.04)] text-[#00B87B] dark:bg-[rgba(0,229,153,0.05)] dark:text-green-45'
-                          : 'border-b-2 border-b-transparent text-gray-new-50 hover:bg-gray-new-95 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:bg-gray-new-10'
+                          ? 'border-black-pure text-black-pure after:opacity-100 dark:border-white dark:text-white'
+                          : 'border-transparent text-gray-new-40 dark:text-gray-new-60'
                       )}
                     >
                       {v}
@@ -141,33 +141,33 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
                   )
                 )}
               </div>
-              <div className="flex items-center gap-2.5 px-3.5">
+              <div className="relative z-10 flex items-center gap-2.5 px-3.5">
                 {state.view === 'schema' && (
-                  <>
-                    <DepthControl value={state.depth} onChange={state.setDepth} />
-                    <span className="h-4 w-px bg-gray-new-90 dark:bg-gray-new-20" />
-                  </>
+                  <DepthControl value={state.depth} onChange={state.setDepth} />
                 )}
                 {operation.response?.example != null && (
-                  <button
-                    type="button"
-                    onClick={() =>
-                      copy('resp', JSON.stringify(operation.response.example, null, 2))
-                    }
-                    className={cn(
-                      'border border-gray-new-80 bg-white p-1.5 text-gray-new-40 transition-[background-color,color] duration-200 hover:bg-gray-new-90 hover:text-gray-new-30 dark:border-gray-new-20 dark:bg-black-pure dark:text-gray-new-60 dark:hover:bg-gray-new-8 dark:hover:text-gray-new-80',
-                      copiedId === 'resp'
-                        ? 'border-green-45/40 text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
-                        : ''
-                    )}
-                    aria-label={copiedId === 'resp' ? 'Copied JSON' : 'Copy JSON'}
-                  >
-                    {copiedId === 'resp' ? (
-                      <CheckIcon className="h-3.5 w-3.5 text-current" />
-                    ) : (
-                      <CopyIcon className="h-3.5 w-3.5 text-current" />
-                    )}
-                  </button>
+                  <>
+                    <span className="h-4 w-px bg-gray-new-90 dark:bg-gray-new-20" />
+                    <button
+                      type="button"
+                      onClick={() =>
+                        copy('resp', JSON.stringify(operation.response.example, null, 2))
+                      }
+                      className={cn(
+                        'border border-gray-new-80 bg-white p-1.5 text-gray-new-40 transition-[background-color,color] duration-200 hover:bg-gray-new-90 hover:text-gray-new-30 dark:border-gray-new-20 dark:bg-black-pure dark:text-gray-new-60 dark:hover:bg-gray-new-8 dark:hover:text-gray-new-80',
+                        copiedId === 'resp'
+                          ? 'border-green-45/40 text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
+                          : ''
+                      )}
+                      aria-label={copiedId === 'resp' ? 'Copied JSON' : 'Copy JSON'}
+                    >
+                      {copiedId === 'resp' ? (
+                        <CheckIcon className="h-3.5 w-3.5 text-current" />
+                      ) : (
+                        <CopyIcon className="h-3.5 w-3.5 text-current" />
+                      )}
+                    </button>
+                  </>
                 )}
               </div>
             </div>

--- a/src/components/pages/doc/api-operation/operation-response.jsx
+++ b/src/components/pages/doc/api-operation/operation-response.jsx
@@ -88,7 +88,7 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
         ) : (
           <p className="text-sm text-gray-new-50 dark:text-gray-new-60">
             Run{' '}
-            <code className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm dark:border-gray-new-30">
+            <code className="rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm text-black-pure dark:border-gray-new-30 dark:text-white">
               neon --help
             </code>{' '}
             to see output format.
@@ -96,7 +96,7 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
         )}
         <p className="mt-3 text-sm leading-relaxed text-gray-new-50 dark:text-gray-new-60">
           For the full response, use{' '}
-          <code className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm dark:border-gray-new-30">
+          <code className="rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm text-black-pure dark:border-gray-new-30 dark:text-white">
             --output json
           </code>
           . The JSON output matches the REST API response.

--- a/src/components/pages/doc/api-operation/operation-response.jsx
+++ b/src/components/pages/doc/api-operation/operation-response.jsx
@@ -5,8 +5,12 @@ import { useState, useCallback } from 'react';
 
 import { AnnotatedField } from 'components/pages/doc/annotated-field';
 import DepthControl from 'components/pages/doc/depth-control';
+import CheckIcon from 'components/shared/code-block-wrapper/images/check.inline.svg';
+import CopyIcon from 'components/shared/code-block-wrapper/images/copy.inline.svg';
+import { INLINE_CODE_STYLES } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
+import ApiCodeBlock from './api-code-block';
 import { SectionHeader, JsonHighlightValue } from './operation-shared';
 
 // Response section — handles API/SDK Schema vs Example tabs, plus the CLI
@@ -65,7 +69,7 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
 
     {/* MCP response hints — plain paragraph, no tabs */}
     {current === 'mcp' && (
-      <p className="text-[13px] leading-relaxed text-gray-new-30 dark:text-gray-new-70">
+      <p className="text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70">
         The MCP client receives the same JSON structure as the REST API response.
       </p>
     )}
@@ -74,28 +78,25 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
     {current === 'cli' && (
       <>
         {operation.cli?.tableOutput ? (
-          <div className="overflow-hidden border border-gray-new-90 dark:border-gray-new-20">
-            <div className="border-b border-gray-new-90 bg-gray-new-98 px-3.5 py-2 dark:border-gray-new-20 dark:bg-gray-new-10">
-              <span className="text-[12px] text-gray-new-50 dark:text-gray-new-60">
-                table (default)
-              </span>
-            </div>
-            <pre className="overflow-x-auto bg-gray-new-98 p-4 font-mono text-[12px] leading-relaxed whitespace-pre text-gray-new-30 dark:bg-gray-new-10 dark:text-gray-new-70">
-              {operation.cli.tableOutput}
-            </pre>
-          </div>
+          <ApiCodeBlock
+            label="table (default)"
+            code={operation.cli.tableOutput}
+            language="text"
+            preClassName="text-sm"
+            wrap={false}
+          />
         ) : (
-          <p className="text-[13px] text-gray-new-50 dark:text-gray-new-60">
+          <p className="text-sm text-gray-new-50 dark:text-gray-new-60">
             Run{' '}
-            <code className="rounded bg-gray-new-95 px-1.5 py-0.5 font-mono text-[12px] dark:bg-gray-new-15">
+            <code className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm dark:border-gray-new-30">
               neon --help
             </code>{' '}
             to see output format.
           </p>
         )}
-        <p className="mt-3 text-[13px] leading-relaxed text-gray-new-50 dark:text-gray-new-60">
+        <p className="mt-3 text-sm leading-relaxed text-gray-new-50 dark:text-gray-new-60">
           For the full response, use{' '}
-          <code className="rounded bg-gray-new-95 px-1.5 py-0.5 font-mono text-[12px] dark:bg-gray-new-15">
+          <code className="border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm dark:border-gray-new-30">
             --output json
           </code>
           . The JSON output matches the REST API response.
@@ -108,18 +109,19 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
       <>
         {operation.response?.descriptionHtml && (
           <div
-            className="mb-4 text-[13px] leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_code]:rounded [&_code]:bg-gray-new-95 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:dark:bg-gray-new-15 [&_p+p]:mt-3"
+            className={cn(
+              'mb-4 text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_p+p]:mt-3',
+              INLINE_CODE_STYLES
+            )}
             dangerouslySetInnerHTML={{ __html: operation.response.descriptionHtml }}
           />
         )}
         {respTree.length === 0 && operation.response?.example == null ? (
-          <p className="text-[13px] text-gray-new-50 dark:text-gray-new-60">
-            No example available.
-          </p>
+          <p className="text-sm text-gray-new-50 dark:text-gray-new-60">No example available.</p>
         ) : (
-          <div className="overflow-hidden border border-gray-new-90 dark:border-gray-new-20">
+          <div className="overflow-hidden border border-gray-new-80 bg-white dark:border-gray-new-20 dark:bg-black-pure">
             {/* Header bar: tabs left, controls right */}
-            <div className="flex items-stretch justify-between border-b border-gray-new-90 bg-gray-new-98 dark:border-gray-new-20 dark:bg-gray-new-10">
+            <div className="flex min-h-11 items-stretch justify-between border-b border-gray-new-80 bg-gray-new-98 dark:border-gray-new-20 dark:bg-gray-new-8">
               <div className="flex">
                 {['schema', ...(operation.response?.example != null ? ['example'] : [])].map(
                   (v) => (
@@ -128,10 +130,10 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
                       type="button"
                       onClick={() => state.setView(v)}
                       className={cn(
-                        'px-4 py-2 text-[11px] font-medium capitalize transition-colors',
+                        'px-4 text-sm leading-none font-medium capitalize transition-colors',
                         state.view === v
                           ? 'border-b-2 border-b-[#00B87B] bg-[rgba(0,229,153,0.04)] text-[#00B87B] dark:bg-[rgba(0,229,153,0.05)] dark:text-green-45'
-                          : 'border-b-2 border-b-transparent text-gray-new-50 hover:bg-gray-new-95 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:bg-gray-new-15'
+                          : 'border-b-2 border-b-transparent text-gray-new-50 hover:bg-gray-new-95 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:bg-gray-new-10'
                       )}
                     >
                       {v}
@@ -153,13 +155,18 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
                       copy('resp', JSON.stringify(operation.response.example, null, 2))
                     }
                     className={cn(
-                      'rounded border px-2 py-0.5 font-mono text-[11px] transition-all',
+                      'border border-gray-new-80 bg-white p-1.5 text-gray-new-40 transition-[background-color,color] duration-200 hover:bg-gray-new-90 hover:text-gray-new-30 dark:border-gray-new-20 dark:bg-black-pure dark:text-gray-new-60 dark:hover:bg-gray-new-8 dark:hover:text-gray-new-80',
                       copiedId === 'resp'
                         ? 'border-green-45/40 text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
-                        : 'border-gray-new-90 text-gray-new-50 hover:border-gray-new-60 dark:border-gray-new-20 dark:text-gray-new-60'
+                        : ''
                     )}
+                    aria-label={copiedId === 'resp' ? 'Copied JSON' : 'Copy JSON'}
                   >
-                    {copiedId === 'resp' ? '✓ Copied' : 'Copy JSON'}
+                    {copiedId === 'resp' ? (
+                      <CheckIcon className="h-3.5 w-3.5 text-current" />
+                    ) : (
+                      <CopyIcon className="h-3.5 w-3.5 text-current" />
+                    )}
                   </button>
                 )}
               </div>
@@ -167,7 +174,7 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
 
             {/* Schema tab */}
             {state.view === 'schema' && (
-              <div className="py-1.5">
+              <div className="py-3">
                 {respTree.length > 0 ? (
                   respTree.map((node) => (
                     <AnnotatedField
@@ -180,7 +187,7 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
                     />
                   ))
                 ) : (
-                  <p className="px-4 py-3 text-[13px] text-gray-new-50 dark:text-gray-new-60">
+                  <p className="px-4 py-3 text-sm text-gray-new-50 dark:text-gray-new-60">
                     No schema available.
                   </p>
                 )}
@@ -189,7 +196,7 @@ export const ResponseSection = ({ operation, respTree, current, state, copy, cop
 
             {/* Example tab — only rendered when example exists */}
             {state.view === 'example' && operation.response?.example != null && (
-              <pre className="max-h-[600px] overflow-auto bg-gray-new-98 p-4 font-mono text-[11px] leading-relaxed dark:bg-gray-new-10">
+              <pre className="max-h-[600px] overflow-auto bg-white p-4 font-mono text-sm leading-relaxed dark:bg-black-pure">
                 <JsonHighlightValue value={operation.response.example} indent={0} />
               </pre>
             )}

--- a/src/components/pages/doc/api-operation/operation-shared.jsx
+++ b/src/components/pages/doc/api-operation/operation-shared.jsx
@@ -2,10 +2,12 @@
 
 import PropTypes from 'prop-types';
 
-import { JSON_SYNTAX_COLORS } from 'utils/api-style';
+import { INLINE_CODE_STYLES, JSON_SYNTAX_COLORS } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
 import cliGlobalFlagsList from '../../../../../scripts/data/cli-global-flags.json';
+
+import ApiCodeBlock from './api-code-block';
 
 // Rendering primitives + constants shared across the operation-* section
 // components. Anything imported by 2+ sibling modules lives here.
@@ -26,7 +28,7 @@ export const SectionHeader = ({ title, badge, right, id }) => (
       {title}
     </h2>
     {badge && (
-      <span className="text-red-600 bg-red-600/10 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold dark:bg-[#FF5645]/10 dark:text-[#FF5645]">
+      <span className="text-red-600 border-red-600/40 border bg-transparent px-1.5 py-0.5 font-mono text-sm font-semibold dark:border-[#FF5645]/40 dark:text-[#FF5645]">
         {badge}
       </span>
     )}
@@ -43,49 +45,21 @@ SectionHeader.propTypes = {
 
 // ── Live code block ─────────────────────────────────────────────────────────
 
-export const LiveCodeBlock = ({ label, code, editCount, onCopy, copied }) => (
-  <div
+export const LiveCodeBlock = ({ label, code, editCount }) => (
+  <ApiCodeBlock
+    label={editCount > 0 ? `${label} - live from your edits` : label}
+    code={code}
     className={cn(
-      'overflow-hidden border transition-colors duration-200',
-      editCount > 0
-        ? 'border-[#00B87B]/20 dark:border-green-45/20'
-        : 'border-gray-new-90 dark:border-gray-new-20'
+      'transition-colors duration-200',
+      editCount > 0 && 'border-[#00B87B]/30 dark:border-green-45/30'
     )}
-  >
-    <div className="flex items-center justify-between border-b border-gray-new-90 bg-gray-new-98 px-3.5 py-2 dark:border-gray-new-20 dark:bg-gray-new-10">
-      <div className="flex items-center gap-2">
-        <span className="text-[12px] text-gray-new-50 dark:text-gray-new-60">{label}</span>
-        {editCount > 0 && (
-          <span className="text-[10px] text-[#00B87B] italic dark:text-green-45">
-            Live from your edits
-          </span>
-        )}
-      </div>
-      <button
-        type="button"
-        onClick={() => onCopy(code)}
-        className={cn(
-          'rounded border px-2 py-0.5 font-mono text-[11px] transition-all duration-150',
-          copied
-            ? 'border-green-45/40 text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
-            : 'border-gray-new-90 text-gray-new-50 hover:border-gray-new-60 hover:text-gray-new-30 dark:border-gray-new-20 dark:text-gray-new-60 dark:hover:border-gray-new-50 dark:hover:text-gray-new-80'
-        )}
-      >
-        {copied ? '✓ Copied' : 'Copy'}
-      </button>
-    </div>
-    <pre className="overflow-x-auto bg-gray-new-98 p-5 text-[13px] leading-relaxed whitespace-pre-wrap text-gray-new-30 dark:bg-gray-new-10 dark:text-gray-new-70">
-      {code}
-    </pre>
-  </div>
+  />
 );
 
 LiveCodeBlock.propTypes = {
   label: PropTypes.string.isRequired,
   code: PropTypes.string.isRequired,
   editCount: PropTypes.number,
-  onCopy: PropTypes.func.isRequired,
-  copied: PropTypes.bool,
 };
 
 // ── CLI positional row ──────────────────────────────────────────────────────
@@ -115,13 +89,13 @@ export const CliPositionalRow = ({
       style={{ gridTemplateColumns: '14px 1fr 1fr' }}
     >
       <div className="flex items-center justify-center pt-0.5">
-        <span className="font-mono text-[10px] leading-none font-bold text-[#E2301D] dark:text-[#FF5645]">
+        <span className="font-mono text-sm leading-none font-bold text-[#E2301D] dark:text-[#FF5645]">
           *
         </span>
       </div>
 
       <div className="flex flex-wrap items-baseline gap-1.5">
-        <code className="font-mono text-[13px] font-semibold text-black-pure dark:text-white">
+        <code className="font-mono text-sm font-semibold text-black-pure dark:text-white">
           {pos.display}
         </code>
         {isEditing ? (
@@ -134,7 +108,7 @@ export const CliPositionalRow = ({
               if (e.key === 'Enter' || e.key === 'Escape') onSetEditing(null);
             }}
             aria-label={ariaLabel}
-            className="rounded border border-green-45/40 bg-green-45/5 px-1 font-mono text-[12px] text-[#EC6F09] outline-none"
+            className="rounded border border-green-45/40 bg-green-45/5 px-1 font-mono text-sm text-[var(--shiki-token-string)] outline-none"
             style={{ width: `${Math.max(80, currentVal.length * 7.5)}px`, maxWidth: '200px' }}
           />
         ) : (
@@ -150,16 +124,16 @@ export const CliPositionalRow = ({
             }}
             aria-label={ariaLabel}
             className={cn(
-              'cursor-text rounded px-0.5 font-mono text-[12px] transition-all',
+              'cursor-text rounded px-0.5 font-mono text-sm transition-all',
               currentVal
-                ? 'border-b border-dashed border-[#00B87B]/20 bg-green-45/5 text-[#EC6F09]'
+                ? 'border-b border-dashed border-[#00B87B]/20 bg-green-45/5 text-[var(--shiki-token-string)]'
                 : 'text-gray-new-50 hover:border-b hover:border-dashed hover:border-gray-new-50 dark:text-gray-new-60'
             )}
           >
             {currentVal || '(string)'}
           </span>
         )}
-        <span className="rounded bg-[#E2301D]/10 px-1.5 py-0.5 font-mono text-[10px] leading-normal font-medium text-[#E2301D] dark:bg-[#FF5645]/10 dark:text-[#FF5645]">
+        <span className="border border-[#E2301D]/40 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]">
           required
         </span>
       </div>
@@ -167,11 +141,14 @@ export const CliPositionalRow = ({
       <div>
         {(() => {
           const descClass =
-            'text-[12px] leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_a]:underline [&_code]:rounded [&_code]:bg-gray-new-94 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[11px] dark:[&_code]:bg-gray-new-15';
+            'text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_a]:underline';
           // Plain-text fallback: don't pipe unsanitized `description` through
           // dangerouslySetInnerHTML if the generator failed to produce HTML.
           return descriptionHtml ? (
-            <span className={descClass} dangerouslySetInnerHTML={{ __html: descriptionHtml }} />
+            <span
+              className={cn(descClass, INLINE_CODE_STYLES)}
+              dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+            />
           ) : (
             <span className={descClass}>{description ?? ''}</span>
           );
@@ -224,7 +201,7 @@ export const CliFlagRow = ({
   >
     <div className="flex items-center justify-center pt-0.5">
       {flag.required ? (
-        <span className="font-mono text-[10px] leading-none font-bold text-[#E2301D] dark:text-[#FF5645]">
+        <span className="font-mono text-sm leading-none font-bold text-[#E2301D] dark:text-[#FF5645]">
           *
         </span>
       ) : (
@@ -255,22 +232,22 @@ export const CliFlagRow = ({
     </div>
 
     <div className="flex flex-wrap items-baseline gap-1.5">
-      <code className="font-mono text-[13px] font-semibold text-black-pure dark:text-white">
+      <code className="font-mono text-sm font-semibold text-black-pure dark:text-white">
         {flag.name}
       </code>
       {flag.alias && (
-        <span className="font-mono text-[11px] text-gray-new-50 dark:text-gray-new-60">
+        <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
           {flag.alias}
         </span>
       )}
       <span
         className={cn(
-          'rounded px-1.5 py-0.5 font-mono text-[10px] leading-normal font-medium',
+          'px-1.5 py-0.5 font-mono text-sm leading-normal font-medium',
           flag.type === 'string'
-            ? 'bg-[#426CE0]/10 text-[#426CE0] dark:bg-blue-70/10 dark:text-blue-70'
+            ? 'border border-[#426CE0]/40 bg-transparent text-[#426CE0] dark:border-blue-70/40 dark:text-blue-70'
             : flag.type === 'boolean'
-              ? 'bg-[#BE8A3C]/10 text-[#BE8A3C] dark:bg-brown-70/10 dark:text-brown-70'
-              : 'bg-[#8458D0]/10 text-[#8458D0] dark:bg-purple-70/10 dark:text-purple-70'
+              ? 'border border-[#BE8A3C]/40 bg-transparent text-[#BE8A3C] dark:border-brown-70/40 dark:text-brown-70'
+              : 'border border-[#8458D0]/40 bg-transparent text-[#8458D0] dark:border-purple-70/40 dark:text-purple-70'
         )}
       >
         {flag.type}
@@ -284,10 +261,10 @@ export const CliFlagRow = ({
               type="button"
               onClick={() => onEdit(opt)}
               className={cn(
-                'rounded px-1.5 py-0 font-mono text-[11px] transition-all',
+                'px-1.5 py-0 font-mono text-sm transition-all',
                 currentVal === String(opt)
-                  ? 'bg-green-45/20 font-semibold text-[#00B87B] dark:text-green-45'
-                  : 'bg-gray-new-90/50 text-gray-new-50 dark:bg-gray-new-20/50 dark:text-gray-new-60'
+                  ? 'border border-[#00B87B]/40 bg-transparent font-semibold text-[#00B87B] dark:border-green-45/40 dark:text-green-45'
+                  : 'border border-gray-new-70 bg-transparent text-gray-new-50 dark:border-gray-new-30 dark:text-gray-new-60'
               )}
             >
               {opt}
@@ -298,7 +275,7 @@ export const CliFlagRow = ({
         <button
           type="button"
           onClick={() => (isIncluded ? onToggleInclude() : onEdit('true'))}
-          className="font-mono text-[12px] text-[#426CE0]"
+          className="font-mono text-sm text-[var(--shiki-token-keyword)]"
         >
           {isIncluded ? 'true' : 'false'}
         </button>
@@ -312,7 +289,7 @@ export const CliFlagRow = ({
             if (e.key === 'Enter' || e.key === 'Escape') onSetEditing(null);
           }}
           aria-label={`Edit ${labelPrefix} ${flag.name}`}
-          className="rounded border border-green-45/40 bg-green-45/5 px-1 font-mono text-[12px] text-[#EC6F09] outline-none"
+          className="rounded border border-green-45/40 bg-green-45/5 px-1 font-mono text-sm text-[var(--shiki-token-string)] outline-none"
           style={{ width: `${Math.max(80, currentVal.length * 7.5)}px`, maxWidth: '200px' }}
         />
       ) : (
@@ -328,9 +305,9 @@ export const CliFlagRow = ({
           }}
           aria-label={`Edit ${labelPrefix} ${flag.name}`}
           className={cn(
-            'cursor-text rounded px-0.5 font-mono text-[12px] transition-all',
+            'cursor-text rounded px-0.5 font-mono text-sm transition-all',
             isIncluded && currentVal
-              ? 'border-b border-dashed border-green-45/60 bg-green-45/5 text-[#EC6F09]'
+              ? 'border-b border-dashed border-green-45/60 bg-green-45/5 text-[var(--shiki-token-string)]'
               : 'text-gray-new-50 hover:border-b hover:border-dashed hover:border-gray-new-50 dark:text-gray-new-60'
           )}
         >
@@ -345,12 +322,12 @@ export const CliFlagRow = ({
       )}
 
       {flag.required && (
-        <span className="rounded bg-[#E2301D]/10 px-1.5 py-0.5 font-mono text-[10px] leading-normal font-medium text-[#E2301D] dark:bg-[#FF5645]/10 dark:text-[#FF5645]">
+        <span className="border border-[#E2301D]/40 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]">
           required
         </span>
       )}
       {flag.default !== undefined && !flag.enum && (
-        <span className="font-mono text-[10px] text-gray-new-60 dark:text-gray-new-50">
+        <span className="font-mono text-sm text-gray-new-60 dark:text-gray-new-50">
           default: {String(flag.default)}
         </span>
       )}
@@ -359,20 +336,23 @@ export const CliFlagRow = ({
     <div>
       {(() => {
         const descClass =
-          'text-[12px] leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_a]:underline [&_code]:rounded [&_code]:bg-gray-new-94 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[11px] dark:[&_code]:bg-gray-new-15';
+          'text-sm leading-relaxed text-gray-new-30 dark:text-gray-new-70 [&_a]:underline';
         return flag.descriptionHtml ? (
-          <span className={descClass} dangerouslySetInnerHTML={{ __html: flag.descriptionHtml }} />
+          <span
+            className={cn(descClass, INLINE_CODE_STYLES)}
+            dangerouslySetInnerHTML={{ __html: flag.descriptionHtml }}
+          />
         ) : (
           <span className={descClass}>{flag.description ?? ''}</span>
         );
       })()}
       {flag.apiEquiv && isHovered && (
-        <div className="mt-0.5 font-mono text-[10px] text-gray-new-60 dark:text-gray-new-50">
+        <div className="mt-0.5 font-mono text-sm text-gray-new-60 dark:text-gray-new-50">
           API: {flag.apiEquiv}
         </div>
       )}
       {flag.cliOnly && isHovered && (
-        <div className="mt-0.5 text-[10px] text-[#E9943E] dark:text-yellow-70">CLI only</div>
+        <div className="mt-0.5 text-sm text-[#E9943E] dark:text-yellow-70">CLI only</div>
       )}
     </div>
   </div>
@@ -506,7 +486,7 @@ export function sortCliFlags(flags) {
 // the REST API or SDK for that field.
 export const UncoveredList = ({ uncovered, operation, findBodyProp }) => (
   <div className="mt-6 border-t border-gray-new-90 pt-5 dark:border-gray-new-20">
-    <p className="mb-3 text-[11px] font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
+    <p className="mb-3 text-sm font-semibold tracking-wider text-gray-new-50 uppercase dark:text-gray-new-60">
       No CLI equivalent
     </p>
     <div>
@@ -522,16 +502,14 @@ export const UncoveredList = ({ uncovered, operation, findBodyProp }) => (
             }`}
           >
             <div className="flex items-center gap-2">
-              <code className="font-mono text-[12px] text-gray-new-20 dark:text-gray-new-80">
-                {f}
-              </code>
+              <code className="font-mono text-sm text-gray-new-20 dark:text-gray-new-80">{f}</code>
               {prop?.type && (
-                <span className="font-mono text-[10px] text-gray-new-50 dark:text-gray-new-60">
+                <span className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
                   {prop.type}
                 </span>
               )}
             </div>
-            <p className="text-[12px] leading-relaxed text-gray-new-50 dark:text-gray-new-60">
+            <p className="text-sm leading-relaxed text-gray-new-50 dark:text-gray-new-60">
               {prop?.description?.split('\n')[0] ??
                 'Not configurable via CLI. Use the REST API or SDK.'}
             </p>
@@ -561,16 +539,16 @@ export const GlobalFlagsCollapsible = ({ flags, state, headerKeyPrefix }) => (
       className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-gray-new-98 dark:hover:bg-gray-new-10"
     >
       <span
-        className="text-[9px] text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
+        className="text-sm text-gray-new-50 transition-transform duration-150 dark:text-gray-new-60"
         style={{ transform: state.globalFlagsOpen ? 'rotate(90deg)' : 'none' }}
       >
         ▶
       </span>
-      <span className="text-[11px] text-gray-new-50 dark:text-gray-new-60">
+      <span className="text-sm text-gray-new-50 dark:text-gray-new-60">
         {state.globalFlagsOpen ? 'global options' : `+ ${flags.length} global options`}
       </span>
       {!state.globalFlagsOpen && (
-        <span className="truncate font-mono text-[10px] text-gray-new-70 dark:text-gray-new-50">
+        <span className="truncate font-mono text-sm text-gray-new-70 dark:text-gray-new-50">
           {flags.map((f) => `--${f.name}`).join('  ')}
         </span>
       )}

--- a/src/components/pages/doc/api-operation/operation-shared.jsx
+++ b/src/components/pages/doc/api-operation/operation-shared.jsx
@@ -28,7 +28,7 @@ export const SectionHeader = ({ title, badge, right, id }) => (
       {title}
     </h2>
     {badge && (
-      <span className="text-red-600 border-red-600/40 border bg-transparent px-1.5 py-0.5 font-mono text-sm font-semibold dark:border-[#FF5645]/40 dark:text-[#FF5645]">
+      <span className="rounded border border-green-44/40 bg-transparent px-1.5 py-0.5 font-mono text-sm font-semibold text-green-44 dark:border-green-44/40">
         {badge}
       </span>
     )}
@@ -63,6 +63,8 @@ LiveCodeBlock.propTypes = {
 };
 
 // ── CLI positional row ──────────────────────────────────────────────────────
+const codeClassName =
+  'rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-black-pure dark:border-gray-new-30 dark:text-white';
 
 export const CliPositionalRow = ({
   pos,
@@ -133,9 +135,7 @@ export const CliPositionalRow = ({
             {currentVal || '(string)'}
           </span>
         )}
-        <span className="border border-[#E2301D]/40 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]">
-          required
-        </span>
+        <span className={codeClassName}>required</span>
       </div>
 
       <div>
@@ -240,18 +240,7 @@ export const CliFlagRow = ({
           {flag.alias}
         </span>
       )}
-      <span
-        className={cn(
-          'px-1.5 py-0.5 font-mono text-sm leading-normal font-medium',
-          flag.type === 'string'
-            ? 'border border-[#426CE0]/40 bg-transparent text-[#426CE0] dark:border-blue-70/40 dark:text-blue-70'
-            : flag.type === 'boolean'
-              ? 'border border-[#BE8A3C]/40 bg-transparent text-[#BE8A3C] dark:border-brown-70/40 dark:text-brown-70'
-              : 'border border-[#8458D0]/40 bg-transparent text-[#8458D0] dark:border-purple-70/40 dark:text-purple-70'
-        )}
-      >
-        {flag.type}
-      </span>
+      <span className={codeClassName}>{flag.type}</span>
 
       {flag.enum ? (
         <span className="flex gap-0.5">
@@ -321,11 +310,7 @@ export const CliFlagRow = ({
         </span>
       )}
 
-      {flag.required && (
-        <span className="border border-[#E2301D]/40 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]">
-          required
-        </span>
-      )}
+      {flag.required && <span className={codeClassName}>required</span>}
       {flag.default !== undefined && !flag.enum && (
         <span className="font-mono text-sm text-gray-new-60 dark:text-gray-new-50">
           default: {String(flag.default)}

--- a/src/components/pages/doc/api-param/api-param.jsx
+++ b/src/components/pages/doc/api-param/api-param.jsx
@@ -25,7 +25,7 @@ const ApiParam = ({
       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1.5">
         <code
           className={cn(
-            'font-mono text-[13px] font-semibold',
+            'font-mono text-sm font-semibold',
             deprecated
               ? 'text-gray-new-50 line-through dark:text-gray-new-50'
               : 'text-black-pure dark:text-white'
@@ -34,31 +34,28 @@ const ApiParam = ({
           {name}
         </code>
         {deprecated && (
-          <span className="bg-yellow-400/15 text-yellow-700 dark:bg-yellow-400/10 dark:text-yellow-400 rounded px-1.5 py-0.5 font-mono text-[10px] leading-normal font-medium">
+          <span className="border-yellow-700/40 text-yellow-700 dark:border-yellow-400/40 dark:text-yellow-400 border bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium">
             deprecated
           </span>
         )}
         {type && (
           <span
-            className={cn(
-              'rounded px-1.5 py-0.5 font-mono text-[10px] leading-normal font-medium',
-              typeStyle
-            )}
+            className={cn('px-1.5 py-0.5 font-mono text-sm leading-normal font-medium', typeStyle)}
           >
             {type}
           </span>
         )}
         {location && (
-          <span className="text-[11px] leading-normal font-medium text-gray-new-50 dark:text-gray-new-60">
+          <span className="text-sm leading-normal font-medium text-gray-new-50 dark:text-gray-new-60">
             {location}
           </span>
         )}
         <span
           className={cn(
-            'ml-auto rounded px-1.5 py-0.5 text-[10px] leading-normal font-semibold uppercase',
+            'ml-auto border bg-transparent px-1.5 py-0.5 text-sm leading-normal font-semibold uppercase',
             required
-              ? 'bg-[#E2301D]/10 text-[#E2301D] dark:bg-[#FF5645]/10 dark:text-[#FF5645]'
-              : 'bg-gray-new-50/10 text-gray-new-50 dark:bg-gray-new-60/10 dark:text-gray-new-60'
+              ? 'border-[#E2301D]/40 text-[#E2301D] dark:border-[#FF5645]/40 dark:text-[#FF5645]'
+              : 'border-gray-new-70 text-gray-new-50 dark:border-gray-new-30 dark:text-gray-new-60'
           )}
         >
           {required ? 'required' : 'optional'}
@@ -70,7 +67,7 @@ const ApiParam = ({
         </div>
       )}
       {defaultValue !== undefined && defaultValue !== null && (
-        <p className="mt-1.5 font-mono text-[11px] text-gray-new-50 dark:text-gray-new-60">
+        <p className="mt-1.5 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
           Default:{' '}
           <span className="text-gray-new-30 dark:text-gray-new-80">{String(defaultValue)}</span>
         </p>

--- a/src/components/pages/doc/api-param/api-param.jsx
+++ b/src/components/pages/doc/api-param/api-param.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 
-import { TYPE_STYLES } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
 const ApiParam = ({
@@ -13,8 +12,6 @@ const ApiParam = ({
   children,
   className,
 }) => {
-  const typeStyle = TYPE_STYLES[type] ?? TYPE_STYLES.string;
-
   return (
     <div
       className={cn(
@@ -39,9 +36,7 @@ const ApiParam = ({
           </span>
         )}
         {type && (
-          <span
-            className={cn('px-1.5 py-0.5 font-mono text-sm leading-normal font-medium', typeStyle)}
-          >
+          <span className="rounded border border-gray-new-70 bg-transparent px-1.5 py-0.5 font-mono text-sm leading-normal font-medium text-black-pure dark:border-gray-new-30 dark:text-white">
             {type}
           </span>
         )}

--- a/src/components/pages/doc/api-resource-grid/api-resource-grid.jsx
+++ b/src/components/pages/doc/api-resource-grid/api-resource-grid.jsx
@@ -46,14 +46,14 @@ const ApiResourceGrid = () => {
 
   return (
     <div className="not-prose">
-      <div className="mb-5 rounded-xl border border-gray-new-90 bg-gray-new-98 p-5 dark:border-gray-new-20 dark:bg-gray-new-10">
+      <div className="mb-5 border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
         <div className="flex items-center justify-between gap-4 sm:flex-col sm:items-start">
-          <p className="font-mono text-[12px] text-gray-new-50 dark:text-gray-new-60">
+          <p className="font-mono text-xs text-gray-new-50 dark:text-gray-new-60">
             {total} endpoints across {resources.length} resources
           </p>
           <a
             href={`${DOCS_BASE_PATH}reference/api/reference`}
-            className="shrink-0 rounded-full border border-green-45/35 px-3 py-1.5 text-[13px] font-medium text-green-45 transition-colors hover:border-green-45/70 hover:bg-green-45/[0.06]"
+            className="shrink-0 rounded-sm border border-green-45/35 px-3 py-1.5 text-sm font-medium text-green-45 transition-colors duration-200 hover:border-green-45/70 hover:bg-green-45/[0.06]"
           >
             Search endpoint index
           </a>
@@ -65,17 +65,17 @@ const ApiResourceGrid = () => {
           <a
             key={tag}
             href={href}
-            className="group flex flex-col gap-1 rounded-xl border border-gray-new-90 p-4 transition-colors duration-150 hover:border-green-45/40 hover:bg-green-45/[0.03] dark:border-gray-new-20 dark:hover:border-green-45/30 dark:hover:bg-green-45/[0.04]"
+            className="group flex flex-col gap-1 border border-gray-new-90 p-4 transition-colors duration-200 hover:border-green-45/40 hover:bg-gray-new-98 dark:border-gray-new-20 dark:hover:border-green-45/30 dark:hover:bg-gray-new-10"
           >
             <div className="flex items-baseline gap-2">
               <span className="text-[15px] font-semibold text-black-pure transition-colors group-hover:text-green-45 dark:text-white dark:group-hover:text-green-45">
                 {display}
               </span>
-              <span className="font-mono text-[12px] text-gray-new-50 dark:text-gray-new-60">
+              <span className="font-mono text-xs text-gray-new-50 dark:text-gray-new-60">
                 {count}
               </span>
             </div>
-            <p className="text-[13px] leading-snug text-gray-new-40 dark:text-gray-new-60">
+            <p className="text-sm leading-snug text-gray-new-40 dark:text-gray-new-60">
               {description}
             </p>
           </a>

--- a/src/components/pages/doc/api-resource-grid/api-resource-grid.jsx
+++ b/src/components/pages/doc/api-resource-grid/api-resource-grid.jsx
@@ -1,6 +1,9 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
+import Link from 'next/link';
+
+import Button from 'components/shared/button';
 import { DOCS_BASE_PATH } from 'constants/docs';
 
 import tagConfig from '../../../../../scripts/data/tag-config.json';
@@ -48,27 +51,28 @@ const ApiResourceGrid = () => {
     <div className="not-prose">
       <div className="mb-5 border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
         <div className="flex items-center justify-between gap-4 sm:flex-col sm:items-start">
-          <p className="font-mono text-xs text-gray-new-50 dark:text-gray-new-60">
+          <p className="text-[0.9375rem] text-gray-new-50 dark:text-gray-new-60">
             {total} endpoints across {resources.length} resources
           </p>
-          <a
+          <Button
             href={`${DOCS_BASE_PATH}reference/api/reference`}
-            className="shrink-0 rounded-sm border border-green-45/35 px-3 py-1.5 text-sm font-medium text-green-45 transition-colors duration-200 hover:border-green-45/70 hover:bg-green-45/[0.06]"
+            theme="outlined-new"
+            className="shrink-0 px-3 py-1.5 text-sm font-medium"
           >
             Search endpoint index
-          </a>
+          </Button>
         </div>
       </div>
 
       <div className="grid grid-cols-3 gap-x-4 gap-y-4 md:grid-cols-2 sm:grid-cols-1">
         {resources.map(({ tag, display, count, description, href }) => (
-          <a
+          <Link
+            className="group flex flex-col gap-1 border border-gray-new-90 p-4 transition-colors duration-200 hover:border-gray-new-70 hover:bg-gray-new-98 dark:border-gray-new-20 dark:hover:border-gray-new-40 dark:hover:bg-gray-new-10"
             key={tag}
             href={href}
-            className="group flex flex-col gap-1 border border-gray-new-90 p-4 transition-colors duration-200 hover:border-green-45/40 hover:bg-gray-new-98 dark:border-gray-new-20 dark:hover:border-green-45/30 dark:hover:bg-gray-new-10"
           >
             <div className="flex items-baseline gap-2">
-              <span className="text-[15px] font-semibold text-black-pure transition-colors group-hover:text-green-45 dark:text-white dark:group-hover:text-green-45">
+              <span className="text-[15px] font-semibold text-black-pure transition-colors dark:text-white">
                 {display}
               </span>
               <span className="font-mono text-xs text-gray-new-50 dark:text-gray-new-60">
@@ -78,7 +82,7 @@ const ApiResourceGrid = () => {
             <p className="text-sm leading-snug text-gray-new-40 dark:text-gray-new-60">
               {description}
             </p>
-          </a>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/components/pages/doc/api-response/api-response.jsx
+++ b/src/components/pages/doc/api-response/api-response.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { getStatusStyle } from 'utils/api-style';
+import { getStatusStyle, INLINE_CODE_STYLES } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
 const ApiResponse = ({ status, description, descriptionHtml, children, className }) => (
@@ -8,7 +8,7 @@ const ApiResponse = ({ status, description, descriptionHtml, children, className
     <div className="mb-3 flex items-start gap-3">
       <span
         className={cn(
-          'mt-0.5 shrink-0 rounded border px-2 py-0.5 font-mono text-[11px] leading-normal font-semibold',
+          'mt-0.5 shrink-0 rounded border px-2 py-0.5 font-mono text-sm leading-normal font-semibold',
           getStatusStyle(status)
         )}
       >
@@ -16,7 +16,10 @@ const ApiResponse = ({ status, description, descriptionHtml, children, className
       </span>
       {descriptionHtml ? (
         <div
-          className="text-sm text-gray-new-30 dark:text-gray-new-70 [&_code]:rounded [&_code]:bg-gray-new-95 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs [&_code]:dark:bg-gray-new-15 [&_li]:mt-1 [&_p+p]:mt-2 [&_strong]:font-semibold [&_ul]:mt-2 [&_ul]:list-disc [&_ul]:pl-4"
+          className={cn(
+            'text-sm text-gray-new-30 dark:text-gray-new-70 [&_li]:mt-1 [&_p+p]:mt-2 [&_strong]:font-semibold [&_ul]:mt-2 [&_ul]:list-disc [&_ul]:pl-4',
+            INLINE_CODE_STYLES
+          )}
           dangerouslySetInnerHTML={{ __html: descriptionHtml }}
         />
       ) : (

--- a/src/components/pages/doc/api-tag-page/api-tag-page.jsx
+++ b/src/components/pages/doc/api-tag-page/api-tag-page.jsx
@@ -54,7 +54,7 @@ const ApiTagPage = async ({
   const groups = buildGroupedOps(operations, tag ? tagGroupsBySlug[tag] : null);
 
   return (
-    <div className="min-w-0 pb-32 lg:pb-24 md:pb-20">
+    <div className="max-w-208 min-w-0 pb-32 lg:max-w-none lg:pb-24 md:pb-20">
       {breadcrumbs?.length > 0 && (
         <Breadcrumbs className="mb-7!" breadcrumbs={breadcrumbs} baseUrl={DOCS_BASE_PATH} />
       )}
@@ -78,27 +78,27 @@ const ApiTagPage = async ({
       )}
 
       {groups ? (
-        <div className="mt-7 grid grid-cols-2 gap-3 sm:grid-cols-1">
+        <div className="mt-7 grid grid-cols-2 gap-3 md:grid-cols-1">
           {groups.map((group) => (
             <div
               key={group.label}
-              className="rounded-[10px] border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10"
+              className="border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10"
             >
               <div className="mb-3 flex items-center justify-between">
-                <h3 className="text-[13px] font-semibold text-black-pure dark:text-white">
+                <h3 className="text-sm font-semibold text-black-pure dark:text-white">
                   {group.label}
                 </h3>
-                <span className="font-mono text-[10px] text-gray-new-50 dark:text-gray-new-60">
+                <span className="font-mono text-xs text-gray-new-50 dark:text-gray-new-60">
                   {group.ops.length}
                 </span>
               </div>
-              <div className="flex flex-col gap-1.5">
+              <div className="flex flex-col gap-2">
                 {group.ops.map((op) => (
                   <a
                     key={op.id}
                     href={`${DOCS_BASE_PATH}reference/api/${op.tag}/${op.id}`}
                     className={cn(
-                      'flex items-center gap-2 text-[13px] transition-colors duration-100 hover:text-green-45 dark:hover:text-green-45',
+                      'flex items-center gap-2 text-sm leading-tight transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
                       op.deprecated
                         ? 'text-gray-new-60 dark:text-gray-new-50'
                         : 'text-gray-new-40 dark:text-gray-new-60'
@@ -113,14 +113,14 @@ const ApiTagPage = async ({
           ))}
         </div>
       ) : (
-        <div className="mt-7 rounded-[10px] border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
-          <div className="flex flex-col gap-1.5">
+        <div className="mt-7 border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
+          <div className="flex flex-col gap-2">
             {operations.map((op) => (
               <a
                 key={op.id}
                 href={`${DOCS_BASE_PATH}reference/api/${op.tag}/${op.id}`}
                 className={cn(
-                  'flex items-center gap-2 text-[13px] transition-colors duration-100 hover:text-green-45 dark:hover:text-green-45',
+                  'flex items-center gap-2 text-sm leading-tight transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
                   op.deprecated
                     ? 'text-gray-new-60 dark:text-gray-new-50'
                     : 'text-gray-new-40 dark:text-gray-new-60'

--- a/src/components/pages/doc/api-tag-page/api-tag-page.jsx
+++ b/src/components/pages/doc/api-tag-page/api-tag-page.jsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import PropTypes from 'prop-types';
 
 import ApiEndpointsTable from 'components/pages/doc/api-endpoints-table/api-endpoints-table';
@@ -94,19 +95,27 @@ const ApiTagPage = async ({
               </div>
               <div className="flex flex-col gap-2">
                 {group.ops.map((op) => (
-                  <a
+                  <Link
                     key={op.id}
                     href={`${DOCS_BASE_PATH}reference/api/${op.tag}/${op.id}`}
                     className={cn(
-                      'flex items-center gap-2 text-sm leading-tight transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
+                      'inline-flex w-fit items-center gap-2 text-sm leading-tight text-balance transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
                       op.deprecated
                         ? 'text-gray-new-60 dark:text-gray-new-50'
                         : 'text-gray-new-40 dark:text-gray-new-60'
                     )}
                   >
-                    {op.summary}
-                    {op.deprecated && <Tag label="deprecated" size="sm" />}
-                  </a>
+                    <span className="text-balance">
+                      {op.summary}
+                      {op.deprecated && (
+                        <Tag
+                          className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                          label="deprecated"
+                          size="sm"
+                        />
+                      )}
+                    </span>
+                  </Link>
                 ))}
               </div>
             </div>
@@ -116,19 +125,27 @@ const ApiTagPage = async ({
         <div className="mt-7 border border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-10">
           <div className="flex flex-col gap-2">
             {operations.map((op) => (
-              <a
+              <Link
                 key={op.id}
                 href={`${DOCS_BASE_PATH}reference/api/${op.tag}/${op.id}`}
                 className={cn(
-                  'flex items-center gap-2 text-sm leading-tight transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
+                  'inline-flex w-fit items-center gap-2 text-sm leading-tight transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
                   op.deprecated
                     ? 'text-gray-new-60 dark:text-gray-new-50'
                     : 'text-gray-new-40 dark:text-gray-new-60'
                 )}
               >
-                {op.summary}
-                {op.deprecated && <Tag label="deprecated" size="sm" />}
-              </a>
+                <span className="text-balance">
+                  {op.summary}
+                  {op.deprecated && (
+                    <Tag
+                      className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                      label="deprecated"
+                      size="sm"
+                    />
+                  )}
+                </span>
+              </Link>
             ))}
           </div>
         </div>

--- a/src/components/pages/doc/api-tag-page/api-tag-page.jsx
+++ b/src/components/pages/doc/api-tag-page/api-tag-page.jsx
@@ -99,7 +99,7 @@ const ApiTagPage = async ({
                     key={op.id}
                     href={`${DOCS_BASE_PATH}reference/api/${op.tag}/${op.id}`}
                     className={cn(
-                      'inline-flex w-fit items-center gap-2 text-sm leading-tight text-balance transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
+                      'inline-flex w-fit items-center gap-2 text-sm leading-tight text-balance transition-colors duration-200 hover:text-black-pure dark:hover:text-white',
                       op.deprecated
                         ? 'text-gray-new-60 dark:text-gray-new-50'
                         : 'text-gray-new-40 dark:text-gray-new-60'
@@ -109,7 +109,7 @@ const ApiTagPage = async ({
                       {op.summary}
                       {op.deprecated && (
                         <Tag
-                          className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                          className="ml-2 inline-flex text-[0.6875rem] font-normal -tracking-tight tabular-nums"
                           label="deprecated"
                           size="sm"
                         />
@@ -129,7 +129,7 @@ const ApiTagPage = async ({
                 key={op.id}
                 href={`${DOCS_BASE_PATH}reference/api/${op.tag}/${op.id}`}
                 className={cn(
-                  'inline-flex w-fit items-center gap-2 text-sm leading-tight transition-colors duration-200 hover:text-green-45 dark:hover:text-green-45',
+                  'inline-flex w-fit items-center gap-2 text-sm leading-tight transition-colors duration-200 hover:text-black-pure dark:hover:text-white',
                   op.deprecated
                     ? 'text-gray-new-60 dark:text-gray-new-50'
                     : 'text-gray-new-40 dark:text-gray-new-60'
@@ -139,7 +139,7 @@ const ApiTagPage = async ({
                   {op.summary}
                   {op.deprecated && (
                     <Tag
-                      className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                      className="ml-2 inline-flex text-[0.6875rem] font-normal -tracking-tight tabular-nums"
                       label="deprecated"
                       size="sm"
                     />

--- a/src/components/pages/doc/depth-control/depth-control.jsx
+++ b/src/components/pages/doc/depth-control/depth-control.jsx
@@ -13,17 +13,15 @@ const OPTIONS = [
 
 const DepthControl = ({ value, onChange, label = 'Depth' }) => (
   <div className="flex items-center gap-1.5">
-    <span className="text-[10px] tracking-wider text-gray-new-50 dark:text-gray-new-60">
-      {label}
-    </span>
-    <div className="flex gap-px rounded-md border border-gray-new-90 bg-gray-new-98 p-0.5 dark:border-gray-new-20 dark:bg-gray-new-10">
+    <span className="text-sm tracking-wide text-gray-new-50 dark:text-gray-new-60">{label}</span>
+    <div className="flex gap-px border border-gray-new-80 bg-white p-0.5 dark:border-gray-new-20 dark:bg-black-pure">
       {OPTIONS.map((opt) => (
         <button
           key={opt.value}
           type="button"
           onClick={() => onChange(opt.value)}
           className={cn(
-            'rounded px-2 py-0.5 font-mono text-[11px] font-semibold transition-all duration-100',
+            'px-2 py-0.5 font-mono text-sm font-semibold transition-all duration-100',
             value === opt.value
               ? 'bg-gray-new-90 text-black-pure dark:bg-gray-new-20 dark:text-white'
               : 'text-gray-new-50 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:text-gray-new-80'

--- a/src/components/pages/doc/endpoint-index/endpoint-index.jsx
+++ b/src/components/pages/doc/endpoint-index/endpoint-index.jsx
@@ -10,17 +10,10 @@ import Breadcrumbs from 'components/pages/doc/breadcrumbs';
 import DocFooter from 'components/shared/doc-footer';
 import NavigationLinks from 'components/shared/navigation-links';
 import { DOCS_BASE_PATH } from 'constants/docs';
+import { METHOD_TEXT_FALLBACK_STYLE, METHOD_TEXT_STYLES } from 'utils/api-style';
 import { cn } from 'utils/cn';
 
 const NEVER_AUTO_EXPAND = new Set(['auth-legacy']);
-
-const METHOD_COLOR = {
-  GET: 'text-[#00B87B] dark:text-green-45',
-  POST: 'text-[#426CE0] dark:text-blue-70',
-  PUT: 'text-[#BE8A3C] dark:text-brown-70',
-  PATCH: 'text-[#E9943E] dark:text-yellow-70',
-  DELETE: 'text-[#E2301D] dark:text-[#FF5645]',
-};
 
 function collectProps(props, names = []) {
   if (!props) return names;
@@ -53,27 +46,24 @@ const MATCH_LABELS = {
 };
 
 const TagSection = ({ tag, display, operations, open, onToggle }) => (
-  <div className="rounded-[10px] border border-gray-new-90 dark:border-gray-new-20">
+  <div className="overflow-hidden border border-gray-new-90 dark:border-gray-new-20">
     <button
       type="button"
       onClick={onToggle}
-      className="flex w-full items-center gap-2 px-4 py-3 text-left"
+      className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors duration-200 hover:bg-gray-new-98 dark:hover:bg-gray-new-10"
     >
       <span
-        className={cn(
-          'text-[11px] transition-transform duration-200',
-          open ? 'rotate-90' : 'rotate-0'
-        )}
+        className={cn('text-xs transition-transform duration-200', open ? 'rotate-90' : 'rotate-0')}
       >
         ▶
       </span>
-      <span className="flex-1 text-[13px] font-semibold text-black-pure dark:text-white">
+      <span className="flex-1 text-sm font-semibold text-black-pure dark:text-white">
         {display}
       </span>
-      <span className="font-mono text-[11px] text-gray-new-50 dark:text-gray-new-60">
+      <span className="font-mono text-xs text-gray-new-50 dark:text-gray-new-60">
         {operations.length}
       </span>
-      <span className="text-[11px] text-gray-new-50 dark:text-gray-new-60">
+      <span className="text-xs text-gray-new-50 dark:text-gray-new-60">
         {open ? 'Hide' : 'Show'}
       </span>
     </button>
@@ -100,16 +90,16 @@ const TagSection = ({ tag, display, operations, open, onToggle }) => (
               >
                 <span
                   className={cn(
-                    'w-[46px] shrink-0 font-mono text-[11px] font-semibold uppercase',
-                    METHOD_COLOR[method] ?? 'text-gray-new-50 dark:text-gray-new-60'
+                    'w-12 shrink-0 font-mono text-xs font-semibold uppercase',
+                    METHOD_TEXT_STYLES[method] ?? METHOD_TEXT_FALLBACK_STYLE
                   )}
                 >
                   {method}
                 </span>
-                <code className="flex-1 overflow-hidden font-mono text-[12px] text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
+                <code className="flex-1 overflow-hidden font-mono text-xs text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
                   {op.path}
                 </code>
-                <span className="shrink-0 text-right text-[12px] text-gray-new-50 group-hover:text-gray-new-40 dark:text-gray-new-60 dark:group-hover:text-gray-new-50">
+                <span className="shrink-0 text-right text-xs text-gray-new-50 group-hover:text-gray-new-40 dark:text-gray-new-60 dark:group-hover:text-gray-new-50 md:hidden">
                   {op.summary}
                 </span>
               </a>
@@ -223,7 +213,7 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
   const results = trimmed.length >= 2 ? fuse.search(trimmed) : null;
 
   return (
-    <div className="min-w-0 flex-1 pb-32 lg:pb-24 md:pb-20">
+    <div className="max-w-208 min-w-0 flex-1 pb-32 lg:max-w-none lg:pb-24 md:pb-20">
       {breadcrumbs?.length > 0 && (
         <Breadcrumbs className="mb-7!" breadcrumbs={breadcrumbs} baseUrl={DOCS_BASE_PATH} />
       )}
@@ -238,7 +228,7 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search endpoints, fields, parameters..."
-          className="w-full rounded-lg border border-gray-new-90 bg-white px-4 py-2.5 font-mono text-sm text-gray-new-20 placeholder-gray-new-50 transition-colors duration-100 outline-none focus:border-gray-new-50 dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-80 dark:placeholder-gray-new-60 dark:focus:border-gray-new-50"
+          className="w-full rounded-sm border border-gray-new-90 bg-white px-4 py-2.5 font-mono text-sm text-gray-new-20 placeholder-gray-new-50 transition-colors duration-200 outline-none focus:border-gray-new-50 dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-80 dark:placeholder-gray-new-60 dark:focus:border-gray-new-50"
         />
         {query && (
           <button
@@ -268,29 +258,29 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
                 <a
                   key={item.id}
                   href={`${DOCS_BASE_PATH}reference/api/${item.tag}/${item.id}`}
-                  className="group flex flex-col gap-1 rounded-[10px] border border-gray-new-90 px-4 py-3 transition-colors duration-100 hover:bg-gray-new-98 dark:border-gray-new-20 dark:hover:bg-gray-new-10"
+                  className="group flex flex-col gap-1 border border-gray-new-90 px-4 py-3 transition-colors duration-200 hover:bg-gray-new-98 dark:border-gray-new-20 dark:hover:bg-gray-new-10"
                 >
                   <div className="flex items-center gap-3">
                     <span
                       className={cn(
-                        'w-[46px] shrink-0 font-mono text-[11px] font-semibold uppercase',
-                        METHOD_COLOR[method] ?? 'text-gray-new-50 dark:text-gray-new-60'
+                        'w-12 shrink-0 font-mono text-xs font-semibold uppercase',
+                        METHOD_TEXT_STYLES[method] ?? METHOD_TEXT_FALLBACK_STYLE
                       )}
                     >
                       {method}
                     </span>
-                    <code className="flex-1 overflow-hidden font-mono text-[12px] text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
+                    <code className="flex-1 overflow-hidden font-mono text-xs text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
                       {item.path}
                     </code>
-                    <span className="shrink-0 rounded bg-gray-new-95 px-1.5 py-0.5 font-mono text-[10px] text-gray-new-50 dark:bg-gray-new-15 dark:text-gray-new-60">
+                    <span className="shrink-0 rounded-sm bg-gray-new-95 px-1.5 py-0.5 font-mono text-xs text-gray-new-50 dark:bg-gray-new-15 dark:text-gray-new-60">
                       {item.tagDisplay}
                     </span>
                   </div>
-                  <p className="pl-[58px] text-[13px] text-gray-new-40 group-hover:text-gray-new-30 dark:text-gray-new-60 dark:group-hover:text-gray-new-50">
+                  <p className="pl-14 text-sm text-gray-new-40 group-hover:text-gray-new-30 dark:text-gray-new-60 dark:group-hover:text-gray-new-50 sm:pl-0">
                     {item.summary}
                   </p>
                   {contextMatch && matchedWord && (
-                    <p className="pl-[58px] text-[11px] text-gray-new-50 dark:text-gray-new-60">
+                    <p className="pl-14 text-xs text-gray-new-50 dark:text-gray-new-60 sm:pl-0">
                       Matched: {MATCH_LABELS[contextMatch.key]}{' '}
                       <code className="font-mono">{matchedWord}</code>
                     </p>
@@ -309,7 +299,7 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
             <button
               type="button"
               onClick={toggleAll}
-              className="text-[12px] text-gray-new-50 transition-colors duration-100 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:text-gray-new-50"
+              className="text-xs text-gray-new-50 transition-colors duration-200 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:text-gray-new-50"
             >
               {allExpanded ? 'Collapse all' : 'Expand all'}
             </button>

--- a/src/components/pages/doc/endpoint-index/endpoint-index.jsx
+++ b/src/components/pages/doc/endpoint-index/endpoint-index.jsx
@@ -228,7 +228,7 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search endpoints, fields, parameters..."
-          className="w-full rounded-sm border border-gray-new-90 bg-white px-4 py-2.5 font-mono text-sm text-gray-new-20 placeholder-gray-new-50 transition-colors duration-200 outline-none focus:border-gray-new-50 dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-80 dark:placeholder-gray-new-60 dark:focus:border-gray-new-50"
+          className="h-9 w-full border border-gray-new-90 bg-white px-4 text-sm text-gray-new-20 placeholder-gray-new-50 transition-colors duration-200 outline-none focus:border-gray-new-50 dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-80 dark:placeholder-gray-new-60 dark:focus:border-gray-new-50 md:text-base"
         />
         {query && (
           <button
@@ -244,7 +244,7 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
 
       {results !== null ? (
         <div className="mt-4">
-          <p className="mb-3 font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
+          <p className="mb-3 text-sm text-gray-new-50 dark:text-gray-new-60">
             {results.length === 0
               ? `No results for "${trimmed}"`
               : `${results.length} result${results.length === 1 ? '' : 's'} for "${trimmed}"`}
@@ -263,16 +263,16 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
                   <div className="flex items-center gap-3">
                     <span
                       className={cn(
-                        'w-12 shrink-0 font-mono text-xs font-semibold uppercase',
+                        'w-12 shrink-0 text-sm font-semibold uppercase',
                         METHOD_TEXT_STYLES[method] ?? METHOD_TEXT_FALLBACK_STYLE
                       )}
                     >
                       {method}
                     </span>
-                    <code className="flex-1 overflow-hidden font-mono text-xs text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
+                    <code className="flex-1 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-gray-new-30 dark:text-gray-new-70">
                       {item.path}
                     </code>
-                    <span className="shrink-0 rounded-sm bg-gray-new-95 px-1.5 py-0.5 font-mono text-xs text-gray-new-50 dark:bg-gray-new-15 dark:text-gray-new-60">
+                    <span className="shrink-0 rounded-sm bg-gray-new-95 px-1.5 py-0.5 text-sm text-gray-new-50 dark:bg-gray-new-15 dark:text-gray-new-60">
                       {item.tagDisplay}
                     </span>
                   </div>
@@ -292,14 +292,14 @@ const EndpointIndexPage = ({ tagGroups, total, breadcrumbs, navigationLinks, cur
         </div>
       ) : (
         <>
-          <div className="mt-1 flex items-center justify-between">
-            <p className="font-mono text-sm text-gray-new-50 dark:text-gray-new-60">
+          <div className="mt-3 flex items-center justify-between">
+            <p className="text-sm text-gray-new-50 dark:text-gray-new-60">
               All {total} Neon API endpoints
             </p>
             <button
               type="button"
               onClick={toggleAll}
-              className="text-xs text-gray-new-50 transition-colors duration-200 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:text-gray-new-50"
+              className="text-sm text-gray-new-50 transition-colors duration-200 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:text-gray-new-50"
             >
               {allExpanded ? 'Collapse all' : 'Expand all'}
             </button>

--- a/src/components/pages/doc/menu/item/item.jsx
+++ b/src/components/pages/doc/menu/item/item.jsx
@@ -135,8 +135,14 @@ const Item = ({
           >
             {ariaLabel && <span className="sr-only">{ariaLabel}</span>}
             <span className="text-pretty" aria-hidden={!!ariaLabel}>
-              {title}&nbsp;
-              {tag && <Tag className="relative -top-px ml-1 inline-block" label={tag} size="sm" />}
+              {title}
+              {tag && (
+                <Tag
+                  className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                  label={tag}
+                  size="sm"
+                />
+              )}
             </span>
           </Link>
           <button
@@ -169,9 +175,15 @@ const Item = ({
         >
           {ariaLabel && <span className="sr-only">{ariaLabel}</span>}
           {method && <MethodDot method={method} />}
-          <span className="text-pretty" aria-hidden={!!ariaLabel}>
-            {title}&nbsp;
-            {tag && <Tag className="relative -top-px ml-1 inline-block" label={tag} size="sm" />}
+          <span className="text-balance" aria-hidden={!!ariaLabel}>
+            {title}
+            {tag && (
+              <Tag
+                className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                label={tag}
+                size="sm"
+              />
+            )}
           </span>
           {items?.length && (
             <Chevron className={cn('ml-auto w-1.5', !isCollapsed && 'rotate-90')} />

--- a/src/components/pages/doc/menu/item/item.jsx
+++ b/src/components/pages/doc/menu/item/item.jsx
@@ -138,7 +138,7 @@ const Item = ({
               {title}
               {tag && (
                 <Tag
-                  className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                  className="ml-2 inline-flex text-[0.6875rem] font-normal -tracking-tight tabular-nums"
                   label={tag}
                   size="sm"
                 />
@@ -179,7 +179,7 @@ const Item = ({
             {title}
             {tag && (
               <Tag
-                className="ml-2 inline-flex text-[0.6875rem] tracking-tight tabular-nums"
+                className="ml-2 inline-flex text-[0.6875rem] font-normal -tracking-tight tabular-nums"
                 label={tag}
                 size="sm"
               />

--- a/src/components/pages/doc/tag/tag.jsx
+++ b/src/components/pages/doc/tag/tag.jsx
@@ -4,7 +4,7 @@ import { cn } from 'utils/cn';
 
 const themes = {
   new: 'text-[#00B87B] dark:text-green-45 bg-[#00B87B]/10 dark:bg-green-45/10',
-  beta: 'text-[#E9943E] dark:text-yellow-70 bg-[#E9943E]/10 dark:bg-yellow-70/10',
+  beta: 'text-blue-70 bg-blue-70/14 dark:text-[#94B5F7] dark:bg-[#94B5F7]/14',
   'coming soon':
     'text-[#92400E] dark:text-[#FCD34D] bg-[#FEF3C7] dark:bg-[#78350F]/30 border border-[#FDE68A] dark:border-[#92400E]/50',
   deprecated: 'text-[#EC6F09] bg-[#EC6F09]/14 dark:text-[#F99D51] dark:bg-[#F99D51]/14',

--- a/src/components/pages/doc/tag/tag.jsx
+++ b/src/components/pages/doc/tag/tag.jsx
@@ -7,7 +7,7 @@ const themes = {
   beta: 'text-[#E9943E] dark:text-yellow-70 bg-[#E9943E]/10 dark:bg-yellow-70/10',
   'coming soon':
     'text-[#92400E] dark:text-[#FCD34D] bg-[#FEF3C7] dark:bg-[#78350F]/30 border border-[#FDE68A] dark:border-[#92400E]/50',
-  deprecated: 'text-[#1897DF] dark:text-blue-80 bg-[#1897DF]/10 dark:bg-blue-80/10',
+  deprecated: 'text-[#EC6F09] bg-[#EC6F09]/14 dark:text-[#F99D51] dark:bg-[#F99D51]/14',
   'private preview':
     'text-gray-new-30 bg-gray-new-90 font-mono dark:text-gray-new-70 dark:bg-gray-new-15',
   default: 'text-gray-new-50 dark:text-gray-new-80 bg-gray-new-50/10 dark:bg-gray-new-80/10',

--- a/src/utils/api-style.js
+++ b/src/utils/api-style.js
@@ -3,45 +3,63 @@
 // color tweaks live in one place and tests catch unintended changes.
 
 export const METHOD_STYLES = {
-  GET: 'text-[#00B87B] dark:text-green-45 bg-[#00B87B]/10 dark:bg-green-45/10 border-[#00B87B]/20 dark:border-green-45/20',
-  POST: 'text-[#426CE0] dark:text-blue-70 bg-[#426CE0]/10 dark:bg-blue-70/10 border-[#426CE0]/20 dark:border-blue-70/20',
-  PUT: 'text-[#BE8A3C] dark:text-brown-70 bg-[#BE8A3C]/10 dark:bg-brown-70/10 border-[#BE8A3C]/20 dark:border-brown-70/20',
+  GET: 'text-[#00B87B] dark:text-green-45 bg-transparent border-[#00B87B]/40 dark:border-green-45/40',
+  POST: 'text-[#426CE0] dark:text-blue-70 bg-transparent border-[#426CE0]/40 dark:border-blue-70/40',
+  PUT: 'text-[#BE8A3C] dark:text-brown-70 bg-transparent border-[#BE8A3C]/40 dark:border-brown-70/40',
   PATCH:
-    'text-[#E9943E] dark:text-yellow-70 bg-[#E9943E]/10 dark:bg-yellow-70/10 border-[#E9943E]/20 dark:border-yellow-70/20',
+    'text-[#E9943E] dark:text-yellow-70 bg-transparent border-[#E9943E]/40 dark:border-yellow-70/40',
   DELETE:
-    'text-[#E2301D] dark:text-[#FF5645] bg-[#E2301D]/10 dark:bg-[#FF5645]/10 border-[#E2301D]/20 dark:border-[#FF5645]/20',
+    'text-[#E2301D] dark:text-[#FF5645] bg-transparent border-[#E2301D]/40 dark:border-[#FF5645]/40',
 };
 
 export const METHOD_FALLBACK_STYLE =
-  'text-gray-new-50 dark:text-gray-new-80 bg-gray-new-50/10 dark:bg-gray-new-80/10 border-gray-new-50/20 dark:border-gray-new-80/20';
+  'text-gray-new-50 dark:text-gray-new-80 bg-transparent border-gray-new-70 dark:border-gray-new-30';
+
+export const METHOD_TEXT_STYLES = {
+  GET: 'text-[#00B87B] dark:text-green-45',
+  POST: 'text-[#426CE0] dark:text-blue-70',
+  PUT: 'text-[#BE8A3C] dark:text-brown-70',
+  PATCH: 'text-[#E9943E] dark:text-yellow-70',
+  DELETE: 'text-[#E2301D] dark:text-[#FF5645]',
+};
+
+export const METHOD_TEXT_FALLBACK_STYLE = 'text-gray-new-50 dark:text-gray-new-60';
+
+export const INLINE_CODE_STYLES =
+  '[&_code]:my-px [&_code]:inline-flex [&_code]:items-center [&_code]:justify-center [&_code]:rounded [&_code]:border [&_code]:border-gray-new-70 [&_code]:bg-transparent [&_code]:px-1! [&_code]:py-px! [&_code]:font-mono! [&_code]:text-sm [&_code]:leading-[1.2] [&_code]:font-normal! [&_code]:tracking-extra-tight [&_code]:break-words [&_code]:text-black-pure! dark:[&_code]:border-gray-new-30 dark:[&_code]:bg-transparent dark:[&_code]:text-white!';
 
 export const TYPE_STYLES = {
-  string: 'text-[#426CE0] dark:text-blue-70 bg-[#426CE0]/10 dark:bg-blue-70/10',
-  integer: 'text-[#8458D0] dark:text-purple-70 bg-[#8458D0]/10 dark:bg-purple-70/10',
-  number: 'text-[#8458D0] dark:text-purple-70 bg-[#8458D0]/10 dark:bg-purple-70/10',
-  boolean: 'text-[#BE8A3C] dark:text-brown-70 bg-[#BE8A3C]/10 dark:bg-brown-70/10',
-  object: 'text-gray-new-40 dark:text-gray-new-70 bg-gray-new-40/10 dark:bg-gray-new-70/10',
-  array: 'text-gray-new-40 dark:text-gray-new-70 bg-gray-new-40/10 dark:bg-gray-new-70/10',
+  string:
+    'border border-[#426CE0]/40 text-[#426CE0] dark:border-blue-70/40 dark:text-blue-70 bg-transparent',
+  integer:
+    'border border-[#8458D0]/40 text-[#8458D0] dark:border-purple-70/40 dark:text-purple-70 bg-transparent',
+  number:
+    'border border-[#8458D0]/40 text-[#8458D0] dark:border-purple-70/40 dark:text-purple-70 bg-transparent',
+  boolean:
+    'border border-[#BE8A3C]/40 text-[#BE8A3C] dark:border-brown-70/40 dark:text-brown-70 bg-transparent',
+  object:
+    'border border-gray-new-70 text-gray-new-40 dark:border-gray-new-30 dark:text-gray-new-70 bg-transparent',
+  array:
+    'border border-gray-new-70 text-gray-new-40 dark:border-gray-new-30 dark:text-gray-new-70 bg-transparent',
 };
 
 // Text-color class for a JSON-ish type, used in inline schema renderings
 // where the type isn't shown as a badge (e.g. body field value previews).
 export const getTypeColor = (type) => {
   if (!type) return 'text-gray-new-40 dark:text-gray-new-70';
-  if (type === 'string') return 'text-[#EC6F09]';
-  if (type === 'integer' || type === 'number') return 'text-[#2D8665]';
-  if (type === 'boolean') return 'text-[#8458D0]';
+  if (type === 'string') return 'text-[var(--shiki-token-string)]';
+  if (type === 'integer' || type === 'number') return 'text-[var(--shiki-token-constant)]';
+  if (type === 'boolean') return 'text-[var(--shiki-token-keyword)]';
   return 'text-gray-new-40 dark:text-gray-new-70';
 };
 
-// VS Code-style palette for the client-side JSON syntax highlighter
-// (see JsonHighlightValue in operation-shared.jsx). Used as inline `style`
-// values, NOT Tailwind class arbitrary values, so it's safe to interpolate.
+// Client-side JSON/schema highlighter colors. These point at the same CSS
+// variables used by Shiki so light and dark docs themes share one palette.
 export const JSON_SYNTAX_COLORS = {
-  keyword: '#8458D0', // null, true, false
-  number: '#2D8665',
-  string: '#EC6F09',
-  key: '#426CE0',
+  keyword: 'var(--shiki-token-keyword)', // null, true, false
+  number: 'var(--shiki-token-constant)',
+  string: 'var(--shiki-token-string)',
+  key: 'var(--shiki-token-string-expression)',
 };
 
 // Status code colors are intentionally aliased to the corresponding HTTP


### PR DESCRIPTION
This PR builds on the API reference v2 work in #5165 and tightens the docs UI details:

- aligns deprecated labels with the updated Figma styling
- switches API examples and response views to code-tab-style controls
- improves response field interactions so object expansion and field details have separate click targets

[Preview](https://neon-next-git-docs-api-ui-adjustments-pixelpoint.vercel.app/docs/reference/api/projects)
