### PR TITLE
chore(ai-gateway): sync /models.json with models.dev neon provider

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -118,7 +118,7 @@
         "tool_call": true,
         "temperature": true,
         "open_weights": false,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
@@ -198,9 +198,14 @@
             "type": "toggle"
           },
           {
-            "type": "budget_tokens",
-            "min": 1024,
-            "max": 127999
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -242,14 +247,20 @@
             "type": "toggle"
           },
           {
-            "type": "budget_tokens",
-            "min": 1024,
-            "max": 127999
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
         "temperature": false,
         "open_weights": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -516,7 +527,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -561,7 +573,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -606,7 +619,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -651,7 +665,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -696,7 +711,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -740,7 +756,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -786,7 +803,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -832,7 +850,8 @@
             "pdf"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -879,7 +898,8 @@
             "pdf"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -926,7 +946,8 @@
             "pdf"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -988,7 +1009,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -1034,7 +1056,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "limit": {
@@ -1583,10 +1606,13 @@
         "reasoning": true,
         "reasoning_options": [
           {
-            "type": "toggle"
-          },
-          {
-            "type": "budget_tokens"
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,


### PR DESCRIPTION
## Summary

Regenerates `src/app/models.json/data.json` (served at `/models.json`) from the deployed [models.dev `neon` provider](https://models.dev/api.json), following the merged catalog updates in [anomalyco/models.dev#3019](https://github.com/anomalyco/models.dev/pull/3019) and [#3021](https://github.com/anomalyco/models.dev/pull/3021).

Key capability updates reflected in the catalog:
- **GPT-5 family**: image output modality on models routed via the Responses API
- **Claude Opus 4.7/4.8**: `reasoning_options` switched from `budget_tokens` to `effort` levels; added `knowledge` cutoff on opus-4-8
- **Claude Opus 4.5**: corrected `knowledge` cutoff
- **Qwen3.5 122B**: `reasoning_options` updated to `effort` (`none`/`low`/`medium`/`high`)

## Test plan

- [x] `npm run generate:models` — wrote 36 models
- [x] `npm run check:models-sync` — `[OK] In sync — 36 models match`