### PR TITLE
docs: revise Azure regions deprecation guide for Oct 5 timeline

### DIFF
--- a/content/docs/import/azure-regions-deprecation.md
+++ b/content/docs/import/azure-regions-deprecation.md
@@ -63,6 +63,10 @@ If none of these fit, [export your data in Postgres-compatible form](/docs/guide
 
 ## Frequently asked questions
 
+### Why are these regions being deprecated?
+
+We're focusing our infrastructure investment where our customers want to run Neon. Most Neon projects run in AWS regions, so concentrating there lets us ship features and reliability improvements faster, rather than splitting effort to maintain Azure in parallel. For teams that need Azure, Databricks Lakebase runs the same Postgres technology as Neon and supports Azure regions.
+
 ### How do I find out which region a project is in?
 
 You can check from the Console, the CLI, or the API:

--- a/content/docs/import/azure-regions-deprecation.md
+++ b/content/docs/import/azure-regions-deprecation.md
@@ -2,13 +2,13 @@
 title: Azure regions deprecation
 subtitle: What's changing, what to do, and answers to common questions
 summary: >-
-  Neon Azure regions (azure-eastus2, azure-westus3, azure-gwc) are deprecated:
-  new project creation is blocked, and existing projects enter maintenance mode.
-  On October 5, 2026, projects in Free organizations that have been inactive for
-  90 days or more are subject to deletion; active and paid projects keep running.
-  This guide covers the timeline, what to do (migrate to a Neon AWS region,
-  migrate to Databricks Lakebase, delete, or export), and how to confirm which
-  region a project is in.
+  Neon Azure regions (azure-eastus2, azure-westus3, azure-gwc) were deprecated on
+  April 7, 2026: new project creation is blocked. After October 5, 2026, these
+  regions stop receiving Neon feature updates, and projects in Free organizations
+  inactive for 90 days or more are subject to deletion; active and paid projects
+  keep running. This guide covers the timeline, what to do (migrate to a Neon AWS
+  region, migrate to Databricks Lakebase, delete, or export), and how to confirm
+  which region a project is in.
 enableTableOfContents: true
 ---
 
@@ -20,9 +20,9 @@ We recommend [migrating projects in Azure regions to another region](#what-to-do
 
 As of April 7, 2026, Neon's Azure regions are deprecated, and you can no longer create new projects in those regions.
 
-On **October 5, 2026**, these regions enter maintenance mode and may not receive new Neon feature updates. Also on October 5, projects on Free plans that have been inactive for 90 days or more are subject to deletion.
+After **October 5, 2026**, these regions will not receive Neon feature updates. Also on October 5, projects on Free plans that have been inactive for 90 days or more are subject to deletion.
 
-You should receive a personalized email about your specific projects and next steps. This guide explains what's changing and what to do.
+Users with projects in Neon Azure regions will receive a personalized email about specific projects and next steps. This guide explains what's changing and what to do.
 
 ## Affected regions
 
@@ -36,29 +36,19 @@ Projects in AWS regions are not affected.
 
 ## Deprecation timeline
 
-| Date                      | What happens                                                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **April 7, 2026**         | Azure regions deprecated. New projects cannot be created in Azure regions. Existing projects keep running.                                                                      |
-| **October 5, 2026**       | Azure regions enter maintenance mode and may not receive new Neon features. Projects in Free organizations that have been inactive for 90 days or more are subject to deletion. |
-| **After October 5, 2026** | A full end-of-support date will be announced in the future.                                                                                                                     |
-
-## What this means for existing projects in Azure regions
-
-Projects in Azure regions should be migrated to alternate regions before October 5, 2026. Migrating now keeps your project on actively developed infrastructure and lets you act on your own schedule rather than a future deadline.
-
-Existing projects will continue to run, but after October 5, 2026 they may not receive new Neon features or capabilities.
-
-## What happens on October 5, 2026
-
-Projects on the Free plan with no compute activity for 90 days or more are subject to deletion as of October 5, 2026. Deletion is permanent; a deleted project and its data cannot be recovered. Active projects and projects on paid plans will not be deleted.
-
-To keep an inactive Free project beyond October 5, 2026, connect to its database and run any SQL query. Any compute activity resets the 90-day inactivity timer. Organization administrators will be notified before any project is deleted.
+| Date                      | What happens                                                                                                                                          |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **April 7, 2026**         | Azure regions deprecated. New projects cannot be created in Azure regions. Existing projects keep running.                                            |
+| **October 5, 2026**       | Azure regions will not receive new Neon features. Projects in Free organizations that have been inactive for 90 days or more are subject to deletion. |
+| **After October 5, 2026** | A final end-of-service date will be announced.                                                                                                        |
 
 ## What to do next
 
-There are three options for moving your Neon projects off of Azure regions.
+**Migrate any projects you want to keep to an alternate region before October 5, 2026.** Migrating now keeps your project on actively developed infrastructure and lets you act on your own schedule.
 
-1. **Migrate to a Neon AWS region.** Best if you don't need Azure residency, and an AWS region in a nearby city will suffice. See [Migrate to another Neon region](/docs/import/migrate-neon-to-another-region).
+There are three options for moving your Neon projects off of Azure regions:
+
+1. **Migrate to a Neon AWS region.** Best if you don't need Azure data residency, and an AWS region in a similar location will suffice. See [Migrate to another Neon region](/docs/import/migrate-neon-to-another-region).
 2. **Migrate to Databricks Lakebase.** Best if you need to keep your Postgres data in Azure. Lakebase is powered by the same serverless Postgres technology as Neon, under the Databricks product line, and supports the deprecated Azure regions. See [Migrate Neon to Lakebase](/docs/guides/migrate-neon-to-lakebase).
 3. **Delete the project** if you no longer need it. This stops storage costs from accruing. See [Delete a project](/docs/manage/projects#delete-a-project).
 

--- a/content/docs/import/azure-regions-deprecation.md
+++ b/content/docs/import/azure-regions-deprecation.md
@@ -12,42 +12,45 @@ summary: >-
 enableTableOfContents: true
 ---
 
-Neon Azure regions are deprecated, and you can no longer create new projects in these regions.
+<Admonition type="warning">
+Neon Azure regions were deprecated on April 7, 2026.
 
-If you have active or paid projects in Azure regions, they will go through the deprecation process outlined below and may not receive new Neon features going forward.
+We recommend [migrating projects in Azure regions to another region](#what-to-do-next) by **October 5, 2026**.
+</Admonition>
 
-Inactive projects in Free organizations will be subject to deletion as of **October 5, 2026.**
+As of April 7, 2026, Neon's Azure regions are deprecated, and you can no longer create new projects in those regions.
 
-You should receive personalized email about your specific projects and next steps. This guide explains what's changing and what to do.
+On **October 5, 2026**, these regions enter maintenance mode and may not receive new Neon feature updates. Also on October 5, projects on Free plans that have been inactive for 90 days or more are subject to deletion.
+
+You should receive a personalized email about your specific projects and next steps. This guide explains what's changing and what to do.
 
 ## Affected regions
 
 Only projects in these Azure regions are affected:
 
-- azure-eastus2 (Virginia)
-- azure-westus3 (Phoenix)
-- azure-gwc (Frankfurt)
+- 🇺🇸 Azure East US 2 (Virginia) - `azure-eastus2`
+- 🇺🇸 Azure West US 3 (Phoenix) - `azure-westus3`
+- 🇩🇪 Azure Germany West Central (Frankfurt) - `azure-gwc`
 
 Projects in AWS regions are not affected.
 
 ## Deprecation timeline
 
-| Date                  | What happens                                                                                                                                                           |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| April 7, 2026         | Azure regions deprecated. New projects cannot be created in Azure regions. Existing projects keep running.                                                             |
-| July 6, 2026          | Migration window begins.                                                                                                                                               |
-| October 5, 2026       | Migration window ends. Projects in Free organizations that have been inactive for 90 days or more are subject to deletion.                                             |
-| After October 5, 2026 | Azure regions remain in maintenance mode, and projects in these regions may not receive new Neon features. A full end-of-support date will be announced in the future. |
+| Date                      | What happens                                                                                                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **April 7, 2026**         | Azure regions deprecated. New projects cannot be created in Azure regions. Existing projects keep running.                                                                      |
+| **October 5, 2026**       | Azure regions enter maintenance mode and may not receive new Neon features. Projects in Free organizations that have been inactive for 90 days or more are subject to deletion. |
+| **After October 5, 2026** | A full end-of-support date will be announced in the future.                                                                                                                     |
 
 ## What this means for existing projects in Azure regions
 
 Projects in Azure regions should be migrated to alternate regions before October 5, 2026. Migrating now keeps your project on actively developed infrastructure and lets you act on your own schedule rather than a future deadline.
 
-Existing projects will continue to run, though they may not receive new Neon features or capabilities.
+Existing projects will continue to run, but after October 5, 2026 they may not receive new Neon features or capabilities.
 
 ## What happens on October 5, 2026
 
-Projects on the Free plan with no compute activity for 90 days or more will start to be deleted on October 5, 2026. Deletion is permanent; a deleted project and its data cannot be recovered. Active projects and projects on paid plans will not be deleted.
+Projects on the Free plan with no compute activity for 90 days or more are subject to deletion as of October 5, 2026. Deletion is permanent; a deleted project and its data cannot be recovered. Active projects and projects on paid plans will not be deleted.
 
 To keep an inactive Free project beyond October 5, 2026, connect to its database and run any SQL query. Any compute activity resets the 90-day inactivity timer. Organization administrators will be notified before any project is deleted.
 
@@ -65,7 +68,7 @@ If none of these fit, [export your data in Postgres-compatible form](/docs/guide
 
 ### Why are these regions being deprecated?
 
-We're focusing our infrastructure investment where our customers want to run Neon. Most Neon projects run in AWS regions, so concentrating there lets us ship features and reliability improvements faster, rather than splitting effort to maintain Azure in parallel. For teams that need Azure, Databricks Lakebase runs the same Postgres technology as Neon and supports Azure regions.
+We're focusing our infrastructure investment where our customers want to run Neon. Most Neon projects run in AWS regions, so concentrating there lets us ship features and reliability improvements faster, rather than splitting effort to maintain Azure in parallel. For teams that need Azure, [Databricks Lakebase](/docs/guides/migrate-neon-to-lakebase) runs the same Postgres technology as Neon and supports Azure regions.
 
 ### How do I find out which region a project is in?
 
@@ -76,6 +79,18 @@ You can check from the Console, the CLI, or the API:
 - **API.** Call `GET /projects` and check the `region_id` field on each project.
 
 ![Project settings widget showing the project region](/docs/import/azure-regions-deprecation/project-settings-region.png)
+
+### Which AWS region should I migrate to?
+
+To keep latency similar, choose the AWS region closest to your current Azure region. For the deprecated Azure regions, the nearest AWS equivalents are:
+
+| Azure region                                            | Nearest AWS region                             |
+| ------------------------------------------------------- | ---------------------------------------------- |
+| 🇺🇸 Azure East US 2 (Virginia) - `azure-eastus2`         | 🇺🇸 AWS US East (N. Virginia) - `aws-us-east-1` |
+| 🇺🇸 Azure West US 3 (Phoenix) - `azure-westus3`          | 🇺🇸 AWS US West (Oregon) - `aws-us-west-2`      |
+| 🇩🇪 Azure Germany West Central (Frankfurt) - `azure-gwc` | 🇩🇪 AWS Europe (Frankfurt) - `aws-eu-central-1` |
+
+If your workload has specific latency or data residency requirements, pick the region closest to your users.
 
 ### What changes about my project when I migrate to a new region?
 

--- a/content/docs/import/azure-regions-deprecation.md
+++ b/content/docs/import/azure-regions-deprecation.md
@@ -2,41 +2,66 @@
 title: Azure regions deprecation
 subtitle: What's changing, what to do, and answers to common questions
 summary: >-
-  Neon Azure regions (azure-eastus2, azure-westus3, azure-gwc) were deprecated
-  on April 7, 2026: new project creation is blocked, but existing projects keep
-  running with no end-of-support date currently set. Readers who need to act can
-  delete the project, migrate to a Neon AWS region, or move to Databricks
-  Lakebase to retain Azure data residency. The page also covers how to confirm
-  which region a project is in via the Console, CLI, or API, and what changes
-  when migrating, including new hostnames and project IDs.
+  Neon Azure regions (azure-eastus2, azure-westus3, azure-gwc) are deprecated:
+  new project creation is blocked, and existing projects enter maintenance mode.
+  On October 5, 2026, projects in Free organizations that have been inactive for
+  90 days or more are subject to deletion; active and paid projects keep running.
+  This guide covers the timeline, what to do (migrate to a Neon AWS region,
+  migrate to Databricks Lakebase, delete, or export), and how to confirm which
+  region a project is in.
 enableTableOfContents: true
 ---
 
-Neon Azure regions are deprecated. You can no longer create new projects in Azure regions, but existing Azure projects continue to be supported until further notice. This guide explains what the deprecation means and what actions are available if you have active projects in Azure regions.
+Neon Azure regions are deprecated, and you can no longer create new projects in these regions.
 
-You should receive personalized email communication about your specific projects and next steps. This guide answers common questions and provides general guidance during the deprecation.
+If you have active or paid projects in Azure regions, they will go through the deprecation process outlined below and may not receive new Neon features going forward.
 
-## What changed
+Inactive projects in Free organizations will be subject to deletion as of **October 5, 2026.**
 
-As of **April 7, 2026**, Azure regions are deprecated and new project creation in Azure regions is restricted. Existing projects keep running normally and remain supported until further notice. There is no end-of-support date today. If that changes, we'll give you advance notice and time to migrate.
+You should receive personalized email about your specific projects and next steps. This guide explains what's changing and what to do.
 
-We'll contact organizations with active Azure projects directly to discuss migration options and timelines.
+## Affected regions
 
-## What to do
+Only projects in these Azure regions are affected:
 
-Your existing Azure projects keep running, so there's no immediate action to take. If you'd like to move off Azure, you have three options:
+- azure-eastus2 (Virginia)
+- azure-westus3 (Phoenix)
+- azure-gwc (Frankfurt)
 
-1. **Delete the project** if you no longer need it. This also stops storage costs from accruing. See [Delete a project](/docs/manage/projects#delete-a-project).
-2. **Migrate to a Neon AWS region.** Best if you don't need Azure residency. See [Migrate to another Neon region](/docs/import/migrate-neon-to-another-region) for the available migration methods.
-3. **Migrate to Databricks Lakebase.** Best if you need to keep your Postgres data in Azure. Lakebase is powered by the same serverless Postgres technology as Neon, under the Databricks product line. See [Migrate Neon to Lakebase](/docs/guides/migrate-neon-to-lakebase).
+Projects in AWS regions are not affected.
 
-If none of these fit your requirements, [export your data in Postgres-compatible form](/docs/guides/export-neon-postgres-compatible) so you can move it elsewhere.
+## Deprecation timeline
+
+| Date                  | What happens                                                                                                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| April 7, 2026         | Azure regions deprecated. New projects cannot be created in Azure regions. Existing projects keep running.                                                             |
+| July 6, 2026          | Migration window begins.                                                                                                                                               |
+| October 5, 2026       | Migration window ends. Projects in Free organizations that have been inactive for 90 days or more are subject to deletion.                                             |
+| After October 5, 2026 | Azure regions remain in maintenance mode, and projects in these regions may not receive new Neon features. A full end-of-support date will be announced in the future. |
+
+## What this means for existing projects in Azure regions
+
+Projects in Azure regions should be migrated to alternate regions before October 5, 2026. Migrating now keeps your project on actively developed infrastructure and lets you act on your own schedule rather than a future deadline.
+
+Existing projects will continue to run, though they may not receive new Neon features or capabilities.
+
+## What happens on October 5, 2026
+
+Projects on the Free plan with no compute activity for 90 days or more will start to be deleted on October 5, 2026. Deletion is permanent; a deleted project and its data cannot be recovered. Active projects and projects on paid plans will not be deleted.
+
+To keep an inactive Free project beyond October 5, 2026, connect to its database and run any SQL query. Any compute activity resets the 90-day inactivity timer. Organization administrators will be notified before any project is deleted.
+
+## What to do next
+
+There are three options for moving your Neon projects off of Azure regions.
+
+1. **Migrate to a Neon AWS region.** Best if you don't need Azure residency, and an AWS region in a nearby city will suffice. See [Migrate to another Neon region](/docs/import/migrate-neon-to-another-region).
+2. **Migrate to Databricks Lakebase.** Best if you need to keep your Postgres data in Azure. Lakebase is powered by the same serverless Postgres technology as Neon, under the Databricks product line, and supports the deprecated Azure regions. See [Migrate Neon to Lakebase](/docs/guides/migrate-neon-to-lakebase).
+3. **Delete the project** if you no longer need it. This stops storage costs from accruing. See [Delete a project](/docs/manage/projects#delete-a-project).
+
+If none of these fit, [export your data in Postgres-compatible form](/docs/guides/export-neon-postgres-compatible) so you can store it elsewhere.
 
 ## Frequently asked questions
-
-### Does this affect my Neon projects?
-
-Only if your project is in an Azure region (`azure-eastus2`, `azure-westus3`, or `azure-gwc`). Projects in AWS regions are not affected.
 
 ### How do I find out which region a project is in?
 
@@ -48,38 +73,16 @@ You can check from the Console, the CLI, or the API:
 
 ![Project settings widget showing the project region](/docs/import/azure-regions-deprecation/project-settings-region.png)
 
-### Will my Azure project keep running?
-
-Yes. Your Azure project keeps running as it does today. Compute, storage, branching, and connections are unaffected. Existing Azure projects remain supported until further notice.
-
-### Will my Azure project be removed?
-
-No. Existing Azure projects remain supported until further notice. If we set a date to end Azure support in the future, we'll notify you in advance and give you time to migrate or export your data.
-
-### What if I do nothing?
-
-Your project continues running as it does today. There's no deadline to migrate. If we decide to end Azure support in the future, we'll contact you ahead of time so you can plan a migration or export.
-
-### I picked Azure for data residency. What are my options?
-
-Migrate to [Databricks Lakebase](/docs/guides/migrate-neon-to-lakebase). Lakebase is powered by the same serverless Postgres technology as Neon, under the Databricks product line. It supports Azure regions, so you can keep your data in Azure. For specific Lakebase region availability, see the [Lakebase Postgres documentation](https://docs.databricks.com/aws/en/oltp).
-
 ### What changes about my project when I migrate to a new region?
 
-A region migration creates a **new** Neon project in the target region. The new project gets a new hostname, so plan to update connection strings in your application. The new project also has a different project ID.
-
-Project-level settings (branches, integrations, autoscaling configuration, IP Allow rules, monitoring, and so on) are configured per project. Review the [migration guide](/docs/import/migrate-neon-to-another-region) for the steps and decisions specific to your migration method.
+A region migration creates a **new** Neon project in the target region. The new project gets a new hostname, so you'll need to update connection strings in your application. The new project also has a different project ID. Project-level settings (branches, integrations, autoscaling, IP Allow rules, monitoring) are configured per project. See the [migration guide](/docs/import/migrate-neon-to-another-region) for method-specific steps.
 
 ### Should I take a backup before migrating?
 
-If your migration method uses `pg_dump` and `pg_restore`, the dump itself is a backup. If you're using logical replication or the [Import Data Assistant](/docs/import/import-data-assistant), it's still good practice to take a `pg_dump` snapshot of your source database before you start. See [Backups](/docs/manage/backups) for details.
-
-### What if I need to stay on Azure for now?
-
-That's fine. Existing Azure projects remain supported until further notice, so you can keep running on Azure. If you have specific constraints, such as regulatory requirements, application architecture changes, or customer migration dependencies, and want to talk through a plan, reply to any migration outreach you receive or contact [Neon Support](https://console.neon.tech/app/projects?modal=support).
+If your migration method uses `pg_dump` and `pg_restore`, the dump itself is a backup. If you're using Postgres logical replication, it's good practice to take a `pg_dump` snapshot of your source database first. See [Backups](/docs/manage/backups).
 
 ### How do I contact Neon about my Azure projects?
 
-Keep an eye on your inbox for communication from us about the deprecation. If you have questions before then, contact [Neon Support](https://console.neon.tech/app/projects?modal=support).
+Keep an eye on your inbox for communication from us. If you have specific constraints, such as regulatory requirements or migration dependencies, reply to any migration outreach you receive or contact [Neon Support](https://console.neon.tech/app/projects?modal=support).
 
 <NeedHelp/>

--- a/content/docs/shared-content/azure-regions-deprecation.md
+++ b/content/docs/shared-content/azure-regions-deprecation.md
@@ -1,5 +1,5 @@
 <Admonition type="warning" title="Azure regions deprecation">
-Neon Azure regions (`azure-eastus2`, `azure-westus3`, `azure-gwc`) are deprecated. You can no longer create new projects in Azure regions. Existing Azure projects continue to be supported until further notice.
+Neon Azure regions (`azure-eastus2`, `azure-westus3`, `azure-gwc`) are deprecated. You can no longer create new projects in Azure regions. Projects on the Free plan that have been inactive for 90 days or more are subject to deletion as of October 5, 2026.
 
-If you have active projects in Azure regions, see [Azure regions deprecation](/docs/import/azure-regions-deprecation) for additional information and recommendations.
+If you have projects in Azure regions, see [Azure regions deprecation](/docs/import/azure-regions-deprecation) for what's changing and your options.
 </Admonition>

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -316,9 +316,9 @@ On February 19th, 2024, Neon will launch new, simplified pricing plans. You can 
 
 **Warning: Azure regions deprecation**
 
-Neon Azure regions (\`azure-eastus2\`, \`azure-westus3\`, \`azure-gwc\`) are deprecated. You can no longer create new projects in Azure regions. Existing Azure projects continue to be supported until further notice.
+Neon Azure regions (\`azure-eastus2\`, \`azure-westus3\`, \`azure-gwc\`) are deprecated. You can no longer create new projects in Azure regions. Projects on the Free plan that have been inactive for 90 days or more are subject to deletion as of October 5, 2026.
 
-If you have active projects in Azure regions, see [Azure regions deprecation](https://neon.com/docs/import/azure-regions-deprecation) for additional information and recommendations.
+If you have projects in Azure regions, see [Azure regions deprecation](https://neon.com/docs/import/azure-regions-deprecation) for what's changing and your options.
 "
 `;
 


### PR DESCRIPTION
## What

Restructures the [Azure regions deprecation](/docs/import/azure-regions-deprecation) guide and updates the shared warning banner to reflect the finalized plan.

### Content changes
- **Migration/deletion date set to October 5, 2026.** Free-organization projects inactive for 90+ days are subject to deletion on that date; active and paid projects keep running.
- **Maintenance-mode framing** added, with an honest "a full end-of-support date will be announced later" signal instead of an invented performance-degradation warning.
- **Deprecation timeline** table (April 7 → July 6 migration window → October 5 → after).
- Shared banner (`shared-content/azure-regions-deprecation.md`) updated to match.

### Structural changes
Applied a single-source-of-truth structure so each fact appears once, removing heavy repetition in the prior version:
- Sections: summary → affected regions → timeline → what it means → what happens Oct 5 → what to do → FAQ.
- FAQ trimmed from 9 to 4 (dropped questions now answered in the body).

## Testing
- Page renders locally (`npm run dev`) at `/docs/import/azure-regions-deprecation`.
- Updated the `process-md-for-llms` snapshot to match the new shared-banner copy; that suite passes.

## Note
The pre-push `neonctl-docs` check fails on two **unrelated** blog posts (`test-your-database-without-mocks.md`, `how-to-build-and-authenticate-an-ai-api-using-modal-neon-and-unkey.md`) that use `neonctl` options removed in neonctl 2.26.6. These are not touched by this PR and fail on `main`; worth a separate fix.

This pull request and its description were written by Isaac.