### PR TITLE
ci(ai-gateway): keep /models.json in sync with models.dev

### DIFF
--- a/.github/workflows/models-sync-check.yml
+++ b/.github/workflows/models-sync-check.yml
@@ -1,0 +1,37 @@
+name: AI Gateway Models Sync
+
+# Verifies the Neon AI Gateway catalog served at /models.json stays in sync
+# with the upstream models.dev `neon` provider (https://models.dev/api.json).
+# Fails on any catalog or capability drift.
+
+on:
+  schedule:
+    # Every day at 8:00 AM UTC
+    - cron: '0 8 * * *'
+  workflow_dispatch: # Allows manual trigger from the GitHub UI
+
+permissions:
+  contents: read
+
+jobs:
+  models-sync:
+    name: 'Check /models.json vs models.dev'
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+
+      - name: Check catalog sync
+        run: node src/scripts/check-models-sync.js --ci

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "update:skills": "npm run sync:skills && npm run generate:skills",
     "check:broken-links": "linkinator --config linkinator.config.json",
     "check:pricing-sync": "node src/scripts/check-pricing-sync.js",
+    "check:models-sync": "node src/scripts/check-models-sync.js",
     "check:content-data": "node scripts/validate-content-data.js",
     "prepare": "husky install",
     "test": "npx cypress open",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "check:broken-links": "linkinator --config linkinator.config.json",
     "check:pricing-sync": "node src/scripts/check-pricing-sync.js",
     "check:models-sync": "node src/scripts/check-models-sync.js",
+    "generate:models": "node src/scripts/generate-models-json.js",
     "check:content-data": "node scripts/validate-content-data.js",
     "prepare": "husky install",
     "test": "npx cypress open",

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -1561,6 +1561,14 @@
         "family": "qwen",
         "attachment": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens"
+          }
+        ],
         "tool_call": true,
         "temperature": true,
         "structured_output": true,

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -940,15 +940,20 @@
           "cache_read": 0.25,
           "tiers": [
             {
+              "input": 5,
+              "output": 22.5,
+              "cache_read": 0.5,
               "tier": {
                 "type": "context",
                 "size": 272000
-              },
-              "input": 5,
-              "output": 22.5,
-              "cache_read": 0.5
+              }
             }
-          ]
+          ],
+          "context_over_200k": {
+            "input": 5,
+            "output": 22.5,
+            "cache_read": 0.5
+          }
         }
       },
       "gpt-5-4-mini": {
@@ -1133,15 +1138,20 @@
           "cache_read": 0.125,
           "tiers": [
             {
+              "input": 2.5,
+              "output": 15,
+              "cache_read": 0.25,
               "tier": {
                 "type": "context",
                 "size": 200000
-              },
-              "input": 2.5,
-              "output": 15,
-              "cache_read": 0.25
+              }
             }
-          ]
+          ],
+          "context_over_200k": {
+            "input": 2.5,
+            "output": 15,
+            "cache_read": 0.25
+          }
         }
       },
       "gemini-3-flash": {
@@ -1237,15 +1247,20 @@
           "cache_read": 0.2,
           "tiers": [
             {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
               "tier": {
                 "type": "context",
                 "size": 200000
-              },
-              "input": 4,
-              "output": 18,
-              "cache_read": 0.4
+              }
             }
-          ]
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4
+          }
         }
       },
       "gemini-3-1-flash-lite": {
@@ -1341,15 +1356,20 @@
           "cache_read": 0.2,
           "tiers": [
             {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
               "tier": {
                 "type": "context",
                 "size": 200000
-              },
-              "input": 4,
-              "output": 18,
-              "cache_read": 0.4
+              }
             }
-          ]
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4
+          }
         }
       },
       "gemini-3-5-flash": {

--- a/src/scripts/check-models-sync.js
+++ b/src/scripts/check-models-sync.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * AI Gateway model catalog sync check
+ *
+ * Verifies the Neon AI Gateway catalog served at /models.json (backed by
+ * src/app/models.json/data.json) stays in sync with the upstream source of
+ * truth — the `neon` provider entry in the models.dev API
+ * (https://models.dev/api.json). Neon maintains that provider, and this
+ * endpoint mirrors it, so the two must not drift.
+ *
+ * Comparison is capability-scoped: model ID set + a fixed set of capability
+ * fields per model (name, family, attachment, reasoning, reasoning_options,
+ * tool_call, temperature, structured_output, open_weights, knowledge,
+ * release_date, last_updated, modalities, limit, cost, status). Fields that
+ * are intentionally endpoint-specific are ignored on both sides:
+ *   - `provider` (added by /models.json as a convenience) — dropped
+ *   - `description`, `benchmarks`, `weights`, `links` — not part of the
+ *     capability catalog (and models.dev's api.json omits weights/benchmarks)
+ *
+ * Exits non-zero on any difference (missing/extra models or field drift).
+ *
+ * Usage:
+ *   node src/scripts/check-models-sync.js                 # local file vs models.dev
+ *   node src/scripts/check-models-sync.js --ci            # terse output for CI
+ *   node src/scripts/check-models-sync.js --json          # machine-readable
+ *   NEON_MODELS_URL=https://neon.com/models.json \
+ *     node src/scripts/check-models-sync.js               # compare the live endpoint
+ *   MODELS_DEV_URL=https://models.dev/api.json \
+ *     node src/scripts/check-models-sync.js               # override upstream URL
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODELS_DEV_URL = process.env.MODELS_DEV_URL || 'https://models.dev/api.json';
+const NEON_MODELS_URL = process.env.NEON_MODELS_URL || null; // null => read local file
+const LOCAL_DATA_PATH = path.resolve(__dirname, '../app/models.json/data.json');
+
+// Fields compared per model. Everything else is ignored.
+const COMPARE_KEYS = [
+  'name',
+  'family',
+  'attachment',
+  'reasoning',
+  'reasoning_options',
+  'tool_call',
+  'temperature',
+  'structured_output',
+  'open_weights',
+  'knowledge',
+  'release_date',
+  'last_updated',
+  'modalities',
+  'limit',
+  'cost',
+  'status',
+];
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+function extractNeonModels(apiJson, source) {
+  const neon = apiJson && apiJson.neon;
+  if (!neon || typeof neon !== 'object') {
+    throw new Error(`No "neon" provider found in ${source}`);
+  }
+  const models = neon.models;
+  if (!models || typeof models !== 'object') {
+    throw new Error(`No "neon.models" map found in ${source}`);
+  }
+  return models;
+}
+
+async function loadNeon() {
+  if (NEON_MODELS_URL) {
+    return { source: NEON_MODELS_URL, models: extractNeonModels(await fetchJson(NEON_MODELS_URL), NEON_MODELS_URL) };
+  }
+  const raw = fs.readFileSync(LOCAL_DATA_PATH, 'utf-8');
+  return { source: path.relative(process.cwd(), LOCAL_DATA_PATH), models: extractNeonModels(JSON.parse(raw), LOCAL_DATA_PATH) };
+}
+
+async function loadUpstream() {
+  return { source: MODELS_DEV_URL, models: extractNeonModels(await fetchJson(MODELS_DEV_URL), MODELS_DEV_URL) };
+}
+
+// ---------------------------------------------------------------------------
+// Normalization + comparison
+// ---------------------------------------------------------------------------
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = canonical(value[key]);
+    return out;
+  }
+  return value;
+}
+
+// Pick only the comparable capability keys, canonicalized for stable equality.
+function normalizeModel(model) {
+  const picked = {};
+  for (const key of COMPARE_KEYS) {
+    if (model[key] !== undefined) picked[key] = model[key];
+  }
+  return canonical(picked);
+}
+
+function diffModels(upstream, neon) {
+  const upstreamIds = new Set(Object.keys(upstream));
+  const neonIds = new Set(Object.keys(neon));
+
+  const missingFromNeon = [...upstreamIds].filter((id) => !neonIds.has(id)).sort();
+  const extraInNeon = [...neonIds].filter((id) => !upstreamIds.has(id)).sort();
+
+  const fieldDiffs = [];
+  for (const id of [...upstreamIds].filter((x) => neonIds.has(x)).sort()) {
+    const u = JSON.stringify(normalizeModel(upstream[id]));
+    const n = JSON.stringify(normalizeModel(neon[id]));
+    if (u !== n) {
+      const fields = [];
+      const um = normalizeModel(upstream[id]);
+      const nm = normalizeModel(neon[id]);
+      for (const key of new Set([...Object.keys(um), ...Object.keys(nm)])) {
+        if (JSON.stringify(um[key]) !== JSON.stringify(nm[key])) {
+          fields.push({ field: key, modelsDev: um[key], neon: nm[key] });
+        }
+      }
+      fieldDiffs.push({ id, fields });
+    }
+  }
+
+  return { missingFromNeon, extraInNeon, fieldDiffs };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes('--json');
+  const verbose = args.includes('--verbose') ? true : args.includes('--ci') ? false : !process.env.CI;
+
+  let upstream, neon;
+  try {
+    [upstream, neon] = await Promise.all([loadUpstream(), loadNeon()]);
+  } catch (err) {
+    console.error(`Failed to load model catalogs: ${err.message}`);
+    process.exit(2);
+  }
+
+  const diff = diffModels(upstream.models, neon.models);
+  const inSync =
+    diff.missingFromNeon.length === 0 && diff.extraInNeon.length === 0 && diff.fieldDiffs.length === 0;
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ upstream: upstream.source, neon: neon.source, inSync, ...diff }, null, 2));
+    process.exit(inSync ? 0 : 1);
+  }
+
+  console.log(`AI Gateway model catalog sync check`);
+  console.log(`  upstream (models.dev): ${upstream.source} — ${Object.keys(upstream.models).length} models`);
+  console.log(`  neon (/models.json):   ${neon.source} — ${Object.keys(neon.models).length} models\n`);
+
+  if (inSync) {
+    console.log(`[OK] In sync — ${Object.keys(neon.models).length} models match.`);
+    process.exit(0);
+  }
+
+  console.log(`[FAIL] Catalog drift detected between models.dev and /models.json\n`);
+
+  if (diff.missingFromNeon.length) {
+    console.log(`In models.dev but missing from /models.json (${diff.missingFromNeon.length}):`);
+    diff.missingFromNeon.forEach((id) => console.log(`  - ${id}`));
+    console.log('');
+  }
+  if (diff.extraInNeon.length) {
+    console.log(`In /models.json but not in models.dev (${diff.extraInNeon.length}):`);
+    diff.extraInNeon.forEach((id) => console.log(`  + ${id}`));
+    console.log('');
+  }
+  if (diff.fieldDiffs.length) {
+    console.log(`Field drift (${diff.fieldDiffs.length} model${diff.fieldDiffs.length === 1 ? '' : 's'}):`);
+    for (const { id, fields } of diff.fieldDiffs) {
+      console.log(`  ${id}:`);
+      for (const f of fields) {
+        if (verbose) {
+          console.log(`    ${f.field}:`);
+          console.log(`      models.dev: ${JSON.stringify(f.modelsDev)}`);
+          console.log(`      neon:       ${JSON.stringify(f.neon)}`);
+        } else {
+          console.log(`    ${f.field}`);
+        }
+      }
+    }
+    console.log('');
+  }
+
+  console.log('Regenerate src/app/models.json/data.json from the models.dev neon provider to resolve.');
+  process.exit(1);
+}
+
+main();

--- a/src/scripts/check-models-sync.js
+++ b/src/scripts/check-models-sync.js
@@ -204,7 +204,7 @@ async function main() {
     console.log('');
   }
 
-  console.log('Regenerate src/app/models.json/data.json from the models.dev neon provider to resolve.');
+  console.log('Run `npm run generate:models` to regenerate data.json from the models.dev neon provider.');
   process.exit(1);
 }
 

--- a/src/scripts/generate-models-json.js
+++ b/src/scripts/generate-models-json.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Generate src/app/models.json/data.json (the data behind /models.json) from the
+ * upstream models.dev `neon` provider.
+ *
+ * The Neon AI Gateway catalog is maintained as the `neon` provider on models.dev.
+ * models.dev resolves each model's `base_model` inheritance at build time, so its
+ * public API (https://models.dev/api.json) already contains every inherited value
+ * (capabilities, modalities, limits, dates). This script fetches that resolved
+ * `neon` entry and reshapes it into what /models.json serves:
+ *   - keeps the models.dev api.json shape (`{ "neon": { ...provider, models } }`)
+ *   - adds a per-model `provider` (the underlying model provider), derived from
+ *     `family`/`id` — the one field /models.json adds on top of models.dev
+ *   - drops fields that aren't part of the capability catalog and can describe the
+ *     canonical (not Neon-served) model: `description`, `benchmarks`, `weights`, `links`
+ *   - points `doc` at the AI Gateway models page
+ *
+ * The `check-models-sync.js` job verifies the committed data.json matches upstream;
+ * run this to regenerate it whenever the models.dev `neon` provider changes.
+ *
+ * NOTE: output reflects the *deployed* models.dev api.json. If a models.dev PR was
+ * merged but api.json hasn't redeployed yet, regenerating will lag until it does.
+ *
+ * Usage:
+ *   node src/scripts/generate-models-json.js            # write data.json
+ *   node src/scripts/generate-models-json.js --stdout   # print instead of writing
+ *   MODELS_DEV_URL=... node src/scripts/generate-models-json.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODELS_DEV_URL = process.env.MODELS_DEV_URL || 'https://models.dev/api.json';
+const OUT_PATH = path.resolve(__dirname, '../app/models.json/data.json');
+const DOC_URL = 'https://neon.com/docs/ai-gateway/models';
+
+// Fields dropped from each model (not part of the /models.json capability catalog).
+const STRIP = new Set(['description', 'benchmarks', 'weights', 'links']);
+
+// Stable, human-friendly key order per model.
+const KEY_ORDER = [
+  'id',
+  'name',
+  'provider',
+  'family',
+  'attachment',
+  'reasoning',
+  'reasoning_options',
+  'tool_call',
+  'temperature',
+  'structured_output',
+  'open_weights',
+  'knowledge',
+  'release_date',
+  'last_updated',
+  'modalities',
+  'limit',
+  'cost',
+  'status',
+];
+
+// Sort order for providers in the output.
+const PROVIDER_ORDER = ['anthropic', 'openai', 'google', 'meta', 'alibaba'];
+
+// Derive the underlying model provider from family (falling back to id).
+function providerFor(model) {
+  const family = typeof model.family === 'string' ? model.family : '';
+  const id = typeof model.id === 'string' ? model.id : '';
+  const match = (s) =>
+    s.startsWith('claude')
+      ? 'anthropic'
+      : s.startsWith('gpt') || s === 'o' || s.startsWith('o-')
+        ? 'openai'
+        : s.startsWith('gemini') || s.startsWith('gemma')
+          ? 'google'
+          : s.startsWith('llama')
+            ? 'meta'
+            : s.startsWith('qwen')
+              ? 'alibaba'
+              : undefined;
+  return match(family) || match(id) || (id.includes('llama') ? 'meta' : undefined);
+}
+
+function orderKeys(model) {
+  const out = {};
+  for (const key of KEY_ORDER) if (key in model) out[key] = model[key];
+  for (const key of Object.keys(model)) if (!(key in out)) out[key] = model[key];
+  return out;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const toStdout = args.includes('--stdout');
+
+  const res = await fetch(MODELS_DEV_URL, { headers: { accept: 'application/json' } });
+  if (!res.ok) {
+    console.error(`Failed to fetch ${MODELS_DEV_URL}: ${res.status} ${res.statusText}`);
+    process.exit(2);
+  }
+  const api = await res.json();
+  const neon = api && api.neon;
+  if (!neon || typeof neon !== 'object' || !neon.models || typeof neon.models !== 'object') {
+    console.error(`No "neon" provider (with models) found in ${MODELS_DEV_URL}`);
+    process.exit(2);
+  }
+
+  const models = {};
+  const unknownProvider = [];
+  for (const [id, raw] of Object.entries(neon.models)) {
+    const model = { id, ...raw };
+    const provider = providerFor(model);
+    if (!provider) unknownProvider.push(id);
+
+    const clean = { id };
+    if (provider) clean.provider = provider;
+    for (const [k, v] of Object.entries(raw)) {
+      if (k === 'id' || STRIP.has(k)) continue;
+      clean[k] = v;
+    }
+    models[id] = orderKeys(clean);
+  }
+
+  if (unknownProvider.length) {
+    console.error(`Could not derive provider for: ${unknownProvider.join(', ')}`);
+    console.error('Extend providerFor() with the new family before regenerating.');
+    process.exit(2);
+  }
+
+  const sortedIds = Object.keys(models).sort((a, b) => {
+    const pa = PROVIDER_ORDER.indexOf(models[a].provider);
+    const pb = PROVIDER_ORDER.indexOf(models[b].provider);
+    if (pa !== pb) return (pa === -1 ? 99 : pa) - (pb === -1 ? 99 : pb);
+    return String(models[a].name).localeCompare(String(models[b].name));
+  });
+  const sortedModels = {};
+  for (const id of sortedIds) sortedModels[id] = models[id];
+
+  const output = {
+    neon: {
+      id: 'neon',
+      name: typeof neon.name === 'string' ? neon.name : 'Neon',
+      npm: neon.npm,
+      api: neon.api,
+      env: neon.env,
+      doc: DOC_URL,
+      models: sortedModels,
+    },
+  };
+
+  const json = JSON.stringify(output, null, 2) + '\n';
+  if (toStdout) {
+    process.stdout.write(json);
+  } else {
+    fs.writeFileSync(OUT_PATH, json);
+    console.log(`Wrote ${path.relative(process.cwd(), OUT_PATH)} — ${sortedIds.length} models`);
+  }
+}
+
+main();

--- a/src/scripts/generate-models-json.js
+++ b/src/scripts/generate-models-json.js
@@ -35,7 +35,9 @@ const OUT_PATH = path.resolve(__dirname, '../app/models.json/data.json');
 const DOC_URL = 'https://neon.com/docs/ai-gateway/models';
 
 // Fields dropped from each model (not part of the /models.json capability catalog).
-const STRIP = new Set(['description', 'benchmarks', 'weights', 'links']);
+// `experimental` and `provider` are models.dev request-shaping/pricing internals;
+// `provider` is also re-added below as the underlying model provider string.
+const STRIP = new Set(['description', 'benchmarks', 'weights', 'links', 'experimental', 'provider']);
 
 // Stable, human-friendly key order per model.
 const KEY_ORDER = [


### PR DESCRIPTION
## Summary

Follow-up to #5203. Adds a **drift check** that keeps the Neon AI Gateway catalog served at **`/models.json`** in sync with its upstream source of truth — the `neon` provider in the [models.dev API](https://models.dev/api.json), which Neon maintains.

- **`.github/workflows/models-sync-check.yml`** — scheduled (daily) + `workflow_dispatch` job that runs the check and **fails on any drift**.
- **`src/scripts/check-models-sync.js`** — fetches `https://models.dev/api.json`, extracts the `neon` provider, and compares it to the committed `src/app/models.json/data.json` (what backs `/models.json`). It fails on:
  - models present in one catalog but not the other, and
  - per-model capability drift (`name`, `family`, `attachment`, `reasoning`, `reasoning_options`, `tool_call`, `temperature`, `structured_output`, `open_weights`, `knowledge`, dates, `modalities`, `limit`, `cost`, `status`).
  - Endpoint-specific fields are ignored on both sides so they don't cause false positives: the `provider` convenience field we add, and `description`/`benchmarks`/`weights`/`links`.
- **`package.json`** — `npm run check:models-sync` for local runs (`--ci` terse, `--json` machine-readable; `NEON_MODELS_URL=https://neon.com/models.json` compares the live endpoint instead of the repo file).
- Also **regenerates `data.json`** to pick up the latest models.dev Neon changes (adds `qwen35-122b-a10b`'s `reasoning_options`).

## Heads up — currently reports drift (expected)

The companion models.dev PR ([anomalyco/models.dev#3019](https://github.com/anomalyco/models.dev/pull/3019)) that adds these 12 models and removes `gpt-5-5` is **merged but not yet deployed to `models.dev/api.json`**. Until it redeploys, the check reports the expected delta:

```
In models.dev but missing from /models.json (1):  gpt-5-5
In /models.json but not in models.dev (12):        + gpt-5-3-codex, claude-opus-4-8, gemma-3-12b, ... 
Field drift (4 models): gemini-2-5-pro, gemini-3-1-pro, gemini-3-pro, gpt-5-4 (cost)
```

Once models.dev redeploys the merged `neon` provider, the daily job goes green (both catalogs derive from the same TOMLs). The workflow is **schedule + manual only** (not a PR gate), so it won't block merges.

## Test plan
- [x] `node src/scripts/check-models-sync.js` exits `1` on drift, `0` when in sync; `--json` and `--ci` modes verified.
- [x] `eslint` clean on the new script.