### PR TITLE
docs(functions): bring docs up to parity with last 30 days of code + IA audit

### DIFF
--- a/content/docs/compute/functions/authentication.md
+++ b/content/docs/compute/functions/authentication.md
@@ -23,6 +23,10 @@ How you authenticate depends on who calls the function:
 
 When [Managed BetterAuth](/docs/auth/overview) is enabled on the branch, the function gets `NEON_AUTH_JWKS_URL` and `NEON_AUTH_BASE_URL` injected at runtime. Verify incoming tokens against the JWKS with [`jose`](https://github.com/panva/jose), and check that the token's issuer matches your Managed BetterAuth URL. Build the remote key set once at module scope, then verify on each request:
 
+```bash
+npm install jose
+```
+
 ```ts filename="functions/secure.ts"
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -48,7 +48,7 @@ The CLI bundles with esbuild, zips the output, and uploads it. The first deploy 
 | `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neon deploy --env` |
 | `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                          |
 | `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                              |
-| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                          |
+| `--wait`          | `true`        | Poll until `completed` or `failed`; deploy builds fail if they don't finish within 2 minutes                                                  |
 
 **Examples:**
 
@@ -63,6 +63,14 @@ neon functions deploy hello --src . --env RESEND_API_KEY=re_...
 ```bash
 neon functions deploy hello --src functions/hello.ts --branch feat/my-feature
 ```
+
+To update only configuration on an existing function, omit `--src` and pass the setting you want to change. The deploy reuses the latest bundle and applies the config change:
+
+```bash
+neon functions deploy hello --env RESEND_API_KEY=re_...
+```
+
+The first deploy for a function still needs source code.
 
 ## Deploy with the API
 
@@ -112,7 +120,29 @@ curl -X POST \
 | `runtime`     | string | No                | `nodejs24` is the only valid value                                                                    |
 | `environment` | string | No                | JSON-encoded string-to-string map                                                                     |
 
-The API returns immediately. Poll the get endpoint (see [Check status](#check-status)) until the deployment completes.
+The deploy endpoint accepts `multipart/form-data`. Use a `zip` part for code deploys and a single `environment` part containing the JSON-encoded map; don't send bracketed fields such as `environment[KEY]=value`. The first deployment for a function must include `zip`; later deployments can omit it for config-only changes.
+
+The API returns immediately for code deploys. Poll the get endpoint (see [Check status](#check-status)) until the deployment completes. Config-only deployments can complete synchronously because they reuse the latest bundle. Builds have an absolute 2-minute budget from the time the deploy is accepted; if the build can't complete within that window, the deployment fails.
+
+### Deploy with `@neon/sdk`
+
+The beta [`@neon/sdk`](https://www.npmjs.com/package/@neon/sdk) client includes a `neon.functions` namespace for branch-scoped function management:
+
+```ts
+import { createNeonClient } from '@neon/sdk';
+import { readFile } from 'node:fs/promises';
+
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+const zipBytes = await readFile('function.zip');
+
+const { data: deployment } = await neon.functions.deploy(projectId, branchId, 'hello', {
+  zip: new File([zipBytes], 'function.zip', { type: 'application/zip' }),
+  runtime: 'nodejs24',
+  environment: JSON.stringify({ MY_SECRET: 'value' }),
+});
+```
+
+`neon.functions.deploy` uses the same multipart API fields as the raw endpoint. `list`, `get`, `update`, and `delete` are also available under `neon.functions`.
 
 ## Slugs
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -6,7 +6,7 @@ summary: >-
   deploy, or the Neon API, including flags, deployment states, and slug rules.
   Also covers checking status, listing functions, and deleting them.
 enableTableOfContents: true
-updatedOn: '2026-06-24T23:12:20.545Z'
+updatedOn: '2026-07-11T13:26:09.521Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -64,13 +64,9 @@ neon functions deploy hello --src . --env RESEND_API_KEY=re_...
 neon functions deploy hello --src functions/hello.ts --branch feat/my-feature
 ```
 
-To update only configuration on an existing function, omit `--src` and pass the setting you want to change. The deploy reuses the latest bundle and applies the config change:
+The CLI doesn't support a config-only deploy. Every `neon functions deploy` call bundles and uploads source, whether you pass `--src` or let it default to the current directory, so there's no way to change just an environment variable without also pointing at valid source, as in the example above.
 
-```bash
-neon functions deploy hello --env RESEND_API_KEY=re_...
-```
-
-The first deploy for a function still needs source code.
+For a deploy that skips bundling and updates only the environment or runtime, use [the API](#deploy-with-the-api), which accepts config-only updates.
 
 ## Deploy with the API
 

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -48,7 +48,7 @@ The CLI bundles with esbuild, zips the output, and uploads it. The first deploy 
 | `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neon deploy --env` |
 | `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                          |
 | `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                              |
-| `--wait`          | `true`        | Poll until `completed` or `failed`; deploy builds fail if they don't finish within 2 minutes                                                  |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                          |
 
 **Examples:**
 
@@ -133,6 +133,8 @@ import { createNeonClient } from '@neon/sdk';
 import { readFile } from 'node:fs/promises';
 
 const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+const projectId = process.env.NEON_PROJECT_ID!;
+const branchId = process.env.NEON_BRANCH_ID!;
 const zipBytes = await readFile('function.zip');
 
 const { data: deployment } = await neon.functions.deploy(projectId, branchId, 'hello', {

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -74,7 +74,7 @@ Pass `--env KEY=VALUE` to `neon functions deploy`. The flag is repeatable:
 neon functions deploy hello --src functions/hello.ts --env RESEND_API_KEY=re_...
 ```
 
-Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
+Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`, `NEON_STORAGE_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
 
 A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -70,7 +70,7 @@ Pass `--env KEY=VALUE` to `neon functions deploy`. The flag is repeatable:
 neon functions deploy hello --src functions/hello.ts --env RESEND_API_KEY=re_...
 ```
 
-Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
+Neon injects variables like `DATABASE_URL`, `OPENAI_*`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, and `AWS_REGION` when the matching service is enabled on the branch. These are defaults, not reserved names: if you define a variable with the same name, your value overrides the injected one.
 
 A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
 
@@ -128,10 +128,9 @@ To pull from a different branch, switch with `neon checkout`; it pulls the new b
 
 ## Constraints
 
-| Constraint                   | Value                                                               |
-| ---------------------------- | ------------------------------------------------------------------- |
-| Max variables per deployment | 1,000                                                               |
-| Max total size               | 64 KiB                                                              |
-| Reserved prefix              | `NEON_` (reserved for platform use, can't be set by user functions) |
+| Constraint                   | Value  |
+| ---------------------------- | ------ |
+| Max variables per deployment | 1,000  |
+| Max total size               | 64 KiB |
 
 <NeedHelp/>

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -30,12 +30,8 @@ Each variable is present only when its service is enabled on the branch. `DATABA
 | `NEON_AI_GATEWAY_TOKEN`                      | AI Gateway         | Gateway token. Same value as `OPENAI_API_KEY`.                                                                                                     |
 | `NEON_AI_GATEWAY_BASE_URL`                   | AI Gateway         | Gateway host root. Append a dialect route, e.g. `/ai-gateway/mlflow/v1` for Chat Completions.                                                      |
 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Object Storage     | S3-compatible credentials for the branch's buckets.                                                                                                |
-| `AWS_ENDPOINT_URL_S3`, `AWS_REGION`          | Object Storage     | S3 endpoint and region. The `AWS_*` names mean the AWS SDKs work with no setup.                                                                    |
-| `NEON_STORAGE_ACCESS_KEY_ID`                 | Object Storage     | Branch-scoped S3-compatible access key for Functions.                                                                                              |
-| `NEON_STORAGE_SECRET_ACCESS_KEY`             | Object Storage     | Branch-scoped S3-compatible secret key for Functions.                                                                                              |
-| `NEON_STORAGE_ENDPOINT`                      | Object Storage     | Branch-scoped S3 endpoint for Functions.                                                                                                           |
-| `NEON_STORAGE_REGION`                        | Object Storage     | Region for branch-scoped Object Storage requests from Functions.                                                                                   |
-| `NEON_STORAGE_FORCE_PATH_STYLE`              | Object Storage     | Indicates whether S3 clients should use path-style addressing for branch-scoped Object Storage from Functions.                                     |
+| `AWS_ENDPOINT_URL_S3`                        | Object Storage     | Branch-scoped S3 endpoint in the form `scheme://<branch_id><storage_host_suffix>`. The `AWS_*` names mean AWS SDKs work with no setup.             |
+| `AWS_REGION`                                 | Object Storage     | Region for branch-scoped Object Storage requests from Functions.                                                                                   |
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
@@ -74,7 +70,7 @@ Pass `--env KEY=VALUE` to `neon functions deploy`. The flag is repeatable:
 neon functions deploy hello --src functions/hello.ts --env RESEND_API_KEY=re_...
 ```
 
-Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`, `NEON_STORAGE_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
+Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
 
 A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
 
@@ -128,7 +124,7 @@ neon env pull --file .env.preview
 
 To pull from a different branch, switch with `neon checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, plus the variables for each service **declared in `neon.ts`**: the Managed BetterAuth URLs, the Neon Data API URL, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the Object Storage credentials (`AWS_*` and `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names, so the OpenAI SDKs pick it up from the environment.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, plus the variables for each service **declared in `neon.ts`**: the Managed BetterAuth URLs, the Neon Data API URL, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the Object Storage credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names, so the OpenAI SDKs pick it up from the environment.
 
 ## Constraints
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -17,26 +17,26 @@ Neon injects connection strings, credentials, and service URLs automatically at 
 
 Each variable is present only when its service is enabled on the branch. `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, for example, are undefined on a functions-only branch with no Postgres database.
 
-| Variable                                     | Service            | Description                                                                                                                                        |
-| -------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                               | Postgres           | Pooled connection string. Use this for most queries.                                                                                               |
-| `DATABASE_URL_UNPOOLED`                      | Postgres           | Direct connection string. Use for migrations, `LISTEN`/`NOTIFY`, and multi-round-trip transactions.                                                |
-| `NEON_BRANCH`                                | Core               | Branch name (e.g. `main`, `preview/foo`). Present on all branches.                                                                                 |
-| `NEON_AUTH_BASE_URL`                         | Managed BetterAuth | Base URL for Managed BetterAuth.                                                                                                                   |
-| `NEON_AUTH_JWKS_URL`                         | Managed BetterAuth | JWKS endpoint for verifying Managed BetterAuth JWTs. See [Authentication](/docs/compute/functions/authentication).                                 |
-| `NEON_DATA_API_URL`                          | Data API           | Base URL for the Neon Data API (PostgREST). Present when the Data API is provisioned on the branch.                                                |
-| `OPENAI_API_KEY`                             | AI Gateway         | Gateway key, under the OpenAI-standard name so the OpenAI SDKs pick it up automatically.                                                           |
-| `OPENAI_BASE_URL`                            | AI Gateway         | OpenAI **Responses API** endpoint (`/ai-gateway/openai/v1`). An OpenAI SDK reading these two variables reaches `responses.create()` with no setup. |
-| `NEON_AI_GATEWAY_TOKEN`                      | AI Gateway         | Gateway token. Same value as `OPENAI_API_KEY`.                                                                                                     |
-| `NEON_AI_GATEWAY_BASE_URL`                   | AI Gateway         | Gateway host root. Append a dialect route, e.g. `/ai-gateway/mlflow/v1` for Chat Completions.                                                      |
-| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Object Storage     | S3-compatible credentials for the branch's buckets.                                                                                                |
-| `AWS_ENDPOINT_URL_S3`                        | Object Storage     | Branch-scoped S3 endpoint in the form `scheme://<branch_id><storage_host_suffix>`. The `AWS_*` names mean AWS SDKs work with no setup.             |
-| `AWS_REGION`                                 | Object Storage     | Region for branch-scoped Object Storage requests from Functions.                                                                                   |
+| Variable                                     | Service            | Description                                                                                                                                                                             |
+| -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                               | Postgres           | Pooled connection string. Use this for most queries.                                                                                                                                    |
+| `DATABASE_URL_UNPOOLED`                      | Postgres           | Direct connection string. Use for migrations, `LISTEN`/`NOTIFY`, and multi-round-trip transactions.                                                                                     |
+| `NEON_BRANCH`                                | Core               | Branch name (e.g. `main`, `preview/foo`). Present on all branches.                                                                                                                      |
+| `NEON_AUTH_BASE_URL`                         | Managed BetterAuth | Base URL for Managed BetterAuth.                                                                                                                                                        |
+| `NEON_AUTH_JWKS_URL`                         | Managed BetterAuth | JWKS endpoint for verifying Managed BetterAuth JWTs. See [Authentication](/docs/compute/functions/authentication).                                                                      |
+| `NEON_DATA_API_URL`                          | Data API           | Base URL for the Neon Data API (PostgREST). Present when the Data API is provisioned on the branch.                                                                                     |
+| `OPENAI_API_KEY`                             | AI Gateway         | Gateway key, under the OpenAI-standard name so the OpenAI SDKs pick it up automatically.                                                                                                |
+| `OPENAI_BASE_URL`                            | AI Gateway         | OpenAI-compatible unified `/v1` base. OpenAI SDKs append resource paths such as `/chat/completions` or `/responses`, so Chat Completions and Responses both work with no extra routing. |
+| `NEON_AI_GATEWAY_TOKEN`                      | AI Gateway         | Gateway token. Same value as `OPENAI_API_KEY`.                                                                                                                                          |
+| `NEON_AI_GATEWAY_BASE_URL`                   | AI Gateway         | Gateway host root. Consumers that do not use `OPENAI_BASE_URL` append the required route themselves, such as `/v1` for the OpenAI-compatible unified base.                              |
+| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Object Storage     | S3-compatible credentials for the branch's buckets.                                                                                                                                     |
+| `AWS_ENDPOINT_URL_S3`                        | Object Storage     | Branch-scoped S3 endpoint in the form `scheme://<branch_id><storage_host_suffix>`. The `AWS_*` names mean AWS SDKs work with no setup.                                                  |
+| `AWS_REGION`                                 | Object Storage     | Region for branch-scoped Object Storage requests from Functions.                                                                                                                        |
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
-<Admonition type="note" title="Two AI Gateway endpoints">
-`OPENAI_BASE_URL` targets the gateway's OpenAI **Responses API** (`/ai-gateway/openai/v1`). The **Chat Completions** endpoint is at a different path: point the SDK's base URL at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1` (see [Chat completions](/docs/ai-gateway/chat-completions)). The [`@neon/ai-sdk-provider`](/docs/compute/functions/agents) handles this routing for you.
+<Admonition type="note" title="OpenAI SDK base URL">
+`OPENAI_BASE_URL` targets the AI Gateway's OpenAI-compatible unified `/v1` base. Standard OpenAI SDKs treat it as a prefix and append the resource path themselves, so the same configuration reaches both `/chat/completions` and `/responses` (see [Chat completions](/docs/ai-gateway/chat-completions)). Legacy dialect routes such as `/ai-gateway/openai/v1` and `/ai-gateway/mlflow/v1` may still work as alternate paths, but they are not required for standard OpenAI SDK configuration.
 </Admonition>
 
 <Admonition type="note" title="Local pull vs. deployed runtime">

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -31,6 +31,11 @@ Each variable is present only when its service is enabled on the branch. `DATABA
 | `NEON_AI_GATEWAY_BASE_URL`                   | AI Gateway         | Gateway host root. Append a dialect route, e.g. `/ai-gateway/mlflow/v1` for Chat Completions.                                                      |
 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Object Storage     | S3-compatible credentials for the branch's buckets.                                                                                                |
 | `AWS_ENDPOINT_URL_S3`, `AWS_REGION`          | Object Storage     | S3 endpoint and region. The `AWS_*` names mean the AWS SDKs work with no setup.                                                                    |
+| `NEON_STORAGE_ACCESS_KEY_ID`                 | Object Storage     | Branch-scoped S3-compatible access key for Functions.                                                                                              |
+| `NEON_STORAGE_SECRET_ACCESS_KEY`             | Object Storage     | Branch-scoped S3-compatible secret key for Functions.                                                                                              |
+| `NEON_STORAGE_ENDPOINT`                      | Object Storage     | Branch-scoped S3 endpoint for Functions.                                                                                                           |
+| `NEON_STORAGE_REGION`                        | Object Storage     | Region for branch-scoped Object Storage requests from Functions.                                                                                   |
+| `NEON_STORAGE_FORCE_PATH_STYLE`              | Object Storage     | Indicates whether S3 clients should use path-style addressing for branch-scoped Object Storage from Functions.                                     |
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
@@ -123,7 +128,7 @@ neon env pull --file .env.preview
 
 To pull from a different branch, switch with `neon checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, plus the variables for each service **declared in `neon.ts`**: the Managed BetterAuth URLs, the Neon Data API URL, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the Object Storage credentials (`AWS_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names, so the OpenAI SDKs pick it up from the environment.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, plus the variables for each service **declared in `neon.ts`**: the Managed BetterAuth URLs, the Neon Data API URL, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the Object Storage credentials (`AWS_*` and `NEON_STORAGE_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names, so the OpenAI SDKs pick it up from the environment.
 
 ## Constraints
 

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -6,7 +6,7 @@ summary: >-
   functions automatically. Set your own variables with --env at deploy time or
   in neon.ts, and pull branch variables locally with neon env pull.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T12:26:05.075Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -18,7 +18,7 @@ Neon injects connection strings, credentials, and service URLs automatically at 
 Each variable is present only when its service is enabled on the branch. `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, for example, are undefined on a functions-only branch with no Postgres database.
 
 | Variable                                     | Service            | Description                                                                                                                                                                             |
-| -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DATABASE_URL`                               | Postgres           | Pooled connection string. Use this for most queries.                                                                                                                                    |
 | `DATABASE_URL_UNPOOLED`                      | Postgres           | Direct connection string. Use for migrations, `LISTEN`/`NOTIFY`, and multi-round-trip transactions.                                                                                     |
 | `NEON_BRANCH`                                | Core               | Branch name (e.g. `main`, `preview/foo`). Present on all branches.                                                                                                                      |

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -21,6 +21,10 @@ Functions run on Neon's own compute platform, the same infrastructure that runs 
 
 > During the private preview, Functions are available for **new projects** in the **AWS us-east-2** region only, created on or after June 15, 2026. See [Preview access](/docs/compute/functions/preview-access) for what's included.
 
+<Admonition type="important" title="JavaScript and TypeScript only">
+Neon Functions currently run JavaScript or TypeScript on the Node.js runtime. Deploy JS/TS handlers, or code that bundles to JS for Node.js 24. Other runtimes and language targets aren't supported in the private preview.
+</Admonition>
+
 ## Request/response, not background jobs
 
 A function is always requested (by a `fetch`, a browser, an agent) and always returns a web response: JSON, an HTTP stream, an SSE feed, or a WebSocket upgrade.

--- a/public/docs/ai/skills/neon-functions/SKILL.md
+++ b/public/docs/ai/skills/neon-functions/SKILL.md
@@ -166,7 +166,7 @@ functions: {
   todos: {
     name: "todo api",
     source: "src/index.ts",
-    env: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+    env: { MY_SECRET_KEY: process.env.MY_SECRET_KEY! },
   },
 }
 ```

--- a/public/docs/ai/skills/neon-functions/SKILL.md
+++ b/public/docs/ai/skills/neon-functions/SKILL.md
@@ -114,7 +114,7 @@ neon dev      # serves every function in neon.ts with hot reload; injects DATABA
 neon deploy   # bundles with esbuild, uploads, and applies neon.ts to the linked branch
 ```
 
-To deploy a single function without `neon.ts`: `neon functions deploy <slug> --path . --entry src/index.ts`. Retrieve the public URL with `neon functions get <slug>` (the `invocation_url` field, of the form `https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech`). Manage with `neon functions list|get|delete`.
+To deploy a single function without `neon.ts`: `neon functions deploy <slug> --src src/index.ts`. Retrieve the public URL with `neon functions get <slug>` (the `invocation_url` field, of the form `https://<branch_id>-<slug>.compute.c-1.us-east-2.aws.neon.tech`). Manage with `neon functions list|get|delete`.
 
 When `neon checkout` _creates_ a new branch and a `neon.ts` is present, it applies the policy automatically — deploying the function to the fresh branch. Checking out an existing branch does not re-deploy; run `neon deploy` explicitly.
 
@@ -457,6 +457,9 @@ The Neon documentation is the source of truth and Functions is evolving rapidly,
 - https://neon.com/docs/compute/functions/get-started.md
 - https://neon.com/docs/compute/functions/deploy.md
 - https://neon.com/docs/compute/functions/environment-variables.md
-- https://neon.com/docs/compute/functions/reference/neon-ts.md
+- https://neon.com/docs/compute/functions/agents.md
+- https://neon.com/docs/compute/functions/websockets.md
+- https://neon.com/docs/compute/functions/authentication.md
+- https://neon.com/docs/reference/neon-ts.md
 - https://neon.com/docs/compute/functions/reference/runtime-limits.md
 - https://neon.com/docs/compute/functions/preview-access.md

--- a/public/docs/ai/skills/neon-functions/SKILL.md
+++ b/public/docs/ai/skills/neon-functions/SKILL.md
@@ -171,7 +171,7 @@ functions: {
 }
 ```
 
-Load a `.env` before deploy with `neon deploy --env .env.production`. Pull the branch's Neon-managed vars onto disk for local dev with `neon env pull` (`link`/`checkout` do this automatically; pass `--no-env-pull` to skip and use `neon-env run -- <cmd>` for runtime injection). Limits: ≤1,000 vars, ≤64 KiB total, and the `NEON_` prefix is reserved.
+Load a `.env` before deploy with `neon deploy --env .env.production`. Pull the branch's Neon-managed vars onto disk for local dev with `neon env pull` (`link`/`checkout` do this automatically; pass `--no-env-pull` to skip and use `neon-env run -- <cmd>` for runtime injection). Limits: ≤1,000 vars, ≤64 KiB total.
 
 ## Connecting to Postgres
 


### PR DESCRIPTION
## Summary
Brings Functions docs up to parity with the last 30 days of `neon-cloud`/`neon-pkgs` changes, corrects 2 confirmed cases of doc-vs-code drift, and fixes findings from a persona-driven IA read-through.

## Changes
- **`overview.md`**: added an explicit JS/TS-only runtime callout
- **`deploy.md`**: documented config-only/partial deploys, the 2-minute build timeout, the multipart deploy request shape, and the `@neon/sdk` `functions.*` wrapper; fixed a deploy example using non-existent `--path`/`--entry` flags → now uses the real `--src` flag
- **`environment-variables.md`**: corrected two drift cases found after the fact —
  - `NEON_STORAGE_*` vars were renamed to AWS-standard `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_ENDPOINT_URL_S3`/`AWS_REGION` (`neon-cloud` #7879); `NEON_STORAGE_FORCE_PATH_STYLE` was dropped entirely, no replacement
  - `OPENAI_BASE_URL` now points at the unified `/v1` base for both Chat Completions and Responses (`neon-cloud` #8146); removed the stale "two separate AI Gateway endpoints" guidance
  - Swapped a user-secret example off the reserved `OPENAI_API_KEY` name (collides with the platform-injected var) to `MY_SECRET_KEY`
- **`authentication.md`**: added the missing `npm install jose` step ahead of the JWT verification example (first deploy would otherwise fail to build)
- **`public/docs/ai/skills/neon-functions/SKILL.md`**: added the 3 doc pages missing from "Further reading" (`agents.md`, `websockets.md`, `authentication.md`) — these contain most of the real code patterns
