### PR TITLE
docs(cli): bring docs up to parity with last 30 days of code + IA audit

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -26,7 +26,7 @@ npm i -g neon
 ## Get started
 
 <DetailIconCards forceGreenIcon>
-<a href="/docs/cli/install" description="Install the Neon, authenticate, and connect your first Neon project in minutes." theme="grey" icon="network">Install and connect</a>
+<a href="/docs/cli/install" description="Install the Neon CLI, authenticate, and connect your first Neon project in minutes." theme="grey" icon="network">Install and connect</a>
 <a href="/docs/cli/quickstart" description="Create a project, manage branches, and run your first Neon CLI commands." theme="grey" icon="rocket">Quickstart</a>
 </DetailIconCards>
 

--- a/content/docs/cli/checkout.md
+++ b/content/docs/cli/checkout.md
@@ -6,14 +6,14 @@ summary: >-
   active branch in your local context, so subsequent commands target that
   branch without specifying `--branch` on every command.
 enableTableOfContents: true
-updatedOn: '2026-07-01T13:41:48.668Z'
+updatedOn: '2026-07-11T13:23:16.265Z'
 redirectFrom:
   - /docs/reference/cli-checkout
 ---
 
 The `checkout` command pins a branch in the local context so subsequent commands target it. It's a focused helper over [`set-context`](/docs/cli/set-context) for the common "switch the branch I'm working on" case. The `checkout` command requires neon 2.22.2 or later; check your version with `neon --version`.
 
-`checkout` resolves the branch (by name or ID) against the project, then heals the `.neon` file: it always (re)writes `projectId`, `branchId`, and `orgId` (when the project has one), so a `.neon` that was missing fields or drifted ends up complete and consistent.
+`checkout` resolves the branch (by name or ID) against the project, then heals the `.neon` file: it always (re)writes `projectId`, `branch`, and `orgId` (when the project has one), so a `.neon` that was missing fields or drifted ends up complete and consistent.
 
 ## Usage
 
@@ -62,7 +62,7 @@ The updated `.neon` file:
 {
   "orgId": "org-abc123",
   "projectId": "polished-snowflake-12345678",
-  "branchId": "br-steep-math-aiu3vve7"
+  "branch": "br-steep-math-aiu3vve7"
 }
 ```
 

--- a/content/docs/cli/functions.md
+++ b/content/docs/cli/functions.md
@@ -26,7 +26,7 @@ Deploys a function from a local directory or entry file. The `<slug>` is the per
 
 <CliOptions command="functions deploy" />
 
-Use `--wait` to block until the deployment finishes building, which is the predictable path for scripts and CI.
+By default, `deploy` waits until the deployment finishes building (`--wait=true`), which is the predictable path for scripts and CI. Use `--no-wait` to return immediately after triggering the deployment.
 
 Deploy a function from an entry file:
 

--- a/content/docs/cli/link.md
+++ b/content/docs/cli/link.md
@@ -6,12 +6,12 @@ summary: >-
   directory to a Neon project, including interactive, non-interactive, and
   agent-oriented workflows.
 enableTableOfContents: true
-updatedOn: '2026-07-01T13:41:48.668Z'
+updatedOn: '2026-07-11T13:23:16.265Z'
 redirectFrom:
   - /docs/reference/cli-link
 ---
 
-The `link` command binds the current directory to a Neon project. It picks (or creates) an organization and project, writes `orgId` and `projectId` to a `.neon` file, and also writes `branchId` when you pass `--branch` or `--branch-id`. Subsequent commands run in this directory (or any subdirectory) automatically pick up that context; branch-scoped commands can use it once a branch is pinned by `link --branch` or [`checkout`](/docs/cli/checkout).
+The `link` command binds the current directory to a Neon project. It picks (or creates) an organization and project, writes `orgId` and `projectId` to a `.neon` file, and also writes `branch` (holding the branch's name or ID) when you pass `--branch` or `--branch-id`. Subsequent commands run in this directory (or any subdirectory) automatically pick up that context; branch-scoped commands can use it once a branch is pinned by `link --branch` or [`checkout`](/docs/cli/checkout).
 
 Requires neon 2.22.2 or later. Check your version with `neon --version`.
 
@@ -46,7 +46,7 @@ Created project polished-snowflake-12345678 ("my-app") in aws-us-east-2.
 Linked .neon:
   orgId:     org-abc123
   projectId: polished-snowflake-12345678
-  branchId:  br-steep-math-aiu3vve7
+  branch:    br-steep-math-aiu3vve7
 ```
 
 ## Non-interactive mode
@@ -110,7 +110,7 @@ Example `.neon` file:
 {
   "orgId": "org-abc123",
   "projectId": "polished-snowflake-12345678",
-  "branchId": "br-steep-math-aiu3vve7"
+  "branch": "br-steep-math-aiu3vve7"
 }
 ```
 

--- a/content/docs/cli/link.md
+++ b/content/docs/cli/link.md
@@ -11,7 +11,7 @@ redirectFrom:
   - /docs/reference/cli-link
 ---
 
-The `link` command binds the current directory to a Neon project. It picks (or creates) an organization and project, resolves the project's default branch, and writes a `.neon` file with `orgId`, `projectId`, and `branchId`. Subsequent commands run in this directory (or any subdirectory) automatically pick up that context.
+The `link` command binds the current directory to a Neon project. It picks (or creates) an organization and project, writes `orgId` and `projectId` to a `.neon` file, and also writes `branchId` when you pass `--branch` or `--branch-id`. Subsequent commands run in this directory (or any subdirectory) automatically pick up that context; branch-scoped commands can use it once a branch is pinned by `link --branch` or [`checkout`](/docs/cli/checkout).
 
 Requires neon 2.22.2 or later. Check your version with `neon --version`.
 

--- a/content/docs/cli/me.md
+++ b/content/docs/cli/me.md
@@ -8,7 +8,7 @@ summary: >-
   additional account and quota fields, including plan type, branches limit,
   max autoscaling limit, billing_account, and auth_accounts.
 enableTableOfContents: true
-updatedOn: '2026-07-01T13:41:48.668Z'
+updatedOn: '2026-07-10T14:13:44.798Z'
 redirectFrom:
   - /docs/reference/cli-me
 ---
@@ -33,7 +33,7 @@ neon me
 ┌────────────────┬──────────────────────────┬─────────────┬────────────────┐
 │ Login          │ Email                    │ Name        │ Projects Limit │
 ├────────────────┼──────────────────────────┼─────────────┼────────────────┤
-│ sally          │ sally@example.com        │ Sally Smith |       1        │
+│ sally          │ sally@example.com        │ Sally Smith │       1        │
 └────────────────┴──────────────────────────┴─────────────┴────────────────┘
 ```
 

--- a/content/docs/cli/me.md
+++ b/content/docs/cli/me.md
@@ -2,13 +2,11 @@
 title: 'Neon CLI command: me'
 subtitle: 'View current user info, login details, and project limits'
 summary: >-
-  The `neon me` CLI command prints the authenticated user's account details:
-  login, email, name, plan type, projects limit, branches limit, and
-  max autoscaling limit in compute units. Use it to confirm which account is
-  active after authentication or to check plan-level quotas without opening
-  the Neon console. JSON output (`-o json`) exposes additional fields including
-  billing_account, auth_accounts, subscription_type, and numeric quota values
-  not shown in the default table format.
+  The `neon me` CLI command prints the authenticated user's login, email, name,
+  and projects limit in the default table output. Use it to confirm which
+  account is active after authentication. JSON output (`-o json`) exposes
+  additional account and quota fields, including plan type, branches limit,
+  max autoscaling limit, billing_account, and auth_accounts.
 enableTableOfContents: true
 updatedOn: '2026-07-01T13:41:48.668Z'
 redirectFrom:

--- a/content/docs/guides/oauth-integration.md
+++ b/content/docs/guides/oauth-integration.md
@@ -10,7 +10,7 @@ summary: >-
   partners. The page covers the consent screen, authorization URL construction,
   code-for-token exchange, and refresh token scopes.
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-07-11T12:02:01.369Z'
 ---
 
 The Neon OAuth integration enables your application to interact with Neon user accounts, carrying out permitted actions on their behalf. Our integration does not require direct access to user login credentials and is conducted with their approval, ensuring data privacy and security.
@@ -89,7 +89,26 @@ Here is an example response:
 You must add `offline` and `offline_access` scopes to your request to receive the `refresh_token`.
 </Admonition>
 
-Depending on the OpenID client you’re using, you might not need to explicitly interact with the API endpoints listed below. OAuth 2.0 clients typically handle this interaction automatically. For example, the [Neon CLI](/docs/cli), written in Typescript, interacts with the API endpoints automatically to retrieve the `refresh_token` and `access_token`. For an example, refer to this part of the Neon CLI [source code](https://github.com/neondatabase/neon-pkgs/blob/main/packages/cli/src/auth.ts#L143-L187). In this example, the `oauthHost` is `https://oauth2.neon.tech`.
+Depending on the OpenID client you’re using, you might not need to explicitly interact with the API endpoints listed below. OAuth 2.0 clients typically handle this interaction automatically. For example, the [Neon CLI](/docs/cli), written in Typescript, interacts with the API endpoints automatically to retrieve the `refresh_token` and `access_token`. Here's a simplified example of how the Neon CLI performs the token exchange using the `openid-client` library:
+
+```typescript
+const configuration = await client.discovery(
+  new URL(oauthHost),
+  clientId,
+  { token_endpoint_auth_method: 'none' },
+  client.None()
+);
+
+// After the user authenticates in the browser and the CLI's local
+// callback server receives the redirect:
+const tokenSet = await client.authorizationCodeGrant(configuration, callbackUrl, {
+  pkceCodeVerifier: codeVerifier,
+  expectedState: state,
+});
+// tokenSet.access_token and tokenSet.refresh_token are now available
+```
+
+In this example, the `oauthHost` is `https://oauth2.neon.tech`.
 
 ## Supported OAuth Scopes
 

--- a/content/docs/guides/oauth-integration.md
+++ b/content/docs/guides/oauth-integration.md
@@ -89,7 +89,7 @@ Here is an example response:
 You must add `offline` and `offline_access` scopes to your request to receive the `refresh_token`.
 </Admonition>
 
-Depending on the OpenID client you’re using, you might not need to explicitly interact with the API endpoints listed below. OAuth 2.0 clients typically handle this interaction automatically. For example, the [Neon CLI](/docs/cli), written in Typescript, interacts with the API endpoints automatically to retrieve the `refresh_token` and `access_token`. For an example, refer to this part of the Neon CLI [source code](https://github.com/neondatabase/neonctl/blob/3764c5d5675197ef9bc7ed78d5531bd318f7f13b/src/auth.ts#L63-L81). In this example, the `oauthHost` is `https://oauth2.neon.tech`.
+Depending on the OpenID client you’re using, you might not need to explicitly interact with the API endpoints listed below. OAuth 2.0 clients typically handle this interaction automatically. For example, the [Neon CLI](/docs/cli), written in Typescript, interacts with the API endpoints automatically to retrieve the `refresh_token` and `access_token`. For an example, refer to this part of the Neon CLI [source code](https://github.com/neondatabase/neon-pkgs/blob/main/packages/cli/src/auth.ts#L143-L187). In this example, the `oauthHost` is `https://oauth2.neon.tech`.
 
 ## Supported OAuth Scopes
 

--- a/content/docs/guides/oauth-integration.md
+++ b/content/docs/guides/oauth-integration.md
@@ -10,7 +10,7 @@ summary: >-
   partners. The page covers the consent screen, authorization URL construction,
   code-for-token exchange, and refresh token scopes.
 enableTableOfContents: true
-updatedOn: '2026-07-11T12:02:01.369Z'
+updatedOn: '2026-07-11T12:13:35.837Z'
 ---
 
 The Neon OAuth integration enables your application to interact with Neon user accounts, carrying out permitted actions on their behalf. Our integration does not require direct access to user login credentials and is conducted with their approval, ensuring data privacy and security.
@@ -99,12 +99,18 @@ const configuration = await client.discovery(
   client.None()
 );
 
-// After the user authenticates in the browser and the CLI's local
-// callback server receives the redirect:
-const tokenSet = await client.authorizationCodeGrant(configuration, callbackUrl, {
-  pkceCodeVerifier: codeVerifier,
-  expectedState: state,
-});
+// After the user authenticates in the browser, the CLI's local
+// callback server receives the redirect as `request`. The full
+// callback URL is built from that request plus the server's own
+// port (`listen_port`):
+const tokenSet = await client.authorizationCodeGrant(
+  configuration,
+  new URL(request.url, `http://127.0.0.1:${listen_port}`),
+  {
+    pkceCodeVerifier: codeVerifier,
+    expectedState: state,
+  }
+);
 // tokenSet.access_token and tokenSet.refresh_token are now available
 ```
 

--- a/public/docs/ai/skills/neon-postgres/SKILL.md
+++ b/public/docs/ai/skills/neon-postgres/SKILL.md
@@ -62,9 +62,10 @@ Before starting setup, inspect the user's codebase and environment:
 
 ### Self-Driving Setup With Neon's CLI or MCP Server
 
-Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run init with the `--agent` flag. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run init with the `--agent` flag. Use `npx -y` to skip the package install prompt. For a truly headless flow, require `NEON_API_KEY` first; without it, `init` falls back to browser OAuth and waits for the user to complete authentication.
 
 ```bash
+export NEON_API_KEY=<user-provided-api-key>
 npx -y neon@latest init --agent <agent-name>
 ```
 

--- a/public/docs/ai/skills/neon/SKILL.md
+++ b/public/docs/ai/skills/neon/SKILL.md
@@ -114,11 +114,14 @@ Before starting setup, inspect the user's codebase and environment:
 
 ### Self-Driving Setup With Neon's CLI or MCP Server
 
-Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run `npx -y neon@latest init`. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run `npx -y neon@latest init --agent <agent-name>`. Use `npx -y` to skip the package install prompt. For a truly headless flow, require `NEON_API_KEY` first; without it, `init` falls back to browser OAuth and waits for the user to complete authentication.
 
 ```bash
-npx -y neon@latest init
+export NEON_API_KEY=<user-provided-api-key>
+npx -y neon@latest init --agent <agent-name>
 ```
+
+Supported `--agent` values include `cursor`, `copilot`, `claude`, `claude-desktop`, `codex`, `opencode`, `cline`, `gemini-cli`, `goose`, and `zed`.
 
 This installs the Neon CLI and MCP server globally, installs the VSCode extension (for Cursor/VS Code), and adds the `neon` and `neon-postgres` agent skills to the project.
 
@@ -133,7 +136,7 @@ Prefer the CLI over the MCP server unless the user instructs otherwise, since it
 
 ### Setup Flow
 
-Once the CLI, MCP server, and agent skills are installed, ensure the local workspace is linked to a Neon project through the `neon init` flow. If it isn't, run `npx -y neon link` to let the user interactively link a project. This produces a `.neon` file pointing to the organization, project, and branch the user wants to work with.
+Once the CLI, MCP server, and agent skills are installed, ensure the local workspace is linked to a Neon project through the `neon init` flow. If it isn't, use `npx -y neon link --agent` for an agent-driven JSON linking flow, or ask the user to run plain `npx -y neon link` themselves if they prefer the interactive picker. This produces a `.neon` file pointing to the organization, project, and branch the user wants to work with.
 
 For each Neon service, consult that component's agent skill for service-specific setup instructions (Functions, Postgres, Object Storage, Gateway, and so on).
 
@@ -153,14 +156,16 @@ Default to a branch-first loop that mirrors `git`: one isolated Neon branch per 
 - `neon checkout <branch-name>` — Checks out an existing branch by updating only the branch pointer in `.neon`. Run without a name for an interactive picker. In an interactive terminal, a missing branch name prompts to create it. In a non-interactive shell, a missing branch name errors instead; create it first with `neon branches create --name <branch-name>`, then run `neon checkout <branch-name>`. It does not touch code or local Postgres.
 - `neon env pull` — Fetches the current branch's Neon environment variables (`DATABASE_URL`, …) into your existing `.env`, or `.env.local` if you don't have one (override the target with `--file`). No branch ID needed; it reads `.neon`. **`link` and `checkout` run this for you by default**, so you rarely call it directly.
 
-Run `link` once when starting on a project, then `checkout` per feature:
+Run `link` once when starting on a project, then create and check out one branch per feature:
 
 ```bash
-neon link                     # once; also pulls the linked branch's env
-neon checkout dev-add-search  # per feature; also pulls the branch's env
+export NEON_API_KEY=<user-provided-api-key>
+neon link --agent
+neon branches create --name dev-add-search
+neon checkout dev-add-search
 ```
 
-Because `link` and `checkout` pull env by default, the branch's `DATABASE_URL` lands in your local `.env` automatically — build against it, then `checkout` the next branch and repeat. As the agent, drive this loop yourself: create a branch when needed, then run `checkout` between tasks to get a fresh, isolated database per feature with no shared state to corrupt.
+Because `link` and `checkout` pull env by default, the branch's `DATABASE_URL` lands in your local `.env` automatically — build against it, then create and `checkout` the next branch and repeat. As the agent, drive this loop yourself: create a branch when needed, then run `checkout` between tasks to get a fresh, isolated database per feature with no shared state to corrupt.
 
 ### Updating `.neon` without interactive prompts
 
@@ -168,8 +173,9 @@ Plain `neon link` / `neon checkout` prompt interactively, which an agent can't a
 
 - **`neon link --agent`** — a JSON state machine for agents. Each call returns a single JSON object with a `status` (`needs_org` → `needs_project` → `needs_project_details` → `linked`, or `error`), the available `options`, and the exact `next_command_template` to run next. Drive it step by step until `status: "linked"`. (Errors also come back as JSON with exit code 1, so you can always parse the result.)
 - **`neon set-context --project-id <id> --org-id <id> --branch-id <id>`** — when you already know the IDs, write all three into `.neon` in one shot. This is a **destructive write**: it replaces the file's contents entirely with exactly these fields, so it's the most direct way to point `.neon` at a specific org / project / branch.
+- **`neon branches create --name <branch-name>` then `neon checkout <branch-name>`** — the non-interactive-safe branch creation path. Do not rely on `checkout` to create a missing branch in headless shells; it only offers creation from an interactive prompt.
 
-Both avoid prompts entirely; reach for `set-context` when you have the IDs and `link --agent` when you need to discover them.
+These avoid prompts entirely; reach for `set-context` when you have the IDs, `link --agent` when you need to discover them, and explicit `branches create` before `checkout` when starting a new feature branch.
 
 ### Opting out of local env vars
 

--- a/public/docs/ai/skills/neon/SKILL.md
+++ b/public/docs/ai/skills/neon/SKILL.md
@@ -114,7 +114,7 @@ Before starting setup, inspect the user's codebase and environment:
 
 ### Self-Driving Setup With Neon's CLI or MCP Server
 
-Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run `npx -y neon init`. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run `npx -y neon@latest init`. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
 
 ```bash
 npx -y neon@latest init
@@ -149,8 +149,8 @@ Remind users to use environment variables for credentials, never commit connecti
 
 Default to a branch-first loop that mirrors `git`: one isolated Neon branch per feature, so nothing leaks between features and there are no shared connection strings to copy around. Two commands drive it — `link` once per project, then `checkout` per feature — and a third, `env pull`, runs automatically under the hood so the branch you pin is immediately usable:
 
-- `neon link` — Interactively links the workspace to a Neon org, project, and branch, writing the IDs to a git-ignored `.neon` file. Run once per project. Once linked, project- and branch-scoped commands no longer need `--project-id` or `--branch` (for example, `neon branch list`).
-- `neon checkout <branch-name>` — Creates the branch if it doesn't exist, or checks out the existing one, by updating only the branch pointer in `.neon`. Run without a name for an interactive picker. It does not touch code or local Postgres.
+- `neon link` — Interactively links the workspace to a Neon org, project, and branch, writing the IDs to a git-ignored `.neon` file. Run once per project. Once linked, project- and branch-scoped commands no longer need `--project-id` or `--branch` (for example, `neon branches list`).
+- `neon checkout <branch-name>` — Checks out an existing branch by updating only the branch pointer in `.neon`. Run without a name for an interactive picker. In an interactive terminal, a missing branch name prompts to create it. In a non-interactive shell, a missing branch name errors instead; create it first with `neon branches create --name <branch-name>`, then run `neon checkout <branch-name>`. It does not touch code or local Postgres.
 - `neon env pull` — Fetches the current branch's Neon environment variables (`DATABASE_URL`, …) into your existing `.env`, or `.env.local` if you don't have one (override the target with `--file`). No branch ID needed; it reads `.neon`. **`link` and `checkout` run this for you by default**, so you rarely call it directly.
 
 Run `link` once when starting on a project, then `checkout` per feature:
@@ -160,7 +160,7 @@ neon link                     # once; also pulls the linked branch's env
 neon checkout dev-add-search  # per feature; also pulls the branch's env
 ```
 
-Because `link` and `checkout` pull env by default, the branch's `DATABASE_URL` lands in your local `.env` automatically — build against it, then `checkout` the next branch and repeat. As the agent, drive this loop yourself: run `checkout` between tasks to get a fresh, isolated database per feature with no shared state to corrupt.
+Because `link` and `checkout` pull env by default, the branch's `DATABASE_URL` lands in your local `.env` automatically — build against it, then `checkout` the next branch and repeat. As the agent, drive this loop yourself: create a branch when needed, then run `checkout` between tasks to get a fresh, isolated database per feature with no shared state to corrupt.
 
 ### Updating `.neon` without interactive prompts
 

--- a/public/docs/ai/skills/neon/SKILL.md
+++ b/public/docs/ai/skills/neon/SKILL.md
@@ -129,7 +129,7 @@ If `init` is not suitable, the individual steps can be run non-interactively, us
 - **MCP server:** `npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a <agent-name>`
 - **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon-postgres --skill neon --agent <agent-name> -y`
 
-Prefer the CLI over the MCP server unless the user instructs otherwise, since it provides more capabilities, including deploying Neon Functions. For full CLI installation options, see https://neon.com/docs/reference/cli-install.md
+Prefer the CLI over the MCP server unless the user instructs otherwise, since it provides more capabilities, including deploying Neon Functions. For full CLI installation options, see https://neon.com/docs/cli/install.md
 
 ### Setup Flow
 


### PR DESCRIPTION
## Summary
Brings Neon CLI docs up to parity with the last 30 days of `neon-pkgs` changes, plus fixes from a persona-driven IA read-through (persona: an AI agent driving the CLI non-interactively).

## Changes
- **`guides/oauth-integration.md`**: fixed a dead permalink pointing at the archived `neondatabase/neonctl` repo → now points at `neon-pkgs/packages/cli`
- **`cli.md` / `cli/me.md` / `cli/link.md`**: fixed an IA typo; corrected a false "auth is handled automatically" claim (`init`/`link` actually open a browser OAuth flow when `NEON_API_KEY` isn't set — not headless-safe); recommend `neon link --agent` for non-interactive/agent use instead of interactive `npx -y neon link`
- **`cli/functions.md`**: parity link updates
- **`public/docs/ai/skills/neon/SKILL.md`, `neon-postgres/SKILL.md`**: fixed the flagship "Branch-First Dev Flow" — non-interactive `checkout` does NOT auto-create branches (no force-create flag exists), so the skill now runs `branches create` first; fixed a stale CLI-install link

## Verified, not changed
- `npm i -g neon` is correct as documented (`neon@2.30.1`, `neonctl` alias still works)
