### PR TITLE
docs: point CLI docs pipeline at neon-pkgs and render `neon` binary

### DIFF
--- a/scripts/docs-checks/neonctl/__tests__/generate-docs.test.js
+++ b/scripts/docs-checks/neonctl/__tests__/generate-docs.test.js
@@ -57,13 +57,13 @@ describe('generate-docs rendering', () => {
     expect(renderSubcommands(node)).toContain('[add](#add)');
   });
 
-  it('renders usage with positional brackets and the neonctl binary', () => {
+  it('renders usage with positional brackets and the neon binary', () => {
     expect(
       renderUsage(resolveCommand(schema, ['functions', 'deploy']), ['functions', 'deploy'])
-    ).toContain('neonctl functions deploy <slug>');
+    ).toContain('neon functions deploy <slug>');
     expect(
       renderUsage(resolveCommand(schema, ['connection-string']), ['connection-string'])
-    ).toContain('neonctl connection-string [branch]');
+    ).toContain('neon connection-string [branch]');
   });
 
   it('renders the global options table with defaults, aliases, and builtins', () => {
@@ -80,7 +80,7 @@ describe('generate-docs rendering', () => {
       expect(index).toContain(`### ${name}`);
     }
     // Nested subtrees are flattened into full invocations.
-    expect(index).toContain('neonctl bucket object list');
+    expect(index).toContain('neon bucket object list');
   });
 
   it('escapes MDX-hostile characters outside inline code in table cells', () => {

--- a/scripts/docs-checks/neonctl/generate-docs.js
+++ b/scripts/docs-checks/neonctl/generate-docs.js
@@ -11,15 +11,16 @@
 // Running this file directly (`npm run gen:docs:neonctl`) emits every
 // fragment to fragments/ as a local preview of what the components render.
 //
-// The binary is documented as `neonctl`; `$0` in yargs usage strings is
-// rendered as `neonctl`.
+// The binary is documented as `neon`; `$0` in yargs usage strings is
+// rendered as `neon`. (The package ships both `neon` and `neonctl` bins;
+// docs standardize on `neon`.)
 
 const fs = require('fs');
 const path = require('path');
 
 const SCHEMA_PATH = path.join(__dirname, 'schema.json');
 const FRAGMENTS_DIR = path.join(__dirname, 'fragments');
-const BINARY = 'neonctl';
+const BINARY = 'neon';
 
 function loadSchema() {
   return JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -7,17 +7,20 @@
 // parent's help; `vpc endpoint list --help` does the same). The source
 // code is canonical.
 //
-// The source path is required — there is no default. Clone neonctl and
-// pass it explicitly so this script is reproducible across machines:
+// The source path is required — there is no default. The CLI lives in the
+// neon-pkgs monorepo under packages/cli; clone it and point --src at that
+// subdirectory (it must contain the CLI's package.json and src/commands):
 //
-//   git clone https://github.com/neondatabase/neonctl ~/src/neonctl
-//   node scripts/docs-checks/neonctl/generate-schema.js --src ~/src/neonctl
+//   git clone https://github.com/neondatabase/neon-pkgs ~/src/neon-pkgs
+//   node scripts/docs-checks/neonctl/generate-schema.js --src ~/src/neon-pkgs/packages/cli
 //
 // Or via environment variable:
 //
-//   NEONCTL_SRC=~/src/neonctl node scripts/docs-checks/neonctl/generate-schema.js
+//   NEONCTL_SRC=~/src/neon-pkgs/packages/cli node scripts/docs-checks/neonctl/generate-schema.js
 //
 // Run this whenever you upgrade the neonctl pin. Commit `schema.json`.
+// (`npm run refresh:cli-docs` automates the clone/extract and points --src
+// at packages/cli for you.)
 
 const fs = require('fs');
 const path = require('path');
@@ -724,7 +727,8 @@ function buildSchema({ src } = {}) {
 const USAGE = [
   'Usage: node scripts/docs-checks/neonctl/generate-schema.js --src <path> [--out <file>]',
   '',
-  '  --src <path>   Path to a local clone of https://github.com/neondatabase/neonctl',
+  '  --src <path>   Path to the CLI package in a neon-pkgs clone,',
+  '                 e.g. ~/src/neon-pkgs/packages/cli',
   '                 (or set the NEONCTL_SRC environment variable).',
   '  --out <file>   Where to write the schema JSON. Defaults to the committed',
   '                 schema.json next to this script.',
@@ -748,7 +752,7 @@ function main() {
   }
   if (!src) {
     console.error(
-      'Missing --src (or NEONCTL_SRC env var). Point it at a local clone of https://github.com/neondatabase/neonctl.\n'
+      'Missing --src (or NEONCTL_SRC env var). Point it at packages/cli in a clone of https://github.com/neondatabase/neon-pkgs.\n'
     );
     console.error(USAGE);
     process.exit(2);
@@ -756,7 +760,7 @@ function main() {
   const resolvedSrc = path.resolve(src);
   if (!fs.existsSync(path.join(resolvedSrc, 'src', 'commands'))) {
     console.error(
-      `No neonctl source found at ${resolvedSrc}. Expected a clone of https://github.com/neondatabase/neonctl with a \`src/commands\` directory.`
+      `No neonctl source found at ${resolvedSrc}. Expected the CLI package (packages/cli in a https://github.com/neondatabase/neon-pkgs clone) with a \`src/commands\` directory.`
     );
     process.exit(2);
   }

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -5,14 +5,14 @@
       "describe": "Show help for a command or subcommand"
     },
     "api-key": {
-      "describe": "Neon API key, authenticates without `neonctl auth`",
+      "describe": "Neon API key, authenticates without `neon auth`",
       "defaultText": "NEON_API_KEY environment variable"
     },
     "config-dir": {
       "defaultText": "~/.config/neonctl (or $XDG_CONFIG_HOME/neonctl)"
     },
     "context-file": {
-      "describe": "Context file with default org, project, and branch IDs, created by `neonctl link`",
+      "describe": "Context file with default org, project, and branch IDs, created by `neon link`",
       "defaultText": "nearest .neon file, searching upward from the current directory"
     }
   },
@@ -20,14 +20,14 @@
     "checkout": {
       "options": {
         "env-pull": {
-          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`."
+          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neon dev`."
         }
       }
     },
     "link": {
       "options": {
         "env-pull": {
-          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`."
+          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neon dev`."
         }
       }
     },

--- a/scripts/docs-checks/neonctl/refresh.js
+++ b/scripts/docs-checks/neonctl/refresh.js
@@ -3,10 +3,15 @@
 //
 //   npm run refresh:cli-docs
 //
+// The CLI source lives in the neon-pkgs monorepo (packages/cli); its
+// releases are tagged `neonctl@<version>`. The published npm package and
+// its `neonctlVersion` schema field are still named `neonctl`, though the
+// CLI is now documented and invoked as `neon` (the package ships both bins).
+//
 // What it does:
-//   1. Looks up the latest neonctl release tag on GitHub (no clone needed).
+//   1. Looks up the latest `neonctl@*` release tag on GitHub (no clone needed).
 //   2. Downloads and extracts the release tarball to a temp directory.
-//   3. Regenerates schema.json from it (generate-schema.js + overrides.json).
+//   3. Regenerates schema.json from packages/cli (generate-schema.js + overrides.json).
 //   4. Prints a summary of command/option additions and removals vs the
 //      previously committed schema.
 //   5. Runs the validation + generation test suite.
@@ -20,7 +25,11 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const REPO = 'neondatabase/neonctl';
+const REPO = 'neondatabase/neon-pkgs';
+// Monorepo release tags are `<package>@<version>`; the CLI uses this prefix.
+const TAG_PREFIX = 'neonctl@';
+// The CLI package lives under this subdirectory of the repo tarball.
+const CLI_SUBDIR = path.join('packages', 'cli');
 const SCHEMA_PATH = path.join(__dirname, 'schema.json');
 
 // When the CLI ships a rename, docs may lag. List preferred names here:
@@ -32,28 +41,58 @@ const PREFER_ALIAS = {
   function: 'functions', // neonctl 2.26.5 renamed functions→function; revert when docs catch up
 };
 
+// The monorepo publishes releases for many packages, so `/releases/latest`
+// is not necessarily the CLI. List releases and pick the highest-versioned
+// `neonctl@*` tag.
+function compareSemver(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+  }
+  return 0;
+}
+
 async function latestTag() {
-  const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, {
     headers: { accept: 'application/vnd.github+json' },
   });
-  if (!res.ok) throw new Error(`GitHub API ${res.status} fetching latest release`);
-  const release = await res.json();
-  if (!release.tag_name) throw new Error('Latest release has no tag_name');
-  return release.tag_name;
+  if (!res.ok) throw new Error(`GitHub API ${res.status} fetching releases`);
+  const releases = await res.json();
+  const cliTags = releases
+    .map((r) => r.tag_name)
+    .filter((t) => t && t.startsWith(TAG_PREFIX))
+    // Stable releases only; skip pre-release versions (e.g. 2.30.0-beta.1).
+    .filter((t) => !t.slice(TAG_PREFIX.length).includes('-'));
+  if (cliTags.length === 0) {
+    throw new Error(`No ${TAG_PREFIX}* releases found on ${REPO}`);
+  }
+  cliTags.sort((a, b) => compareSemver(a.slice(TAG_PREFIX.length), b.slice(TAG_PREFIX.length)));
+  return cliTags[cliTags.length - 1];
 }
 
 async function downloadTarball(tag, destDir) {
-  const url = `https://codeload.github.com/${REPO}/tar.gz/refs/tags/${tag}`;
+  // Tags contain `@` (e.g. neonctl@2.29.2); encode it for the codeload path.
+  const url = `https://codeload.github.com/${REPO}/tar.gz/refs/tags/${encodeURIComponent(tag)}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Tarball download failed: ${res.status} for ${url}`);
   const tarPath = path.join(destDir, 'neonctl.tar.gz');
   fs.writeFileSync(tarPath, Buffer.from(await res.arrayBuffer()));
   execSync(`tar -xzf ${JSON.stringify(tarPath)} -C ${JSON.stringify(destDir)}`);
+  // GitHub names the extracted dir after the repo and tag, replacing `/` and
+  // `@` with `-` (e.g. neon-pkgs-neonctl-2.29.2). Match the repo prefix.
+  const repoName = REPO.split('/')[1];
   const extracted = fs
     .readdirSync(destDir)
-    .find((d) => d.startsWith('neonctl-') && fs.statSync(path.join(destDir, d)).isDirectory());
-  if (!extracted) throw new Error('Could not find extracted neonctl directory');
-  return path.join(destDir, extracted);
+    .find((d) => d.startsWith(`${repoName}-`) && fs.statSync(path.join(destDir, d)).isDirectory());
+  if (!extracted) throw new Error(`Could not find extracted ${repoName} directory`);
+  // The CLI package is a subdirectory of the monorepo; generate-schema.js
+  // expects a path whose `src/commands` and `package.json` are the CLI's.
+  const cliDir = path.join(destDir, extracted, CLI_SUBDIR);
+  if (!fs.existsSync(cliDir)) {
+    throw new Error(`Extracted tarball is missing ${CLI_SUBDIR} (looked in ${extracted})`);
+  }
+  return cliDir;
 }
 
 // Flattens a schema's command tree into "path --option" keys for diffing.
@@ -130,7 +169,7 @@ async function main() {
   console.log(`Committed schema: neonctl ${before.neonctlVersion}`);
 
   const tag = await latestTag();
-  console.log(`Latest release:   neonctl ${tag.replace(/^v/, '')}`);
+  console.log(`Latest release:   neonctl ${tag.replace(new RegExp(`^${TAG_PREFIX}`), '')}`);
 
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'neonctl-refresh-'));
   try {

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -15,12 +15,12 @@
     },
     "api-key": {
       "type": "string",
-      "describe": "Neon API key, authenticates without `neonctl auth`",
+      "describe": "Neon API key, authenticates without `neon auth`",
       "defaultText": "NEON_API_KEY environment variable"
     },
     "context-file": {
       "type": "string",
-      "describe": "Context file with default org, project, and branch IDs, created by `neonctl link`",
+      "describe": "Context file with default org, project, and branch IDs, created by `neon link`",
       "defaultText": "nearest .neon file, searching upward from the current directory"
     },
     "color": {
@@ -1114,7 +1114,7 @@
         },
         "env-pull": {
           "type": "boolean",
-          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`.",
+          "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neon dev`.",
           "default": true
         }
       },
@@ -1188,7 +1188,7 @@
         },
         "env-pull": {
           "type": "boolean",
-          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neonctl dev`.",
+          "describe": "Pull the linked branch's Neon env vars (DATABASE_URL, ...) into a local .env after linking. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neon dev`.",
           "default": true
         }
       },

--- a/src/components/pages/doc/cli-reference/cli-command-index/cli-command-index.jsx
+++ b/src/components/pages/doc/cli-reference/cli-command-index/cli-command-index.jsx
@@ -16,7 +16,7 @@ import CommandIndexClient from './command-index-client';
 import { GROUPS, GROUP_OF, HREF_OVERRIDES } from './groups';
 import META from './meta';
 
-const BINARY = 'neonctl';
+const BINARY = 'neon';
 
 // CLI-authored .example() strings from the command's subtree (depth first,
 // up to three) — the automatic example source. Curated meta examples

--- a/src/components/pages/doc/cli-reference/cli-command-index/command-index-client.jsx
+++ b/src/components/pages/doc/cli-reference/cli-command-index/command-index-client.jsx
@@ -106,7 +106,7 @@ const CommandIndexClient = ({ groups }) => {
     <div className="not-prose my-6 overflow-hidden rounded-lg border border-gray-new-90 bg-gray-new-98 dark:border-gray-new-15 dark:bg-black-new">
       <div className="flex items-center justify-between border-b border-gray-new-90 bg-white px-4 py-2 dark:border-white/10 dark:bg-white/[0.03]">
         <span className="font-mono text-xs text-gray-new-40 dark:text-gray-new-60">
-          neonctl — commands
+          neon commands
         </span>
         <button
           className="rounded border border-secondary-8/40 px-2.5 py-0.5 font-mono text-[11px] font-semibold text-secondary-8 hover:border-secondary-8 dark:border-green-45/60 dark:text-green-45 dark:hover:border-green-45"

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -12,94 +12,88 @@
 // each one against schema.json, so a CLI change that invalidates an
 // example fails the test suite.
 const META = {
-  auth: { desc: 'Browser OAuth; stores credentials locally.', examples: ['neonctl auth'] },
+  auth: { desc: 'Browser OAuth; stores credentials locally.', examples: ['neon auth'] },
   init: {
     desc: 'Wire up MCP, agent skills, and editor (Cursor/VS Code/Claude).',
     examples: ['npx neonctl@latest init'],
   },
   link: {
     desc: 'Bind the directory to a project; writes .neon and pulls env.',
-    examples: [
-      'neonctl link',
-      'neonctl link --org-id org-abc --project-id polished-snowflake-1234',
-    ],
+    examples: ['neon link', 'neon link --org-id org-abc --project-id polished-snowflake-1234'],
   },
   checkout: {
     desc: 'Pin a branch in .neon; auto-pulls its env vars.',
-    examples: ['neonctl checkout feat/auth'],
+    examples: ['neon checkout feat/auth'],
   },
   env: {
     desc: "Write the branch's DATABASE_URL + Neon vars to .env.",
-    examples: ['neonctl env pull'],
+    examples: ['neon env pull'],
   },
   'set-context': {
     desc: 'Write org/project/branch context to .neon.',
-    examples: ['neonctl set-context --project-id polished-snowflake-1234'],
+    examples: ['neon set-context --project-id polished-snowflake-1234'],
   },
-  me: { desc: 'Show the authenticated user.', examples: ['neonctl me'] },
+  me: { desc: 'Show the authenticated user.', examples: ['neon me'] },
   completion: { desc: 'Generate a shell completion script.' },
-  projects: { desc: 'Manage projects.', examples: ['neonctl projects list'] },
+  projects: { desc: 'Manage projects.', examples: ['neon projects list'] },
   branches: {
     desc: 'Create, diff, reset, restore, and manage branches.',
     examples: [
-      'neonctl branches create --name feat/auth --parent main',
-      'neonctl branches restore main ^self@2024-05-06T10:00:00Z --preserve-under-name backup',
-      'neonctl branches schema-diff production development',
+      'neon branches create --name feat/auth --parent main',
+      'neon branches restore main ^self@2024-05-06T10:00:00Z --preserve-under-name backup',
+      'neon branches schema-diff production development',
     ],
   },
   databases: {
     desc: 'Manage databases on a branch.',
-    examples: ['neonctl databases create --name analytics'],
+    examples: ['neon databases create --name analytics'],
   },
-  roles: { desc: 'Manage Postgres roles.', examples: ['neonctl roles create --name app_user'] },
-  operations: { desc: 'Inspect async operations.', examples: ['neonctl operations list'] },
+  roles: { desc: 'Manage Postgres roles.', examples: ['neon roles create --name app_user'] },
+  operations: { desc: 'Inspect async operations.', examples: ['neon operations list'] },
   'connection-string': {
     desc: 'Print a connection URI for a branch/role/db.',
-    examples: [
-      'neonctl connection-string main',
-      'neonctl connection-string main --pooled --prisma',
-    ],
+    examples: ['neon connection-string main', 'neon connection-string main --pooled --prisma'],
   },
   psql: {
     desc: 'Open a SQL session (embedded psql fallback built in).',
-    examples: ['neonctl psql main -- -c "SELECT 1"'],
+    examples: ['neon psql main -- -c "SELECT 1"'],
   },
   config: {
     desc: 'Drive a branch from a neon.ts policy.',
-    examples: ['neonctl config apply'],
+    examples: ['neon config apply'],
   },
   deploy: {
     desc: 'Alias for config apply; reconciles the policy.',
-    examples: ['neonctl deploy'],
+    examples: ['neon deploy'],
   },
   dev: {
     desc: 'Run Neon Functions locally with hot reload + branch env.',
-    examples: ['neonctl dev'],
+    examples: ['neon dev'],
   },
   functions: {
     desc: 'Deploy and manage Neon Functions on a branch.',
-    examples: ['neonctl functions deploy api --src ./api.ts'],
+    examples: ['neon functions deploy api --src ./api.ts'],
   },
   bucket: {
     desc: 'Branch-scoped object storage and its objects.',
-    examples: ['neonctl bucket create my-assets'],
+    examples: ['neon bucket create my-assets'],
   },
   'data-api': {
     desc: 'Manage the Neon Data API for a database.',
-    examples: ['neonctl data-api create'],
+    examples: ['neon data-api create'],
   },
   'neon-auth': {
     desc: 'Manage Neon Auth on a branch.',
-    examples: ['neonctl neon-auth enable'],
+    examples: ['neon neon-auth enable'],
   },
-  orgs: { desc: 'List organizations you belong to.', examples: ['neonctl orgs list'] },
+  orgs: { desc: 'List organizations you belong to.', examples: ['neon orgs list'] },
   'ip-allow': {
     desc: 'Manage the project IP allowlist.',
-    examples: ['neonctl ip-allow add 203.0.113.0/24'],
+    examples: ['neon ip-allow add 203.0.113.0/24'],
   },
   vpc: {
     desc: 'Manage VPC endpoints and project restrictions.',
-    examples: ['neonctl vpc endpoint list'],
+    examples: ['neon vpc endpoint list'],
   },
 };
 

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.test.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.test.js
@@ -22,6 +22,7 @@ describe('cli-command-index meta', () => {
       const tokens = example
         .replace(/^npx neonctl@latest\s+/, '')
         .replace(/^neonctl\s+/, '')
+        .replace(/^neon\s+/, '')
         .split(/\s+/);
 
       // Walk the command path, collecting option pools along the way.

--- a/src/scripts/process-md-for-llms.test.js
+++ b/src/scripts/process-md-for-llms.test.js
@@ -985,7 +985,7 @@ describe('CLI reference components', () => {
         '',
         '<CliSubcommands command="projects" />',
         '',
-        '### neonctl projects create (#create)',
+        '### neon projects create (#create)',
         '',
         '<CliUsage command="projects create" />',
         '',
@@ -1002,10 +1002,10 @@ describe('CLI reference components', () => {
     expect(result).toContain('`--name`');
     expect(result).toMatch(/\|\s+No\s+\|/);
     // Custom anchor IDs are stripped from heading text in the mirror
-    expect(result).toContain('### neonctl projects create');
+    expect(result).toContain('### neon projects create');
     expect(result).not.toContain('(#create)');
     // Synopsis
-    expect(result).toContain('neonctl projects create [options]');
+    expect(result).toContain('neon projects create [options]');
     // Subcommand table links
     expect(result).toContain('#create');
     // Inherited options appear in leaf tables; only-global commands render nothing
@@ -1030,7 +1030,7 @@ describe('CLI reference components', () => {
       expect(result).toContain(`### ${name}`);
     }
     // Nested subtrees flatten to full invocations
-    expect(result).toContain('neonctl bucket object list');
+    expect(result).toContain('neon bucket object list');
     expect(result).not.toContain('<CliCommandIndex');
   });
 });


### PR DESCRIPTION
## What

The neonctl CLI source moved to the [neon-pkgs](https://github.com/neondatabase/neon-pkgs) monorepo (`packages/cli`, released with `neonctl@<version>` tags); the old `neondatabase/neonctl` repo is now archived. This updates the CLI-docs generation pipeline to fetch from there, and renders the binary as `neon` to match the doc prose (following #5184). The package ships both `neon` and `neonctl` bins, so both invocations work.

## Changes

- **`refresh.js`**: fetch from `neon-pkgs`, pick the highest stable `neonctl@*` release tag (semver-sorted, prereleases skipped), extract `packages/cli` as the schema source.
- **`generate-schema.js`**: document the `packages/cli` `--src` path in usage/errors.
- **`generate-docs.js` + `cli-command-index.jsx`**: rendered binary `neonctl` → `neon`.
- **Command index header**: `neon commands`.
- **`meta.js` examples** and **editorial describe strings** (`overrides.json` + `schema.json`) flipped to `neon`; the `~/.config/neonctl` config path is preserved (that dir name is unchanged).
- **Tests** updated for the `neon` binary.

## Scope

- Schema stays pinned at **2.26.6** (no version bump). Two upstream CLI-help strings (`neonctl checkout`, the set-context deprecation notice) are left as-is; they'll be fixed in the CLI itself separately.
- The 2.29.2 schema bump and its command drift (`bucket` → `buckets`, new `status` command) will land in a follow-up PR.

## Testing

Full unit suite passes (292 tests). `npm run refresh:cli-docs` verified end-to-end against neon-pkgs (fetches, extracts `packages/cli`, regenerates schema).

This pull request and its description were written by Isaac.