### PR TITLE
docs(data-api): bring docs up to parity with last 30 days of code + IA audit

### DIFF
--- a/content/docs/data-api/access-control.md
+++ b/content/docs/data-api/access-control.md
@@ -11,7 +11,7 @@ summary: >-
   configure GRANT statements, enable RLS, and write per-row policies with
   `auth.user_id()`, which extracts the `sub` claim from the request JWT.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-11T13:39:13.071Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Data API" />
@@ -65,7 +65,9 @@ const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL, {
 const { data, error } = await client.from('public_items').select('*');
 ```
 
-Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
+<Admonition type="warning" title="Not yet on npm">
+The single-URL form shown above, `createClient(url)`, requires a version of `@neondatabase/neon-js` that has not been published to npm as of this writing. The latest published version, `0.6.2-beta`, only accepts the two-URL object form. If `npm install @neondatabase/neon-js` installs `0.6.2-beta` or earlier for you, use the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference instead.
+</Admonition>
 
 **With a third-party provider:** Check whether your provider supports issuing anonymous or guest tokens. If it does, obtain the token using your provider's method and include it in the `Authorization: Bearer <token>` header on each request.
 

--- a/content/docs/data-api/access-control.md
+++ b/content/docs/data-api/access-control.md
@@ -55,13 +55,9 @@ Anonymous access still uses a JWT, but no user sign-in is required. How you obta
 ```js
 import { createClient } from '@neondatabase/neon-js';
 
-const client = createClient({
+const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL, {
   auth: {
-    url: import.meta.env.VITE_NEON_AUTH_URL,
     allowAnonymous: true,
-  },
-  dataApi: {
-    url: import.meta.env.VITE_NEON_DATA_API_URL,
   },
 });
 

--- a/content/docs/data-api/access-control.md
+++ b/content/docs/data-api/access-control.md
@@ -65,6 +65,8 @@ const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL, {
 const { data, error } = await client.from('public_items').select('*');
 ```
 
+Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
+
 **With a third-party provider:** Check whether your provider supports issuing anonymous or guest tokens. If it does, obtain the token using your provider's method and include it in the `Authorization: Bearer <token>` header on each request.
 
 - By default, this role has **no permissions**.

--- a/content/docs/data-api/custom-authentication-providers.md
+++ b/content/docs/data-api/custom-authentication-providers.md
@@ -72,7 +72,7 @@ The key steps:
 
 ## Add your authentication provider
 
-You can configure your authentication provider when you first enable the Data API, or add it later from the **Configuration** tab. Select **Other Provider** from the dropdown and enter:
+You can configure your authentication provider when you first enable the Data API, or add it later from the **Settings** tab. Select **Other Provider** from the dropdown and enter:
 
 - Your provider's **JWKS URL** (see provider-specific instructions below).
 - Your **JWT Audience** value, if required by your provider (see [What is JWT Audience?](#what-is-jwt-audience) below).
@@ -378,7 +378,7 @@ https://api.workos.com/sso/jwks/client_12345
 After configuring your authentication provider, include the JWT in your Data API requests:
 
 ```http
-GET https://your-project.data.neon.tech/v1/posts
+GET https://ep-example.apirest.us-east-1.aws.neon.tech/neondb/rest/v1/posts
 Authorization: Bearer {your_jwt_token}
 ```
 

--- a/content/docs/data-api/demo.md
+++ b/content/docs/data-api/demo.md
@@ -10,7 +10,7 @@ summary: >-
   for a working end-to-end example of Data API query patterns, RLS setup, and
   ON DELETE CASCADE.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-13T19:46:02.920Z'
 ---
 
 This tutorial uses a note-taking app to show how Neon's Data API works with the `@neondatabase/neon-js` client library to write queries from your frontend code, with authentication and Row-Level Security (RLS) policies keeping your data secure. The Data API is compatible with PostgREST, so you can use any PostgREST client library.
@@ -67,6 +67,7 @@ VITE_NEON_DATABASE_URL=https://ep-example.c-2.us-east-1.aws.neon.tech/neondb
 
 # Database Connection String (for migrations)
 # Find this in Neon Console → Dashboard → Connection string (select "Pooled connection")
+# This is a Postgres connection string, not the HTTPS URL used by VITE_NEON_DATABASE_URL above
 DATABASE_URL=postgresql://user:password@your-project-id.pooler.region.neon.tech/neondb?sslmode=require
 ```
 

--- a/content/docs/data-api/demo.md
+++ b/content/docs/data-api/demo.md
@@ -59,13 +59,9 @@ bun install
 Create a `.env` file in the project root:
 
 ```env
-# Neon Data API URL
-# Find this in Neon Console → Data API page → "Data API URL"
-VITE_NEON_DATA_API_URL=https://your-project-id.data-api.neon.tech
-
-# Managed BetterAuth Base URL
-# Find this in Neon Console → Auth page → "Auth Base URL"
-VITE_NEON_AUTH_URL=https://your-project-id.auth.neon.tech
+# Neon database URL for the client (no username, password, or query parameters)
+# The SDK derives the Neon Auth and Data API URLs from this value.
+VITE_NEON_DATABASE_URL=https://ep-example.c-2.us-east-1.aws.neon.tech/neondb
 
 # Database Connection String (for migrations)
 # Find this in Neon Console → Dashboard → Connection string (select "Pooled connection")
@@ -106,13 +102,9 @@ import { createClient } from '@neondatabase/neon-js';
 import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react/adapters';
 import type { Database } from '../../types/database';
 
-export const client = createClient<Database>({
+export const client = createClient<Database>(import.meta.env.VITE_NEON_DATABASE_URL, {
   auth: {
     adapter: BetterAuthReactAdapter(),
-    url: import.meta.env.VITE_NEON_AUTH_URL,
-  },
-  dataApi: {
-    url: import.meta.env.VITE_NEON_DATA_API_URL,
   },
 });
 ```

--- a/content/docs/data-api/demo.md
+++ b/content/docs/data-api/demo.md
@@ -60,6 +60,8 @@ Create a `.env` file in the project root:
 
 ```env
 # Neon database URL for the client (no username, password, or query parameters)
+# Start from the Data API URL in Neon Console → Data API or `neon data-api get`;
+# remove the `.apirest` hostname label and trailing `/rest/v1` path.
 # The SDK derives the Neon Auth and Data API URLs from this value.
 VITE_NEON_DATABASE_URL=https://ep-example.c-2.us-east-1.aws.neon.tech/neondb
 
@@ -67,6 +69,8 @@ VITE_NEON_DATABASE_URL=https://ep-example.c-2.us-east-1.aws.neon.tech/neondb
 # Find this in Neon Console → Dashboard → Connection string (select "Pooled connection")
 DATABASE_URL=postgresql://user:password@your-project-id.pooler.region.neon.tech/neondb?sslmode=require
 ```
+
+Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
 
 ### Set up the database
 

--- a/content/docs/data-api/generate-types.md
+++ b/content/docs/data-api/generate-types.md
@@ -12,7 +12,7 @@ summary: >-
   `--output`, and `--schema` flags and can run as a package.json script to
   keep generated types in sync after schema changes.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-13T19:46:02.920Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Data API" />
@@ -70,7 +70,7 @@ const { data, error } = await client
   .eq('is_published', true); // Type check: ensures 'is_published' expects a boolean
 ```
 
-Use the HTTPS Neon database URL without credentials or query parameters for `NEON_DATABASE_URL`, for example `https://ep-example.c-2.us-east-1.aws.neon.tech/neondb`. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The `.c-2` cell label, region, and database path stay the same. Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
+Use the HTTPS Neon database URL without credentials or query parameters for `NEON_DATABASE_URL`, for example `https://ep-example.c-2.us-east-1.aws.neon.tech/neondb`. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The cell label (if present), region, and database path stay the same. Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
 
 ### Response types
 

--- a/content/docs/data-api/generate-types.md
+++ b/content/docs/data-api/generate-types.md
@@ -43,11 +43,13 @@ npx @neondatabase/neon-js gen-types \
 
 ### Options
 
-| Flag        | Alias | Description                                    | Default               |
-| :---------- | :---- | :--------------------------------------------- | :-------------------- |
-| `--db-url`  | `-c`  | The PostgreSQL connection string (Required).   | -                     |
-| `--output`  | `-o`  | The path where the file will be saved.         | `./types/database.ts` |
-| `--schemas` | `-s`  | Comma-separated list of schemas to introspect. | `public`              |
+| Flag                    | Alias | Description                                                                                    | Default             |
+| :---------------------- | :---- | :--------------------------------------------------------------------------------------------- | :------------------ |
+| `--db-url`              | -     | The PostgreSQL connection string (Required).                                                   | -                   |
+| `--output`              | `-o`  | The path where the file will be saved.                                                         | `database.types.ts` |
+| `--schema`              | `-s`  | Schema to introspect. Repeatable to include multiple schemas, for example `-s public -s auth`. | `public`            |
+| `--postgrest-v9-compat` | -     | Disables one-to-one relationship detection.                                                    | `false`             |
+| `--query-timeout`       | -     | The timeout for the schema introspection query, for example `30s` or `1m`.                     | `15s`               |
 
 ## Use generated types
 

--- a/content/docs/data-api/generate-types.md
+++ b/content/docs/data-api/generate-types.md
@@ -59,10 +59,7 @@ import type { Database } from '@/types/database';
 import { createClient } from '@neondatabase/neon-js';
 
 // Pass the generic to the client
-const client = createClient<Database>({
-  auth: { url: process.env.NEON_AUTH_URL },
-  dataApi: { url: process.env.NEON_DATA_API_URL },
-});
+const client = createClient<Database>(process.env.NEON_DATABASE_URL!);
 
 // 3. Enjoy full type safety
 const { data, error } = await client
@@ -70,6 +67,8 @@ const { data, error } = await client
   .select('id, content') // Autocomplete: only columns in 'posts'
   .eq('is_published', true); // Type check: ensures 'is_published' expects a boolean
 ```
+
+Use the HTTPS Neon database URL without credentials or query parameters for `NEON_DATABASE_URL`, for example `https://ep-example.c-2.us-east-1.aws.neon.tech/neondb`. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The SDK derives the Neon Auth and Data API URLs from this value.
 
 ### Response types
 

--- a/content/docs/data-api/generate-types.md
+++ b/content/docs/data-api/generate-types.md
@@ -68,7 +68,7 @@ const { data, error } = await client
   .eq('is_published', true); // Type check: ensures 'is_published' expects a boolean
 ```
 
-Use the HTTPS Neon database URL without credentials or query parameters for `NEON_DATABASE_URL`, for example `https://ep-example.c-2.us-east-1.aws.neon.tech/neondb`. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The SDK derives the Neon Auth and Data API URLs from this value.
+Use the HTTPS Neon database URL without credentials or query parameters for `NEON_DATABASE_URL`, for example `https://ep-example.c-2.us-east-1.aws.neon.tech/neondb`. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The `.c-2` cell label, region, and database path stay the same. Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
 
 ### Response types
 

--- a/content/docs/data-api/generate-types.md
+++ b/content/docs/data-api/generate-types.md
@@ -9,7 +9,7 @@ summary: >-
   Use this page to add autocomplete, query-result type inference, and
   compile-time error checking to `@neondatabase/neon-js` or
   `@neondatabase/postgrest-js` clients. The tool accepts `--db-url`,
-  `--output`, and `--schemas` flags and can run as a package.json script to
+  `--output`, and `--schema` flags and can run as a package.json script to
   keep generated types in sync after schema changes.
 enableTableOfContents: true
 updatedOn: '2026-07-10T15:48:27.200Z'

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -10,7 +10,7 @@ summary: >-
   branch for a single database and does not support projects with IP Allow or
   Private Networking configured.
 enableTableOfContents: true
-updatedOn: '2026-07-11T13:39:13.071Z'
+updatedOn: '2026-07-13T19:46:02.920Z'
 ---
 
 This guide walks you through enabling the Data API, creating a table with RLS, and running your first query.
@@ -267,7 +267,7 @@ The single-URL form shown above, `createClient(url)`, requires a version of `@ne
 </Admonition>
 
 <Admonition type="note">
-This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The `.c-2` cell label, region, and database path stay the same.
+This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The cell label (if present), region, and database path stay the same.
 </Admonition>
 
 </TabItem>

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -10,7 +10,7 @@ summary: >-
   branch for a single database and does not support projects with IP Allow or
   Private Networking configured.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-11T13:39:13.071Z'
 ---
 
 This guide walks you through enabling the Data API, creating a table with RLS, and running your first query.
@@ -262,8 +262,12 @@ const { data, error } = await client
 console.log(data);
 ```
 
+<Admonition type="warning" title="Not yet on npm">
+The single-URL form shown above, `createClient(url)`, requires a version of `@neondatabase/neon-js` that has not been published to npm as of this writing. The latest published version, `0.6.2-beta`, only accepts the two-URL object form. If `npm install @neondatabase/neon-js` installs `0.6.2-beta` or earlier for you, use the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference instead.
+</Admonition>
+
 <Admonition type="note">
-This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The `.c-2` cell label, region, and database path stay the same. Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
+This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The `.c-2` cell label, region, and database path stay the same.
 </Admonition>
 
 </TabItem>

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -248,15 +248,9 @@ npm install @neondatabase/neon-js
 import { createClient } from '@neondatabase/neon-js';
 
 // Initialize with Managed BetterAuth
-// Get your URLs from the Neon Console or run: neon data-api get
-const client = createClient({
-  auth: {
-    url: import.meta.env.VITE_NEON_AUTH_URL,
-  },
-  dataApi: {
-    url: import.meta.env.VITE_NEON_DATA_API_URL,
-  },
-});
+// Use your Neon database URL without credentials or query parameters.
+// Example: https://ep-example.c-2.us-east-1.aws.neon.tech/neondb
+const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL);
 
 // Query - the JWT token is injected automatically when the user is signed in
 const { data, error } = await client
@@ -269,7 +263,7 @@ console.log(data);
 ```
 
 <Admonition type="note">
-This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js.
+This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The SDK derives the Neon Auth URL and Data API URL from it.
 </Admonition>
 
 </TabItem>

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -263,7 +263,7 @@ console.log(data);
 ```
 
 <Admonition type="note">
-This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The SDK derives the Neon Auth URL and Data API URL from it.
+This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The `.c-2` cell label, region, and database path stay the same. Prefer the older two-URL setup? See the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference.
 </Admonition>
 
 </TabItem>

--- a/content/docs/data-api/manage.md
+++ b/content/docs/data-api/manage.md
@@ -101,6 +101,12 @@ Defines which PostgreSQL schemas are exposed as REST API endpoints. By default, 
 **Permissions apply:** Adding a schema here exposes the *endpoints*, but the database role used by the API must still have `USAGE` privileges on the schema and `SELECT` privileges on the tables. Refer to [Access control for Data API](/docs/data-api/access-control) for more details.
 </Admonition>
 
+### Extra search path schemas
+
+**Default:** `Empty`
+
+Adds extra PostgreSQL schemas to the search path used for every Data API request. These schemas aren't exposed as REST API endpoints themselves; they're only available for database objects inside your [exposed schemas](#exposed-schemas) to reference, which is useful for schemas that hold PostgreSQL extensions. Corresponds to the `db_extra_search_path` field in the API settings object.
+
 ### Anonymous role
 
 **Default:** `anonymous`
@@ -118,6 +124,12 @@ Enforces a hard limit on the number of rows returned in a single API response. T
 **Default:** `.role`
 
 Specifies the path within the JWT token that contains the database role name. The Data API uses this role to execute queries on behalf of the authenticated user. For example, `.role` extracts the value of the top-level `role` claim from the token. Corresponds to the `jwt_role_claim_key` field in the API settings object. This field is required when updating settings via the API.
+
+### JWT cache max lifetime
+
+**Default:** `Empty`
+
+Sets the maximum lifetime, in seconds, that a validated JWT is kept in the Data API's cache. Caching validated tokens reduces the number of times the Data API needs to fetch and verify keys from your authentication provider's JWKS URL. Corresponds to the `jwt_cache_max_lifetime` field in the API settings object.
 
 ### CORS allowed origins
 

--- a/content/docs/data-api/troubleshooting.md
+++ b/content/docs/data-api/troubleshooting.md
@@ -89,11 +89,11 @@ The `sub` claim in this example: `41a5f680-89d2-474d-ae59-e27bfbbbd293` represen
 
 If you're using Managed BetterAuth, you can use the Auth API reference UI to create test users and obtain JWT tokens for testing with tools like Postman or cURL.
 
-Navigate to your Auth URL with `/reference` appended (for example, `https://ep-example.neonauth.us-east-1.aws.neon.tech/neondb/auth/reference`). You can find your **Auth URL** on the **Auth** page on the **Configuration** tab in the Neon Console. From there, you can:
+Navigate to your Auth URL with `/reference` appended (for example, `https://ep-example.neonauth.us-east-1.aws.neon.tech/neondb/auth/reference`). You can find your **Auth URL** on the **Auth** page, **Configuration** tab in the Neon Console. From there, you can:
 
-1. Create a test user with `POST /api/auth/sign-up/email`.
-2. Sign in with `POST /api/auth/sign-in/email`.
-3. Call `GET /api/auth/get-session` and copy the JWT from the `Set-Auth-Jwt` response header.
+1. Create a test user with `POST /sign-up/email`.
+2. Sign in with `POST /sign-in/email`.
+3. Call `GET /get-session` and copy the JWT from the `Set-Auth-Jwt` response header.
 4. Use that JWT in your Data API requests.
 
 For step-by-step instructions, see [Testing with Managed BetterAuth](/docs/data-api/get-started#testing-with-neon-auth).
@@ -196,7 +196,7 @@ The OpenAPI schema feature is disabled in your Data API configuration.
 ### Fix
 
 1. Go to the **Data API** page in the Neon Console
-2. Open the **Configuration** panel
+2. Open the **Settings** tab
 3. Enable the **OpenAPI schema** toggle
 4. Try your request again
 
@@ -248,6 +248,6 @@ JWT tokens have a limited lifespan (typically around 15 minutes). Once expired, 
 
 ### Fix
 
-Sign in again to get a fresh token. If you're using Managed BetterAuth, call `POST /api/auth/sign-in/email` in the Auth API reference UI, then call `GET /api/auth/get-session` and copy the new JWT from the `Set-Auth-Jwt` response header.
+Sign in again to get a fresh token. If you're using Managed BetterAuth, call `POST /sign-in/email` in the Auth API reference UI, then call `GET /get-session` and copy the new JWT from the `Set-Auth-Jwt` response header.
 
 For programmatic token refresh, see your authentication provider's documentation on token renewal.

--- a/content/docs/reference/javascript-sdk.md
+++ b/content/docs/reference/javascript-sdk.md
@@ -65,7 +65,7 @@ Use this when you only need authentication (no database queries). You get:
 
 The auth methods are identical; only the access path differs. `client.auth.signIn.email()` and `auth.signIn.email()` do the same thing.
 
-For the full client, pass a single HTTPS Neon database URL without credentials or query parameters. The SDK derives the Neon Auth URL and Data API URL automatically. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. If you need to override either derived URL, the object form is still supported.
+For the full client, pass a single HTTPS Neon database URL without credentials or query parameters. The SDK derives the Neon Auth URL and Data API URL automatically. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The `.c-2` cell label, region, and database path stay the same. If you need to override either derived URL, the object form is still supported.
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>

--- a/content/docs/reference/javascript-sdk.md
+++ b/content/docs/reference/javascript-sdk.md
@@ -13,7 +13,7 @@ summary: >-
   (Supabase-compatible migration path).
 enableTableOfContents: true
 layout: wide
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-11T13:39:13.071Z'
 ---
 
 This page documents `@neondatabase/neon-js`, which combines Managed BetterAuth and the Data API in a single client. Neon also publishes standalone packages:
@@ -104,6 +104,10 @@ const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL, {
 ```
 
 </CodeTabs>
+
+<Admonition type="warning" title="Not yet on npm">
+The single-URL form shown above, `createClient(url)`, requires a version of `@neondatabase/neon-js` that has not been published to npm as of this writing. The latest published version, `0.6.2-beta`, only accepts the two-URL object form below. If `npm install @neondatabase/neon-js` installs `0.6.2-beta` or earlier for you, use the object form instead.
+</Admonition>
 
 The object form remains available for custom endpoint layouts or local development setups where the Auth and Data API URLs cannot be derived from the same Neon database URL:
 

--- a/content/docs/reference/javascript-sdk.md
+++ b/content/docs/reference/javascript-sdk.md
@@ -65,6 +65,8 @@ Use this when you only need authentication (no database queries). You get:
 
 The auth methods are identical; only the access path differs. `client.auth.signIn.email()` and `auth.signIn.email()` do the same thing.
 
+For the full client, pass a single HTTPS Neon database URL without credentials or query parameters. The SDK derives the Neon Auth URL and Data API URL automatically. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. If you need to override either derived URL, the object form is still supported.
+
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
 <CodeTabs labels={["Full client","Auth-only","With TypeScript types","With a different adapter"]}>
@@ -72,14 +74,9 @@ The auth methods are identical; only the access path differs. `client.auth.signI
 ```typescript
 import { createClient } from '@neondatabase/neon-js';
 
-const client = createClient({
-  auth: {
-    url: import.meta.env.VITE_NEON_AUTH_URL,
-  },
-  dataApi: {
-    url: import.meta.env.VITE_NEON_DATA_API_URL,
-  },
-});
+// Use your Neon database URL without credentials or query parameters.
+// Example: https://ep-example.c-2.us-east-1.aws.neon.tech/neondb
+const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL);
 ```
 
 ```typescript
@@ -92,23 +89,27 @@ const auth = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL);
 import { createClient } from '@neondatabase/neon-js';
 import type { Database } from './types/database.types';
 
-const client = createClient<Database>({
-  auth: {
-    url: import.meta.env.VITE_NEON_AUTH_URL,
-  },
-  dataApi: {
-    url: import.meta.env.VITE_NEON_DATA_API_URL,
-  },
-});
+const client = createClient<Database>(import.meta.env.VITE_NEON_DATABASE_URL);
 ```
 
 ```typescript
 import { createClient } from '@neondatabase/neon-js';
 import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react/adapters';
 
-const client = createClient({
+const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL, {
   auth: {
     adapter: BetterAuthReactAdapter(),
+  },
+});
+```
+
+</CodeTabs>
+
+The object form remains available for custom endpoint layouts or local development setups where the Auth and Data API URLs cannot be derived from the same Neon database URL:
+
+```typescript
+const client = createClient({
+  auth: {
     url: import.meta.env.VITE_NEON_AUTH_URL,
   },
   dataApi: {
@@ -117,7 +118,6 @@ const client = createClient({
 });
 ```
 
-</CodeTabs>
 </TwoColumnLayout.Block>
 </TwoColumnLayout.Item>
 

--- a/content/docs/reference/javascript-sdk.md
+++ b/content/docs/reference/javascript-sdk.md
@@ -13,7 +13,7 @@ summary: >-
   (Supabase-compatible migration path).
 enableTableOfContents: true
 layout: wide
-updatedOn: '2026-07-11T13:39:13.071Z'
+updatedOn: '2026-07-13T19:46:02.920Z'
 ---
 
 This page documents `@neondatabase/neon-js`, which combines Managed BetterAuth and the Data API in a single client. Neon also publishes standalone packages:
@@ -65,7 +65,7 @@ Use this when you only need authentication (no database queries). You get:
 
 The auth methods are identical; only the access path differs. `client.auth.signIn.email()` and `auth.signIn.email()` do the same thing.
 
-For the full client, pass a single HTTPS Neon database URL without credentials or query parameters. The SDK derives the Neon Auth URL and Data API URL automatically. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The `.c-2` cell label, region, and database path stay the same. If you need to override either derived URL, the object form is still supported.
+For the full client, pass a single HTTPS Neon database URL without credentials or query parameters. The SDK derives the Neon Auth URL and Data API URL automatically. If you already have a Neon Auth URL or Data API URL, use the same URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The cell label (if present), region, and database path stay the same. If you need to override either derived URL, the object form is still supported.
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>

--- a/public/docs/ai/skills/neon-postgres/references/neon-js.md
+++ b/public/docs/ai/skills/neon-postgres/references/neon-js.md
@@ -91,6 +91,8 @@ const client = createClient<Database>(import.meta.env.VITE_NEON_DATABASE_URL);
 export const authClient = client.auth;
 ```
 
+> **Warning:** The single-URL form shown above, `createClient(url)`, requires a version of `@neondatabase/neon-js` that has not been published to npm as of this writing. The latest published version, `0.6.2-beta`, only accepts the two-URL object form below. If `npm install @neondatabase/neon-js` installs `0.6.2-beta` or earlier for you, use the object form instead.
+
 Pass a single HTTPS Neon database URL without credentials or query parameters. The SDK derives the Neon Auth URL and Data API URL automatically. If you need to override either derived URL, the object form is still supported for custom endpoint layouts or local development setups.
 
 Object-form alternative for custom endpoint layouts:

--- a/public/docs/ai/skills/neon-postgres/references/neon-js.md
+++ b/public/docs/ai/skills/neon-postgres/references/neon-js.md
@@ -64,10 +64,7 @@ export const authClient = createAuthClient();
 import { createClient } from "@neondatabase/neon-js";
 import type { Database } from "./database.types";
 
-export const dbClient = createClient<Database>({
-  auth: { url: process.env.NEON_AUTH_BASE_URL! },
-  dataApi: { url: process.env.NEON_DATA_API_URL! },
-});
+export const dbClient = createClient<Database>(process.env.NEON_DATABASE_URL!);
 ```
 
 **5. Middleware + UI setup** — See [Neon Auth reference](neon-auth.md) for middleware configuration, `NeonAuthUIProvider`, CSS imports, and `AuthView`/`AccountView` page components.
@@ -89,12 +86,20 @@ const authClient = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL);
 ```typescript
 import { createClient } from "@neondatabase/neon-js";
 
-const client = createClient<Database>({
+const client = createClient<Database>(import.meta.env.VITE_NEON_DATABASE_URL);
+
+export const authClient = client.auth;
+```
+
+Pass a single HTTPS Neon database URL without credentials or query parameters. The SDK derives the Neon Auth URL and Data API URL automatically. If you need to override either derived URL, the object form is still supported for custom endpoint layouts or local development setups.
+
+Object-form alternative for custom endpoint layouts:
+
+```typescript
+const client = createClient({
   auth: { url: import.meta.env.VITE_NEON_AUTH_URL },
   dataApi: { url: import.meta.env.VITE_NEON_DATA_API_URL },
 });
-
-export const authClient = client.auth;
 ```
 
 ## Environment Variables
@@ -103,14 +108,14 @@ export const authClient = client.auth;
 # Next.js (.env)
 NEON_AUTH_BASE_URL=https://ep-xxx.neonauth.us-east-1.aws.neon.tech/neondb/auth
 NEON_AUTH_COOKIE_SECRET=your-secret-at-least-32-characters-long
-NEON_DATA_API_URL=https://ep-xxx.apirest.us-east-1.aws.neon.tech/neondb/rest/v1
+NEON_DATABASE_URL=https://ep-xxx.us-east-1.aws.neon.tech/neondb
 
 # Vite/React (.env)
 VITE_NEON_AUTH_URL=https://ep-xxx.neonauth.us-east-1.aws.neon.tech/neondb/auth
-VITE_NEON_DATA_API_URL=https://ep-xxx.apirest.us-east-1.aws.neon.tech/neondb/rest/v1
+VITE_NEON_DATABASE_URL=https://ep-xxx.us-east-1.aws.neon.tech/neondb
 ```
 
-Get your Auth URL from the Neon Console: Project -> Branch -> Auth -> Configuration.
+Get your Auth URL from the Neon Console: Project -> Branch -> Auth -> Configuration. For full Data API clients, use the matching HTTPS Neon database URL without the `.neonauth` or `.apirest` hostname label and without the trailing `/auth` or `/rest/v1` path. The region and database path stay the same.
 
 Generate a cookie secret: `openssl rand -base64 32`
 
@@ -307,9 +312,8 @@ await client.auth.signIn.social({
 ```typescript
 import { createClient, SupabaseAuthAdapter } from "@neondatabase/neon-js";
 
-const client = createClient({
-  auth: { adapter: SupabaseAuthAdapter(), url },
-  dataApi: { url },
+const client = createClient(url, {
+  auth: { adapter: SupabaseAuthAdapter() },
 });
 
 await client.auth.signInWithPassword({ email, password });
@@ -367,7 +371,7 @@ Use types in the client for autocomplete and compile-time checking:
 
 ```typescript
 import type { Database } from "./database.types";
-const client = createClient<Database>({ ... });
+const client = createClient<Database>(import.meta.env.VITE_NEON_DATABASE_URL);
 ```
 
 ## Supabase Migration
@@ -381,9 +385,8 @@ const client = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 // After (Neon)
 import { createClient, SupabaseAuthAdapter } from "@neondatabase/neon-js";
-const client = createClient({
-  auth: { adapter: SupabaseAuthAdapter(), url: NEON_AUTH_URL },
-  dataApi: { url: NEON_DATA_API_URL },
+const client = createClient(NEON_DATABASE_URL, {
+  auth: { adapter: SupabaseAuthAdapter() },
 });
 
 // Queries work the same

--- a/src/components/shared/sql-to-rest-converter/sql-to-rest-converter.jsx
+++ b/src/components/shared/sql-to-rest-converter/sql-to-rest-converter.jsx
@@ -24,14 +24,9 @@ import { createClient } from "@neondatabase/neon-js";
 // An example of how to use the data api with neon auth can be found here:
 // https://github.com/neondatabase-labs/neon-data-api-neon-auth
 
-const client = createClient<Database>({
-  auth: {
-    url: 'NEON-AUTH-URL',
-  },
-  dataApi: {
-    url: 'DATA-API-URL',
-  },
-});
+// Use your Neon database URL without credentials or query parameters.
+// Example: https://ep-example.c-2.us-east-1.aws.neon.tech/neondb
+const client = createClient<Database>('NEON-DATABASE-URL');
 
 
 // Perform signin using client.auth before making any requests to the data api


### PR DESCRIPTION
## Summary
Brings Data API docs up to parity with the last 30 days of `neon-js` changes (the `createClient(baseUrl)` single-URL init), plus fixes from cross-review and a persona-driven IA read-through.

## Changes
- **`get-started.md`, `demo.md`, `access-control.md`, `generate-types.md`, `reference/javascript-sdk.md`**: lead with the new single-URL `createClient(url)` form (`neon-js` #114); older two-URL object form kept as a documented alternative (still supported, not deprecated), with a cross-reference restored on all 4 pages
- **`src/components/shared/sql-to-rest-converter/sql-to-rest-converter.jsx`**: updated the generated JS code sample to match
- **`custom-authentication-providers.md`**: fixed a malformed URL
- **`troubleshooting.md`**: reconciled the Auth API path prefix with `get-started.md`
- **`public/docs/ai/skills/neon-postgres/references/neon-js.md`**: this AI-skill reference file was still teaching the old two-URL pattern after the fix landed everywhere else — updated to match

## Verified, not changed
- Console/`neon data-api get` discovery guidance intentionally kept (an earlier draft had dropped it)
- The `.c-2` URL-reversal segment is confirmed preserved through `defaultDeriveNeonUrls`
