### PR TITLE
docs: show how to load .env.local in Drizzle Kit config

### DIFF
--- a/content/docs/guides/drizzle.md
+++ b/content/docs/guides/drizzle.md
@@ -10,7 +10,7 @@ summary: >-
   guide also shows how to point Drizzle at different Neon branches per
   environment by selecting a connection string based on NODE_ENV.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-02T16:34:30.445Z'
 ---
 
 <CopyPrompt src="/prompts/drizzle-prompt.md" 
@@ -144,6 +144,24 @@ export default defineConfig({
   },
 });
 ```
+
+<Admonition type="tip" title="Loading a .env.local file">
+`import 'dotenv/config'` loads variables from a `.env` file. If you keep your connection string in `.env.local` (a common convention in Next.js and other frameworks), point dotenv at it explicitly instead:
+
+```typescript
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+
+import { defineConfig } from 'drizzle-kit';
+
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL is not set in .env.local');
+}
+
+// ...rest of config unchanged
+```
+
+</Admonition>
 
 ## Initialize the Drizzle client
 


### PR DESCRIPTION
## Problem

User feedback in Slack (June 25, 2026) on the [Drizzle guide](https://neon.com/docs/guides/drizzle): the "Configure Drizzle Kit" example only shows `import 'dotenv/config'`, which loads a `.env` file. Many developers keep their connection string in `.env.local` (a common Next.js convention) and had to work out the dotenv config themselves. A teammate accepted the suggestion and asked for the example to be added.

## Change

Adds a tip to the "Configure Drizzle Kit" section of `content/docs/guides/drizzle.md` showing how to point dotenv at `.env.local`:

```typescript
import { config } from 'dotenv';
config({ path: '.env.local' });
```

The default `.env` example is unchanged, keeping it consistent with the "Get your connection string" section earlier on the page.

This pull request and its description were written by Isaac.