### PR TITLE
docs: reapply branch recovery docs (#4861)

### DIFF
--- a/content/docs/cli/branches.md
+++ b/content/docs/cli/branches.md
@@ -532,6 +532,8 @@ neon branches delete br-rough-sky-158193
 └─────────────────────┴─────────────────┴──────────────────────┴──────────────────────┘
 ```
 
+Branches are soft-deleted by default, and enter a 7-day [deletion recovery period](/docs/manage/branches#recover-a-deleted-branch) before being permanently removed.
+
 ## neon branches get (#get)
 
 Retrieves details about a branch.

--- a/content/docs/cli/projects.md
+++ b/content/docs/cli/projects.md
@@ -237,6 +237,8 @@ neon projects delete muddy-wood-859533
 
 Verify the deletion with `neon projects list`.
 
+Projects are soft-deleted by default, and enter a 7-day [deletion recovery period](/docs/manage/projects#recover-a-deleted-project) before being permanently removed.
+
 ## neon projects recover (#recover)
 
 Recovers a deleted project within the deletion recovery period. The `<id>` is the project ID, which you can obtain by listing recoverable projects with `neon projects list --recoverable-only`.

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -42,13 +42,13 @@ neon functions deploy <slug> [--src <dir-or-entry-file>] [--env KEY=VALUE] [--wa
 
 The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. See the [neon functions reference](/docs/cli/functions) for the full command surface.
 
-| Flag              | Default       | Description                                                                                                                                      |
-| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--src`           | (none)        | Function source: a directory containing `index.ts`, `index.mjs`, or `index.js`, or a path to the entry file                                      |
+| Flag              | Default       | Description                                                                                                                                   |
+| ----------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--src`           | (none)        | Function source: a directory containing `index.ts`, `index.mjs`, or `index.js`, or a path to the entry file                                   |
 | `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neon deploy --env` |
-| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                             |
-| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                                 |
-| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                             |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                          |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                              |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                          |
 
 **Examples:**
 

--- a/content/docs/get-started/platform-private-preview.md
+++ b/content/docs/get-started/platform-private-preview.md
@@ -146,8 +146,8 @@ Once applied, environment variables for all your services are written to `.env.l
 
 The Neon CLI supports a full local development workflow for the platform. You link a directory to a project, declare your infrastructure in `neon.ts`, develop functions locally with hot reload, and deploy when you're ready. Branching is built into the workflow: `neon checkout` creates an isolated branch with its own database, storage, and functions, so you can develop and test without touching your main branch. Here are the commands that make up that workflow, each with a link to its full reference.
 
-| Command                                           | What it does                                                                                                                                                   |
-| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command                                        | What it does                                                                                                                                                   |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`neon link`](/docs/cli/link)                  | Bind the current directory to a Neon project. Writes a `.neon` context file so all subsequent commands target the right project and branch automatically.      |
 | [`neon checkout <branch>`](/docs/cli/checkout) | Switch the active branch in your local context. Creates the branch if it doesn't exist. Pulls updated env vars into `.env.local` after switching.              |
 | [`neon config plan`](/docs/cli/config)         | Dry run your `neon.ts` changes. Shows what will be created, updated, or removed without applying anything.                                                     |

--- a/content/docs/guides/backup-restore.md
+++ b/content/docs/guides/backup-restore.md
@@ -521,4 +521,6 @@ Use this option if you need to inspect the restored data before you switch over 
 - Instant restore (PITR) is currently not supported on branches created from a snapshot restore. If you restore a snapshot to create a new branch, you cannot perform point-in-time restore on that branch at this time. Attempting to do so will return an error: `restore from snapshot on target branch is still ongoing`.
 - **Reset from parent is unavailable on child branches for up to 24 hours after restoring a parent from a snapshot.** When you restore a branch from a snapshot, any child branches of that restored branch cannot use the [Reset from parent](/docs/guides/reset-from-parent) feature for up to 24 hours.
 
+For deleted branches, see [Recover a deleted branch](/docs/manage/branches#recover-a-deleted-branch). That's a separate recovery path from the point-in-time and snapshot features on this page.
+
 <NeedHelp/>

--- a/content/docs/guides/branch-expiration.md
+++ b/content/docs/guides/branch-expiration.md
@@ -73,7 +73,7 @@ When you set an expiration timestamp on a branch:
 3. If you reset a branch from its parent, the TTL countdown restarts using the original interval
 
 <Admonition type="important">
-Branch deletion is permanent and cannot be recovered. All associated data and compute endpoints are also deleted. Verify expiration times carefully before setting them.
+Branches are soft-deleted by default, and enter a 7-day [deletion recovery period](/docs/manage/branches#recover-a-deleted-branch) before being permanently removed. All associated data and compute endpoints are also deleted. Verify expiration times carefully before setting them.
 </Admonition>
 
 ## Setting branch expiration

--- a/content/docs/guides/reset-from-parent.md
+++ b/content/docs/guides/reset-from-parent.md
@@ -10,7 +10,7 @@ summary: >-
   cannot be reset, and branches with their own children must have those children
   deleted first.
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-07-01T19:45:33.907Z'
 ---
 
 Neon's **Reset from parent** feature lets you instantly reset all databases on a branch to the latest schema and data from its parent branch, helping you recover from issues, start on new feature development, or keep the different branches in your environment in sync.
@@ -143,3 +143,4 @@ This ensures staging accurately reflects the current production state for reliab
 ## Limitations
 
 - **Reset from parent is unavailable for up to 24 hours after a parent is restored from a snapshot.** If a parent branch is restored from a snapshot, its child branches cannot be reset from that parent for up to 24 hours. If you need to update a child branch during this period, consider using [Instant restore](/docs/introduction/branch-restore) to restore the child branch from the parent directly.
+- **Soft-deleted children still block reset.** Since branches are [soft-deleted by default](/docs/manage/branches#recover-a-deleted-branch), a deleted child branch still counts until permanently removed. Permanently delete children (`hard_delete=true`), or pass [`preserve_under_name`](/docs/introduction/branch-restore#how-to-use-instant-restore) on the restore request to reset without deleting them.

--- a/content/docs/guides/vercel-branch-cleanup.md
+++ b/content/docs/guides/vercel-branch-cleanup.md
@@ -12,7 +12,7 @@ summary: >-
   Stale branches count toward plan branch limits and incur storage costs even
   after being auto-archived.
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-06-30T18:18:03.819Z'
 ---
 
 <InfoBlock>
@@ -54,12 +54,12 @@ If you're using the **Vercel-Managed integration**, you might expect preview bra
 
 1. **Vercel retains preview deployments for 6 months by default.** As of [October 2025](https://vercel.com/changelog/updated-defaults-for-deployment-retention), Vercel's default retention for pre-production deployments is 180 days. The clock starts when the deployment is created, not when the PR is closed.
 2. **Vercel's cleanup job runs asynchronously.** After the retention period expires, Vercel deletes the deployment in a batch process. This typically happens within hours to days of the expiration date, not instantly. Vercel offers a [30-day recovery window](https://vercel.com/docs/deployment-retention#restoring-a-deleted-deployment) to restore deleted deployments, but this does not delay cleanup for connected integrations.
-3. **Neon deletes the branch when Vercel deletes the deployment.** Neon receives a cleanup webhook and removes the corresponding preview branch immediately.
+3. **Neon deletes the branch when Vercel deletes the deployment.** Neon receives a cleanup webhook and removes the corresponding preview branch. The branch enters a **7-day recovery period** before permanent deletion. See [Recover a deleted branch](/docs/manage/branches#recover-a-deleted-branch).
 
 In the worst case (a deployment created moments before the PR is closed), this means up to **~6 months** before the Neon branch is automatically deleted.
 
 <Admonition type="warning" title="Restoring deleted deployments">
-Vercel lets you [restore deleted deployments](https://vercel.com/docs/deployment-retention#restoring-a-deleted-deployment) within a 30-day recovery window. However, restoring a Vercel deployment does **not** restore the associated Neon branch. The restored deployment will have no database behind it. To recover, you would need to recreate the Neon branch manually or push a new commit to trigger the integration.
+Vercel lets you [restore deleted deployments](https://vercel.com/docs/deployment-retention#restoring-a-deleted-deployment) within a 30-day recovery window. Restoring a Vercel deployment does **not** restore the associated Neon branch. The restored deployment will have no database behind it. If the Neon branch was deleted recently, you may be able to [recover the branch](/docs/manage/branches#recover-a-deleted-branch) within 7 days. After that, recreate it manually or push a new commit to trigger the integration.
 </Admonition>
 
 ### Retention exceptions
@@ -163,6 +163,8 @@ To remove stale branches:
 - **Neon Console**: Go to the **Branches** page and delete branches individually
 - **Neon CLI**: Use `neon branches delete <branch-id-or-name>` to remove specific branches. See [CLI branches reference](/docs/cli/branches#delete).
 - **Neon API**: Use `DELETE /projects/{project_id}/branches/{branch_id}`. See [Delete a branch with the API](/docs/manage/branches#delete-a-branch-with-the-api).
+
+Branches deleted this way enter a 7-day recovery period before being permanently removed. See [Recover a deleted branch](/docs/manage/branches#recover-a-deleted-branch).
 
 ---
 

--- a/content/docs/introduction/branch-restore.md
+++ b/content/docs/introduction/branch-restore.md
@@ -30,6 +30,7 @@ updatedOn: '2026-06-11T23:50:21.258Z'
 
 <DocsList title="Related docs" theme="docs">
   <a href="/docs/introduction/history-window">History window for instant restore</a>
+  <a href="/docs/manage/branches#recover-a-deleted-branch">Recover a deleted branch</a>
 </DocsList>
 </InfoBlock>
 

--- a/content/docs/manage/branches.md
+++ b/content/docs/manage/branches.md
@@ -198,7 +198,7 @@ You can use the Neon Console, CLI, or API. For more details, see [Instant restor
 
 ## Delete a branch
 
-Deleting a branch is a permanent action. Deleting a branch also deletes the databases and roles that belong to the branch as well as the compute associated with the branch. You cannot delete a branch that has child branches. The child branches must be deleted first.
+Deleting a branch removes the branch along with its databases, roles, and associated compute. You cannot delete a branch that has child branches. The child branches must be deleted first.
 
 To delete a branch:
 
@@ -211,6 +211,65 @@ To delete a branch:
 <Admonition type="tip">
 For temporary branches, consider setting an expiration date when creating them to automate cleanup and reduce manual deletion overhead.
 </Admonition>
+
+## Recover a deleted branch
+
+Branches are soft-deleted by default, and enter a 7-day deletion recovery period before being permanently removed. To bypass the recovery period and delete immediately, use `hard_delete=true`.
+
+<Admonition type="note">
+This is different from [instant restore](/docs/introduction/branch-restore), which rolls back a branch to an earlier point in time.
+
+To recover a deleted project, see [Recover a deleted project](/docs/manage/projects#recover-a-deleted-project).
+</Admonition>
+
+### What's recovered
+
+When you recover a deleted branch:
+
+- Branch data and configuration are restored
+- Endpoints return to an idle state
+- Connection strings remain valid
+
+### Recovery API
+
+To list deleted branches that can be recovered, use `include_deleted=true`:
+
+```http
+GET /projects/{project_id}/branches?include_deleted=true
+```
+
+**Example:**
+
+```bash
+curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches?include_deleted=true' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" | jq
+```
+
+Each deleted branch includes a `recovery` object with `deleted_at`, `recoverable_until`, and `deletion_method` fields.
+
+To recover a deleted branch:
+
+```http
+POST /projects/{project_id}/branches/{branch_id}/recover
+```
+
+**Example:**
+
+```bash
+curl -X POST \
+  'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-curly-wave-af4i4oeu/recover' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" | jq
+```
+
+The API returns a `200` status code with the restored branch object.
+
+To skip the recovery window, add `hard_delete=true` to the delete request:
+
+```http
+DELETE /projects/{project_id}/branches/{branch_id}?hard_delete=true
+```
 
 ## Check the data size
 

--- a/content/docs/manage/orgs-manage.md
+++ b/content/docs/manage/orgs-manage.md
@@ -102,6 +102,8 @@ All Members can create new projects from the Organization's **Projects** page; h
 - Any Member can create a project under the organization's ownership.
 - Only Admins can delete projects owned by the organization.
 
+Projects are soft-deleted by default, and enter a 7-day [deletion recovery period](/docs/manage/projects#recover-a-deleted-project) before being permanently removed.
+
 ## Manage billing
 
 When you create a new organization, you'll choose a plan for that organization. Each organization manages its own billing and plan.

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -419,7 +419,7 @@ After enabling logical replication, the next steps involve creating publications
 
 ### Delete a project
 
-Deleting a project is a permanent action, which also deletes any computes, branches, databases, and roles that belong to the project.
+Deleting a project removes all its computes, branches, databases, and roles. Deleted projects can be [recovered within 7 days](#recover-a-deleted-project).
 
 To delete a project:
 
@@ -926,7 +926,7 @@ For attribute definitions, find the [Delete project](https://api-docs.neon.tech/
 If you accidentally delete a project, you can recover it within 7 days. This **deletion recovery period** allows you to restore deleted projects with all their data and configuration intact.
 
 <Admonition type="note">
-The deletion recovery period is different from the [history window](/docs/introduction/history-window) used for **instant restore** on branch data. The history window enables point-in-time recovery (PITR) for branch data, while the deletion recovery period allows you to recover (undelete) an entire deleted project.
+The deletion recovery period is different from the [history window](/docs/introduction/history-window) used for **instant restore** on branch data. The history window enables point-in-time recovery (PITR) for branch data, while the deletion recovery period allows you to recover (undelete) an entire deleted project. To recover a deleted branch, see [Recover a deleted branch](/docs/manage/branches#recover-a-deleted-branch).
 </Admonition>
 
 ### What's recovered

--- a/content/docs/reference/neon-ts.md
+++ b/content/docs/reference/neon-ts.md
@@ -220,11 +220,11 @@ The key list autocompletes from your config, so selecting a variable from a serv
 
 ## CLI commands
 
-| Command                                     | What it does                                                                                              |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Command                                  | What it does                                                                                              |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [`neon link`](/docs/cli/link)            | Connect the current directory to a Neon project. Required to use linked branch defaults in other commands |
-| [`neon deploy`](/docs/cli/config)        | Apply `neon.ts` to the linked branch (alias for `neon config apply`)                                   |
-| [`neon config plan`](/docs/cli/config)   | Preview what `neon deploy` would change, without applying                                              |
+| [`neon deploy`](/docs/cli/config)        | Apply `neon.ts` to the linked branch (alias for `neon config apply`)                                      |
+| [`neon config plan`](/docs/cli/config)   | Preview what `neon deploy` would change, without applying                                                 |
 | [`neon config status`](/docs/cli/config) | Show the current live state of the branch as a `neon.ts`-shaped config                                    |
 | [`neon env pull`](/docs/cli/env)         | Write the branch's Neon-managed variables to `.env.local` (or `.env` if it already exists)                |
 | [`neon checkout`](/docs/cli/checkout)    | Switch to or create a branch; new branches are created from the `neon.ts` policy (TTL, compute, services) |


### PR DESCRIPTION
Standing draft PR to restore the branch recovery docs.

- Original docs merged in #4861
- Temporarily removed from production in #5197 (feature not yet live)
- This PR reverts that revert — byte-identical restore of the original content

**Merge this when the branch recovery feature ships.** If main drifts on the affected files before then, rebase to resolve.