### PR TITLE
chore: consolidate CLI docs scripts into one dispatcher + add scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,7 @@
     "test:unit:run": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
     "check:docs": "vitest run scripts/docs-checks/**/__tests__/*.test.js",
-    "check:docs:neonctl": "vitest run scripts/docs-checks/neonctl/__tests__/",
-    "gen:schema:neonctl": "node scripts/docs-checks/neonctl/generate-schema.js",
-    "gen:docs:neonctl": "node scripts/docs-checks/neonctl/generate-docs.js",
-    "refresh:cli-docs": "node scripts/docs-checks/neonctl/refresh.js"
+    "cli-docs": "node scripts/docs-checks/neonctl/cli.js"
   },
   "dependencies": {
     "@codemirror/lang-sql": "^6.9.1",

--- a/scripts/docs-checks/README.md
+++ b/scripts/docs-checks/README.md
@@ -7,7 +7,7 @@ defs, OpenAPI specs, etc.). Each check is self-contained in its own subfolder.
 
 ```bash
 npm run check:docs              # all checks
-npm run check:docs:neonctl      # one check
+npm run cli-docs -- check       # just the neonctl CLI checks (see neonctl/README.md)
 ```
 
 Exits non-zero on any validation error.

--- a/scripts/docs-checks/neonctl/README.md
+++ b/scripts/docs-checks/neonctl/README.md
@@ -19,10 +19,16 @@ for values the parser can't resolve.
 
 ## Run
 
+All commands run through a single `cli-docs` dispatcher. Run it with no
+subcommand for the full help listing:
+
 ```bash
-npm run check:docs:neonctl    # validation + renderer contract tests
-npm run gen:docs:neonctl      # emit all fragments to fragments/ (local preview)
-npm run refresh:cli-docs      # full refresh from the latest GitHub release
+npm run cli-docs                          # print help
+npm run cli-docs -- check                 # validation + renderer contract tests
+npm run cli-docs -- refresh               # full refresh from the latest GitHub release
+npm run cli-docs -- schema --src <path>   # regenerate schema.json from a CLI checkout
+npm run cli-docs -- scaffold <name> --group <group-id>   # wire a new command
+npm run cli-docs -- preview               # emit fragments to fragments/ (local preview)
 ```
 
 For a local Markdown validation report:
@@ -34,7 +40,7 @@ node scripts/docs-checks/neonctl/validate.js --out /tmp/report.md
 ## Maintenance: when neonctl releases
 
 ```bash
-npm run refresh:cli-docs
+npm run cli-docs -- refresh
 ```
 
 That downloads the latest release tarball, regenerates `schema.json`,
@@ -43,8 +49,16 @@ the diff and commit `schema.json` — pages and the mirror pick it up at the
 next build with no page edits. New top-level commands additionally need a
 doc page (`content/docs/cli/<name>.md`), a `navigation.yaml` entry, and a
 group mapping in
-`src/components/pages/doc/cli-reference/cli-command-index/groups.js` —
-all three are enforced by tests (`cli-command-index/meta.test.js`).
+`src/components/pages/doc/cli-reference/cli-command-index/groups.js` — all
+three are enforced by the coverage tests. Scaffold them in one step:
+
+```bash
+npm run cli-docs -- scaffold <name> --group <group-id>
+```
+
+That adds the group mapping, creates the doc page from a template (seeded
+with the command's `describe` text), and inserts the nav entry. Fill in the
+page's TODOs, then run `npm run cli-docs -- check`.
 Optionally add curated overview copy (description, examples)
 in `cli-command-index/meta.js`; without an entry the row falls back to the
 schema's describe text and signature. meta.js examples are themselves
@@ -83,8 +97,10 @@ override deletes a stale key.
 | `generate-schema.js`              | Parses neonctl's TS source → `schema.json`.                   |
 | `overrides.json`                  | Hand-maintained patches for parser-unresolvable values.       |
 | `generate-docs.js`                | Markdown renderers shared by components + llms mirror; `--fragments` preview. |
-| `fragments/`                      | Local-only preview dump from `npm run gen:docs:neonctl` (gitignored). |
-| `refresh.js`                      | `npm run refresh:cli-docs` implementation.                    |
+| `cli.js`                          | The `npm run cli-docs` dispatcher; routes to the scripts below. |
+| `fragments/`                      | Local-only preview dump from `npm run cli-docs -- preview` (gitignored). |
+| `refresh.js`                      | `npm run cli-docs -- refresh` implementation.                 |
+| `scaffold-command.js`             | `npm run cli-docs -- scaffold` implementation.                |
 | `check-staleness.js`              | predev/prebuild version nudge.                                |
 | `schema.js`                       | Loads schema; resolves argv to command node + valid options.  |
 | `extract-examples.js`             | Scans Markdown for fenced bash blocks and inline backticks.   |

--- a/scripts/docs-checks/neonctl/__tests__/coverage.test.js
+++ b/scripts/docs-checks/neonctl/__tests__/coverage.test.js
@@ -15,7 +15,7 @@ import schema from '../schema.json';
 // Invariants the overview index relies on: every schema command must have a
 // group mapping (buildRows throws at build otherwise), a doc page, and a
 // navigation entry. This lives with the schema checks (not next to the
-// component) so `npm run check:docs:neonctl` (which refresh.js runs after
+// component) so `npm run cli-docs -- check` (which refresh.js runs after
 // regenerating schema.json) fails here with a clear message instead of
 // failing mid-build or shipping an orphan page.
 describe('cli command coverage invariants', () => {
@@ -24,7 +24,15 @@ describe('cli command coverage invariants', () => {
 
   it('every schema command has a group mapping', () => {
     const unmapped = Object.keys(schema.commands).filter((name) => !GROUP_OF[name]);
-    expect(unmapped).toEqual([]);
+    expect(
+      unmapped,
+      unmapped.length
+        ? `Unmapped CLI command(s): ${unmapped.join(', ')}.\n` +
+            `Scaffold each with: npm run cli-docs -- scaffold <name> --group <group-id>\n` +
+            `(or add a GROUP_OF entry by hand in ` +
+            `src/components/pages/doc/cli-reference/cli-command-index/groups.js).`
+        : undefined
+    ).toEqual([]);
   });
 
   it('sidebar grouping matches the overview index grouping', () => {
@@ -69,8 +77,23 @@ describe('cli command coverage invariants', () => {
       if (!fs.existsSync(page)) missingPages.push(name);
       if (!nav.includes(`slug: ${slug}`)) missingNav.push(name);
     }
-    expect(missingPages).toEqual([]);
-    expect(missingNav).toEqual([]);
+    expect(
+      missingPages,
+      missingPages.length
+        ? `CLI command(s) missing a doc page: ${missingPages.join(', ')}.\n` +
+            `Scaffold each with: npm run cli-docs -- scaffold <name> --group <group-id>\n` +
+            `(or create content/docs/cli/<name>.md by hand).`
+        : undefined
+    ).toEqual([]);
+    expect(
+      missingNav,
+      missingNav.length
+        ? `CLI command(s) missing a navigation entry: ${missingNav.join(', ')}.\n` +
+            `Scaffold each with: npm run cli-docs -- scaffold <name> --group <group-id>\n` +
+            `(or add "slug: cli/<name>" under the matching CLI section in ` +
+            `content/docs/navigation.yaml).`
+        : undefined
+    ).toEqual([]);
   });
 
   // Every <CliSubcommands> table links each subcommand to a #anchor; the page

--- a/scripts/docs-checks/neonctl/check-staleness.js
+++ b/scripts/docs-checks/neonctl/check-staleness.js
@@ -28,7 +28,7 @@ async function main() {
     if (version && version !== neonctlVersion) {
       console.warn(
         `\n[neonctl docs] schema.json is pinned to neonctl ${neonctlVersion}, but ${version} is the latest on npm.\n` +
-          `[neonctl docs] Run: npm run refresh:cli-docs\n`
+          `[neonctl docs] Run: npm run cli-docs -- refresh\n`
       );
     }
   } catch {

--- a/scripts/docs-checks/neonctl/cli.js
+++ b/scripts/docs-checks/neonctl/cli.js
@@ -1,0 +1,90 @@
+// One entry point for the Neon CLI docs pipeline. Routes to the individual
+// scripts so `package.json` has a single `cli-docs` script and the whole
+// workflow is discoverable from one place:
+//
+//   npm run cli-docs                 # print this help
+//   npm run cli-docs -- refresh      # fetch latest neonctl, regen schema, diff, test
+//   npm run cli-docs -- schema --src <path>   # regen schema.json from a CLI checkout
+//   npm run cli-docs -- scaffold <name> --group <group-id>   # wire a new command
+//   npm run cli-docs -- check        # run the coverage + generation tests
+//   npm run cli-docs -- preview      # emit markdown fragments to fragments/ (dev only)
+//
+// Each subcommand forwards its remaining args to the underlying script with
+// stdio inherited, so per-script flags (--src, --group, ...) work unchanged.
+// The schema is the source of truth; see README.md for the full model.
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const HERE = __dirname;
+const ROOT = path.join(HERE, '..', '..', '..');
+
+const SUBCOMMANDS = {
+  refresh: {
+    summary: 'Fetch the latest neonctl release, regenerate schema.json, print a diff, run tests.',
+    run: (args) => node(path.join(HERE, 'refresh.js'), args),
+  },
+  schema: {
+    summary: 'Regenerate schema.json from a CLI source checkout. Requires --src <path>.',
+    run: (args) => node(path.join(HERE, 'generate-schema.js'), args),
+  },
+  scaffold: {
+    summary: 'Wire a new command: group mapping + doc page + nav entry. <name> --group <group-id>.',
+    run: (args) => node(path.join(HERE, 'scaffold-command.js'), args),
+  },
+  check: {
+    summary: 'Run the coverage + generation test suite (schema/pages/nav invariants).',
+    // Run the locally-installed vitest bin through node — same `node <script>`
+    // shape as the other subcommands, and no npx install prompt on a clean box.
+    run: () =>
+      node(path.join(ROOT, 'node_modules', '.bin', 'vitest'), [
+        'run',
+        'scripts/docs-checks/neonctl/__tests__/',
+      ]),
+  },
+  preview: {
+    summary: 'Emit every rendered markdown fragment to fragments/ for local preview (dev only).',
+    run: (args) => node(path.join(HERE, 'generate-docs.js'), args),
+  },
+};
+
+function node(script, args) {
+  return spawnSync('node', [script, ...args], { stdio: 'inherit', cwd: ROOT });
+}
+
+function printHelp() {
+  console.log('Neon CLI docs pipeline. Usage:\n');
+  console.log('  npm run cli-docs -- <subcommand> [args]\n');
+  const width = Math.max(...Object.keys(SUBCOMMANDS).map((s) => s.length));
+  for (const [name, { summary }] of Object.entries(SUBCOMMANDS)) {
+    console.log(`  ${name.padEnd(width)}  ${summary}`);
+  }
+  console.log('\nExamples:');
+  console.log('  npm run cli-docs -- refresh');
+  console.log('  npm run cli-docs -- scaffold api --group network');
+  console.log('  npm run cli-docs -- schema --src ~/git/neon-pkgs/packages/cli');
+}
+
+function main() {
+  const [sub, ...args] = process.argv.slice(2);
+  if (!sub || sub === 'help' || sub === '--help' || sub === '-h') {
+    printHelp();
+    process.exit(0);
+  }
+  const command = SUBCOMMANDS[sub];
+  if (!command) {
+    console.error(`Unknown subcommand "${sub}".\n`);
+    printHelp();
+    process.exit(1);
+  }
+  const result = command.run(args);
+  // spawnSync sets .error (and null .status) when the process fails to launch;
+  // don't let that masquerade as success.
+  if (result && result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+  process.exit(result && typeof result.status === 'number' ? result.status : 0);
+}
+
+main();

--- a/scripts/docs-checks/neonctl/generate-docs.js
+++ b/scripts/docs-checks/neonctl/generate-docs.js
@@ -8,7 +8,7 @@
 //   - src/scripts/process-md-for-llms.js — expands the same components in
 //     the agent-facing .md mirror
 //
-// Running this file directly (`npm run gen:docs:neonctl`) emits every
+// Running this file directly (`npm run cli-docs -- preview`) emits every
 // fragment to fragments/ as a local preview of what the components render.
 //
 // The binary is documented as `neon`; `$0` in yargs usage strings is

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -19,7 +19,7 @@
 //   NEONCTL_SRC=~/src/neon-pkgs/packages/cli node scripts/docs-checks/neonctl/generate-schema.js
 //
 // Run this whenever you upgrade the neonctl pin. Commit `schema.json`.
-// (`npm run refresh:cli-docs` automates the clone/extract and points --src
+// (`npm run cli-docs -- refresh` automates the clone/extract and points --src
 // at packages/cli for you.)
 
 const fs = require('fs');

--- a/scripts/docs-checks/neonctl/refresh.js
+++ b/scripts/docs-checks/neonctl/refresh.js
@@ -1,7 +1,7 @@
 // One-command maintenance for the neonctl docs pipeline. Run when a new
 // neonctl version ships:
 //
-//   npm run refresh:cli-docs
+//   npm run cli-docs -- refresh
 //
 // The CLI source lives in the neon-pkgs monorepo (packages/cli); its
 // releases are tagged `neonctl@<version>`. The published npm package and
@@ -206,7 +206,7 @@ async function main() {
     }
 
     console.log('\nRunning validation...');
-    execSync('npm run check:docs:neonctl', {
+    execSync('npm run cli-docs -- check', {
       stdio: 'inherit',
       cwd: path.join(__dirname, '..', '..', '..'),
     });

--- a/scripts/docs-checks/neonctl/scaffold-command.js
+++ b/scripts/docs-checks/neonctl/scaffold-command.js
@@ -1,0 +1,276 @@
+// Scaffold the docs wiring for a new Neon CLI command. Run when
+// `cli-docs -- refresh` reports a new top-level command (or the coverage test
+// fails with an unmapped/undocumented command):
+//
+//   npm run cli-docs -- scaffold <name> --group <group-id>
+//
+// It performs the three manual steps the coverage invariants require:
+//   1. adds a GROUP_OF entry in cli-command-index/groups.js
+//   2. creates content/docs/cli/<name>.md from a template (leaf or parent,
+//      seeded with the command's describe text and CLI components)
+//   3. inserts a navigation.yaml entry under the matching CLI subgroup
+//
+// It reads the committed schema.json, so run a schema regen first (refresh
+// or gen:schema) if the command isn't in the schema yet. The generated page
+// is a starting point: fill in the prose, examples, and captured output.
+// Idempotent per file — skips any step already done, so it is safe to rerun.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+const SCHEMA_PATH = path.join(__dirname, 'schema.json');
+const GROUPS_PATH = path.join(
+  ROOT,
+  'src/components/pages/doc/cli-reference/cli-command-index/groups.js'
+);
+const NAV_PATH = path.join(ROOT, 'content/docs/navigation.yaml');
+const CLI_DOCS_DIR = path.join(ROOT, 'content/docs/cli');
+
+// group id -> exact navigation.yaml subgroup title. The titles differ from
+// groups.js by design ("&" in the overview index vs "and" in the sidebar),
+// so this editorial map is the seam between them. The group IDS, however, are
+// NOT duplicated here — they are read from groups.js at runtime
+// (groupIdsFromSource) and validated against these keys, so adding a group in
+// one place without the other fails loudly instead of silently drifting.
+const NAV_TITLE_BY_GROUP = {
+  setup: 'Setup and context',
+  core: 'Projects and branches',
+  connect: 'Connect to Postgres',
+  config: 'Config as code',
+  surfaces: 'Functions, storage and data',
+  network: 'Organizations and networking',
+};
+
+// Extract group ids from the GROUPS array literal in groups.js, so the list of
+// valid groups has a single source of truth. Matches `{ id: 'setup', title: ...`.
+function groupIdsFromSource(src) {
+  return [...src.matchAll(/\{\s*id:\s*'([^']+)'\s*,\s*title:/g)].map((m) => m[1]);
+}
+
+function parseArgs(argv) {
+  const args = { name: null, group: null };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--group') {
+      args.group = rest[++i];
+    } else if (a.startsWith('--group=')) {
+      args.group = a.slice('--group='.length);
+    } else if (!a.startsWith('-') && !args.name) {
+      args.name = a;
+    }
+  }
+  return args;
+}
+
+function fail(msg) {
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+}
+
+function loadSchema() {
+  return JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+}
+
+// --- groups.js -------------------------------------------------------------
+
+function addGroupMapping(name, group) {
+  const src = fs.readFileSync(GROUPS_PATH, 'utf8');
+  const key = /^[a-z][a-z0-9-]*$/.test(name) ? name : `'${name}'`;
+  if (new RegExp(`\\n\\s*'?${name}'?:\\s`).test(src)) {
+    return { changed: false, note: `groups.js already maps "${name}"` };
+  }
+  // Match the GROUP_OF object body and append the new entry before its closing
+  // brace. Anchoring on the object itself (not a neighbouring comment) keeps
+  // this working if surrounding code is edited.
+  const objRe = /(const GROUP_OF = \{[\s\S]*?)(\n\};)/;
+  if (!objRe.test(src)) {
+    fail('could not locate the GROUP_OF object in groups.js — add the mapping by hand');
+  }
+  const updated = src.replace(objRe, `$1\n  ${key}: '${group}',$2`);
+  fs.writeFileSync(GROUPS_PATH, updated);
+  return { changed: true, note: `groups.js: added ${key}: '${group}'` };
+}
+
+// --- doc page --------------------------------------------------------------
+
+function pageTemplate(name, node) {
+  const describe = (node.describe || '').replace(/\s+/g, ' ').trim();
+  const subs = Object.keys(node.commands || {});
+  const hasSubs = subs.length > 0;
+
+  const fm = [
+    '---',
+    `title: 'Neon CLI command: ${name}'`,
+    `subtitle: 'TODO: one-line subtitle for ${name}'`,
+    'summary: >-',
+    `  TODO: SEO summary for the \`neon ${name}\` command.` +
+      (describe ? ` The CLI describes it as: ${describe}` : ''),
+    'enableTableOfContents: true',
+    '---',
+    '',
+  ].join('\n');
+
+  // Intro is a stub for the author to rewrite. Quote the CLI's describe text
+  // verbatim rather than splicing it into a sentence (which mangles grammar,
+  // e.g. "The api command call any...").
+  const intro = describe
+    ? `TODO: intro for the \`${name}\` command. The CLI describes it as: "${describe}".`
+    : `TODO: describe the \`${name}\` command.`;
+
+  if (hasSubs) {
+    const sections = subs
+      .map((sub) => {
+        const anchor = sub.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        return [
+          `## neon ${name} ${sub} (#${anchor})`,
+          '',
+          `TODO: describe \`neon ${name} ${sub}\`.`,
+          '',
+          `<CliUsage command="${name} ${sub}" />`,
+          '',
+          `<CliOptions command="${name} ${sub}" />`,
+          '',
+          '```bash',
+          `neon ${name} ${sub}`,
+          '```',
+        ].join('\n');
+      })
+      .join('\n\n');
+    return `${fm}\n${intro}\n\n<CliSubcommands command="${name}" />\n\n${sections}\n`;
+  }
+
+  return (
+    `${fm}\n${intro}\n\n` +
+    `## Usage\n\n<CliUsage command="${name}" />\n\n` +
+    `## Options\n\n<CliOptions command="${name}" />\n\n` +
+    `## Examples\n\n\`\`\`bash\nneon ${name}\n\`\`\`\n`
+  );
+}
+
+function createDocPage(name, node) {
+  const file = path.join(CLI_DOCS_DIR, `${name}.md`);
+  if (fs.existsSync(file)) {
+    return { changed: false, note: `content/docs/cli/${name}.md already exists` };
+  }
+  fs.writeFileSync(file, pageTemplate(name, node));
+  return { changed: true, note: `created content/docs/cli/${name}.md (fill in the TODOs)` };
+}
+
+// --- navigation.yaml -------------------------------------------------------
+
+function addNavEntry(name, group) {
+  const navTitle = NAV_TITLE_BY_GROUP[group];
+  if (!navTitle) {
+    fail(
+      `no navigation subgroup mapped for group "${group}" — ` +
+        `add it to NAV_TITLE_BY_GROUP in scaffold-command.js`
+    );
+  }
+  const nav = fs.readFileSync(NAV_PATH, 'utf8');
+  const slug = `cli/${name}`;
+  if (nav.includes(`slug: ${slug}`)) {
+    return { changed: false, note: `navigation.yaml already lists ${slug}` };
+  }
+
+  const lines = nav.split('\n');
+  // Line-splice rather than a YAML round-trip (which would reformat/reorder the
+  // whole 800-line nav). Assumes the CLI subgroup is a `- title: <navTitle>`
+  // block whose `items:` is the next `items:` line and whose children are
+  // indented two spaces under it — true for this file. If the structure drifts,
+  // the exact-match lookups below fail loudly (fail()), so a bad insert can't
+  // land silently; wire the entry by hand in that case.
+  // Find the subgroup's `- title: <navTitle>` line, then its `items:` line,
+  // and insert the new entry as the first child (matching that indentation).
+  let titleIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === `- title: ${navTitle}`) {
+      titleIdx = i;
+      break;
+    }
+  }
+  if (titleIdx === -1) {
+    fail(`could not find CLI subgroup "- title: ${navTitle}" in navigation.yaml`);
+  }
+  let itemsIdx = -1;
+  for (let i = titleIdx + 1; i < lines.length; i++) {
+    if (lines[i].trim() === 'items:') {
+      itemsIdx = i;
+      break;
+    }
+    if (lines[i].trim().startsWith('- title:')) break; // next sibling — no items:
+  }
+  if (itemsIdx === -1) {
+    fail(`could not find "items:" under "${navTitle}" in navigation.yaml`);
+  }
+  // Indentation of the first child = items: indent + 2 spaces, entries use
+  // "- title:" at that depth. Derive from the existing next line if present.
+  const itemsIndent = lines[itemsIdx].match(/^\s*/)[0];
+  const childIndent = `${itemsIndent}  `;
+  const entry = [`${childIndent}- title: ${name}`, `${childIndent}  slug: ${slug}`];
+  lines.splice(itemsIdx + 1, 0, ...entry);
+  fs.writeFileSync(NAV_PATH, lines.join('\n'));
+  return { changed: true, note: `navigation.yaml: added ${slug} under "${navTitle}"` };
+}
+
+// --- main ------------------------------------------------------------------
+
+function main() {
+  const { name, group } = parseArgs(process.argv);
+  if (!name || !group) {
+    fail('usage: npm run cli-docs -- scaffold <name> --group <group-id>');
+  }
+  // Group ids come from groups.js (single source of truth); the nav-title map
+  // must cover exactly them, or one was added without the other.
+  const groupsSrc = fs.readFileSync(GROUPS_PATH, 'utf8');
+  const validGroups = groupIdsFromSource(groupsSrc);
+  const missingNavTitles = validGroups.filter((id) => !NAV_TITLE_BY_GROUP[id]);
+  if (missingNavTitles.length) {
+    fail(
+      `groups.js defines group(s) with no navigation title: ${missingNavTitles.join(', ')}. ` +
+        `Add them to NAV_TITLE_BY_GROUP in scaffold-command.js.`
+    );
+  }
+  if (!validGroups.includes(group)) {
+    fail(`unknown group "${group}". Valid groups: ${validGroups.join(', ')}`);
+  }
+
+  const schema = loadSchema();
+  const node = schema.commands[name];
+  if (!node) {
+    fail(
+      `command "${name}" is not in schema.json — regenerate the schema first ` +
+        `(npm run cli-docs -- refresh, or cli-docs -- schema --src <path>)`
+    );
+  }
+
+  // Scaffold assumes a standalone page at /docs/cli/<name>. A command listed in
+  // HREF_OVERRIDES is documented inside another page's section instead, so a
+  // generated page would be an orphan — bail and let the author wire it by hand.
+  const hrefBlock = groupsSrc.match(/const HREF_OVERRIDES = \{([\s\S]*?)\}/);
+  if (hrefBlock && new RegExp(`['"]?${name}['"]?\\s*:`).test(hrefBlock[1])) {
+    fail(
+      `command "${name}" has an HREF_OVERRIDES entry — it lives in another page's ` +
+        `section, not a standalone page. Wire it by hand.`
+    );
+  }
+
+  const results = [
+    addGroupMapping(name, group),
+    createDocPage(name, node),
+    addNavEntry(name, group),
+  ];
+
+  console.log(`Scaffolded "${name}" (group: ${group}):\n`);
+  for (const r of results) console.log(`  ${r.changed ? '✓' : '•'} ${r.note}`);
+  console.log(
+    `\nNext:\n` +
+      `  1. Fill in the TODOs in content/docs/cli/${name}.md (subtitle, summary, prose, examples).\n` +
+      `  2. Run: npm run cli-docs -- check`
+  );
+}
+
+if (require.main === module) main();
+
+module.exports = { addGroupMapping, createDocPage, addNavEntry, pageTemplate, NAV_TITLE_BY_GROUP };


### PR DESCRIPTION
## What

Replaces the five separate `neonctl` npm scripts with a single `cli-docs`
dispatcher, and adds a `scaffold` subcommand that wires up a new CLI command
in one step.

## Why

The scripts had three naming conventions (`gen:schema:neonctl`,
`refresh:cli-docs`, `check:docs:neonctl`) and no discoverability. Adding a new
CLI command meant three manual, easily-forgotten steps (group mapping, doc
page, nav entry) — the coverage tests caught the omission but only printed a
bare `expected ['api'] to deeply equal []`.

## Changes

- **One dispatcher:** `npm run cli-docs -- <refresh|schema|scaffold|check|preview>`.
  Run `npm run cli-docs` for help.
- **New `scaffold`:** creates the group mapping, a templated doc page, and the
  nav entry for a new command. Valid group ids are read from `groups.js` (single
  source of truth).
- **Clearer test failures:** coverage tests now print the exact scaffold command
  to run.
- Renamed the old `gen:docs` to `preview` — it dumps throwaway fragments, it
  doesn't generate the live docs.

No content or site-component changes. Tooling only.