### PR TITLE
Sync hosted skills to @neon/sdk migration

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -4,65 +4,65 @@
     {
       "name": "neon-postgres",
       "type": "skill-md",
-      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about \"Neon setup\", \"connect to Neon\", \"Neon project\", \"DATABASE_URL\", \"serverless Postgres\", \"Neon CLI\", \"neonctl\", \"Neon MCP\", \"Neon Auth\", \"@neondatabase/serverless\", \"@neondatabase/neon-js\", \"scale to zero\", \"Neon autoscaling\", \"Neon read replica\", or \"Neon connection pooling\".",
+      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about \"Neon setup\", \"connect to Neon\", \"Neon project\", \"DATABASE_URL\", \"serverless Postgres\", \"Neon CLI\", \"neon\", \"Neon MCP\", \"Neon Auth\", \"@neondatabase/serverless\", \"@neondatabase/neon-js\", \"scale to zero\", \"Neon autoscaling\", \"Neon read replica\", or \"Neon connection pooling\".",
       "url": "/.well-known/agent-skills/neon-postgres/SKILL.md",
-      "digest": "sha256:e86b39e63798b79736645bbc5d3925ac52f8dbe7c0c9cc0b106a592771dbc338"
+      "digest": "sha256:899046429e5df4c2c07c606ba6fa79a77faa4aae6fb8969cea9f2f17e9872a5d"
     },
     {
       "name": "claimable-postgres",
       "type": "skill-md",
       "description": "Provision instant temporary Postgres databases via Claimable Postgres by Neon (neon.new) with no login, signup, or credit card. Supports REST API, CLI, and SDK. Use when users ask for a quick Postgres environment, a throwaway DATABASE_URL for prototyping/tests, or \"just give me a DB now\". Triggers include: \"quick postgres\", \"temporary postgres\", \"no signup database\", \"no credit card database\", \"instant DATABASE_URL\", \"npx neon-new\", \"neon.new\", \"neon.new API\", \"claimable postgres API\".",
       "url": "/.well-known/agent-skills/claimable-postgres/SKILL.md",
-      "digest": "sha256:d05a1a6618d517f985b79bc7a627f4dc6d7f0d19acd81be7febaeb1e506db056"
+      "digest": "sha256:2fac20cc7ff291c78f8d98977bf12b321128f15caf171ce0a52829acf451526f"
     },
     {
       "name": "neon-postgres-egress-optimizer",
       "type": "skill-md",
       "description": "Diagnose and fix excessive Postgres egress (network data transfer) in a codebase. Use when a user mentions high database bills, unexpected data transfer costs, network transfer charges, egress spikes, \"why is my Neon bill so high\", \"database costs jumped\", SELECT * optimization, query overfetching, reduce Neon costs, optimize database usage, or wants to reduce data sent from their database to their application. Also use when reviewing query patterns for cost efficiency, even if the user doesn't explicitly mention egress or data transfer.",
       "url": "/.well-known/agent-skills/neon-postgres-egress-optimizer/SKILL.md",
-      "digest": "sha256:cb86cc3fce7d5c5ecd1cd581683292478c6cfa6104fff229a9e52feeec957e00"
+      "digest": "sha256:1348b9196d06d3e3e66f31c2f2977897277b7c2731b22c83fce372b6f04af4f5"
     },
     {
       "name": "neon-postgres-branches",
       "type": "skill-md",
       "description": "Choose and create the right Neon branch type for testing and development. Use when users ask about Neon branching, migration testing with real data, isolated test environments, schema-only branch workflows for sensitive data, or branch creation via Neon CLI or Neon MCP. Triggers include \"Neon branch\", \"test migrations safely\", \"branch production data\", \"schema-only branch\", \"reset branch\" and \"sensitive data testing\".",
       "url": "/.well-known/agent-skills/neon-postgres-branches/SKILL.md",
-      "digest": "sha256:14ec4806726465de30bb6dd309025d380e25de0036465479dc2169453d6d1b32"
+      "digest": "sha256:e5067c64c3312b7a1b5c29c57e55a123aede7750424dc5c00a1a55639ede1c4e"
     },
     {
       "name": "neon",
       "type": "skill-md",
       "description": "Overview of the Neon platform for apps and agents, spanning Postgres, Auth, Data API, and the new services: Object Storage, Compute Functions, and AI Gateway. Use whenever \"Neon\" is mentioned for an overview of how to work with Neon and how to get started. Otherwise, the individual capabilities are the triggers: \"object storage\" or \"S3-compatible storage\", \"serverless functions\", \"background jobs\", or \"run code near my database\", \"AI gateway\", \"LLM proxy\", \"model routing\", or \"call an LLM\" → AI Gateway; \"database\", \"Postgres\", or \"authentication\" → Postgres and Auth.",
       "url": "/.well-known/agent-skills/neon/SKILL.md",
-      "digest": "sha256:76e46a0b9ec7fac1491ea6a36fb5afb98ebcc2de856943409fb34b9fb1f41211"
+      "digest": "sha256:22ebfb6c356f4b909aa7f24653cef06a489104c75f65baa79ff3d0578d594f59"
     },
     {
       "name": "neon-postgres-agent-platforms",
       "type": "skill-md",
       "description": "Build and operate multi-tenant AI agent platforms on Neon. Use this skill whenever the user is designing an agent/app builder, provisioning a Neon project or database per user/app/agent run, managing thousands of tenant projects, separating sponsored free users from paid customers, moving projects between orgs, choosing personal vs organization vs project-scoped API keys, tracking fleet consumption or Agent Plan costs, creating compound checkpoints that combine DB snapshots with source revisions/secrets/deploy metadata, or orchestrating snapshot/restore flows for generated apps. Also use it for Neon Agent Program, Agent Plan, org/project limits, HIPAA, co-marketing, support, or neondatabase/neon-for-agent-platforms examples.",
       "url": "/.well-known/agent-skills/neon-postgres-agent-platforms/SKILL.md",
-      "digest": "sha256:4d72d322ab52b97669a9fd1cf91bc9577f365c427345b5365f01799236d35c44"
+      "digest": "sha256:425808169958410fd1a0e7e4aaad9be02828f20c3d9a0e39ef384206b60cc083"
     },
     {
       "name": "neon-object-storage",
       "type": "skill-md",
       "description": "S3-compatible object storage that branches with your Neon project, so files and the database stay in sync across every branch. Use when a user wants object storage, a bucket, blob/file storage, or somewhere to put uploads, images, documents, avatars, or user-generated files for their app or agent — especially when they already use (or are setting up) Neon Postgres and don't want to add a separate storage provider like AWS S3, Cloudflare R2, or Supabase Storage. Triggers include \"object storage\", \"bucket\", \"blob storage\", \"file storage\", \"store uploads/images/files\", \"S3-compatible storage\", \"presigned URL\", \"where do I put files\", \"Neon Object Storage\", \"Neon Storage\", and \"storage that branches with my database\".",
       "url": "/.well-known/agent-skills/neon-object-storage/SKILL.md",
-      "digest": "sha256:ed70709e80d09b3e33030f9b1b42d48c5eec21668d20d9cd7c9cb48d7bb3009a"
+      "digest": "sha256:8375fb6a2b7a9716f1f0da81d25b10aaae27eb170c7fbd063faa4232c6e60b00"
     },
     {
       "name": "neon-ai-gateway",
       "type": "skill-md",
       "description": "One API and one credential for frontier and open-source LLMs, built into your Neon branch and powered by Databricks. Use when a user wants to call an LLM, add AI/chat/an agent to their app, route between model providers (OpenAI, Anthropic, Google/Gemini, Meta, Alibaba, DeepSeek), or avoid juggling separate provider API keys and accounts — especially when they already use Neon and want AI requests to branch with their project. Works with the OpenAI SDK, Anthropic SDK, google-genai, the Vercel AI SDK, and Mastra by changing only the base URL. Triggers include \"call an LLM\", \"add AI to my app\", \"chat completion\", \"model routing\", \"LLM proxy/gateway\", \"one API for all models\", \"use Claude/GPT/Gemini\", \"AI SDK\", \"Mastra agent\", \"Neon AI Gateway\", and \"log/rate-limit AI calls\".",
       "url": "/.well-known/agent-skills/neon-ai-gateway/SKILL.md",
-      "digest": "sha256:a32bb5f9f5aae67a45d19f6a9600b30429a0c4c75b911b5156b7705b17cefc7b"
+      "digest": "sha256:e8cc82012fd2c42817641402b1b2ae4bf83c9c1e86f0fdd0b44edfaadf64d64c"
     },
     {
       "name": "neon-functions",
       "type": "skill-md",
       "description": "Long-running, serverless Node.js HTTP functions deployed onto your Neon branch, with DATABASE_URL injected automatically and compute that runs next to your data. Use when a user wants to host an API, an AI agent with long streaming responses, a WebSocket or server-sent-events (SSE) server, a webhook handler, a Discord bot, or any request/response workload that risks timing out on short, lambda-style serverless functions — and wants it to branch with their database. Triggers include \"serverless function\", \"deploy an API\", \"long-running function\", \"streaming agent\", \"SSE server\", \"WebSocket server\", \"webhook handler\", \"run code next to my database\", \"function that won't time out\", \"Neon Functions\", and \"Neon Compute\".",
       "url": "/.well-known/agent-skills/neon-functions/SKILL.md",
-      "digest": "sha256:5ca4e8453578e9bd3947971f1f516aabb468aa48b37912ca24238696e2193501"
+      "digest": "sha256:dbf4344fc6828d2b611c5905a61bb57d788931bd7bd28ef19530d1f2d8ca59b6"
     }
   ]
 }

--- a/public/.well-known/skills/index.json
+++ b/public/.well-known/skills/index.json
@@ -2,7 +2,7 @@
   "skills": [
     {
       "name": "neon-postgres",
-      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about \"Neon setup\", \"connect to Neon\", \"Neon project\", \"DATABASE_URL\", \"serverless Postgres\", \"Neon CLI\", \"neonctl\", \"Neon MCP\", \"Neon Auth\", \"@neondatabase/serverless\", \"@neondatabase/neon-js\", \"scale to zero\", \"Neon autoscaling\", \"Neon read replica\", or \"Neon connection pooling\".",
+      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about \"Neon setup\", \"connect to Neon\", \"Neon project\", \"DATABASE_URL\", \"serverless Postgres\", \"Neon CLI\", \"neon\", \"Neon MCP\", \"Neon Auth\", \"@neondatabase/serverless\", \"@neondatabase/neon-js\", \"scale to zero\", \"Neon autoscaling\", \"Neon read replica\", or \"Neon connection pooling\".",
       "files": [
         "SKILL.md"
       ]

--- a/public/docs/.well-known/agent-skills/index.json
+++ b/public/docs/.well-known/agent-skills/index.json
@@ -6,63 +6,63 @@
       "type": "skill-md",
       "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about \"Neon setup\", \"connect to Neon\", \"Neon project\", \"DATABASE_URL\", \"serverless Postgres\", \"Neon CLI\", \"neon\", \"Neon MCP\", \"Neon Auth\", \"@neondatabase/serverless\", \"@neondatabase/neon-js\", \"scale to zero\", \"Neon autoscaling\", \"Neon read replica\", or \"Neon connection pooling\".",
       "url": "/docs/.well-known/agent-skills/neon-postgres/SKILL.md",
-      "digest": "sha256:e86b39e63798b79736645bbc5d3925ac52f8dbe7c0c9cc0b106a592771dbc338"
+      "digest": "sha256:899046429e5df4c2c07c606ba6fa79a77faa4aae6fb8969cea9f2f17e9872a5d"
     },
     {
       "name": "claimable-postgres",
       "type": "skill-md",
       "description": "Provision instant temporary Postgres databases via Claimable Postgres by Neon (neon.new) with no login, signup, or credit card. Supports REST API, CLI, and SDK. Use when users ask for a quick Postgres environment, a throwaway DATABASE_URL for prototyping/tests, or \"just give me a DB now\". Triggers include: \"quick postgres\", \"temporary postgres\", \"no signup database\", \"no credit card database\", \"instant DATABASE_URL\", \"npx neon-new\", \"neon.new\", \"neon.new API\", \"claimable postgres API\".",
       "url": "/docs/.well-known/agent-skills/claimable-postgres/SKILL.md",
-      "digest": "sha256:d05a1a6618d517f985b79bc7a627f4dc6d7f0d19acd81be7febaeb1e506db056"
+      "digest": "sha256:2fac20cc7ff291c78f8d98977bf12b321128f15caf171ce0a52829acf451526f"
     },
     {
       "name": "neon-postgres-egress-optimizer",
       "type": "skill-md",
       "description": "Diagnose and fix excessive Postgres egress (network data transfer) in a codebase. Use when a user mentions high database bills, unexpected data transfer costs, network transfer charges, egress spikes, \"why is my Neon bill so high\", \"database costs jumped\", SELECT * optimization, query overfetching, reduce Neon costs, optimize database usage, or wants to reduce data sent from their database to their application. Also use when reviewing query patterns for cost efficiency, even if the user doesn't explicitly mention egress or data transfer.",
       "url": "/docs/.well-known/agent-skills/neon-postgres-egress-optimizer/SKILL.md",
-      "digest": "sha256:cb86cc3fce7d5c5ecd1cd581683292478c6cfa6104fff229a9e52feeec957e00"
+      "digest": "sha256:1348b9196d06d3e3e66f31c2f2977897277b7c2731b22c83fce372b6f04af4f5"
     },
     {
       "name": "neon-postgres-branches",
       "type": "skill-md",
       "description": "Choose and create the right Neon branch type for testing and development. Use when users ask about Neon branching, migration testing with real data, isolated test environments, schema-only branch workflows for sensitive data, or branch creation via Neon CLI or Neon MCP. Triggers include \"Neon branch\", \"test migrations safely\", \"branch production data\", \"schema-only branch\", \"reset branch\" and \"sensitive data testing\".",
       "url": "/docs/.well-known/agent-skills/neon-postgres-branches/SKILL.md",
-      "digest": "sha256:14ec4806726465de30bb6dd309025d380e25de0036465479dc2169453d6d1b32"
+      "digest": "sha256:e5067c64c3312b7a1b5c29c57e55a123aede7750424dc5c00a1a55639ede1c4e"
     },
     {
       "name": "neon",
       "type": "skill-md",
       "description": "Overview of the Neon platform for apps and agents, spanning Postgres, Auth, Data API, and the new services: Object Storage, Compute Functions, and AI Gateway. Use whenever \"Neon\" is mentioned for an overview of how to work with Neon and how to get started. Otherwise, the individual capabilities are the triggers: \"object storage\" or \"S3-compatible storage\", \"serverless functions\", \"background jobs\", or \"run code near my database\", \"AI gateway\", \"LLM proxy\", \"model routing\", or \"call an LLM\" → AI Gateway; \"database\", \"Postgres\", or \"authentication\" → Postgres and Auth.",
       "url": "/docs/.well-known/agent-skills/neon/SKILL.md",
-      "digest": "sha256:76e46a0b9ec7fac1491ea6a36fb5afb98ebcc2de856943409fb34b9fb1f41211"
+      "digest": "sha256:22ebfb6c356f4b909aa7f24653cef06a489104c75f65baa79ff3d0578d594f59"
     },
     {
       "name": "neon-postgres-agent-platforms",
       "type": "skill-md",
       "description": "Build and operate multi-tenant AI agent platforms on Neon. Use this skill whenever the user is designing an agent/app builder, provisioning a Neon project or database per user/app/agent run, managing thousands of tenant projects, separating sponsored free users from paid customers, moving projects between orgs, choosing personal vs organization vs project-scoped API keys, tracking fleet consumption or Agent Plan costs, creating compound checkpoints that combine DB snapshots with source revisions/secrets/deploy metadata, or orchestrating snapshot/restore flows for generated apps. Also use it for Neon Agent Program, Agent Plan, org/project limits, HIPAA, co-marketing, support, or neondatabase/neon-for-agent-platforms examples.",
       "url": "/docs/.well-known/agent-skills/neon-postgres-agent-platforms/SKILL.md",
-      "digest": "sha256:4d72d322ab52b97669a9fd1cf91bc9577f365c427345b5365f01799236d35c44"
+      "digest": "sha256:425808169958410fd1a0e7e4aaad9be02828f20c3d9a0e39ef384206b60cc083"
     },
     {
       "name": "neon-object-storage",
       "type": "skill-md",
       "description": "S3-compatible object storage that branches with your Neon project, so files and the database stay in sync across every branch. Use when a user wants object storage, a bucket, blob/file storage, or somewhere to put uploads, images, documents, avatars, or user-generated files for their app or agent — especially when they already use (or are setting up) Neon Postgres and don't want to add a separate storage provider like AWS S3, Cloudflare R2, or Supabase Storage. Triggers include \"object storage\", \"bucket\", \"blob storage\", \"file storage\", \"store uploads/images/files\", \"S3-compatible storage\", \"presigned URL\", \"where do I put files\", \"Neon Object Storage\", \"Neon Storage\", and \"storage that branches with my database\".",
       "url": "/docs/.well-known/agent-skills/neon-object-storage/SKILL.md",
-      "digest": "sha256:ed70709e80d09b3e33030f9b1b42d48c5eec21668d20d9cd7c9cb48d7bb3009a"
+      "digest": "sha256:8375fb6a2b7a9716f1f0da81d25b10aaae27eb170c7fbd063faa4232c6e60b00"
     },
     {
       "name": "neon-ai-gateway",
       "type": "skill-md",
       "description": "One API and one credential for frontier and open-source LLMs, built into your Neon branch and powered by Databricks. Use when a user wants to call an LLM, add AI/chat/an agent to their app, route between model providers (OpenAI, Anthropic, Google/Gemini, Meta, Alibaba, DeepSeek), or avoid juggling separate provider API keys and accounts — especially when they already use Neon and want AI requests to branch with their project. Works with the OpenAI SDK, Anthropic SDK, google-genai, the Vercel AI SDK, and Mastra by changing only the base URL. Triggers include \"call an LLM\", \"add AI to my app\", \"chat completion\", \"model routing\", \"LLM proxy/gateway\", \"one API for all models\", \"use Claude/GPT/Gemini\", \"AI SDK\", \"Mastra agent\", \"Neon AI Gateway\", and \"log/rate-limit AI calls\".",
       "url": "/docs/.well-known/agent-skills/neon-ai-gateway/SKILL.md",
-      "digest": "sha256:a32bb5f9f5aae67a45d19f6a9600b30429a0c4c75b911b5156b7705b17cefc7b"
+      "digest": "sha256:e8cc82012fd2c42817641402b1b2ae4bf83c9c1e86f0fdd0b44edfaadf64d64c"
     },
     {
       "name": "neon-functions",
       "type": "skill-md",
       "description": "Long-running, serverless Node.js HTTP functions deployed onto your Neon branch, with DATABASE_URL injected automatically and compute that runs next to your data. Use when a user wants to host an API, an AI agent with long streaming responses, a WebSocket or server-sent-events (SSE) server, a webhook handler, a Discord bot, or any request/response workload that risks timing out on short, lambda-style serverless functions — and wants it to branch with their database. Triggers include \"serverless function\", \"deploy an API\", \"long-running function\", \"streaming agent\", \"SSE server\", \"WebSocket server\", \"webhook handler\", \"run code next to my database\", \"function that won't time out\", \"Neon Functions\", and \"Neon Compute\".",
       "url": "/docs/.well-known/agent-skills/neon-functions/SKILL.md",
-      "digest": "sha256:5ca4e8453578e9bd3947971f1f516aabb468aa48b37912ca24238696e2193501"
+      "digest": "sha256:dbf4344fc6828d2b611c5905a61bb57d788931bd7bd28ef19530d1f2d8ca59b6"
     }
   ]
 }

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/SKILL.md
@@ -332,7 +332,8 @@ Runnable Management API automation from
 - **Doc index:**
 [SCRIPT-OVERVIEW.md](https://github.com/neondatabase/neon-for-agent-platforms/blob/main/skills/neon-postgres-agent-platforms/references/SCRIPT-OVERVIEW.md)
 
-All scripts use `@neondatabase/api-client` only. Shared
+All scripts use `@neon/sdk` only. Shared
 [utils.ts](https://github.com/neondatabase/neon-for-agent-platforms/blob/main/skills/neon-postgres-agent-platforms/scripts/utils.ts)
-polls async operations. For SQL access from app code (drivers, pooling, ORMs),
+builds the client and resolves the default branch; the SDK polls async
+operations (readiness) for you. For SQL access from app code (drivers, pooling, ORMs),
 use `**neon-postgres`**.

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/references/CHECKPOINT_ORCHESTRATION_PATTERN.md
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/references/CHECKPOINT_ORCHESTRATION_PATTERN.md
@@ -12,7 +12,7 @@ This skill’s **`scripts/*.ts`** files stay **API-sized**: they cover the Neon 
 
 | Layer | Responsibility |
 | ----- | ---------------- |
-| **Neon integration** | Wrap `@neondatabase/api-client`: projects, branches, logical snapshots, restore, connection URIs, operation polling (patterns align with [`utils.ts`](../scripts/utils.ts) and the sample scripts). |
+| **Neon integration** | Wrap `@neon/sdk`: projects, branches, logical snapshots, restore, connection URIs, readiness polling (patterns align with [`utils.ts`](../scripts/utils.ts) and the sample scripts). |
 | **Meta database** | Version rows that bind `neon_snapshot_id` (and related Neon ids) to `git_commit_hash` / artifact id / timestamps / optional assistant or run ids. Often separate tables for tenant secrets or env snapshots. |
 | **Checkpoint workflow** | When the user or agent creates a checkpoint: resolve **latest source revision** and **create a Neon snapshot** (often in parallel), then insert one **version** row so code and DB state stay aligned. |
 | **HTTP or queue entry** | User-facing `POST …/checkpoint` or internal job that starts the workflow (workflow engine is product-specific). |

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/references/COMPOUND_CHECKPOINTS_FOR_AGENT_PLATFORMS.md
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/references/COMPOUND_CHECKPOINTS_FOR_AGENT_PLATFORMS.md
@@ -25,7 +25,7 @@ The scripts in **`scripts/`** intentionally stay **Management API-sized**: they 
 
 ## Mapping Neon calls to your compound ledger
 
-The Management API shapes below match the **`@neondatabase/api-client`** scripts under **`scripts/`**. They are **one slice** of a checkpoint, you still persist the non-Neon dimensions in your platform store.
+The Management API shapes below match the **`@neon/sdk`** scripts under **`scripts/`**. They are **one slice** of a checkpoint, you still persist the non-Neon dimensions in your platform store.
 
 | Concern | Minimal API surface (Neon) | Sample script (`scripts/`) |
 | ------- | -------------------------- | --------------------- |

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/references/MANAGEMENT_API_SAMPLES.md
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/references/MANAGEMENT_API_SAMPLES.md
@@ -1,8 +1,8 @@
 # Management API samples (`scripts/`)
 
-Small **Node.js + TypeScript** scripts that call Neon’s official **[Management API TypeScript SDK](https://neon.com/docs/reference/typescript-sdk.md)** ([`@neondatabase/api-client`](https://registry.npmjs.org/@neondatabase/api-client)) via **`createApiClient`**, **no other Neon npm packages**. Sources live in **[`scripts/`](../scripts/)**; **`npm run build`** runs **`tsc`** and emits **`dist/scripts/*.js`** per **[`tsconfig.json`](../scripts/tsconfig.json)**. **`npm run typecheck`** runs **`tsc --noEmit`** (no emit). Scripts **`import "dotenv/config"`** so variables from **`.env`** load automatically; run with **`node dist/scripts/<name>.js`** or **`npm run …`** (each npm script runs **`build`** then **`node dist/scripts/...`**).
+Small **Node.js + TypeScript** scripts that call Neon’s official **[Management API TypeScript SDK](https://neon.com/docs/reference/typescript-sdk.md)** ([`@neon/sdk`](https://registry.npmjs.org/@neon/sdk)) via **`createNeonClient`**, **no other Neon npm packages**. Sources live in **[`scripts/`](../scripts/)**; **`npm run build`** runs **`tsc`** and emits **`dist/scripts/*.js`** per **[`tsconfig.json`](../scripts/tsconfig.json)**. **`npm run typecheck`** runs **`tsc --noEmit`** (no emit). Scripts **`import "dotenv/config"`** so variables from **`.env`** load automatically; run with **`node dist/scripts/<name>.js`** or **`npm run …`** (each npm script runs **`build`** then **`node dist/scripts/...`**).
 
-**When we say “Neon TypeScript SDK” here, we mean [`@neondatabase/api-client`](https://registry.npmjs.org/@neondatabase/api-client) and nothing else**, not `@neondatabase/serverless`, `@neondatabase/neon-js`, `@neondatabase/toolkit`, or any other `@neondatabase/*` package.
+**When we say “Neon TypeScript SDK” here, we mean [`@neon/sdk`](https://registry.npmjs.org/@neon/sdk) and nothing else**, not `@neondatabase/serverless`, `@neondatabase/neon-js`, `@neondatabase/toolkit`, or any other Neon package.
 
 Use these to prototype **per-tenant provisioning**, **fleet branching/snapshot orchestration**, **database versioning** (snapshots + restore), **org transfer** (free ↔ paid org), **consumption** polling, and **Neon Auth management** endpoints, not introductory app connectivity (that is **`neon-postgres`** + app docs).
 
@@ -14,7 +14,7 @@ For the full mapping (keys, patterns, which script covers which fleet operation)
 
 ### Application REST API vs Neon Management API
 
-Scripts in **`scripts/`** call Neon’s **Management API** (`console.neon.tech`, `@neondatabase/api-client`), provisioning, branches, snapshots, org transfer, consumption, Neon Auth management endpoints.
+Scripts in **`scripts/`** call Neon’s **Management API** (`console.neon.tech`, `@neon/sdk`), provisioning, branches, snapshots, org transfer, consumption, Neon Auth management endpoints.
 
 For **`curl`** examples aimed at **your product’s own REST API** (checkpoints, versions, etc.), see **[application-rest-api/CURL_REFERENCE.md](application-rest-api/CURL_REFERENCE.md)**. Those routes are **not** Neon control-plane calls. **Compound checkpoints** are described in **[COMPOUND_CHECKPOINTS_FOR_AGENT_PLATFORMS.md](COMPOUND_CHECKPOINTS_FOR_AGENT_PLATFORMS.md)**.
 
@@ -225,7 +225,7 @@ node --env-file=.env dist/scripts/auth-users.js meta
 
 ## Shared helpers
 
-[`scripts/utils.ts`](../scripts/utils.ts) holds **shared helpers** on top of the same **`@neondatabase/api-client`** surface: **operation polling** (`waitForOperationsToSettle`), **error formatting**, and small **compose** helpers around **`createApiClient`** calls so scripts stay readable. There is no second Neon client package.
+[`scripts/utils.ts`](../scripts/utils.ts) holds **shared helpers** on top of the same **`@neon/sdk`** surface: a configured client factory (`neonClient` — `throwOnError` + `waitForReadiness`) and default-branch resolution (`getProductionBranchId`). The SDK itself handles **readiness polling**, retries, and typed errors, so the scripts no longer hand-roll an operation poller. There is no second Neon client package.
 
 ---
 

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/auth-users.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/auth-users.ts
@@ -1,13 +1,18 @@
 /**
  * Neon Auth: application users (REST) and how they show up in Postgres.
  *
+ * The auth-user endpoints aren't wrapped by an ergonomic namespace yet, so this
+ * drops to the raw layer (`raw.createBranchNeonAuthNewUser` /
+ * `raw.deleteBranchNeonAuthUser`) and reuses the client's auth via `neon.client`.
+ *
  * Subcommands:
  *   meta     print [meta] map: REST vs Postgres, doc links
  *   create   POST .../auth/users (needs USER_EMAIL, optional USER_NAME)
  *   delete   DELETE .../auth/users/{id} (needs AUTH_USER_ID)
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
+import { raw } from "@neon/sdk";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -89,7 +94,7 @@ if (!projectId || !branchId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
+const neon = neonClient(apiKey);
 
 if (cmd === "create") {
   const email = process.env.USER_EMAIL;
@@ -98,9 +103,11 @@ if (cmd === "create") {
     console.error("Set USER_EMAIL for create.");
     process.exit(1);
   }
-  const { data } = await api.createBranchNeonAuthNewUser(projectId, branchId, {
-    email,
-    ...(name ? { name } : {}),
+  const { data } = await raw.createBranchNeonAuthNewUser({
+    client: neon.client,
+    path: { project_id: projectId, branch_id: branchId },
+    body: { email, ...(name ? { name } : {}) },
+    throwOnError: true,
   });
   console.log(JSON.stringify(data, null, 2));
   process.exit(0);
@@ -112,7 +119,15 @@ if (cmd === "delete") {
     console.error("Set AUTH_USER_ID for delete.");
     process.exit(1);
   }
-  await api.deleteBranchNeonAuthUser(projectId, branchId, authUserId);
+  await raw.deleteBranchNeonAuthUser({
+    client: neon.client,
+    path: {
+      project_id: projectId,
+      branch_id: branchId,
+      auth_user_id: authUserId,
+    },
+    throwOnError: true,
+  });
   console.log(JSON.stringify({ ok: true, deleted: authUserId }, null, 2));
   process.exit(0);
 }

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/branch.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/branch.ts
@@ -1,5 +1,5 @@
 /**
- * List branches or create a dev branch from production (main / production).
+ * List branches or create a dev branch from production (the default branch).
  *
  * Usage (from `scripts/` after `npm run build`):
  *   NEON_API_KEY=... NEON_PROJECT_ID=... node dist/scripts/branch.js list
@@ -7,9 +7,7 @@
  * Or: npm run branch -- list | create <branch-name>
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import { createBranchWithOperations, getProductionBranchId } from "./utils.js";
+import { getProductionBranchId, neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -25,17 +23,24 @@ if (!projectId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
+const neon = neonClient(apiKey);
 
 if (cmd === "list") {
-  const { data } = await api.listProjectBranches({ projectId });
-  const branches = (data.branches ?? []).map((b) => ({
-    id: b.id,
-    name: b.name,
-    created_at: b.created_at,
-    parent_id: b.parent_id,
-  }));
-  console.log(JSON.stringify(branches, null, 2));
+  // `list()` is cursor-paginated; `.all()` concatenates every page.
+  const { data: branches, error } = await neon.branches.list(projectId).all();
+  if (error) throw error;
+  console.log(
+    JSON.stringify(
+      branches.map((b) => ({
+        id: b.id,
+        name: b.name,
+        created_at: b.created_at,
+        parent_id: b.parent_id,
+      })),
+      null,
+      2,
+    ),
+  );
   process.exit(0);
 }
 
@@ -44,19 +49,15 @@ if (cmd === "create") {
     console.error("Usage: npm run branch -- create <branch-name>");
     process.exit(1);
   }
-  const prodId =
+  const parentId =
     process.env.NEON_PARENT_BRANCH_ID?.trim() ||
-    (await getProductionBranchId(api, projectId));
-  if (!prodId) {
-    console.error("Could not resolve production branch (main or production).");
-    process.exit(1);
-  }
-  const { id } = await createBranchWithOperations(api, projectId, {
+    (await getProductionBranchId(neon, projectId));
+  const branch = await neon.branches.create(projectId, {
     name: branchName,
-    parentId: prodId,
+    parent_id: parentId,
   });
   console.log(
-    JSON.stringify({ branchId: id, parentBranchId: prodId }, null, 2),
+    JSON.stringify({ branchId: branch.id, parentBranchId: parentId }, null, 2),
   );
   process.exit(0);
 }

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/consumption-query.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/consumption-query.ts
@@ -1,25 +1,26 @@
 /**
  * GET /consumption_history/v2/projects: usage-based metrics aligned with billing.
  *
- * `metrics` query parameter: comma-separated or repeated; each value must be one of:
- * `compute_unit_seconds`, `root_branch_bytes_month`, `child_branch_bytes_month`,
- * `instant_restore_bytes_month`, `snapshot_storage_bytes_month`,
+ * `metrics` must each be one of: `compute_unit_seconds`, `root_branch_bytes_month`,
+ * `child_branch_bytes_month`, `instant_restore_bytes_month`, `snapshot_storage_bytes_month`,
  * `public_network_transfer_bytes`, `private_network_transfer_bytes`, `extra_branches_month`.
  *
- * Do not use legacy `GET /consumption_history/account` for new work; it is deprecated with a planned
- * sunset of **2026-06-01** — use this v2 project endpoint (or legacy per-project metrics only if you
- * still need legacy fields). See Neon’s consumption docs.
+ * The SDK's `consumption.perProjectV2` is cursor-paginated; `.all()` streams every page
+ * for you (pass CONSUMPTION_LIMIT to tune the page size).
  * @see https://neon.com/docs/guides/consumption-metrics
- * @see https://neon.com/docs/guides/consumption-metrics-legacy
  */
 import "dotenv/config";
-import {
-  ConsumptionHistoryGranularity,
-  createApiClient,
-} from "@neondatabase/api-client";
+import { neonClient } from "./utils.js";
+
+const GRANULARITIES = ["hourly", "daily", "monthly"] as const;
+type Granularity = (typeof GRANULARITIES)[number];
+
+function isGranularity(value: string): value is Granularity {
+  return (GRANULARITIES as readonly string[]).includes(value);
+}
 
 const apiKey = process.env.NEON_API_KEY?.trim();
-const orgId = process.env.NEON_ORG_ID;
+const orgId = process.env.NEON_ORG_ID?.trim();
 const from = process.env.CONSUMPTION_FROM;
 const to = process.env.CONSUMPTION_TO;
 const granularityRaw = process.env.CONSUMPTION_GRANULARITY || "daily";
@@ -39,7 +40,7 @@ const metricsRaw = process.env.CONSUMPTION_METRICS;
 const metrics = metricsRaw
   ? metricsRaw
       .split(",")
-      .map((s: string) => s.trim())
+      .map((s) => s.trim())
       .filter(Boolean)
   : DEFAULT_METRICS;
 
@@ -47,41 +48,38 @@ const projectIdsRaw = process.env.CONSUMPTION_PROJECT_IDS;
 const projectIds = projectIdsRaw
   ? projectIdsRaw
       .split(",")
-      .map((s: string) => s.trim())
+      .map((s) => s.trim())
       .filter(Boolean)
   : undefined;
 
-const GRANULARITY_BY_ENV: Record<string, ConsumptionHistoryGranularity> = {
-  hourly: ConsumptionHistoryGranularity.Hourly,
-  daily: ConsumptionHistoryGranularity.Daily,
-  monthly: ConsumptionHistoryGranularity.Monthly,
-};
-
 if (!apiKey || !orgId || !from || !to) {
   console.error(
-    "Set NEON_API_KEY, NEON_ORG_ID, CONSUMPTION_FROM, CONSUMPTION_TO (RFC 3339). Optional: CONSUMPTION_GRANULARITY, CONSUMPTION_METRICS (comma list), CONSUMPTION_PROJECT_IDS.",
+    "Set NEON_API_KEY, NEON_ORG_ID, CONSUMPTION_FROM, CONSUMPTION_TO (RFC 3339). Optional: CONSUMPTION_GRANULARITY, CONSUMPTION_METRICS (comma list), CONSUMPTION_PROJECT_IDS, CONSUMPTION_LIMIT.",
   );
   process.exit(1);
 }
 
-const granularity = GRANULARITY_BY_ENV[granularityRaw];
-if (granularity === undefined) {
+if (!isGranularity(granularityRaw)) {
   console.error("CONSUMPTION_GRANULARITY must be hourly, daily, or monthly.");
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
-const { data } = await api.getConsumptionHistoryPerProjectV2({
-  org_id: orgId,
-  from,
-  to,
-  granularity,
-  metrics,
-  project_ids: projectIds,
-  limit: process.env.CONSUMPTION_LIMIT
-    ? Number(process.env.CONSUMPTION_LIMIT)
-    : undefined,
-  cursor: process.env.CONSUMPTION_CURSOR || undefined,
-});
+const neon = neonClient(apiKey);
+const { data: projects, error } = await neon.consumption
+  .perProjectV2({
+    org_id: orgId,
+    from,
+    to,
+    granularity: granularityRaw,
+    metrics,
+    ...(projectIds ? { project_ids: projectIds } : {}),
+    ...(process.env.CONSUMPTION_LIMIT
+      ? { limit: Number(process.env.CONSUMPTION_LIMIT) }
+      : {}),
+  })
+  .all();
+if (error) throw error;
 
-console.log(JSON.stringify(data, null, 2));
+console.log(
+  JSON.stringify({ from, to, granularity: granularityRaw, projects }, null, 2),
+);

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/create-project-with-auth.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/create-project-with-auth.ts
@@ -1,18 +1,18 @@
 /**
  * Create a Neon project, then enable Neon Auth on the default branch (Better Auth).
  *
+ * Enabling Neon Auth isn't wrapped by an ergonomic namespace yet, so this drops
+ * to the raw layer (`raw.createNeonAuth`) and reuses the client's auth via
+ * `neon.client`.
+ *
  * Prints Neon Auth keys once; store pub_client_key / secret_server_key securely.
  */
 import "dotenv/config";
-import {
-  createApiClient,
-  NeonAuthSupportedAuthProvider,
-} from "@neondatabase/api-client";
-
-import { createProjectWithOperations, getProductionBranchId } from "./utils.js";
+import { raw } from "@neon/sdk";
+import { getProductionBranchId, neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
-const orgId = process.env.NEON_ORG_ID;
+const orgId = process.env.NEON_ORG_ID?.trim();
 const name =
   process.env.NEON_PROJECT_NAME?.trim() || `tenant-auth-${Date.now()}`;
 const authDb = process.env.NEON_AUTH_DATABASE_NAME?.trim();
@@ -22,33 +22,28 @@ if (!apiKey) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
+const neon = neonClient(apiKey);
 
-const { projectId, databaseUrl } = await createProjectWithOperations(api, {
+const { project, connectionString } = await neon.projects.createAndConnect({
   name,
-  orgId: orgId || undefined,
-  endpointSettings: {
+  ...(orgId ? { org_id: orgId } : {}),
+  default_endpoint_settings: {
     autoscaling_limit_min_cu: 0.25,
     autoscaling_limit_max_cu: 2,
     suspend_timeout_seconds: 300,
   },
 });
 
-const prodBranchId = await getProductionBranchId(api, projectId);
-if (!prodBranchId) {
-  console.error(
-    JSON.stringify(
-      { error: "No production branch after create", projectId },
-      null,
-      2,
-    ),
-  );
-  process.exit(1);
-}
+const prodBranchId = await getProductionBranchId(neon, project.id);
 
-const { data: neonAuth } = await api.createNeonAuth(projectId, prodBranchId, {
-  auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
-  ...(authDb ? { database_name: authDb } : {}),
+const { data: neonAuth } = await raw.createNeonAuth({
+  client: neon.client,
+  path: { project_id: project.id, branch_id: prodBranchId },
+  body: {
+    auth_provider: "better_auth",
+    ...(authDb ? { database_name: authDb } : {}),
+  },
+  throwOnError: true,
 });
 
 console.error(
@@ -58,9 +53,9 @@ console.error(
 console.log(
   JSON.stringify(
     {
-      projectId,
+      projectId: project.id,
       branchId: prodBranchId,
-      databaseUrl,
+      databaseUrl: connectionString,
       name,
       neonAuth,
     },

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/create-project.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/create-project.ts
@@ -1,13 +1,14 @@
 /**
  * Create a Neon project (REST API). Optional org + autoscaling match multi-tenant / Agent Program flows.
+ *
+ * `createAndConnect` creates the project, waits for provisioning to finish, and
+ * returns a ready-to-use pooled connection string in one call.
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import { createProjectWithOperations } from "./utils.js";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
-const orgId = process.env.NEON_ORG_ID;
+const orgId = process.env.NEON_ORG_ID?.trim();
 const name = process.env.NEON_PROJECT_NAME?.trim() || `tenant-${Date.now()}`;
 
 if (!apiKey) {
@@ -15,16 +16,22 @@ if (!apiKey) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
+const neon = neonClient(apiKey);
 
-const { projectId, databaseUrl } = await createProjectWithOperations(api, {
+const { project, connectionString } = await neon.projects.createAndConnect({
   name,
-  orgId: orgId || undefined,
-  endpointSettings: {
+  ...(orgId ? { org_id: orgId } : {}),
+  default_endpoint_settings: {
     autoscaling_limit_min_cu: 0.25,
     autoscaling_limit_max_cu: 2,
     suspend_timeout_seconds: 300,
   },
 });
 
-console.log(JSON.stringify({ projectId, databaseUrl, name }, null, 2));
+console.log(
+  JSON.stringify(
+    { projectId: project.id, databaseUrl: connectionString, name },
+    null,
+    2,
+  ),
+);

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/delete-branch.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/delete-branch.ts
@@ -5,9 +5,7 @@
  * @see https://neon.com/docs/ai/ai-database-versioning#cleanup-strategy
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import { deleteBranchWithWait } from "./utils.js";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -22,6 +20,6 @@ console.error(
   "[delete-branch] Deleting branch; irreversible for that branch environment.",
 );
 
-const api = createApiClient({ apiKey });
-await deleteBranchWithWait(api, projectId, branchId);
+const neon = neonClient(apiKey);
+await neon.branches.delete(projectId, branchId);
 console.log(JSON.stringify({ ok: true, projectId, branchId }, null, 2));

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/delete-project.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/delete-project.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -14,6 +14,6 @@ if (!projectId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
-await api.deleteProject(projectId);
+const neon = neonClient(apiKey);
+await neon.projects.delete(projectId);
 console.log(`Deleted project ${projectId}`);

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/delete-snapshot.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/delete-snapshot.ts
@@ -3,9 +3,7 @@
  * @see https://neon.com/docs/ai/ai-database-versioning#delete-snapshot
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import { deleteSnapshotWithWait } from "./utils.js";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -16,6 +14,6 @@ if (!apiKey || !projectId || !snapshotId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
-await deleteSnapshotWithWait(api, projectId, snapshotId);
+const neon = neonClient(apiKey);
+await neon.snapshots.delete(projectId, snapshotId);
 console.log(JSON.stringify({ ok: true, projectId, snapshotId }, null, 2));

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/list-projects.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/list-projects.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 if (!apiKey) {
@@ -8,14 +8,11 @@ if (!apiKey) {
   );
 }
 
-const api = createApiClient({ apiKey });
+const neon = neonClient(apiKey);
 
-const { data } = await api.listProjects({ limit: 400 });
-const projects = data.projects ?? [];
-
-for (const p of projects) {
-  const id = p.id;
-  const name = p.name ?? "";
-  if (!id) continue;
-  console.log(`${id}\t${name}`);
+// `list()` is cursor-paginated; the async iterator streams every page for you
+// (and throws on a page error).
+for await (const project of neon.projects.list()) {
+  if (!project.id) continue;
+  console.log(`${project.id}\t${project.name ?? ""}`);
 }

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/list-snapshots.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/list-snapshots.ts
@@ -3,7 +3,7 @@
  * @see https://neon.com/docs/ai/ai-database-versioning#list-available-snapshots
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -13,7 +13,6 @@ if (!apiKey || !projectId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
-const { data } = await api.listSnapshots(projectId);
-const snapshots = data.snapshots ?? [];
+const neon = neonClient(apiKey);
+const snapshots = await neon.snapshots.list(projectId);
 console.log(JSON.stringify({ projectId, snapshots }, null, 2));

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/package.json
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/package.json
@@ -33,7 +33,7 @@
     "auth-users": "npm run build && node dist/scripts/auth-users.js"
   },
   "dependencies": {
-    "@neondatabase/api-client": "^2.7.1",
+    "@neon/sdk": "^0.2.0",
     "dotenv": "^16.5.0"
   },
   "devDependencies": {

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/promote-safe-production.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/promote-safe-production.ts
@@ -7,14 +7,7 @@
  *   node dist/scripts/promote-safe-production.js <subcommand>
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import {
-  applySnapshotToBranch,
-  createLogicalSnapshot,
-  getProductionBranchId,
-  restoreSnapshotAsNewBranch,
-} from "./utils.js";
+import { getProductionBranchId, neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectIdEnv = process.env.NEON_PROJECT_ID;
@@ -40,18 +33,12 @@ if (!sub) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
+const neon = neonClient(apiKey);
 
 async function prodBranchId(): Promise<string> {
   const id = process.env.NEON_PROD_BRANCH_ID?.trim();
   if (id) return id;
-  const prod = await getProductionBranchId(api, projectId);
-  if (!prod) {
-    throw new Error(
-      "No production branch (main/production) and NEON_PROD_BRANCH_ID unset",
-    );
-  }
-  return prod;
+  return getProductionBranchId(neon, projectId);
 }
 
 const runId = Date.now();
@@ -62,26 +49,22 @@ if (sub === "bootstrap-dev") {
   console.error(
     `[bootstrap-dev] Snapshot production branch, restore as new branch "${newName}"...`,
   );
-  const snapId = await createLogicalSnapshot(api, projectId, {
-    branchId: pre,
+  const snapshot = await neon.snapshots.create(projectId, pre, {
     name:
       process.env.NEON_SNAPSHOT_BOOTSTRAP_NAME?.trim() ??
       `bootstrap-from-prod-${runId}`,
   });
-  const branchId = await restoreSnapshotAsNewBranch(
-    api,
-    projectId,
-    snapId,
-    newName,
-    false,
-  );
+  // No `targetBranchId` → restore as a new branch.
+  const branch = await neon.snapshots.restore(projectId, snapshot.id, {
+    name: newName,
+  });
   console.log(
     JSON.stringify(
       {
         phase: "bootstrap-dev",
         prodBranchId: pre,
-        snapshotFromProdId: snapId,
-        newDevBranchId: branchId,
+        snapshotFromProdId: snapshot.id,
+        newDevBranchId: branch.id,
         newDevBranchName: newName,
         note: "Point dev workloads at newDevBranchId; cleanup orphaned branches in Console if needed.",
       },
@@ -109,23 +92,22 @@ if (sub === "promote") {
     `dev_snap_${runId}_candidate`;
 
   console.error("[promote] 1/3 Snapshot prod (rollback point)...");
-  const rollbackSnapId = await createLogicalSnapshot(api, projectId, {
-    branchId: prodId,
+  const rollback = await neon.snapshots.create(projectId, prodId, {
     name: preName,
   });
 
   console.error("[promote] 2/3 Snapshot dev (candidate to publish)...");
-  const candidateSnapId = await createLogicalSnapshot(api, projectId, {
-    branchId: devBranchId,
+  const candidate = await neon.snapshots.create(projectId, devBranchId, {
     name: candName,
   });
 
   console.error(
     "[promote] 3/3 Restore dev snapshot onto prod (finalize); brief connection drop on prod...",
   );
-  await applySnapshotToBranch(api, projectId, candidateSnapId, prodId, {
-    finalizeRestore: true,
-    restoreBranchName:
+  await neon.snapshots.restore(projectId, candidate.id, {
+    targetBranchId: prodId,
+    finalize: true,
+    name:
       process.env.NEON_RESTORE_BACKUP_BRANCH_NAME ?? `before_promote_${runId}`,
   });
 
@@ -137,8 +119,8 @@ if (sub === "promote") {
       {
         phase: "promote",
         prodBranchIdBeforeNote: prodId,
-        rollbackSnapshotId: rollbackSnapId,
-        promotedSnapshotId: candidateSnapId,
+        rollbackSnapshotId: rollback.id,
+        promotedSnapshotId: candidate.id,
         warning:
           "Production writes after rollbackSnapId was taken are not included. Delete orphaned backup branches when ready.",
       },
@@ -163,15 +145,15 @@ if (sub === "refresh-dev") {
     `prod_snap_${runId}_refresh_dev`;
 
   console.error("[refresh-dev] 1/2 Snapshot prod...");
-  const prodSnapId = await createLogicalSnapshot(api, projectId, {
-    branchId: prodId,
+  const prodSnap = await neon.snapshots.create(projectId, prodId, {
     name: snapName,
   });
 
   console.error("[refresh-dev] 2/2 Restore prod snapshot onto dev...");
-  await applySnapshotToBranch(api, projectId, prodSnapId, devBranchId, {
-    finalizeRestore: true,
-    restoreBranchName:
+  await neon.snapshots.restore(projectId, prodSnap.id, {
+    targetBranchId: devBranchId,
+    finalize: true,
+    name:
       process.env.NEON_RESTORE_BACKUP_BRANCH_NAME ??
       `before_refresh_dev_${runId}`,
   });
@@ -182,7 +164,7 @@ if (sub === "refresh-dev") {
         phase: "refresh-dev",
         prodBranchId: prodId,
         devBranchId,
-        prodSnapshotId: prodSnapId,
+        prodSnapshotId: prodSnap.id,
       },
       null,
       2,
@@ -202,9 +184,10 @@ if (sub === "rollback-prod") {
   const prodId = await prodBranchId();
 
   console.error("[rollback-prod] Restore snapshot onto prod...");
-  await applySnapshotToBranch(api, projectId, snap, prodId, {
-    finalizeRestore: true,
-    restoreBranchName:
+  await neon.snapshots.restore(projectId, snap, {
+    targetBranchId: prodId,
+    finalize: true,
+    name:
       process.env.NEON_RESTORE_BACKUP_BRANCH_NAME ?? `before_rollback_${runId}`,
   });
 

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/rename-snapshot.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/rename-snapshot.ts
@@ -3,7 +3,7 @@
  * @see https://neon.com/docs/ai/ai-database-versioning#update-snapshot-name
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -17,8 +17,6 @@ if (!apiKey || !projectId || !snapshotId || !name) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
-await api.updateSnapshot(projectId, snapshotId, {
-  snapshot: { name },
-});
+const neon = neonClient(apiKey);
+await neon.snapshots.update(projectId, snapshotId, { name });
 console.log(JSON.stringify({ ok: true, projectId, snapshotId, name }, null, 2));

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/restore-snapshot.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/restore-snapshot.ts
@@ -4,9 +4,7 @@
  * @see https://neon.com/docs/ai/ai-database-versioning
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import { applySnapshotToBranch } from "./utils.js";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -20,8 +18,17 @@ if (!apiKey || !projectId || !snapshotId || !targetBranchId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
-await applySnapshotToBranch(api, projectId, snapshotId, targetBranchId);
+const neon = neonClient(apiKey);
+
+// Restore onto an existing branch and finalize immediately (swap computes onto
+// the restored data). Pass a `preview` callback instead of `finalize` to inspect
+// the restored branch before committing.
+await neon.snapshots.restore(projectId, snapshotId, {
+  targetBranchId,
+  finalize: true,
+  name: `before_restore_${Date.now()}`,
+});
+
 console.log(
   JSON.stringify(
     {

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/snapshot.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/snapshot.ts
@@ -2,13 +2,11 @@
  * Create a logical snapshot on the default branch (same pattern as many agent hosts).
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import { createLogicalSnapshot } from "./utils.js";
+import { getProductionBranchId, neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
-const snapshotName = process.env.NEON_SNAPSHOT_NAME;
+const snapshotName = process.env.NEON_SNAPSHOT_NAME?.trim();
 const expiresAt = process.env.NEON_SNAPSHOT_EXPIRES_AT?.trim();
 const lsn = process.env.NEON_SNAPSHOT_LSN?.trim();
 
@@ -22,10 +20,14 @@ if (!projectId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
-const snapshotId = await createLogicalSnapshot(api, projectId, {
-  name: snapshotName || undefined,
+const neon = neonClient(apiKey);
+const branchId = await getProductionBranchId(neon, projectId);
+
+const snapshot = await neon.snapshots.create(projectId, branchId, {
+  ...(snapshotName ? { name: snapshotName } : {}),
   ...(expiresAt ? { expiresAt } : {}),
-  ...(lsn ? { lsn } : {}),
+  // A snapshot is taken at an `lsn` or a `timestamp`; default to "now".
+  ...(lsn ? { lsn } : { timestamp: new Date().toISOString() }),
 });
-console.log(JSON.stringify({ snapshotId, projectId }, null, 2));
+
+console.log(JSON.stringify({ snapshotId: snapshot.id, projectId }, null, 2));

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/transfer-project.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/transfer-project.ts
@@ -6,7 +6,7 @@
  * @see https://neon.com/docs/manage/orgs-project-transfer
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
+import { neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const sourceOrgId = process.env.NEON_SOURCE_ORG_ID;
@@ -23,14 +23,16 @@ if (!apiKey || !sourceOrgId || !destinationOrgId || !rawIds.trim()) {
 
 const projectIds = rawIds
   .split(",")
-  .map((s: string) => s.trim())
+  .map((s) => s.trim())
   .filter(Boolean);
 
-const api = createApiClient({ apiKey });
-await api.transferProjectsFromOrgToOrg(sourceOrgId, {
-  destination_org_id: destinationOrgId,
-  project_ids: projectIds,
+const neon = neonClient(apiKey);
+await neon.projects.transfer({
+  fromOrgId: sourceOrgId,
+  toOrgId: destinationOrgId,
+  projectIds,
 });
+
 console.log(
   JSON.stringify(
     {

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/utils.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/utils.ts
@@ -1,264 +1,31 @@
 /**
- * Shared Neon Management API utilities (operation polling + common SDK call patterns).
- * Uses {@link createApiClient} types only; no alternate Neon packages.
+ * Shared @neon/sdk helpers for the example scripts.
+ *
+ * The scripts use a single client configured with `throwOnError` (methods
+ * return the resource directly and throw a typed NeonError on failure) and
+ * `waitForReadiness` (mutations block until their provisioning operations
+ * settle, so the returned resource is ready to use). That readiness polling is
+ * built into the SDK, so these scripts no longer hand-roll an operation poller.
  */
-import type { Api } from "@neondatabase/api-client";
-import {
-  OperationStatus,
-  type GeneralError,
-  type Operation,
-} from "@neondatabase/api-client";
+import { createNeonClient, type NeonClient } from "@neon/sdk";
 
-export function formatNeonManagementError(err: unknown): Error {
-  if (err && typeof err === "object" && "response" in err) {
-    const data = (err as { response?: { data?: GeneralError } }).response?.data;
-    if (data?.message) {
-      const text = data.code ? `${data.code}: ${data.message}` : data.message;
-      return new Error(text);
-    }
-  }
-  if (err instanceof Error) return err;
-  return new Error(String(err));
+/** Build an ergonomic Neon client from a raw API key. */
+export function neonClient(apiKey: string): NeonClient<true> {
+  return createNeonClient<true>({
+    apiKey,
+    throwOnError: true,
+    waitForReadiness: true,
+  });
 }
 
-export function operationIdsFrom(ops: Operation[] | undefined): string[] {
-  return (ops ?? [])
-    .map((o) => o.id)
-    .filter((id): id is string => typeof id === "string" && id.length > 0);
-}
-
-function isTerminalSuccess(status: string): boolean {
-  return (
-    status === OperationStatus.Finished ||
-    status === OperationStatus.Skipped ||
-    status === OperationStatus.Cancelled
-  );
-}
-
-function isTerminalFailure(status: string): boolean {
-  return status === OperationStatus.Failed || status === OperationStatus.Error;
-}
-
-export async function waitForOperationsToSettle(
-  api: Api<unknown>,
-  projectId: string,
-  operationIds: string[],
-  options: { pollIntervalMs?: number; timeoutMs?: number } = {},
-): Promise<void> {
-  const pollIntervalMs = options.pollIntervalMs ?? 2000;
-  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
-
-  for (const opId of operationIds) {
-    const startedAt = Date.now();
-    for (;;) {
-      const { data } = await api.getProjectOperation(projectId, opId);
-      const status = data.operation?.status;
-      if (!status) throw new Error(`Operation status missing for ${opId}`);
-      if (isTerminalFailure(status)) {
-        throw new Error(`Operation ${opId} ended with status ${status}`);
-      }
-      if (isTerminalSuccess(status)) break;
-      if (Date.now() - startedAt > timeoutMs) {
-        throw new Error(
-          `Timed out waiting for operation ${opId} (last status: ${status})`,
-        );
-      }
-      await new Promise((r) => setTimeout(r, pollIntervalMs));
-    }
-  }
-}
-
+/**
+ * Resolve the project's default (production) branch id. Uses the SDK's
+ * `getDefault`, which resolves by the `default` flag rather than by name.
+ */
 export async function getProductionBranchId(
-  api: Api<unknown>,
+  neon: NeonClient<true>,
   projectId: string,
-): Promise<string | undefined> {
-  const { data } = await api.listProjectBranches({ projectId });
-  const branches = data.branches ?? [];
-  const main = branches.find((b) => b.name === "main");
-  const prod = branches.find((b) => b.name === "production");
-  const chosen = main ?? prod;
-  return typeof chosen?.id === "string" ? chosen.id : undefined;
-}
-
-export async function createProjectWithOperations(
-  api: Api<unknown>,
-  params: {
-    name: string;
-    orgId?: string;
-    endpointSettings?: {
-      autoscaling_limit_min_cu?: number;
-      autoscaling_limit_max_cu?: number;
-      suspend_timeout_seconds?: number;
-    };
-  },
-): Promise<{ projectId: string; databaseUrl: string }> {
-  const { data } = await api.createProject({
-    project: {
-      name: params.name,
-      ...(params.orgId ? { org_id: params.orgId } : {}),
-      ...(params.endpointSettings
-        ? { default_endpoint_settings: params.endpointSettings }
-        : {}),
-    },
-  });
-  const projectId = data.project?.id;
-  if (!projectId)
-    throw new Error("Create project: missing project id in response");
-  const databaseUrl = data.connection_uris?.[0]?.connection_uri;
-  if (!databaseUrl) {
-    throw new Error("Create project: missing connection URI in response");
-  }
-  const opIds = operationIdsFrom(data.operations);
-  if (opIds.length > 0) {
-    await waitForOperationsToSettle(api, projectId, opIds);
-  }
-  return { projectId, databaseUrl };
-}
-
-export async function createLogicalSnapshot(
-  api: Api<unknown>,
-  projectId: string,
-  options: {
-    branchId?: string;
-    name?: string;
-    timestamp?: string;
-    lsn?: string;
-    expiresAt?: string;
-  },
 ): Promise<string> {
-  let branchId = options.branchId;
-  if (!branchId) {
-    const prodId = await getProductionBranchId(api, projectId);
-    if (!prodId) {
-      throw new Error(
-        "No production branch (expected name main or production)",
-      );
-    }
-    branchId = prodId;
-  }
-  const base = {
-    projectId,
-    branchId,
-    ...(options.name ? { name: options.name } : {}),
-    ...(options.expiresAt ? { expires_at: options.expiresAt } : {}),
-  };
-  const { data } = await api.createSnapshot(
-    options.lsn
-      ? { ...base, lsn: options.lsn }
-      : {
-          ...base,
-          timestamp: options.timestamp ?? new Date().toISOString(),
-        },
-  );
-  const snapshotId = data.snapshot?.id;
-  if (!snapshotId)
-    throw new Error("Create snapshot: missing snapshot id in response");
-  const opIds = operationIdsFrom(data.operations);
-  if (opIds.length > 0) {
-    await waitForOperationsToSettle(api, projectId, opIds);
-  }
-  return snapshotId;
-}
-
-export async function applySnapshotToBranch(
-  api: Api<unknown>,
-  projectId: string,
-  snapshotId: string,
-  targetBranchId: string,
-  options: {
-    restoreBranchName?: string;
-    finalizeRestore?: boolean;
-  } = {},
-): Promise<void> {
-  try {
-    const { data } = await api.restoreSnapshot(
-      { projectId, snapshotId },
-      {
-        name: options.restoreBranchName ?? `before_restore_${Date.now()}`,
-        finalize_restore: options.finalizeRestore !== false,
-        target_branch_id: targetBranchId,
-      },
-    );
-    const opIds = operationIdsFrom(data.operations);
-    if (opIds.length > 0) {
-      await waitForOperationsToSettle(api, projectId, opIds);
-    }
-  } catch (e) {
-    throw formatNeonManagementError(e);
-  }
-}
-
-export async function restoreSnapshotAsNewBranch(
-  api: Api<unknown>,
-  projectId: string,
-  snapshotId: string,
-  newBranchName: string,
-  finalizeRestore = false,
-): Promise<string> {
-  try {
-    const { data } = await api.restoreSnapshot(
-      { projectId, snapshotId },
-      {
-        name: newBranchName,
-        finalize_restore: finalizeRestore,
-      },
-    );
-    const opIds = operationIdsFrom(data.operations);
-    if (opIds.length > 0) {
-      await waitForOperationsToSettle(api, projectId, opIds);
-    }
-    const branchId = data.branch?.id;
-    if (!branchId) {
-      throw new Error(
-        "restoreSnapshotAsNewBranch: missing branch id in response",
-      );
-    }
-    return branchId;
-  } catch (e) {
-    throw formatNeonManagementError(e);
-  }
-}
-
-export async function createBranchWithOperations(
-  api: Api<unknown>,
-  projectId: string,
-  params: { name: string; parentId?: string },
-): Promise<{ id: string }> {
-  const { data } = await api.createProjectBranch(projectId, {
-    branch: {
-      name: params.name,
-      ...(params.parentId ? { parent_id: params.parentId } : {}),
-    },
-  });
-  const id = data.branch?.id;
-  if (!id) throw new Error("Create branch: missing id in response");
-  const opIds = operationIdsFrom(data.operations);
-  if (opIds.length > 0) {
-    await waitForOperationsToSettle(api, projectId, opIds);
-  }
-  return { id };
-}
-
-export async function deleteSnapshotWithWait(
-  api: Api<unknown>,
-  projectId: string,
-  snapshotId: string,
-): Promise<void> {
-  const { data } = await api.deleteSnapshot(projectId, snapshotId);
-  const opIds = operationIdsFrom(data.operations);
-  if (opIds.length > 0) {
-    await waitForOperationsToSettle(api, projectId, opIds);
-  }
-}
-
-export async function deleteBranchWithWait(
-  api: Api<unknown>,
-  projectId: string,
-  branchId: string,
-): Promise<void> {
-  const { data } = await api.deleteProjectBranch(projectId, branchId);
-  const opIds = operationIdsFrom(data.operations);
-  if (opIds.length > 0) {
-    await waitForOperationsToSettle(api, projectId, opIds);
-  }
+  const branch = await neon.branches.getDefault(projectId);
+  return branch.id;
 }

--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/versioning-flow.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/versioning-flow.ts
@@ -3,21 +3,14 @@
  *
  * 1. Snapshot the production branch (baseline).
  * 2. Create a child branch from production (sandbox).
- * 3. SQL mutation step removed; this package uses only @neondatabase/api-client (no DB query client).
+ * 3. SQL mutation step omitted; this package uses only @neon/sdk (no DB query client).
  * 4. Logical snapshots are **root-branch only** in the Neon API for non-root branches.
  * 5. Restore the baseline snapshot onto the child branch (undo / rewind).
  *
  * @see https://neon.com/docs/ai/ai-database-versioning
  */
 import "dotenv/config";
-import { createApiClient } from "@neondatabase/api-client";
-
-import {
-  applySnapshotToBranch,
-  createBranchWithOperations,
-  createLogicalSnapshot,
-  getProductionBranchId,
-} from "./utils.js";
+import { getProductionBranchId, neonClient } from "./utils.js";
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID;
@@ -27,13 +20,9 @@ if (!apiKey || !projectId) {
   process.exit(1);
 }
 
-const api = createApiClient({ apiKey });
+const neon = neonClient(apiKey);
 
-const prodBranchId = await getProductionBranchId(api, projectId);
-if (!prodBranchId) {
-  console.error("No production branch (main or production).");
-  process.exit(1);
-}
+const prodBranchId = await getProductionBranchId(neon, projectId);
 
 const runId = Date.now();
 const baselineName =
@@ -42,15 +31,14 @@ const demoBranchName =
   process.env.VERSION_DEMO_BRANCH_NAME ?? `versioning-demo-${runId}`;
 
 console.error("[versioning-flow] 1/5 Snapshot production branch (baseline)...");
-const baselineSnapshotId = await createLogicalSnapshot(api, projectId, {
-  branchId: prodBranchId,
+const baseline = await neon.snapshots.create(projectId, prodBranchId, {
   name: baselineName,
 });
 
 console.error("[versioning-flow] 2/5 Create child branch from production...");
-const { id: demoBranchId } = await createBranchWithOperations(api, projectId, {
+const demoBranch = await neon.branches.create(projectId, {
   name: demoBranchName,
-  parentId: prodBranchId,
+  parent_id: prodBranchId,
 });
 
 const sqlNote =
@@ -64,15 +52,19 @@ console.error(
 console.error(
   "[versioning-flow] 5/5 Restore baseline snapshot onto demo branch (rewind)...",
 );
-await applySnapshotToBranch(api, projectId, baselineSnapshotId, demoBranchId);
+await neon.snapshots.restore(projectId, baseline.id, {
+  targetBranchId: demoBranch.id,
+  finalize: true,
+  name: `before_restore_${runId}`,
+});
 
 console.log(
   JSON.stringify(
     {
       projectId,
       productionBranchId: prodBranchId,
-      baselineSnapshotId,
-      demoBranchId,
+      baselineSnapshotId: baseline.id,
+      demoBranchId: demoBranch.id,
       demoBranchName,
       afterSnapshotId: null,
       afterSnapshotNote:

--- a/public/docs/ai/skills/neon-postgres/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres/SKILL.md
@@ -204,7 +204,7 @@ Link: https://neon.com/docs/reference/api-reference.md
 
 ### Neon TypeScript SDK
 
-Use this when implementing typed programmatic control of Neon resources in TypeScript via `@neondatabase/api-client`.
+Use this when implementing typed programmatic control of Neon resources in TypeScript via `@neon/sdk` (the fetch-based, zero-dependency successor to `@neondatabase/api-client`).
 
 Link: https://neon.com/docs/reference/typescript-sdk.md
 
@@ -273,7 +273,7 @@ Since `neon.ts` is TypeScript, invalid combinations fail to compile with an acti
 Read the resulting env back, typed and validated against the policy, with `parseEnv` from `@neon/env`:
 
 ```typescript
-import { parseEnv } from "@neon/env/v1";
+import { parseEnv } from "@neon/env";
 import config from "./neon";
 
 const env = parseEnv(config);

--- a/public/docs/ai/skills/neon-postgres/references/neon-typescript-sdk.md
+++ b/public/docs/ai/skills/neon-postgres/references/neon-typescript-sdk.md
@@ -1,6 +1,6 @@
 # Neon TypeScript SDK
 
-The `@neondatabase/api-client` TypeScript SDK is a typed wrapper around the Neon REST API for managing Neon resources programmatically.
+The `@neon/sdk` TypeScript SDK is a modern, fetch-based, zero-dependency, typed client for the Neon REST API for managing Neon resources programmatically. It is the successor to `@neondatabase/api-client`.
 
 For core concepts (Organization, Project, Branch, Endpoint, etc.), see `https://neon.com/docs/ai/skills/neon-postgres/references/what-is-neon.md`.
 
@@ -9,15 +9,28 @@ See the [official TypeScript SDK docs](https://neon.com/docs/reference/typescrip
 ## Installation
 
 ```bash
-npm install @neondatabase/api-client
+npm install @neon/sdk
 ```
 
 ## Authentication
 
 ```typescript
-import { createApiClient } from "@neondatabase/api-client";
+import { createNeonClient } from "@neon/sdk";
 
-const apiClient = createApiClient({ apiKey: process.env.NEON_API_KEY! });
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+```
+
+The SDK has two layers: the ergonomic `createNeonClient` (used below, organized into resource namespaces) and `raw` (the full generated 1:1 surface, `import { raw } from "@neon/sdk"`) for any endpoint not wrapped by a namespace.
+
+## The result model
+
+By default every method resolves to a discriminated `{ data, error }` envelope, so no `try/catch` is needed. Pass `throwOnError: true` (on the client or per call) to get the bare resource and throw a typed `NeonError` instead. Mutations can block until their provisioning operations finish with `waitForReadiness: true`.
+
+```typescript
+const neon = createNeonClient({
+  apiKey: process.env.NEON_API_KEY!,
+  waitForReadiness: true, // mutations return only once the resource is ready
+});
 ```
 
 ## Org-Aware Workflow
@@ -26,110 +39,132 @@ All Neon accounts are organization-based. You must discover the user's org first
 
 ```typescript
 // 1. Get the user's organizations
-const { data: orgs } = await apiClient.getCurrentUserOrganizations();
-const orgId = orgs.organizations[0].id;
+const { data: orgs, error } = await neon.user.organizations();
+if (error) throw error;
+const orgId = orgs[0].id;
 
-// 2. List projects within the org
-const { data: projects } = await apiClient.listProjects({ org_id: orgId });
+// 2. List projects within the org (the async iterator auto-paginates)
+for await (const project of neon.projects.list({ org_id: orgId })) {
+  console.log(project.id, project.name);
+}
 ```
+
+You can also set `orgId` once on the client (`createNeonClient({ apiKey, orgId })`) and it is applied to project create/list and as the default transfer source.
 
 ## Method Quick Reference
 
 ### Projects
 
-| Operation          | Method                                                                          |
-| ------------------ | ------------------------------------------------------------------------------- |
-| List projects      | `apiClient.listProjects({ org_id })`                                            |
-| Create project     | `apiClient.createProject({ project: { name, pg_version, region_id, org_id } })` |
-| Get project        | `apiClient.getProject(projectId)`                                               |
-| Update project     | `apiClient.updateProject(projectId, { project: { name } })`                     |
-| Delete project     | `apiClient.deleteProject(projectId)`                                            |
-| Get connection URI | `apiClient.getConnectionUri({ projectId, database_name, role_name, pooled })`   |
+| Operation             | Method                                                              |
+| --------------------- | ------------------------------------------------------------------- |
+| List projects         | `neon.projects.list({ org_id })` (returns a paginated list)         |
+| Create project        | `neon.projects.create({ name, pg_version, region_id, org_id })`     |
+| Create + connect      | `neon.projects.createAndConnect({ name })` → `{ project, connectionString }` |
+| Get project           | `neon.projects.get(projectId)`                                      |
+| Update project        | `neon.projects.update(projectId, { name })`                         |
+| Delete project        | `neon.projects.delete(projectId)`                                   |
+| Transfer projects     | `neon.projects.transfer({ toOrgId, projectIds })`                   |
+| Get connection string | `neon.postgres.connectionString({ projectId, databaseName, roleName, pooled })` |
+
+Paginated lists (`list()`) expose `.all()` (every page → `{ data, error }`), `.page()` (one page), and an async iterator (`for await …`, throws on a page error).
 
 ### Branches
 
-| Operation     | Method                                                                                  |
-| ------------- | --------------------------------------------------------------------------------------- |
-| Create branch | `apiClient.createProjectBranch(projectId, { branch: { name }, endpoints: [{ type }] })` |
-| List branches | `apiClient.listProjectBranches({ projectId })`                                          |
-| Get branch    | `apiClient.getProjectBranch(projectId, branchId)`                                       |
-| Update branch | `apiClient.updateProjectBranch(projectId, branchId, { branch: { name } })`              |
-| Delete branch | `apiClient.deleteProjectBranch(projectId, branchId)`                                    |
+| Operation            | Method                                                                  |
+| -------------------- | ----------------------------------------------------------------------- |
+| Create branch        | `neon.branches.create(projectId, { name, parent_id })`                  |
+| Create + compute     | `neon.branches.createWithCompute(projectId, { name })` → `{ branch, endpoint, connectionString }` |
+| List branches        | `neon.branches.list(projectId)` (paginated)                             |
+| Get branch           | `neon.branches.get(projectId, branchId)`                                |
+| Update branch        | `neon.branches.update(projectId, branchId, { name })`                   |
+| Delete branch        | `neon.branches.delete(projectId, branchId)`                             |
+| Resolve default      | `neon.branches.getDefault(projectId)`                                   |
+| Set default          | `neon.branches.setDefault(projectId, branchId)`                         |
 
 ### Databases
 
-| Operation       | Method                                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------ |
-| Create database | `apiClient.createProjectBranchDatabase(projectId, branchId, { database: { name, owner_name } })` |
-| List databases  | `apiClient.listProjectBranchDatabases(projectId, branchId)`                                      |
-| Delete database | `apiClient.deleteProjectBranchDatabase(projectId, branchId, databaseName)`                       |
+| Operation       | Method                                                                    |
+| --------------- | ------------------------------------------------------------------------- |
+| Create database | `neon.postgres.databases.create(projectId, branchId, { name, owner_name })` |
+| List databases  | `neon.postgres.databases.list(projectId, branchId)`                       |
+| Delete database | `neon.postgres.databases.delete(projectId, branchId, databaseName)`       |
 
 ### Roles
 
-| Operation   | Method                                                                       |
-| ----------- | ---------------------------------------------------------------------------- |
-| Create role | `apiClient.createProjectBranchRole(projectId, branchId, { role: { name } })` |
-| List roles  | `apiClient.listProjectBranchRoles(projectId, branchId)`                      |
-| Delete role | `apiClient.deleteProjectBranchRole(projectId, branchId, roleName)`           |
+| Operation      | Method                                                          |
+| -------------- | -------------------------------------------------------------- |
+| Create role    | `neon.postgres.roles.create(projectId, branchId, { name })`    |
+| List roles     | `neon.postgres.roles.list(projectId, branchId)`                |
+| Delete role    | `neon.postgres.roles.delete(projectId, branchId, roleName)`    |
+| Reveal password| `neon.postgres.roles.password(projectId, branchId, roleName)`  |
+| Reset password | `neon.postgres.roles.resetPassword(projectId, branchId, roleName)` |
 
 ### Endpoints
 
-| Operation        | Method                                                                          |
-| ---------------- | ------------------------------------------------------------------------------- |
-| Create endpoint  | `apiClient.createProjectEndpoint(projectId, { endpoint: { branch_id, type } })` |
-| List endpoints   | `apiClient.listProjectEndpoints(projectId)`                                     |
-| Start endpoint   | `apiClient.startProjectEndpoint(projectId, endpointId)`                         |
-| Suspend endpoint | `apiClient.suspendProjectEndpoint(projectId, endpointId)`                       |
-| Restart endpoint | `apiClient.restartProjectEndpoint(projectId, endpointId)`                       |
-| Update endpoint  | `apiClient.updateProjectEndpoint(projectId, endpointId, { endpoint: {...} })`   |
-| Delete endpoint  | `apiClient.deleteProjectEndpoint(projectId, endpointId)`                        |
+| Operation        | Method                                                                 |
+| ---------------- | ---------------------------------------------------------------------- |
+| Create endpoint  | `neon.postgres.endpoints.create(projectId, { branch_id, type })`       |
+| List endpoints   | `neon.postgres.endpoints.list(projectId)`                              |
+| Get endpoint     | `neon.postgres.endpoints.get(projectId, endpointId)`                   |
+| Start endpoint   | `neon.postgres.endpoints.start(projectId, endpointId)`                 |
+| Suspend endpoint | `neon.postgres.endpoints.suspend(projectId, endpointId)`               |
+| Restart endpoint | `neon.postgres.endpoints.restart(projectId, endpointId)`               |
+| Update endpoint  | `neon.postgres.endpoints.update(projectId, endpointId, { ... })`       |
+| Delete endpoint  | `neon.postgres.endpoints.delete(projectId, endpointId)`                |
 
 ### API Keys
 
-| Operation  | Method                                 |
-| ---------- | -------------------------------------- |
-| List keys  | `apiClient.listApiKeys()`              |
-| Create key | `apiClient.createApiKey({ key_name })` |
-| Revoke key | `apiClient.revokeApiKey(keyId)`        |
+| Operation  | Method                            |
+| ---------- | --------------------------------- |
+| List keys  | `neon.apiKeys.list()`             |
+| Create key | `neon.apiKeys.create(keyName)`    |
+| Revoke key | `neon.apiKeys.revoke(keyId)`      |
 
 ### Operations
 
-| Operation       | Method                                                  |
-| --------------- | ------------------------------------------------------- |
-| List operations | `apiClient.listProjectOperations({ projectId })`        |
-| Get operation   | `apiClient.getProjectOperation(projectId, operationId)` |
+| Operation           | Method                                          |
+| ------------------- | ----------------------------------------------- |
+| List operations     | `neon.operations.list(projectId)` (paginated)   |
+| Get operation       | `neon.operations.get(projectId, operationId)`   |
+| Wait for operations | `neon.operations.waitFor(operations)`           |
 
 ### Organizations
 
-| Operation      | Method                                                                   |
-| -------------- | ------------------------------------------------------------------------ |
-| List user orgs | `apiClient.getCurrentUserOrganizations()`                                |
-| Get org        | `apiClient.getOrganization(orgId)`                                       |
-| List members   | `apiClient.getOrganizationMembers(orgId)`                                |
-| Create org key | `apiClient.createOrgApiKey(orgId, { key_name, project_id? })`            |
-| Invite member  | `apiClient.createOrganizationInvitations(orgId, { invitations: [...] })` |
+Only `user.organizations()` is wrapped; the rest of organization management is available via the `raw` layer (pass `neon.client` to reuse auth).
+
+| Operation      | Method                                                                                       |
+| -------------- | -------------------------------------------------------------------------------------------- |
+| List user orgs | `neon.user.organizations()`                                                                  |
+| Get org        | `raw.getOrganization({ client: neon.client, path: { org_id } })`                             |
+| List members   | `raw.getOrganizationMembers({ client: neon.client, path: { org_id } })`                      |
+| Create org key | `raw.createOrgApiKey({ client: neon.client, path: { org_id }, body: { key_name } })`         |
+| Invite member  | `raw.createOrganizationInvitations({ client: neon.client, path: { org_id }, body: { invitations: [...] } })` |
 
 ## Error Handling
 
+The `error` channel carries a typed hierarchy (all `Error` subclasses with a `kind` discriminant), so you can branch on `error.kind` instead of inspecting HTTP internals:
+
 ```typescript
-try {
-  const response = await apiClient.getProject(projectId);
-  return response.data;
-} catch (error: any) {
-  if (error.isAxiosError) {
-    const status = error.response?.status;
-    // 401 = bad API key, 404 = not found, 429 = rate limited
-    console.error("API error:", status, error.response?.data?.message);
-  }
+const { data, error } = await neon.projects.get(projectId);
+if (error) {
+  // error.kind: "not_found" (404) | "auth" (401/403) | "rate_limit" (429)
+  //           | "api" | "operation" | "timeout" | "network" | "client"
+  if (error.kind === "not_found") return null;
+  console.error("API error:", error.kind, error.message);
   return null;
 }
+return data;
 ```
+
+Prefer exceptions? Set `throwOnError: true` and wrap calls in `try/catch` — the same typed `NeonError` is thrown, and return types narrow accordingly. The SDK also retries always-safe statuses (`423`, `429`, `503`) automatically.
 
 ## Key Types
 
-```typescript
-import { EndpointType, MemberRole } from "@neondatabase/api-client";
+All request, response, and error types are re-exported flat from `@neon/sdk` for `import type { … }`:
 
-// EndpointType.ReadWrite, EndpointType.ReadOnly
-// MemberRole.Admin, MemberRole.Member
+```typescript
+import type { EndpointType, MemberRole, Project, Branch } from "@neon/sdk";
+
+// EndpointType: "read_write" | "read_only"
+// MemberRole: "admin" | "member" | "editor" | "viewer" | "collaborator"
 ```

--- a/src/app/.well-known/ai-catalog.json/catalog.json
+++ b/src/app/.well-known/ai-catalog.json/catalog.json
@@ -23,7 +23,7 @@
       "identifier": "urn:air:neon.com:skill:neon-postgres",
       "type": "application/agent-skills+md",
       "url": "https://neon.com/.well-known/agent-skills/neon-postgres/SKILL.md",
-      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about \"Neon setup\", \"connect to Neon\", \"Neon project\", \"DATABASE_URL\", \"serverless Postgres\", \"Neon CLI\", \"neonctl\", \"Neon MCP\", \"Neon Auth\", \"@neondatabase/serverless\", \"@neondatabase/neon-js\", \"scale to zero\", \"Neon autoscaling\", \"Neon read replica\", or \"Neon connection pooling\"."
+      "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about \"Neon setup\", \"connect to Neon\", \"Neon project\", \"DATABASE_URL\", \"serverless Postgres\", \"Neon CLI\", \"neon\", \"Neon MCP\", \"Neon Auth\", \"@neondatabase/serverless\", \"@neondatabase/neon-js\", \"scale to zero\", \"Neon autoscaling\", \"Neon read replica\", or \"Neon connection pooling\"."
     },
     {
       "identifier": "urn:air:neon.com:skill:claimable-postgres",


### PR DESCRIPTION
## Summary

Updates the hosted agent-skill files under `public/docs/ai/skills/` to reflect the migration from `@neondatabase/api-client` (Axios-based) to the new fetch-based, zero-dependency **`@neon/sdk`**.

- **`neon-postgres-agent-platforms`** — re-synced from `neondatabase/neon-for-agent-platforms@main` via `npm run sync:skills`. All 16 sample scripts + `utils.ts` now use `@neon/sdk` (`createNeonClient` with `throwOnError` + `waitForReadiness`, the `raw` layer for Neon Auth), and `package.json` drops `@neondatabase/api-client` (removing the transitive axios).
- **`neon-postgres`** — re-synced `SKILL.md` from `neondatabase/agent-skills@main` (the "Neon TypeScript SDK" entry now points at `@neon/sdk`).
- **`neon-postgres/references/neon-typescript-sdk.md`** — this reference has no upstream source in `agent-skills` anymore (that skill no longer ships a `references/` dir), so the sync can't refresh it. Rewrote it in place to the `@neon/sdk` API (result model, resource-namespace method reference, typed errors, `raw` for org management, correct `EndpointType` / `MemberRole` unions).
- Regenerated the skill discovery indexes (`npm run generate:skills`).

Source-repo changes this mirrors: `neondatabase/neon-for-agent-platforms@cfd3a7d`, `neondatabase/agent-skills@8703a12`.

## Verification

The migrated scripts were smoke-tested end-to-end against live Neon (18/19 script entrypoints pass; the 2 non-passes are Neon plan limits — custom suspend interval + transfer destination plan — not code issues), and `tsc`/Prettier are clean in the source repo.

## Notes

- The only remaining `@neondatabase/api-client` strings in the hosted skills are intentional "successor to `@neondatabase/api-client`" descriptions.
- Out of scope (not skill files): `content/docs/**`, `content/guides/**`, `content/changelog/**`, `public/prompts/**` still reference the old client and can be updated separately if desired.