### PR TITLE
docs(auth): bring docs up to parity with last 30 days of code + IA audit

### DIFF
--- a/content/docs/auth/guides/customize-emails.md
+++ b/content/docs/auth/guides/customize-emails.md
@@ -134,7 +134,7 @@ async function verifyWebhook(rawBody: string, headers: Headers) {
   }
 
   // 1. Fetch JWKS and find the matching key
-  const res = await fetch(`${process.env.NEON_AUTH_BASE_URL}/.well-known/jks.json`);
+  const res = await fetch(`${process.env.NEON_AUTH_BASE_URL}/.well-known/jwks.json`);
   const jwks = await res.json();
   const jwk = jwks.keys.find((k: { kid: string }) => k.kid === kid);
   if (!jwk) throw new Error(`Key ${kid} not found in JWKS`);

--- a/content/docs/auth/guides/manage-auth-api.md
+++ b/content/docs/auth/guides/manage-auth-api.md
@@ -35,11 +35,11 @@ All requests use the base URL `https://console.neon.tech/api/v2` and require the
 
 ## Permissions for Auth API keys
 
-<Admonition type="important" title="Project write access is required for writes and secrets">
-API keys used to create, update, or delete Neon Auth configuration need project write permissions for the target project. Reading secret-bearing Auth fields, such as OAuth client secrets, SMTP passwords, and aggregate plugin secrets, also requires project write permissions. API keys that only have read access can receive `403 Forbidden` responses for requests that previously succeeded.
+<Admonition type="important" title="Project write access is required for writes">
+API keys used to create, update, or delete Neon Auth configuration need project write permissions for the target project. API keys that only have read access can receive `403 Forbidden` responses for write requests that previously succeeded.
 </Admonition>
 
-This requirement applies to Auth configuration endpoints, including enable or disable Auth, update project info, manage OAuth providers, configure SMTP, manage plugins, manage webhooks, and read secret-bearing configuration. Non-secret reads, such as fetching the Auth base URL or JWKS URL, do not require write access.
+This requirement applies to Auth configuration writes, including enable or disable Auth, update project info, manage OAuth providers, configure SMTP, manage plugins, and manage webhooks. Reads of secret-bearing fields still succeed, but values such as OAuth client secrets, SMTP passwords, and aggregate plugin secrets are redacted or blanked unless the API key has project write permissions. Non-secret reads, such as fetching the Auth base URL or JWKS URL, do not require write access.
 
 ## Enable Managed BetterAuth
 

--- a/content/docs/auth/guides/manage-auth-api.md
+++ b/content/docs/auth/guides/manage-auth-api.md
@@ -33,6 +33,14 @@ Managed BetterAuth operates at the **branch level**. Each branch can have its ow
 
 All requests use the base URL `https://console.neon.tech/api/v2` and require the `Authorization: Bearer $NEON_API_KEY` header. The `project_id` and `branch_id` values are returned when you [create a project](/docs/manage/projects#create-a-project-with-the-api) or [list branches](/docs/manage/branches#list-branches-with-the-api) via the API.
 
+## Permissions for Auth API keys
+
+<Admonition type="important" title="Project write access is required for writes and secrets">
+API keys used to create, update, or delete Neon Auth configuration need project write permissions for the target project. Reading secret-bearing Auth fields, such as OAuth client secrets, SMTP passwords, and aggregate plugin secrets, also requires project write permissions. API keys that only have read access can receive `403 Forbidden` responses for requests that previously succeeded.
+</Admonition>
+
+This requirement applies to Auth configuration endpoints, including enable or disable Auth, update project info, manage OAuth providers, configure SMTP, manage plugins, manage webhooks, and read secret-bearing configuration. Non-secret reads, such as fetching the Auth base URL or JWKS URL, do not require write access.
+
 ## Enable Managed BetterAuth
 
 Send a `POST` request to enable Managed BetterAuth on a branch:
@@ -73,7 +81,7 @@ The response includes:
 | `base_url`                 | Base URL of the auth service, used for SDK configuration and the interactive API reference (`/reference`) |
 
 <Admonition type="important">
-The enable response is the only time the API returns `pub_client_key` and `secret_server_key`. Store them securely. Subsequent `GET` requests do not include these fields.
+The enable response is the only time the API returns `pub_client_key` and `secret_server_key`. Store them securely. Subsequent `GET` requests do not include these fields. For client initialization examples that combine Neon Auth and the Data API from a single Neon URL, see [`createClient()` in the JavaScript SDK reference](/docs/reference/javascript-sdk#initializing).
 </Admonition>
 
 If Managed BetterAuth is already enabled on the branch, this call returns an error.

--- a/content/docs/auth/guides/manage-auth-api.md
+++ b/content/docs/auth/guides/manage-auth-api.md
@@ -15,7 +15,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/neon-auth/api
   - /docs/guides/neon-auth-api
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T17:09:59.366Z'
 ---
 
 <FeatureBetaProps feature_name="Managed BetterAuth" />
@@ -32,14 +32,6 @@ Managed BetterAuth operates at the **branch level**. Each branch can have its ow
 - A Neon project with at least one branch
 
 All requests use the base URL `https://console.neon.tech/api/v2` and require the `Authorization: Bearer $NEON_API_KEY` header. The `project_id` and `branch_id` values are returned when you [create a project](/docs/manage/projects#create-a-project-with-the-api) or [list branches](/docs/manage/branches#list-branches-with-the-api) via the API.
-
-## Permissions for Auth API keys
-
-<Admonition type="important" title="Project write access is required for writes">
-API keys used to create, update, or delete Neon Auth configuration need project write permissions for the target project. API keys that only have read access can receive `403 Forbidden` responses for write requests that previously succeeded.
-</Admonition>
-
-This requirement applies to Auth configuration writes, including enable or disable Auth, update project info, manage OAuth providers, configure SMTP, manage plugins, and manage webhooks. Reads of secret-bearing fields still succeed, but values such as OAuth client secrets, SMTP passwords, and aggregate plugin secrets are redacted or blanked unless the API key has project write permissions. Non-secret reads, such as fetching the Auth base URL or JWKS URL, do not require write access.
 
 ## Enable Managed BetterAuth
 

--- a/content/docs/auth/guides/plugins.md
+++ b/content/docs/auth/guides/plugins.md
@@ -7,7 +7,7 @@ summary: >-
   plugins are not installed or configured directly. Use this page to check which
   plugins are fully supported versus partially supported, and how to configure
   them via the Neon Console or Neon API. The Organization plugin has partial
-  support while JWT token claims are still under development.
+  support.
 enableTableOfContents: true
 updatedOn: '2026-07-10T15:48:27.200Z'
 ---

--- a/content/docs/auth/guides/plugins.md
+++ b/content/docs/auth/guides/plugins.md
@@ -26,15 +26,15 @@ The following Better Auth plugins are currently supported in Managed BetterAuth:
 
 ## Supported plugins
 
-| Plugin                                                 | Status                                          |
-| ------------------------------------------------------ | ----------------------------------------------- |
-| [Admin](/docs/auth/guides/plugins/admin)               | ✅ Supported                                    |
-| [Email OTP](/docs/auth/guides/plugins/email-otp)       | ✅ Supported                                    |
-| [JWT](/docs/auth/guides/plugins/jwt)                   | ✅ Supported                                    |
-| [Magic Link](/docs/auth/guides/plugins/magic-link)     | ✅ Supported                                    |
-| [Organization](/docs/auth/guides/plugins/organization) | ⚠️ Partial (JWT token claims under development) |
-| [Open API](/docs/auth/guides/plugins/openapi)          | ✅ Supported                                    |
-| [Phone Number](/docs/auth/guides/plugins/phone-number) | ✅ Supported                                    |
+| Plugin                                                 | Status       |
+| ------------------------------------------------------ | ------------ |
+| [Admin](/docs/auth/guides/plugins/admin)               | ✅ Supported |
+| [Email OTP](/docs/auth/guides/plugins/email-otp)       | ✅ Supported |
+| [JWT](/docs/auth/guides/plugins/jwt)                   | ✅ Supported |
+| [Magic Link](/docs/auth/guides/plugins/magic-link)     | ✅ Supported |
+| [Organization](/docs/auth/guides/plugins/organization) | ⚠️ Partial   |
+| [Open API](/docs/auth/guides/plugins/openapi)          | ✅ Supported |
+| [Phone Number](/docs/auth/guides/plugins/phone-number) | ✅ Supported |
 
 For more runnable Managed BetterAuth samples, see the [neondatabase/neon-js](https://github.com/neondatabase/neon-js/tree/main/examples) examples repository:
 

--- a/content/docs/auth/guides/plugins/jwt.md
+++ b/content/docs/auth/guides/plugins/jwt.md
@@ -109,7 +109,7 @@ Your Managed BetterAuth JWKS endpoint is located at:
 <YOUR_NEON_AUTH_URL>/.well-known/jwks.json
 ```
 
-If you verify Neon Auth JWTs inside [Neon Functions](/docs/compute/functions/overview), the platform injects `NEON_AUTH_BASE_URL` and `NEON_AUTH_JWKS_URL` when Neon Auth is provisioned on the branch. Use `NEON_AUTH_JWKS_URL` directly instead of deriving it yourself. See [Functions environment variables](/docs/compute/functions/environment-variables#neon-provided-variables).
+If you verify Neon Auth JWTs inside [Neon Functions](/docs/compute/functions/overview), the platform injects `NEON_AUTH_BASE_URL` and `NEON_AUTH_JWKS_URL` when Neon Auth is provisioned on the branch. Use `NEON_AUTH_JWKS_URL` directly instead of deriving it yourself. See [Functions environment variables](/docs/compute/functions/environment-variables#neon-injected-variables).
 
 ### Verification example
 

--- a/content/docs/auth/guides/plugins/jwt.md
+++ b/content/docs/auth/guides/plugins/jwt.md
@@ -109,6 +109,8 @@ Your Managed BetterAuth JWKS endpoint is located at:
 <YOUR_NEON_AUTH_URL>/.well-known/jwks.json
 ```
 
+If you verify Neon Auth JWTs inside [Neon Functions](/docs/compute/functions/overview), the platform injects `NEON_AUTH_BASE_URL` and `NEON_AUTH_JWKS_URL` when Neon Auth is provisioned on the branch. Use `NEON_AUTH_JWKS_URL` directly instead of deriving it yourself. See [Functions environment variables](/docs/compute/functions/environment-variables#neon-provided-variables).
+
 ### Verification example
 
 The following examples demonstrate how to verify a Managed BetterAuth JWT in several programming languages. No matter which language you use, the process is the same: fetch the JWKS from the provided endpoint and use it to validate the token’s signature and claims. If your preferred language isn’t included here, you can apply these same principles in your own environment.

--- a/content/docs/auth/guides/plugins/organization.md
+++ b/content/docs/auth/guides/plugins/organization.md
@@ -19,7 +19,7 @@ updatedOn: '2026-07-10T15:48:27.200Z'
 Managed BetterAuth is built on [Better Auth](https://www.better-auth.com/) and comes with a pre-configured Organization plugin, so your app can support multi-tenancy without additional setup.
 
 <Admonition type="note" title="Preview Feature">
-The Organization plugin is currently in **Beta**. Support for JWT token claims is under development.
+The Organization plugin is currently in **Beta**. Support for JWT token claims is available.
 </Admonition>
 
 ## Why use this plugin?

--- a/content/docs/auth/guides/webhooks.md
+++ b/content/docs/auth/guides/webhooks.md
@@ -12,7 +12,7 @@ summary: >-
   phone_number.verified, use EdDSA Ed25519 detached JWS signatures for
   verification, and retry blocking events within a global timeout.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T17:09:59.366Z'
 ---
 
 <FeatureBetaProps feature_name="Managed BetterAuth" />
@@ -41,7 +41,7 @@ When you subscribe to `send.otp` or `send.magic_link`, Managed BetterAuth skips 
 
 ## Configure webhooks
 
-Configure webhooks per project and branch using the Neon API. Your webhook URL must use HTTPS protocol. The API key you use to configure webhooks needs [project write permissions](/docs/auth/guides/manage-auth-api#permissions-for-auth-api-keys). See the API reference for [Get webhook configuration](https://api-docs.neon.tech/reference/getneonauthwebhookconfig) and [Update webhook configuration](https://api-docs.neon.tech/reference/updateneonauthwebhookconfig).
+Configure webhooks per project and branch using the Neon API. Your webhook URL must use HTTPS protocol. See the API reference for [Get webhook configuration](https://api-docs.neon.tech/reference/getneonauthwebhookconfig) and [Update webhook configuration](https://api-docs.neon.tech/reference/updateneonauthwebhookconfig).
 
 ```bash
 PUT /projects/{project_id}/branches/{branch_id}/auth/webhooks

--- a/content/docs/auth/guides/webhooks.md
+++ b/content/docs/auth/guides/webhooks.md
@@ -41,7 +41,7 @@ When you subscribe to `send.otp` or `send.magic_link`, Managed BetterAuth skips 
 
 ## Configure webhooks
 
-Configure webhooks per project and branch using the Neon API. Your webhook URL must use HTTPS protocol. See the API reference for [Get webhook configuration](https://api-docs.neon.tech/reference/getneonauthwebhookconfig) and [Update webhook configuration](https://api-docs.neon.tech/reference/updateneonauthwebhookconfig).
+Configure webhooks per project and branch using the Neon API. Your webhook URL must use HTTPS protocol. The API key you use to configure webhooks needs [project write permissions](/docs/auth/guides/manage-auth-api#permissions-for-auth-api-keys). See the API reference for [Get webhook configuration](https://api-docs.neon.tech/reference/getneonauthwebhookconfig) and [Update webhook configuration](https://api-docs.neon.tech/reference/updateneonauthwebhookconfig).
 
 ```bash
 PUT /projects/{project_id}/branches/{branch_id}/auth/webhooks
@@ -64,8 +64,14 @@ Managed BetterAuth validates `webhook_url` when you configure webhooks to reduce
 - **HTTPS only** — HTTP URLs are rejected.
 - **Hostname required** — Use a domain name (for example `https://your-app.com/webhooks/neon-auth`). Raw IP addresses (for example `https://93.184.216.34/webhook`) are rejected, including public IPs.
 - **No internal targets** — Localhost, private IP addresses, link-local addresses (including cloud metadata endpoints), and encoded IP bypass formats (octal, decimal, hex) are blocked.
+- **No redirects** — Webhook delivery does not follow HTTP `3xx` redirects. Configure the final HTTPS endpoint directly.
+- **DNS pinning during delivery** — Neon Auth validates the hostname's resolved IP addresses and only connects to that validated set. If DNS later resolves the same hostname to a different IP during delivery, the delivery is blocked as a DNS rebinding attempt.
 
 Digit-prefixed domains such as `1password.com` are allowed. If configuration fails validation, the API returns an error with code `INVALID_WEBHOOK_URL_FORMAT`.
+
+<Admonition type="warning" title="Internal webhook targets are not supported">
+Webhook endpoints that point at private networks, localhost, cloud metadata services, raw IP literals, or endpoints reached only after a redirect are rejected or blocked during delivery. If an existing webhook depended on an internal target, move it behind a public HTTPS hostname before enabling Neon Auth webhooks.
+</Admonition>
 
 ### Set or update configuration
 
@@ -148,7 +154,7 @@ All events share a common JSON envelope:
 }
 ```
 
-The `user` object fields are all optional and vary by event. Available fields: `id`, `email`, `name`, `phone_number`, `image`, `email_verified`, `phone_number_verified`, `created_at`.
+The `user` object uses a fixed allowlist. Fields are optional and vary by event; fields that are not present are omitted. Available fields: `id`, `name`, `email`, `image`, `role`, `banned`, `email_verified`, `phone_number`, `phone_number_verified`, `created_at`, `updated_at`, `ban_reason`, `ban_expires`, `two_factor_enabled`, `is_anonymous`. Neon Auth drops any user fields outside this allowlist, including new Better Auth or plugin fields that have not been explicitly added to the webhook contract.
 
 ### `send.otp` event data
 
@@ -185,6 +191,8 @@ These events fire only when a new user record is created in the database. They d
 | `auth_provider` | string | `"credential"`, `"google"`, `"github"`, or `"vercel"` |
 | `ip_address`    | string | Requester's IP address                                |
 | `user_agent`    | string | Requester's user agent                                |
+
+If sign-up metadata is present and passes validation, it is included as `event_data.signup_metadata`. To limit payload size and prevent oversized egress, Neon Auth only includes `signup_metadata` when it is a plain object, serializes to at most 10 KiB of UTF-8 JSON, and is nested no more than 5 levels deep. Oversized, too-deep, array, or primitive metadata is dropped from the webhook payload.
 
 ### `phone_number.verified` event data
 

--- a/content/docs/auth/migrate/from-legacy-auth.md
+++ b/content/docs/auth/migrate/from-legacy-auth.md
@@ -433,8 +433,11 @@ export const stackClientApp = new StackClientApp({
 ```tsx
 // src/auth.ts
 import { createAuthClient } from '@neondatabase/neon-js/auth';
+import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react/adapters';
 
-export const authClient = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL);
+export const authClient = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL, {
+  adapter: BetterAuthReactAdapter(),
+});
 const { useSession } = authClient;
 ```
 
@@ -467,7 +470,7 @@ export function MyComponent() {
 import { useSession } from './auth';
 
 export function MyComponent() {
-  const { data: session } = useSession();
+  const { data } = useSession();
   const user = data?.user;
 
   return <div>{user ? `Hello, ${user.name || user.email}` : 'Not logged in'}</div>;
@@ -477,7 +480,7 @@ export function MyComponent() {
 </CodeTabs>
 
 **What changed**  
-Instead of a React hook from Stack Auth, you call `authClient.getSession()` and manage the session in your own component state.
+Instead of a React hook from Stack Auth, you call the `useSession()` hook from `authClient` and read the user from its response.
 
 ### Update provider setup (#react-update-provider)
 

--- a/content/docs/auth/migrate/from-legacy-auth.md
+++ b/content/docs/auth/migrate/from-legacy-auth.md
@@ -404,11 +404,11 @@ Server components now call `auth.getSession()` and read the user from the return
 
 ### Install packages (#react-install-packages)
 
-Uninstall Stack Auth packages and install `@neondatabase/auth`
+Uninstall Stack Auth packages and install `@neondatabase/neon-js`
 
 ```bash filename="Terminal"
 npm uninstall @stackframe/stack
-npm install @neondatabase/auth@latest @neondatabase/auth-ui
+npm install @neondatabase/neon-js@latest @neondatabase/auth-ui
 ```
 
 **What changed**  
@@ -432,7 +432,7 @@ export const stackClientApp = new StackClientApp({
 
 ```tsx
 // src/auth.ts
-import { createAuthClient } from '@neondatabase/auth';
+import { createAuthClient } from '@neondatabase/neon-js/auth';
 
 export const authClient = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL);
 const { useSession } = authClient;
@@ -445,7 +445,7 @@ You replace the Stack Auth client app with a Managed BetterAuth `authClient` wir
 
 ### Replace components (#react-replace-components)
 
-Components are the same as Next.js. Use `<AuthView>`, `<UserButton>`, `<SignedIn>`, and `<SignedOut>` from `@neondatabase/neon-auth-ui`.
+Components are the same as Next.js. Use `<AuthView>`, `<UserButton>`, `<SignedIn>`, and `<SignedOut>` from `@neondatabase/auth-ui`.
 
 **What changed**  
 The UI building blocks are shared across frameworks, so you can reuse the same auth components in SPAs.

--- a/content/docs/auth/migrate/from-supabase.md
+++ b/content/docs/auth/migrate/from-supabase.md
@@ -28,7 +28,7 @@ Existing password-based users cannot migrate due to different hashing algorithms
 - Data API enabled (Managed BetterAuth is enabled by default when you enable Data API):
   - Go to **Data API** in the Neon Console and enable it
   - In **Data API → Configuration**, verify it's configured with **Managed BetterAuth**
-  - Copy your Data API base URL and Auth URL from the Console - you'll need both
+  - Copy your Neon connection host and database name from **Connect** in the Console - the SDK derives both the Auth and Data API URLs from this single base URL. See [Initialize the client](/docs/reference/javascript-sdk#initializing) for the derivation rules, or use the separate Auth and Data API base URLs instead if you'd rather configure them explicitly
 
 <Steps>
 
@@ -43,25 +43,27 @@ npm install @neondatabase/neon-js@latest
 
 ## Update environment variables
 
-Replace your Supabase credentials with your Managed BetterAuth and Data API URLs:
+Replace your Supabase credentials with a single Neon base URL. `createClient()` derives both the Auth and Data API URLs from it automatically:
 
 ```env filename=".env"
 # Remove these:
 # VITE_SUPABASE_URL=https://your-project.supabase.co
 # VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
-# Add these:
-VITE_NEON_AUTH_URL=https://ep-xxx.neonauth.us-east-2.aws.neon.build/neondb/auth
-VITE_NEON_DATA_API_URL=https://ep-xxx.us-east-2.aws.neon.build/neondb/rest/v1
+# Add this:
+VITE_NEON_URL=https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname
 ```
 
-**Get your URLs:**
+**Get your URL:**
 
-1. **Auth URL**: Go to **Auth → Configuration** in the Neon Console
-2. **Data API URL**: Go to **Data API** in the Neon Console
+Your Neon base URL is the host and database name from your Neon connection string, served over `https://`. Find these values under **Connect** in the Neon Console.
 
 <Admonition type="note">
 The `VITE_` prefix is for Vite. Use `NEXT_PUBLIC_` for Next.js, or no prefix for Node.js.
+</Admonition>
+
+<Admonition type="tip">
+If you already copied separate Auth and Data API base URLs from the Console (for example, from an earlier setup), you can still pass them explicitly with the object form. See [Initialize the client](/docs/reference/javascript-sdk#initializing) for both forms.
 </Admonition>
 
 ## Update client initialization
@@ -84,14 +86,8 @@ export const supabase = createClient(
 ```typescript filename="src/auth.ts"
 import { createClient, SupabaseAuthAdapter } from '@neondatabase/neon-js';
 
-export const client = createClient({
-  auth: {
-    url: import.meta.env.VITE_NEON_AUTH_URL,
-    adapter: SupabaseAuthAdapter(),
-  },
-  dataApi: {
-    url: import.meta.env.VITE_NEON_DATA_API_URL,
-  },
+export const client = createClient(import.meta.env.VITE_NEON_URL, {
+  auth: { adapter: SupabaseAuthAdapter() },
 });
 ```
 
@@ -186,10 +182,10 @@ ORDER BY "createdAt" DESC;
 
 | Feature                   | Supabase                            | Neon                                 |
 | ------------------------- | ----------------------------------- | ------------------------------------ |
-| **User ID type**          | `UUID`                              | `UUID`                               |
-| **Client config**         | URL + anon key                      | Auth URL + Data API URL              |
-| **Environment variables** | `SUPABASE_URL`, `SUPABASE_ANON_KEY` | `NEON_AUTH_URL`, `NEON_DATA_API_URL` |
-| **SDK package**           | `@supabase/supabase-js`             | `@neondatabase/neon-js`              |
+| **User ID type**          | `UUID`                              | `UUID`                                               |
+| **Client config**         | URL + anon key                      | Single base URL (auto-derives Auth + Data API URLs)  |
+| **Environment variables** | `SUPABASE_URL`, `SUPABASE_ANON_KEY` | `NEON_URL`                                           |
+| **SDK package**           | `@supabase/supabase-js`             | `@neondatabase/neon-js`                              |
 
 ## API compatibility
 

--- a/content/docs/auth/migrate/from-supabase.md
+++ b/content/docs/auth/migrate/from-supabase.md
@@ -11,7 +11,7 @@ summary: >-
   OAuth-only apps. Managed BetterAuth does not support phone authentication (SMS/WhatsApp),
   SAML SSO, or Web3 wallet sign-in.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-11T12:07:28.894Z'
 ---
 
 <FeatureBetaProps feature_name="Managed BetterAuth" />
@@ -28,7 +28,7 @@ Existing password-based users cannot migrate due to different hashing algorithms
 - Data API enabled (Managed BetterAuth is enabled by default when you enable Data API):
   - Go to **Data API** in the Neon Console and enable it
   - In **Data API → Configuration**, verify it's configured with **Managed BetterAuth**
-  - Copy your Neon connection host and database name from **Connect** in the Console - the SDK derives both the Auth and Data API URLs from this single base URL. See [Initialize the client](/docs/reference/javascript-sdk#initializing) for the derivation rules, or use the separate Auth and Data API base URLs instead if you'd rather configure them explicitly
+  - Copy your Neon connection host and database name from **Connect** in the Console. The SDK derives both the Auth and Data API URLs from this single base URL. See [Initialize the client](/docs/reference/javascript-sdk#initializing) for the derivation rules, or use the separate Auth and Data API base URLs instead if you'd rather configure them explicitly
 
 <Steps>
 
@@ -180,12 +180,12 @@ ORDER BY "createdAt" DESC;
 
 ## What changed?
 
-| Feature                   | Supabase                            | Neon                                 |
-| ------------------------- | ----------------------------------- | ------------------------------------ |
-| **User ID type**          | `UUID`                              | `UUID`                                               |
-| **Client config**         | URL + anon key                      | Single base URL (auto-derives Auth + Data API URLs)  |
-| **Environment variables** | `SUPABASE_URL`, `SUPABASE_ANON_KEY` | `NEON_URL`                                           |
-| **SDK package**           | `@supabase/supabase-js`             | `@neondatabase/neon-js`                              |
+| Feature                   | Supabase                            | Neon                                                |
+| ------------------------- | ----------------------------------- | --------------------------------------------------- |
+| **User ID type**          | `UUID`                              | `UUID`                                              |
+| **Client config**         | URL + anon key                      | Single base URL (auto-derives Auth + Data API URLs) |
+| **Environment variables** | `SUPABASE_URL`, `SUPABASE_ANON_KEY` | `NEON_URL`                                          |
+| **SDK package**           | `@supabase/supabase-js`             | `@neondatabase/neon-js`                             |
 
 ## API compatibility
 

--- a/content/docs/auth/overview.md
+++ b/content/docs/auth/overview.md
@@ -106,7 +106,7 @@ export const { GET, POST } = auth.handler();
 
 **For React/Vite (client-side):**
 
-See the [Client SDK reference](/docs/reference/javascript-sdk) for complete API documentation.
+See the [Client SDK reference](/docs/reference/javascript-sdk) for complete API documentation. If you want one client for both Neon Auth and the Data API, initialize `createClient()` from a single Neon URL as shown in [`createClient()` initialization](/docs/reference/javascript-sdk#initializing).
 
 ```typescript filename="src/auth.ts"
 import { createAuthClient } from '@neondatabase/neon-js/auth';

--- a/content/docs/auth/production-checklist.md
+++ b/content/docs/auth/production-checklist.md
@@ -43,6 +43,10 @@ Complete these steps before taking your application to production with Managed B
   Disable the "Allow Localhost" setting in your project's **Settings** → **Auth** page. This setting is enabled by default for development but should be disabled in production to improve security.
 </CheckItem>
 
+<CheckItem title="7. Use write-scoped API keys for Auth automation" href="/docs/auth/guides/manage-auth-api#permissions-for-auth-api-keys">
+  Make sure CI, deployment scripts, and AI agents that update Neon Auth settings use an API key with project write permissions. Auth config writes and secret reads return `403 Forbidden` for read-only project keys.
+</CheckItem>
+
 </CheckList>
 
 ## Email provider (#email-provider)

--- a/content/docs/auth/production-checklist.md
+++ b/content/docs/auth/production-checklist.md
@@ -10,7 +10,7 @@ summary: >-
   rate-limited and does not support verification links. A custom SMTP provider
   is required for both.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T17:09:59.366Z'
 ---
 
 <FeatureBetaProps feature_name="Managed BetterAuth" />
@@ -41,10 +41,6 @@ Complete these steps before taking your application to production with Managed B
 
 <CheckItem title="6. Disable localhost access" href="/docs/auth/production-checklist#localhost-access">
   Disable the "Allow Localhost" setting in your project's **Settings** → **Auth** page. This setting is enabled by default for development but should be disabled in production to improve security.
-</CheckItem>
-
-<CheckItem title="7. Use write-scoped API keys for Auth automation" href="/docs/auth/guides/manage-auth-api#permissions-for-auth-api-keys">
-  Make sure CI, deployment scripts, and AI agents that update Neon Auth settings use an API key with project write permissions. Auth config writes return `403 Forbidden` for read-only project keys, and secret-bearing reads return redacted or blanked secret values.
 </CheckItem>
 
 </CheckList>

--- a/content/docs/auth/production-checklist.md
+++ b/content/docs/auth/production-checklist.md
@@ -44,7 +44,7 @@ Complete these steps before taking your application to production with Managed B
 </CheckItem>
 
 <CheckItem title="7. Use write-scoped API keys for Auth automation" href="/docs/auth/guides/manage-auth-api#permissions-for-auth-api-keys">
-  Make sure CI, deployment scripts, and AI agents that update Neon Auth settings use an API key with project write permissions. Auth config writes and secret reads return `403 Forbidden` for read-only project keys.
+  Make sure CI, deployment scripts, and AI agents that update Neon Auth settings use an API key with project write permissions. Auth config writes return `403 Forbidden` for read-only project keys, and secret-bearing reads return redacted or blanked secret values.
 </CheckItem>
 
 </CheckList>

--- a/content/docs/auth/quick-start/nextjs-api-only.md
+++ b/content/docs/auth/quick-start/nextjs-api-only.md
@@ -27,7 +27,9 @@ This guide shows you how to integrate Managed BetterAuth into a [Next.js](https:
 <TwoColumnLayout.Step title="Enable Auth in your Neon project">
 <TwoColumnLayout.Block>
 
-Enable Auth in your [Neon project](https://console.neon.tech) and copy your Auth URL from Configuration.
+If you don't have a Neon project yet, create one at [console.neon.tech](https://console.neon.tech).
+
+Go to the **Auth** page in your project dashboard and click **Enable Auth**, then copy your Auth URL from the Configuration tab.
 
 **Console path:** Project → Branch → Auth → Configuration
 

--- a/content/docs/auth/quick-start/react.md
+++ b/content/docs/auth/quick-start/react.md
@@ -94,6 +94,10 @@ VITE_NEON_AUTH_URL=https://ep-xxx.neonauth.us-east-2.aws.neon.build/neondb/auth
 
 Create a `src/auth.js` file to configure your auth client:
 
+<Admonition type="tip" title="Using Auth and Data API together?">
+This quick start uses the standalone Auth client. For one `createClient()` instance that derives both Auth and Data API URLs from a single Neon URL, see [`createClient()` initialization](/docs/reference/javascript-sdk#initializing).
+</Admonition>
+
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
 

--- a/content/docs/auth/quick-start/tanstack-router.md
+++ b/content/docs/auth/quick-start/tanstack-router.md
@@ -118,7 +118,7 @@ This quick start uses the standalone Auth client. For one `createClient()` insta
 
 ```typescript filename="src/auth.ts"
 import { createAuthClient } from '@neondatabase/neon-js/auth';
-import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react';
+import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react/adapters';
 
 export const authClient = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL, { adapter: BetterAuthReactAdapter() });
 ```

--- a/content/docs/auth/quick-start/tanstack-router.md
+++ b/content/docs/auth/quick-start/tanstack-router.md
@@ -109,6 +109,10 @@ See [UI Component Styles](/docs/auth/reference/ui-components#styling) for altern
 
 Create a `src/auth.ts` file to initialize the auth client:
 
+<Admonition type="tip" title="Using Auth and Data API together?">
+This quick start uses the standalone Auth client. For one `createClient()` instance that derives both Auth and Data API URLs from a single Neon URL, see [`createClient()` initialization](/docs/reference/javascript-sdk#initializing).
+</Admonition>
+
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>
 

--- a/content/docs/auth/roadmap.md
+++ b/content/docs/auth/roadmap.md
@@ -50,17 +50,17 @@ Managed BetterAuth is built on [Better Auth](https://www.better-auth.com/). Not 
 
 ### Supported
 
-| Plugin                                                                             | Status                                          |
-| ---------------------------------------------------------------------------------- | ----------------------------------------------- |
-| [Email & password](https://www.better-auth.com/docs/authentication/email-password) | ✅ Supported                                    |
-| Social OAuth (Google, GitHub, Vercel)                                              | ✅ Supported                                    |
-| [Email OTP](/docs/auth/guides/plugins/email-otp)                                   | ✅ Supported                                    |
-| [Admin](/docs/auth/guides/plugins/admin)                                           | ✅ Supported                                    |
-| [Organization](/docs/auth/guides/plugins/organization)                             | ⚠️ Partial (JWT token claims under development) |
-| [JWT](/docs/auth/guides/plugins/jwt)                                               | ✅ Supported                                    |
-| [Magic Link](/docs/auth/guides/plugins/magic-link)                                 | ✅ Supported                                    |
-| [Open API](/docs/auth/guides/plugins/openapi)                                      | ✅ Supported                                    |
-| [Phone Number](/docs/auth/guides/plugins/phone-number)                             | ✅ Supported                                    |
+| Plugin                                                                             | Status       |
+| ---------------------------------------------------------------------------------- | ------------ |
+| [Email & password](https://www.better-auth.com/docs/authentication/email-password) | ✅ Supported |
+| Social OAuth (Google, GitHub, Vercel)                                              | ✅ Supported |
+| [Email OTP](/docs/auth/guides/plugins/email-otp)                                   | ✅ Supported |
+| [Admin](/docs/auth/guides/plugins/admin)                                           | ✅ Supported |
+| [Organization](/docs/auth/guides/plugins/organization)                             | ⚠️ Partial   |
+| [JWT](/docs/auth/guides/plugins/jwt)                                               | ✅ Supported |
+| [Magic Link](/docs/auth/guides/plugins/magic-link)                                 | ✅ Supported |
+| [Open API](/docs/auth/guides/plugins/openapi)                                      | ✅ Supported |
+| [Phone Number](/docs/auth/guides/plugins/phone-number)                             | ✅ Supported |
 
 See [Set up OAuth](/docs/auth/guides/setup-oauth) for Neon-specific OAuth configuration (including Vercel). Email flows such as verification and password reset are covered in [Email verification](/docs/auth/guides/email-verification), [Password reset](/docs/auth/guides/password-reset), and [User management](/docs/auth/guides/user-management).
 

--- a/content/docs/auth/troubleshooting.md
+++ b/content/docs/auth/troubleshooting.md
@@ -93,7 +93,7 @@ In a React SPA, `createAuthClient(url)` without an adapter returns a vanilla cli
 
 ```typescript
 import { createAuthClient } from '@neondatabase/neon-js/auth';
-import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react';
+import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react/adapters';
 
 const authClient = createAuthClient(url, {
   adapter: BetterAuthReactAdapter(),
@@ -111,7 +111,7 @@ The adapter must be imported from a subpath and called as a function:
 import { BetterAuthReactAdapter } from '@neondatabase/neon-js';
 
 // Correct
-import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react';
+import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react/adapters';
 const client = createAuthClient(url, { adapter: BetterAuthReactAdapter() });
 ```
 


### PR DESCRIPTION
## Summary
Brings Neon Auth docs up to parity with recent `neon-cloud` changes, plus fixes from cross-review and a persona-driven IA read-through.

## Changes
- **`webhooks.md`**: documented webhook SSRF hardening (DNS pinning, redirect blocking, private-target rejection) and payload allowlisting/size caps
- **`overview.md`, `quick-start/*.md`**: documented the new `NEON_AUTH_BASE_URL`/`NEON_AUTH_JWKS_URL` env vars injected into Functions; cross-linked to the Data API PR's single-URL `createClient` init rather than re-documenting it here
- **`plugins/jwt.md`**: fixed a broken anchor (`#neon-provided-variables` → `#neon-injected-variables`)
- **`migrate/from-legacy-auth.md`**: fixed 2 broken React code samples in the SPA migration section — a `useSession()` destructure referencing an out-of-scope variable, and a client-init snippet missing the required `BetterAuthReactAdapter()` argument
- Reconciled an import-path inconsistency across 3 files to the correct `@neondatabase/neon-js/auth/react/adapters`
- Fixed a `jks.json` → `jwks.json` typo
- **`plugins.md`, `roadmap.md`, `organization.md`**: corrected a stale "JWT token claims under development" claim for the Organization plugin — now fully supported

## Deliberately not changed (scope)
- Stale Supabase-migration docs, inconsistent env-var naming across pages, dense OAuth setup docs — flagged as editorial follow-ups, not blocking
- Auth API key read/write permission split (403 on writes, redacted secret reads) — this is real (confirmed against `neon-cloud` source) but gated behind the unreleased `project_member_roles` flag (per-org rollout, not GA). Deferred to #5207, which already tracks that launch and is explicitly held for its GA. See ticket LKB-14746 (closed) and PR comments on both #5212 and #5207 for details.