### PR TITLE
fix: uneven white space in the what you will learn section

### DIFF
--- a/src/components/pages/doc/docs-list/docs-list.jsx
+++ b/src/components/pages/doc/docs-list/docs-list.jsx
@@ -11,7 +11,7 @@ import PageIcon from './images/page.inline.svg';
 const Icon = ({ theme = 'default', className = null }) => {
   if (theme === 'docs') return <PageIcon className={cn('top-1', className)} aria-hidden />;
   if (theme === 'repo') return <GitHubIcon className={cn('top-1', className)} aria-hidden />;
-  return <CheckIcon className={cn('top-[5px]', className)} aria-hidden />;
+  return <CheckIcon className={cn('top-[12px]', className)} aria-hidden />;
 };
 
 Icon.propTypes = {


### PR DESCRIPTION
Fixes:#5031

**Problem:**

Uneven white space in the what you will learn sections of the pages 
1 - https://neon.com/docs/reference/typescript-sdk
2 - https://neon.com/docs/reference/python-sdk

<img width="974" height="473" alt="image" src="https://github.com/user-attachments/assets/d0a1885c-32c6-4b96-9bc7-f27e98a14bc5" />

**Fix:** 
Adjusted the vertical positioning of the CheckIcon component from `top-[5px]` to `top-[12px]` to align it properly with the text baseline.

**Testing:**
Passes 293 unit tests.
Page renders locally (npm run dev).