### PR TITLE
docs(storage): bring docs up to parity with last 30 days of code + IA audit

### DIFF
--- a/content/docs/guides/branch-archiving.md
+++ b/content/docs/guides/branch-archiving.md
@@ -10,7 +10,7 @@ summary: >-
   this page to understand archiving thresholds, blocking conditions, and how to
   monitor archive and unarchive operations via the Console, CLI, or API.
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-07-09T23:22:00.344Z'
 ---
 
 <InfoBlock>
@@ -21,7 +21,7 @@ updatedOn: '2026-06-11T23:50:21.258Z'
 </DocsList>
 
 <DocsList title="Related docs" theme="docs">
-  <a href="/docs/introduction/architecture-overview#archive-storage">Archive storage</a>
+  <a href="/docs/reference/glossary#archive-storage">Archive storage</a>
   <a href="/docs/cli/branches#list">Branches list command (Neon CLI)</a>
   <a href="https://api-docs.neon.tech/reference/getprojectbranch">Get branch details (Neon API)</a>
 </DocsList>
@@ -85,7 +85,7 @@ Archive and unarchive operations can also be monitored in the Neon Console or us
 
 ## About archive storage
 
-For Neon projects created in AWS regions, inactive branches are archived in Amazon S3 storage. For Neon projects created in Azure regions, branches are archived in Azure Blob storage. For more information about how archive storage works in Neon, refer to [Archive storage](/docs/introduction/architecture-overview#archive-storage) in our architecture documentation.
+For Neon projects created in AWS regions, inactive branches are archived in Amazon S3 storage. For Neon projects created in Azure regions, branches are archived in Azure Blob storage. For more information about how archive storage works in Neon, refer to [Archive storage](/docs/reference/glossary#archive-storage) in our architecture documentation.
 
 ## Is branch archiving configurable?
 

--- a/content/docs/introduction/architecture-overview.md
+++ b/content/docs/introduction/architecture-overview.md
@@ -15,7 +15,7 @@ redirectFrom:
   - /docs/storage-engine/architecture-overview
   - /docs/conceptual-guides/architecture-overview
   - /docs/guides/neon-features
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-09T14:41:19.380Z'
 ---
 
 ## Top level overview
@@ -95,7 +95,7 @@ Safekeepers are responsible for one thing: **durable replication of WAL**. When 
 This is a fundamental difference from how traditional Postgres works:
 
 - Correctness in Neon is enforced through replication and consensus
-- Commit latency depends on network RTT, not disk fsync
+- Commit latency is primarily quorum/network-bound, with safekeepers batching WAL flushes rather than relying on compute-local fsync
 - No single machine defines the durable state of the database
 
 ### Pageserver: WAL ⇄ pages

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-06-25T17:41:39.717Z'
+updatedOn: '2026-07-08T17:42:37.841Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -26,7 +26,13 @@ To follow this guide, you need:
 
 ## Recommended: enable storage with neon.ts
 
-The recommended way to enable storage and get credentials is via `neon.ts`, Neon's infrastructure-as-code config file. Declare buckets under `preview.buckets`, then run `neon deploy` to provision them on the linked branch and pull credentials into `.env.local` automatically:
+The recommended way to enable storage and get credentials is via `neon.ts`, Neon's infrastructure-as-code config file. Install the config package, link your local app to the Neon project and branch you want to target, declare buckets under `preview.buckets`, then run `neon deploy` to provision them on the linked branch and pull credentials into `.env.local` automatically:
+
+```bash
+npm install @neon/config
+neon link           # choose the project and branch for this app
+neon branches list  # confirm the linked target branch before deploy
+```
 
 ```typescript filename="neon.ts"
 import { defineConfig } from '@neon/config/v1';
@@ -57,7 +63,36 @@ neon env pull
 
 If you prefer to manage credentials manually (for example, for CI or production deployments), follow the steps below. Replace `{project_id}` and `{branch_id}` in the API examples with your own IDs. You can find them in the Neon Console URL, or with `neon projects list` and `neon branches list`.
 
+If you need a new branch, [create it first](/docs/manage/branches#create-a-branch), then wait until the branch is ready before calling Storage APIs. Branch creation is asynchronous, so a freshly-created branch can still be initializing even after the create request returns.
+
 <Steps>
+
+## Find your branch endpoint
+
+Fetch your branch's storage state from the Neon API. Do this before creating credentials so you know the branch is ready for Storage calls. The response includes the full S3 endpoint URL, the region, and whether path-style addressing is required:
+
+```bash shouldWrap
+curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/storage" \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+```json
+{
+  "enabled": true,
+  "s3_endpoint": "https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech",
+  "region": "us-east-2",
+  "force_path_style": true
+}
+```
+
+Set these as environment variables:
+
+```bash
+export AWS_ENDPOINT_URL_S3=https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech
+export AWS_REGION=us-east-2
+```
+
+A `404` response means Storage is not available for that branch. There is no separate manual enable API call: use the recommended `neon.ts` flow above, or make sure your project has Storage private preview access and is in the AWS `us-east-2` region.
 
 ## Create a credential
 
@@ -86,33 +121,6 @@ Set these as environment variables:
 export AWS_ACCESS_KEY_ID=nak_live_...   # token_id
 export AWS_SECRET_ACCESS_KEY=nsk_live_...   # s3_secret_access_key
 ```
-
-## Find your branch endpoint
-
-Fetch your branch's storage state from the Neon API. The response includes the full S3 endpoint URL, the region, and whether path-style addressing is required:
-
-```bash shouldWrap
-curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/storage" \
-  -H "Authorization: Bearer $NEON_API_KEY"
-```
-
-```json
-{
-  "enabled": true,
-  "s3_endpoint": "https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech",
-  "region": "us-east-2",
-  "force_path_style": true
-}
-```
-
-Set these as environment variables:
-
-```bash
-export AWS_ENDPOINT_URL_S3=https://br-winter-pond-aptw82ef.storage.c-2.us-east-2.aws.neon.tech
-export AWS_REGION=us-east-2
-```
-
-A `404` response means Storage is not yet enabled for that branch. Make sure you're using a project in the AWS us-east-2 region.
 
 ## Install dependencies
 
@@ -189,9 +197,17 @@ aws configure set endpoint_url "$AWS_ENDPOINT_URL_S3"
 If you're using [Neon Functions](/docs/compute/functions/overview), the `AWS_*` credentials are injected automatically when a bucket is declared in `neon.ts`. No `.env` setup is needed inside a function.
 </Admonition>
 
-## Upload a file
+## Create a bucket
 
-You need an existing bucket before uploading. [Create one](/docs/storage/buckets#create-a-bucket), or declare it in `neon.ts` and run `neon deploy`.
+Create the bucket before uploading, or declare it in `neon.ts` and run `neon deploy`:
+
+```bash
+neon buckets create my-bucket
+```
+
+See [Buckets](/docs/storage/buckets#create-a-bucket) for Neon API, S3 SDK, Python, and AWS CLI examples.
+
+## Upload a file
 
 <CodeTabs labels={["Files SDK", "S3 Client", "Python", "AWS CLI"]}>
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -17,7 +17,12 @@ To set up Neon Storage with an AI coding assistant, install the Neon Platform (`
 npx skills add neondatabase/agent-skills -s neon -s neon-object-storage
 ```
 
-To follow this guide, you need a new project in the AWS us-east-2 region.
+To follow this guide, you need:
+
+- Early access to the Neon Storage private preview
+- A new Neon project in the AWS `us-east-2` region
+- The Neon CLI installed and authenticated if you use the recommended `neon.ts` flow
+- A Neon API key in `NEON_API_KEY` if you use the manual API flow
 
 ## Recommended: enable storage with neon.ts
 
@@ -50,7 +55,7 @@ neon env pull
 
 ---
 
-If you prefer to manage credentials manually (for example, for CI or production deployments), follow the steps below.
+If you prefer to manage credentials manually (for example, for CI or production deployments), follow the steps below. Replace `{project_id}` and `{branch_id}` in the API examples with your own IDs. You can find them in the Neon Console URL, or with `neon projects list` and `neon branches list`.
 
 <Steps>
 
@@ -81,8 +86,6 @@ Set these as environment variables:
 export AWS_ACCESS_KEY_ID=nak_live_...   # token_id
 export AWS_SECRET_ACCESS_KEY=nsk_live_...   # s3_secret_access_key
 ```
-
-Your project ID and branch ID are available in the Neon Console URL or via `neon projects list` and `neon branches list`.
 
 ## Find your branch endpoint
 


### PR DESCRIPTION
## Summary
Brings Storage docs up to parity with the last 30 days of `hadron`/`neon-cloud` changes, plus fixes from a persona-driven IA read-through.

## Changes
- **`storage/get-started.md`**
  - Reordered prerequisites: `{project_id}`/`{branch_id}` lookup now comes before the first manual API call
  - Promoted bucket creation to its own explicit step; moved endpoint lookup before credentials
  - Added a branch-readiness note and 404 troubleshooting guidance
- **`introduction/architecture-overview.md`**
  - Corrected a commit-latency/fsync behavior claim (DOC-26588)

## Verified, not changed
- `neon.neon_backpressure_status()` exists in the extension but is intentionally left undocumented (that reference page is scoped to LFC, not exhaustive)
- "Up to 5 protected branches" is still accurate today; flagging a forward-looking watch item — `hadron` PR #7196 hard-codes "one protected timeline per tenant" behind an opt-out flag with no production callers yet
