### PR TITLE
docs: bump neon cli node requirement to v20

### DIFF
--- a/content/docs/cli/install.md
+++ b/content/docs/cli/install.md
@@ -9,7 +9,7 @@ summary: >-
   Vercel-Managed Integration users must use an API key because web auth requires
   a Neon-registered account.
 enableTableOfContents: true
-updatedOn: '2026-07-02T13:13:39.256Z'
+updatedOn: '2026-07-02T22:08:19.260Z'
 redirectFrom:
   - /docs/reference/cli-install
 ---
@@ -34,7 +34,7 @@ brew install neonctl
 npm i -g neon
 ```
 
-Requires [Node.js 22](https://nodejs.org/en/download/) or higher.
+Requires [Node.js 20](https://nodejs.org/en/download/) or higher.
 
 **Install with bun**
 
@@ -66,7 +66,7 @@ neon <command> [options]
 npm i -g neon
 ```
 
-Requires [Node.js 22](https://nodejs.org/en/download/) or higher.
+Requires [Node.js 20](https://nodejs.org/en/download/) or higher.
 
 **Install with bun**
 

--- a/content/docs/cli/install.md
+++ b/content/docs/cli/install.md
@@ -34,7 +34,7 @@ brew install neonctl
 npm i -g neon
 ```
 
-Requires [Node.js 18.0](https://nodejs.org/en/download/) or higher.
+Requires [Node.js 22](https://nodejs.org/en/download/) or higher.
 
 **Install with bun**
 
@@ -66,7 +66,7 @@ neon <command> [options]
 npm i -g neon
 ```
 
-Requires [Node.js 18.0](https://nodejs.org/en/download/) or higher.
+Requires [Node.js 22](https://nodejs.org/en/download/) or higher.
 
 **Install with bun**
 

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -7,7 +7,7 @@ summary: >-
   neon deploy. The function gets a public HTTPS URL with DATABASE_URL
   injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-06-24T23:12:20.545Z'
+updatedOn: '2026-07-01T17:19:05.132Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -20,7 +20,7 @@ A function takes a request and returns a web response, running on long-lived Nod
 
 - A Neon account with Functions preview access. See [Preview access](/docs/compute/functions/preview-access).
 - The latest `neon`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neon@latest`).
-- Node.js 18 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
+- Node.js 22 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
 Functions are available on new projects in AWS us-east-2 only, created on or after June 15, 2026.
 

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -7,7 +7,7 @@ summary: >-
   neon deploy. The function gets a public HTTPS URL with DATABASE_URL
   injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-07-01T17:19:05.132Z'
+updatedOn: '2026-07-02T22:08:19.260Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -20,7 +20,7 @@ A function takes a request and returns a web response, running on long-lived Nod
 
 - A Neon account with Functions preview access. See [Preview access](/docs/compute/functions/preview-access).
 - The latest `neon`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neon@latest`).
-- Node.js 22 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
+- Node.js 20 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
 Functions are available on new projects in AWS us-east-2 only, created on or after June 15, 2026.
 


### PR DESCRIPTION
Bumps the documented Node.js floor from 18 to 20 for the Neon CLI and Neon Functions.