### PR TITLE
chore: rename @neondatabase/* config libraries to @neon/*

### DIFF
--- a/content/changelog/2026-06-12.md
+++ b/content/changelog/2026-06-12.md
@@ -95,10 +95,10 @@ neonctl env pull                      # or run directly anytime to refresh or us
 
 In **neonctl v2.24.1**, `link` and `checkout` run `env pull` automatically after pinning a branch, so your `DATABASE_URL` and any Auth or Data API URLs land in `.env` without a separate step. Use `--no-env-pull` to opt out, for example when injecting env at runtime via `neonctl dev`.
 
-If you'd rather not write secrets to disk, the `@neondatabase/env` package injects branch-scoped variables at runtime:
+If you'd rather not write secrets to disk, the `@neon/env` package injects branch-scoped variables at runtime:
 
 ```bash
-npm i @neondatabase/env
+npm i @neon/env
 neon-env run -- npm run dev
 ```
 

--- a/content/changelog/2026-06-19.md
+++ b/content/changelog/2026-06-19.md
@@ -25,7 +25,7 @@ Sign up below and we'll send you the **private preview guide** to get started.
 `neon.ts` is a TypeScript config file you commit to your repo. Use it as branch policy infrastructure as code (for example, TTL, compute sizing, and scale-to-zero settings), and to declare which Neon services your project uses:
 
 ```ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   auth: true,
@@ -53,7 +53,7 @@ export default defineConfig({
 });
 ```
 
-Apply it with `neonctl deploy`, preview changes first with `neonctl config plan`. The `@neondatabase/env` package gives you type-safe access to the environment variables each declared service injects, so missing or misconfigured variables surface at build time rather than runtime.
+Apply it with `neonctl deploy`, preview changes first with `neonctl config plan`. The `@neon/env` package gives you type-safe access to the environment variables each declared service injects, so missing or misconfigured variables surface at build time rather than runtime.
 
 If you've signed up for the **Neon backend for apps and agents private preview**, the `preview` block enables Functions, Storage buckets, and AI Gateway in the same config. Fork a branch and you get an isolated copy of your database, files, storage, functions, and AI gateway.
 

--- a/content/docs/compute/functions/agents.md
+++ b/content/docs/compute/functions/agents.md
@@ -20,7 +20,7 @@ Neon Functions use different limits: begin responding within 15 minutes, then ke
 Declare the AI Gateway and the function in `neon.ts`. `neonctl deploy` provisions the gateway and injects its credentials at runtime:
 
 ```ts filename="neon.ts"
-import { defineConfig } from '@neondatabase/config/v1';
+import { defineConfig } from '@neon/config/v1';
 
 export default defineConfig({
   preview: {
@@ -38,13 +38,13 @@ export default defineConfig({
 Install the AI SDK, the Neon provider, and `pg`:
 
 ```bash
-npm install ai @neondatabase/ai-sdk-provider pg zod
+npm install ai @neon/ai-sdk-provider pg zod
 ```
 
-The handler streams a tool-calling agent. The `@neondatabase/ai-sdk-provider` reads the injected gateway credentials on its own, so `neon('<model>')` is the only model configuration you need. Tools run inside the function, right next to Postgres:
+The handler streams a tool-calling agent. The `@neon/ai-sdk-provider` reads the injected gateway credentials on its own, so `neon('<model>')` is the only model configuration you need. Tools run inside the function, right next to Postgres:
 
 ```ts filename="functions/agent.ts"
-import { neon } from '@neondatabase/ai-sdk-provider';
+import { neon } from '@neon/ai-sdk-provider';
 import { streamText, tool, stepCountIs, type ModelMessage } from 'ai';
 import { z } from 'zod';
 import { Pool } from 'pg';

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -82,10 +82,10 @@ zip -j function.zip dist/index.mjs
 
 The archive's entry file must be named `index.mjs` or `index.js`; the runtime looks for those names.
 
-From Node.js, `buildFunctionBundle` from [`@neondatabase/config-runtime`](https://www.npmjs.com/package/@neondatabase/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
+From Node.js, `buildFunctionBundle` from [`@neon/config-runtime`](https://www.npmjs.com/package/@neon/config-runtime) does both steps in one call and produces exactly the archive the deploy endpoint expects:
 
 ```ts
-import { buildFunctionBundle } from "@neondatabase/config-runtime/v1";
+import { buildFunctionBundle } from "@neon/config-runtime/v1";
 
 const zip = await buildFunctionBundle({
   slug: "hello",

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -35,17 +35,17 @@ Each variable is present only when its service is enabled on the branch. `DATABA
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
 <Admonition type="note" title="Two AI Gateway endpoints">
-`OPENAI_BASE_URL` targets the gateway's OpenAI **Responses API** (`/ai-gateway/openai/v1`). The **Chat Completions** endpoint is at a different path: point the SDK's base URL at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1` (see [Chat completions](/docs/ai-gateway/chat-completions)). The [`@neondatabase/ai-sdk-provider`](/docs/compute/functions/agents) handles this routing for you.
+`OPENAI_BASE_URL` targets the gateway's OpenAI **Responses API** (`/ai-gateway/openai/v1`). The **Chat Completions** endpoint is at a different path: point the SDK's base URL at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1` (see [Chat completions](/docs/ai-gateway/chat-completions)). The [`@neon/ai-sdk-provider`](/docs/compute/functions/agents) handles this routing for you.
 </Admonition>
 
 <Admonition type="note" title="Local pull vs. deployed runtime">
 A deployed function gets credentials injected automatically for every service enabled on its branch, so you don't ship a `.env`. For local development, `neonctl env pull` writes credentials for the services you **declare in `neon.ts`**, which can be a subset. Declare a service (`auth: true`, `dataApi: true`, `aiGateway: true`, `buckets: { ... }`) to pull its credentials locally and to get type-safe access.
 </Admonition>
 
-For type-safe access, the [`@neondatabase/env`](https://www.npmjs.com/package/@neondatabase/env) package ships `parseEnv`. It takes your `neon.ts` config and returns a typed env object validated against the services the config declares:
+For type-safe access, the [`@neon/env`](https://www.npmjs.com/package/@neon/env) package ships `parseEnv`. It takes your `neon.ts` config and returns a typed env object validated against the services the config declares:
 
 ```ts
-import { parseEnv } from '@neondatabase/env';
+import { parseEnv } from '@neon/env';
 import config from './neon';
 
 const env = parseEnv(config);
@@ -82,7 +82,7 @@ A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pa
 Declare variables under the function's `env` field. Values are resolved when `neonctl deploy` runs, so you can read from `process.env` to avoid hardcoding secrets:
 
 ```ts filename="neon.ts"
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   preview: {

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -55,7 +55,7 @@ To start from a working example instead, run `neonctl bootstrap`. It scaffolds a
 Create `neon.ts` at your project root. It declares your functions and is what `neonctl dev` and `neonctl deploy` read:
 
 ```ts filename="neon.ts"
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   // preview groups features still in beta: functions, AI Gateway, and object-storage buckets.
@@ -77,7 +77,7 @@ The slug is permanent: it can't be renamed after the first deploy. See the [neon
 Install dependencies:
 
 ```bash
-npm install @neondatabase/config hono pg
+npm install @neon/config hono pg
 npm install --save-dev @types/pg
 ```
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -29,7 +29,7 @@ When the platform stops a function, it sends `SIGINT`. If the process is still r
 
 ```ts
 import { Hono } from 'hono';
-import { waitUntil } from '@neondatabase/functions';
+import { waitUntil } from '@neon/functions';
 
 const app = new Hono();
 

--- a/content/docs/get-started/platform-private-preview.md
+++ b/content/docs/get-started/platform-private-preview.md
@@ -100,13 +100,13 @@ Similar to `vercel link`, this connects the directory to a Neon project and crea
 `neon.ts` is the infrastructure-as-code config for your Neon project. Install the config package first:
 
 ```bash
-npm install @neondatabase/config
+npm install @neon/config
 ```
 
 Then create `neon.ts` in your project root. This example enables the AI Gateway, creates a storage bucket, and declares a function:
 
 ```ts filename="neon.ts"
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   preview: {

--- a/content/docs/reference/neon-ts.md
+++ b/content/docs/reference/neon-ts.md
@@ -22,7 +22,7 @@ Specifically:
 Services and branch policy are independent. Use one, the other, or both.
 
 ```bash
-npm install @neondatabase/config
+npm install @neon/config
 ```
 
 The package source is on [GitHub](https://github.com/neondatabase/neon-pkgs/tree/main/packages/config).
@@ -36,7 +36,7 @@ neonctl link
 ## Config structure
 
 ```ts filename="neon.ts"
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   // Services: what exists on every branch
@@ -68,7 +68,7 @@ export default defineConfig({
 The `branch` closure works on any Neon project. The examples below configure the default branch and apply TTL and compute to new branches at creation. Returning `{}` for existing branches is deliberate: it avoids overwriting settings on branches already in use:
 
 ```ts filename="neon.ts"
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   branch: (branch) => {
@@ -97,7 +97,7 @@ export default defineConfig({
 On paid plans, you can also protect the default branch and control suspend timeouts:
 
 ```ts filename="neon.ts"
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   branch: (branch) => {
@@ -188,14 +188,14 @@ dataApi: {
 
 ## Type-safe environment variables
 
-`@neondatabase/env` gives you type-safe access to your branch's injected variables. It reads `process.env` at runtime and validates each variable against the services declared in your `neon.ts` config. Missing or empty variables throw with a clear error.
+`@neon/env` gives you type-safe access to your branch's injected variables. It reads `process.env` at runtime and validates each variable against the services declared in your `neon.ts` config. Missing or empty variables throw with a clear error.
 
 ```bash
-npm install @neondatabase/env
+npm install @neon/env
 ```
 
 ```ts
-import { parseEnv } from '@neondatabase/env';
+import { parseEnv } from '@neon/env';
 import config from './neon';
 
 const env = parseEnv(config);
@@ -307,7 +307,7 @@ Bucket names follow S3 naming rules. `public_read` makes objects accessible with
 All services combined. `neonctl deploy` provisions everything and writes credentials to `.env.local`.
 
 ```ts filename="neon.ts"
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   auth: true,

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -24,7 +24,7 @@ To follow this guide, you need a new project in the AWS us-east-2 region.
 The recommended way to enable storage and get credentials is via `neon.ts`, Neon's infrastructure-as-code config file. Declare buckets under `preview.buckets`, then run `neonctl deploy` to provision them on the linked branch and pull credentials into `.env.local` automatically:
 
 ```typescript filename="neon.ts"
-import { defineConfig } from '@neondatabase/config/v1';
+import { defineConfig } from '@neon/config/v1';
 
 export default defineConfig({
   preview: {

--- a/content/guides/neon-ts-demo.md
+++ b/content/guides/neon-ts-demo.md
@@ -20,7 +20,7 @@ In this guide, you will build a simple application that uses `neon.ts` to provis
 
 - Define Neon services in code.
 - Enforce branch-level compute limits for feature branches.
-- Use `@neondatabase/env` to access type-safe environment variables.
+- Use `@neon/env` to access type-safe environment variables.
 - Automatically provision isolated database environments for each branch.
 
 ## Prerequisites
@@ -45,7 +45,7 @@ cd neon-ts-demo
 Install the Neon config and env packages:
 
 ```bash
-npm install @neondatabase/config @neondatabase/env
+npm install @neon/config @neon/env
 ```
 
 Link your local project to a Neon project using the Neon CLI:
@@ -63,7 +63,7 @@ After linking, you will see a `.neon` file in your project root. This file conta
 Create a file named `neon.ts` in the root of your project directory. This file acts as the blueprint for your Neon services and branching logic:
 
 ```typescript
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
 
@@ -220,7 +220,7 @@ Traditional `.env` files are just strings, making it easy to make a typo or forg
 Create a new file `env.ts` at the root of your project to parse the environment variables from `.env.local`:
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neon/env/v1";
 import config from "./neon";
 
 export const env = parseEnv(config);
@@ -282,7 +282,7 @@ The example above renders connection strings directly on the frontend for demons
 Not every process needs every environment variable. If you only need the database connection string, pass an array of keys to `parseEnv` to validate and return just those:
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neon/env/v1";
 import config from "./neon";
 
 const { postgres } = parseEnv(config, ["DATABASE_URL"]);

--- a/public/docs/ai/skills/claimable-postgres/SKILL.md
+++ b/public/docs/ai/skills/claimable-postgres/SKILL.md
@@ -199,12 +199,12 @@ Users cannot claim into Vercel-linked orgs; they must choose another Neon org.
 Claimable databases are deliberately throwaway and provisioned through `neon.new` (above), so they aren't managed by `neon.ts`. Once a user **claims** a database into a Neon account it becomes a normal Neon project — at which point `neon.ts`, Neon's infrastructure-as-code file, is how you manage it going forward (see the `neon` skill for the full reference): declare the services its branches should have, program per-branch compute, and get type-safe env vars.
 
 ```bash
-npm i @neondatabase/config
+npm i @neon/config
 ```
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   auth: true, // Neon Auth, once you outgrow a bare connection string

--- a/public/docs/ai/skills/neon-ai-gateway/SKILL.md
+++ b/public/docs/ai/skills/neon-ai-gateway/SKILL.md
@@ -44,7 +44,7 @@ The gateway is part of `neon.ts` (see the `neon` skill for the branch-first work
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   preview: {
@@ -69,7 +69,7 @@ neonctl config apply    # enable the gateway on the branch  (neonctl deploy is a
 
 The gateway is **branch-scoped**: each branch gets its own gateway host. When a `neon.ts` is present, `neonctl checkout` applies the policy as it _creates_ a branch, so a fresh preview/CI branch comes up with the gateway already enabled. Checking out an _existing_ branch doesn't reconcile it — run `neonctl deploy` to apply changes. Provisioning (`config apply` / `deploy`), `link`, and `checkout` also pull the branch's gateway credentials into your local `.env.local`, so local runs hit the same branch gateway as the deployed function (no manual `env pull` needed).
 
-For typed, validated access to the injected credentials, pass the same config object to `parseEnv` from `@neondatabase/env` — it returns an `env.aiGateway` namespace (`apiKey`, `baseUrl`) derived from your `neon.ts`.
+For typed, validated access to the injected credentials, pass the same config object to `parseEnv` from `@neon/env` — it returns an `env.aiGateway` namespace (`apiKey`, `baseUrl`) derived from your `neon.ts`.
 
 ## Environment variables
 
@@ -82,7 +82,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **O
 | `NEON_AI_GATEWAY_TOKEN`    | Same bearer as `OPENAI_API_KEY` (survives a user overriding `OPENAI_*` with their own keys)                                                |
 | `NEON_AI_GATEWAY_BASE_URL` | **Bare branch gateway host** (`scheme://host`, **no path** — no `/ai-gateway`): `https://<branch-id>-api.ai.<region>.aws.neon.tech`        |
 
-The two base URLs are **different**: `OPENAI_BASE_URL` already includes the full `/ai-gateway/openai/v1` (Responses) route, while `NEON_AI_GATEWAY_BASE_URL` is just the bare host, so you append `/ai-gateway/<dialect>` yourself (this is also what the `@neondatabase/ai-sdk-provider` does for you). The routes under the host are:
+The two base URLs are **different**: `OPENAI_BASE_URL` already includes the full `/ai-gateway/openai/v1` (Responses) route, while `NEON_AI_GATEWAY_BASE_URL` is just the bare host, so you append `/ai-gateway/<dialect>` yourself (this is also what the `@neon/ai-sdk-provider` does for you). The routes under the host are:
 
 - `/ai-gateway/mlflow/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider.
 - `/ai-gateway/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`). This is the route `OPENAI_BASE_URL` already points at, because the `@ai-sdk/openai` provider uses the Responses API by default.
@@ -91,7 +91,7 @@ The two base URLs are **different**: `OPENAI_BASE_URL` already includes the full
 
 So `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1` equals `OPENAI_BASE_URL`, and so on. If you only have `OPENAI_BASE_URL` and need chat completions, swap the dialect: `baseUrl.replace("/openai/v1", "/mlflow/v1")` (this is what the Mastra example does).
 
-For typed access, `parseEnv` (from `@neondatabase/env`) returns `env.aiGateway` (`apiKey`, `baseUrl`) derived from your `neon.ts`.
+For typed access, `parseEnv` (from `@neon/env`) returns `env.aiGateway` (`apiKey`, `baseUrl`) derived from your `neon.ts`.
 
 ## Build agents with the Vercel AI SDK (recommended)
 
@@ -116,10 +116,10 @@ const result = streamText({
 return result.toUIMessageStreamResponse();
 ```
 
-For multi-provider routing from a single call, the dedicated `@neondatabase/ai-sdk-provider` reads `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` and routes each model to the best endpoint (Anthropic → Messages, OpenAI/Codex → Responses, everything else → MLflow):
+For multi-provider routing from a single call, the dedicated `@neon/ai-sdk-provider` reads `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` and routes each model to the best endpoint (Anthropic → Messages, OpenAI/Codex → Responses, everything else → MLflow):
 
 ```typescript
-import { neon } from "@neondatabase/ai-sdk-provider";
+import { neon } from "@neon/ai-sdk-provider";
 import { generateText } from "ai";
 
 const { text } = await generateText({
@@ -131,7 +131,7 @@ const { text } = await generateText({
 To build an **agent** — a model that calls tools in a loop and then answers — add `tools` and a `stopWhen` budget. The loop runs in-process, so on a Neon Function it isn't cut off by lambda-style timeouts:
 
 ```typescript
-import { neon } from "@neondatabase/ai-sdk-provider";
+import { neon } from "@neon/ai-sdk-provider";
 import { generateText, tool, stepCountIs } from "ai";
 import { z } from "zod";
 
@@ -157,7 +157,7 @@ For a full AI SDK agent deployed as a Neon Function (streaming, tool calling, im
 
 ```typescript
 import { Agent } from "@mastra/core/agent";
-import { parseEnv } from "@neondatabase/env";
+import { parseEnv } from "@neon/env";
 import config from "../neon";
 
 const env = parseEnv(config);

--- a/public/docs/ai/skills/neon-functions/SKILL.md
+++ b/public/docs/ai/skills/neon-functions/SKILL.md
@@ -50,11 +50,11 @@ Either way, secure a Function like any standalone REST API: verify a JWT or API 
 
 ## Setup
 
-Functions are declared in `neon.ts` (see the `neon` skill for the branch-first workflow and `neon.ts` basics). Add `@neondatabase/config` and declare functions under `preview.functions`, keyed by **slug**:
+Functions are declared in `neon.ts` (see the `neon` skill for the branch-first workflow and `neon.ts` basics). Add `@neon/config` and declare functions under `preview.functions`, keyed by **slug**:
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   preview: {
@@ -78,7 +78,7 @@ A minimal function — a Hono app that queries the branch's Postgres via the inj
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
-import { parseEnv } from "@neondatabase/env";
+import { parseEnv } from "@neon/env";
 import config from "../neon";
 import { todos } from "./db/schema";
 
@@ -197,7 +197,7 @@ const db = drizzle(pool);
 
 Keep `max` small (e.g. `5`): each isolate keeps its own pool, so total connections to Postgres scale with the number of live isolates. You don't need to close the pool on shutdown — when the runtime evicts an isolate it sends `SIGINT`/`SIGTERM`, and Neon's pooler reclaims those connections for you, so an explicit drain handler is redundant.
 
-> Reading `process.env.DATABASE_URL` directly works everywhere. The function in [Setup](#setup) instead uses `@neondatabase/env`'s `parseEnv(config)` to read the same value in a typed, validated way — either is fine.
+> Reading `process.env.DATABASE_URL` directly works everywhere. The function in [Setup](#setup) instead uses `@neon/env`'s `parseEnv(config)` to read the same value in a typed, validated way — either is fine.
 
 ## WebSocket servers
 
@@ -388,7 +388,7 @@ Functions are long-running but **still serverless** — they are a request/respo
 
 - **Time to first byte: 15 minutes.** Your handler must _begin_ returning a response within 15 minutes of receiving a request. Most handlers finish in seconds; the 15-minute ceiling exists so agent workloads like image/video generation have room.
 - **Heartbeat: 15 minutes.** Open WebSocket/SSE connections stay alive as long as data flows. The timeout only fires when a connection goes silent — send at least one byte every 15 minutes to keep a quiet stream alive.
-- **`waitUntil`: 15 minutes.** Work registered with `waitUntil` keeps the invocation alive after the response is sent, up to 15 minutes — for cleanup like analytics writes and audit logs, **not** a background job runner. (`waitUntil` from `@neondatabase/functions` is currently a stub during the preview.)
+- **`waitUntil`: 15 minutes.** Work registered with `waitUntil` keeps the invocation alive after the response is sent, up to 15 minutes — for cleanup like analytics writes and audit logs, **not** a background job runner. (`waitUntil` from `@neon/functions` is currently a stub during the preview.)
 - **Idle eviction.** With no active connections the platform shuts the function down; it may also evict/restart for operational reasons — e.g. maintenance, or moving the function to a different compute node (active functions can run for hours first). Treat eviction like a process restart — WebSocket/SSE clients must reconnect. The platform sends `SIGINT` before evicting, so a `process.on("SIGINT", ...)` handler lets you detect that the function is about to be evicted and run any last-minute cleanup. You don't need one just to close Postgres connections — Neon's pooler reclaims those on its own.
 
 - **Runtime:** Node.js 24, memory fixed at 2048 MiB during the preview. Slugs must match `^[a-z0-9]{1,20}$`. **An isolate is reused across many requests** — multiple requests can be in flight on the same isolate at once (interleaved on Node's single-threaded event loop), and under load the runtime runs several isolates in parallel, each with its own copy of module state. State held in module scope is therefore per-isolate (shared by every request that isolate handles) and in-memory only — persist anything that must survive eviction in Postgres. This reuse is exactly why you create a connection pool once at module scope rather than per request (see [Connecting to Postgres](#connecting-to-postgres)).

--- a/public/docs/ai/skills/neon-functions/references/ai-sdk.md
+++ b/public/docs/ai/skills/neon-functions/references/ai-sdk.md
@@ -12,7 +12,7 @@ The agent needs the AI Gateway (and, for the image example, an Object Storage bu
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   preview: {
@@ -27,11 +27,11 @@ export default defineConfig({
 
 ## 2. The handler: stream a tool-calling agent
 
-The function's default export is a web-standard `{ fetch }` handler. The `@neondatabase/ai-sdk-provider` reads the injected gateway credentials automatically, so `neon("<model>")` is all the model config you need — it routes each model to the right dialect (Anthropic → Messages, OpenAI/Codex → Responses, everything else → MLflow). Return `result.toUIMessageStreamResponse()` so the AI SDK's `useChat` hooks can consume the stream:
+The function's default export is a web-standard `{ fetch }` handler. The `@neon/ai-sdk-provider` reads the injected gateway credentials automatically, so `neon("<model>")` is all the model config you need — it routes each model to the right dialect (Anthropic → Messages, OpenAI/Codex → Responses, everything else → MLflow). Return `result.toUIMessageStreamResponse()` so the AI SDK's `useChat` hooks can consume the stream:
 
 ```typescript
 // src/index.ts
-import { neon } from "@neondatabase/ai-sdk-provider";
+import { neon } from "@neon/ai-sdk-provider";
 import { streamText, tool, stepCountIs, type ModelMessage } from "ai";
 import { z } from "zod";
 import { drizzle } from "drizzle-orm/node-postgres";
@@ -81,7 +81,7 @@ export default {
 The gateway exposes the OpenAI Responses **`image_generation`** built-in tool (GPT-5 models only; the image comes back inline as base64). Persist generated assets to Object Storage and index them in Postgres so they branch together — the **recommended** storage client is the Files SDK `neon` adapter (see the `neon-object-storage` skill):
 
 ```typescript
-import { neon } from "@neondatabase/ai-sdk-provider";
+import { neon } from "@neon/ai-sdk-provider";
 import { streamText } from "ai";
 import { Files } from "files-sdk";
 import { neon as neonFiles } from "files-sdk/neon";
@@ -134,6 +134,6 @@ curl -N -X POST "$(neonctl functions get agent -o json | jq -r .invocation_url)"
 
 ## Further reading
 
-- Neon AI Gateway dialects, models, and the `@neondatabase/ai-sdk-provider`: the `neon-ai-gateway` skill
+- Neon AI Gateway dialects, models, and the `@neon/ai-sdk-provider`: the `neon-ai-gateway` skill
 - Storing generated assets that branch with the database: the `neon-object-storage` skill
 - AI SDK agents/tools: https://ai-sdk.dev/docs/foundations/agents

--- a/public/docs/ai/skills/neon-functions/references/mastra-studio.md
+++ b/public/docs/ai/skills/neon-functions/references/mastra-studio.md
@@ -11,7 +11,7 @@ Use the gateway's **MLflow (chat-completions) dialect**, which serves every prov
 ```typescript
 // src/mastra/agents/pricing.ts
 import { Agent } from "@mastra/core/agent";
-import { parseEnv } from "@neondatabase/env";
+import { parseEnv } from "@neon/env";
 import config from "../../../neon";
 
 const env = parseEnv(config);

--- a/public/docs/ai/skills/neon-object-storage/SKILL.md
+++ b/public/docs/ai/skills/neon-object-storage/SKILL.md
@@ -43,7 +43,7 @@ Object storage is part of the `neon.ts` infrastructure-as-code config (see the `
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   preview: {
@@ -73,7 +73,7 @@ neonctl config apply    # create the declared buckets  (neonctl deploy is an ali
 
 Buckets are **branch-scoped**: when a `neon.ts` is present, `neonctl checkout` applies the policy as it _creates_ a branch, so a fresh preview/CI branch comes up with its buckets already provisioned (and copy-on-write objects inherited from the parent). Checking out an _existing_ branch doesn't reconcile it — run `neonctl deploy` to apply changes. Provisioning (`config apply` / `deploy`), `link`, and `checkout` also pull the branch's S3 credentials into your local `.env.local`, so the same `env pull` step shown below happens for you on those commands.
 
-For typed, validated access to the injected S3 credentials, pass the same config object to `parseEnv` from `@neondatabase/env` — it returns an `env.storage` namespace (`accessKeyId`, `secretAccessKey`, `endpoint`, `region`) derived from your `neon.ts`.
+For typed, validated access to the injected S3 credentials, pass the same config object to `parseEnv` from `@neon/env` — it returns an `env.storage` namespace (`accessKeyId`, `secretAccessKey`, `endpoint`, `region`) derived from your `neon.ts`.
 
 ## Environment variables
 
@@ -139,7 +139,7 @@ const s3 = new S3Client({
 });
 ```
 
-If you prefer typed access instead of reading `process.env` directly, `parseEnv` (from `@neondatabase/env`) returns a validated `env.storage` namespace (`accessKeyId`, `secretAccessKey`, `endpoint`, `region`) derived from your `neon.ts` — see the `neon` skill.
+If you prefer typed access instead of reading `process.env` directly, `parseEnv` (from `@neon/env`) returns a validated `env.storage` namespace (`accessKeyId`, `secretAccessKey`, `endpoint`, `region`) derived from your `neon.ts` — see the `neon` skill.
 
 Then upload, download, and presign with the raw command objects:
 

--- a/public/docs/ai/skills/neon-postgres-branches/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres-branches/SKILL.md
@@ -202,12 +202,12 @@ After branch creation, ask whether the user wants to update local environment cr
 Beyond creating branches imperatively (CLI / MCP / API above), you can **program what configuration new branches receive** declaratively in `neon.ts` — Neon's infrastructure-as-code file (see the `neon` skill for the full reference). The `branch` property is a function of the branch being evaluated that returns its settings, so every branch born from your project gets a consistent lifecycle and compute profile without per-branch flags.
 
 ```bash
-npm i @neondatabase/config
+npm i @neon/config
 ```
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   branch: (branch) => {

--- a/public/docs/ai/skills/neon-postgres-egress-optimizer/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres-egress-optimizer/SKILL.md
@@ -211,12 +211,12 @@ After applying fixes:
 The fixes above cut **egress** (data transferred out of Postgres). The other big non-prod cost lever is **compute**, and you can codify it durably in `neon.ts` — Neon's infrastructure-as-code file (see the `neon` skill for the full reference) — so dev, preview, and CI branches stay cheap by default instead of relying on per-branch flags:
 
 ```bash
-npm i @neondatabase/config
+npm i @neon/config
 ```
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   branch: (branch) => {

--- a/public/docs/ai/skills/neon-postgres/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres/SKILL.md
@@ -226,15 +226,15 @@ Neon Auth is also embedded in the Neon JS SDK. Depending on your use case, you m
 
 `neon.ts` is Neon's branch config and infrastructure-as-code file: declare which services your branches have, get type-safe env vars, and program per-branch compute — all in TypeScript (see the `neon` skill for the full reference). Postgres always exists on every branch, so you never declare the database itself; what you codify here is the Postgres-adjacent surface — Neon Auth, the Data API, and per-branch compute settings (autoscaling and scale-to-zero).
 
-Add it with `@neondatabase/config`:
+Add it with `@neon/config`:
 
 ```bash
-npm i @neondatabase/config
+npm i @neon/config
 ```
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   auth: true, // Neon Auth (adds NEON_AUTH_* env vars)
@@ -270,10 +270,10 @@ Because `neonctl checkout` applies the policy as it **creates** a branch, a fres
 
 Since `neon.ts` is TypeScript, invalid combinations fail to compile with an actionable message: the Data API verifies requests with Neon Auth by default, so `dataApi: true` without `auth: true` is a type error (the fix — `auth: true`, or `authProvider: 'external'` with a `jwksUrl` — is in the message). See the `neon` skill's type-safe config note.
 
-Read the resulting env back, typed and validated against the policy, with `parseEnv` from `@neondatabase/env`:
+Read the resulting env back, typed and validated against the policy, with `parseEnv` from `@neon/env`:
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neon/env/v1";
 import config from "./neon";
 
 const env = parseEnv(config);

--- a/public/docs/ai/skills/neon/SKILL.md
+++ b/public/docs/ai/skills/neon/SKILL.md
@@ -175,9 +175,9 @@ Both avoid prompts entirely; reach for `set-context` when you have the IDs and `
 
 If env vars are injected at runtime instead of written to disk — or you simply don't want secrets in the working tree — pass `--no-env-pull` to `link` / `checkout` and supply the env another way:
 
-- `neon-env run -- <your dev command>` (from `@neondatabase/env`) fetches the branch's vars from your `neon.ts` and injects them into the child process at runtime — no `.env` file needed. This is the runtime counterpart to the on-disk `env pull`.
-- `neon-env export` (from `@neondatabase/env`) prints the branch's env to stdout as dotenv lines or, with `--format json`, JSON — for piping into another env manager rather than running a command. For example, [varlock](https://varlock.dev) can bulk-load it from a `.env.schema` with `@setValuesBulk(exec("neon-env export --format json"), format=json)`.
-- `fetchEnv` from `@neondatabase/env` is the programmatic version of the same thing: resolve the branch's env in code at runtime instead of shelling out to `neon-env run`.
+- `neon-env run -- <your dev command>` (from `@neon/env`) fetches the branch's vars from your `neon.ts` and injects them into the child process at runtime — no `.env` file needed. This is the runtime counterpart to the on-disk `env pull`.
+- `neon-env export` (from `@neon/env`) prints the branch's env to stdout as dotenv lines or, with `--format json`, JSON — for piping into another env manager rather than running a command. For example, [varlock](https://varlock.dev) can bulk-load it from a `.env.schema` with `@setValuesBulk(exec("neon-env export --format json"), format=json)`.
+- `fetchEnv` from `@neon/env` is the programmatic version of the same thing: resolve the branch's env in code at runtime instead of shelling out to `neon-env run`.
 - `neonctl dev` injects the same vars into your local dev server — it's part of Neon Functions local development (a private preview feature).
 
 When an agent should not write a local `.env`, instruct it (for example in your `AGENTS.md`) to run `neonctl checkout <branch> --no-env-pull` and rely on runtime injection.
@@ -186,15 +186,15 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Neon Infrastructure as Code
 
-`neon.ts` is Neon's branch config and infrastructure-as-code file: declare which Neon services your project's branches should have, get type-safe env vars, and program branch settings — all in TypeScript. It's the config layer for Neon as a platform, and it composes with the branch-first loop above. Add it with `@neondatabase/config`:
+`neon.ts` is Neon's branch config and infrastructure-as-code file: declare which Neon services your project's branches should have, get type-safe env vars, and program branch settings — all in TypeScript. It's the config layer for Neon as a platform, and it composes with the branch-first loop above. Add it with `@neon/config`:
 
 ```bash
-npm i @neondatabase/config
+npm i @neon/config
 ```
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   auth: true,
@@ -232,14 +232,14 @@ neonctl deploy          # alias for `neonctl config apply`
 
 ### Type-safe env vars with parseEnv
 
-`@neondatabase/env`'s `parseEnv` takes your `neon.ts` config object and returns a parsed, typed env object, validated against the services you declared. The shape of `env` follows your config — enable `auth` and you get `env.auth`, enable `dataApi` and you get `env.dataApi` — and missing variables are flagged with clear errors (for you and your agents). Use it to read env you already have (typically pulled into `.env` by `checkout` / `env pull`); for fetching env at runtime without a file, reach for `fetchEnv` / `neon-env run` instead.
+`@neon/env`'s `parseEnv` takes your `neon.ts` config object and returns a parsed, typed env object, validated against the services you declared. The shape of `env` follows your config — enable `auth` and you get `env.auth`, enable `dataApi` and you get `env.dataApi` — and missing variables are flagged with clear errors (for you and your agents). Use it to read env you already have (typically pulled into `.env` by `checkout` / `env pull`); for fetching env at runtime without a file, reach for `fetchEnv` / `neon-env run` instead.
 
 ```bash
-npm i @neondatabase/env
+npm i @neon/env
 ```
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neon/env/v1";
 import config from "./neon";
 
 const env = parseEnv(config);
@@ -251,7 +251,7 @@ console.log(env.auth.baseUrl);
 By default `parseEnv` requires _every_ variable your config implies. When a process only uses a subset — a common case in frameworks like Next.js, where you might read `DATABASE_URL` but never the unpooled URL — pass an array of env-var keys to require and return only those. The keys are typesafe: autocomplete only offers variables your config enables, and the returned shape is narrowed to exactly what you selected (so unselected variables are neither enforced nor present).
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neon/env/v1";
 import config from "./neon";
 
 // Only DATABASE_URL is required and returned; DATABASE_URL_UNPOOLED is not enforced.
@@ -273,7 +273,7 @@ Beyond services, `neon.ts` can program what configuration _new_ branches receive
 
 ```typescript
 // neon.ts
-import { defineConfig } from "@neondatabase/config/v1";
+import { defineConfig } from "@neon/config/v1";
 
 export default defineConfig({
   auth: true,

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -20,14 +20,14 @@
     "checkout": {
       "options": {
         "env-pull": {
-          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neondatabase/env`) or `neonctl dev`."
+          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`."
         }
       }
     },
     "link": {
       "options": {
         "env-pull": {
-          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neondatabase/env`) or `neonctl dev`."
+          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`."
         }
       }
     },

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1114,7 +1114,7 @@
         },
         "env-pull": {
           "type": "boolean",
-          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neondatabase/env`) or `neonctl dev`.",
+          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`.",
           "default": true
         }
       },
@@ -1188,7 +1188,7 @@
         },
         "env-pull": {
           "type": "boolean",
-          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neondatabase/env`) or `neonctl dev`.",
+          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`.",
           "default": true
         }
       },


### PR DESCRIPTION
The five Neon library packages are now published under the **`@neon`** npm org. Find-replace their references in the docs to the new names:

- `@neondatabase/config` → `@neon/config`
- `@neondatabase/config-runtime` → `@neon/config-runtime`
- `@neondatabase/env` → `@neon/env`
- `@neondatabase/functions` → `@neon/functions`
- `@neondatabase/ai-sdk-provider` → `@neon/ai-sdk-provider`

Covers `content/` docs + guides + changelog, the published skills under `public/docs/ai/skills/`, and the `neonctl` docs-check fixtures (23 files, 84 replacements).

**Not touched** (not migrated): `@neondatabase/serverless` (the Postgres driver, incl. its JSR `@neon/serverless` listing), `@neondatabase/api-client`, `@neondatabase/neon-js`.

⚠️ Hold until the `@neon/*` packages are confirmed live on npm (they are now) and you're ready to flip the public docs.