### PR TITLE
docs: replace api-client SDK reference with @neon/sdk

### DIFF
--- a/content/docs/guides/ai-agent-integration.md
+++ b/content/docs/guides/ai-agent-integration.md
@@ -11,7 +11,7 @@ summary: >-
   Project transfers require a personal API key.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-06-26T13:04:31.464Z'
+updatedOn: '2026-07-09T23:12:37.869Z'
 ---
 
 This guide covers the technical implementation of the Neon agent plan for your platform. You'll learn how to provision databases, implement versioning, manage user upgrades, and monitor usage at scale.
@@ -527,7 +527,7 @@ See [Configure consumption limits](/docs/guides/consumption-limits) for details.
 All platform integrations use the Neon API. You can call it directly or use language-specific SDKs:
 
 - **[Neon API](https://api-docs.neon.tech/reference/getting-started-with-neon-api)**: All operations (projects, branches, databases, monitoring) are API-driven; language-agnostic REST interface. Agent plan participants receive higher rate limits optimized for high-volume operations.
-- **SDKs**: [TypeScript SDK](/docs/reference/typescript-sdk), [Python SDK](/docs/reference/python-sdk), [Go SDK](https://github.com/kislerdm/neon-sdk-go), [Node.js/Deno SDK](https://github.com/paambaati/neon-js-sdk). See [Neon SDKs](/docs/reference/sdk) for all options.
+- **SDKs**: [Neon Management SDK](/docs/reference/typescript-sdk), [Python SDK](/docs/reference/python-sdk). See [Neon SDKs](/docs/reference/sdk) for all options.
 
 ## Cost management
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -431,7 +431,7 @@
 
             - section: Tools
               items:
-                - title: Neon TypeScript SDK
+                - title: Neon Auth and Data API SDK
                   slug: reference/javascript-sdk
                 - title: SQL to REST API Translator
                   slug: data-api/sql-to-rest
@@ -515,7 +515,7 @@
 
             - section: Reference
               items:
-                - title: Neon TypeScript SDK
+                - title: Neon Auth and Data API SDK
                   slug: reference/javascript-sdk
                 - title: Next.js Server SDK
                   slug: auth/reference/nextjs-server
@@ -825,18 +825,12 @@
           items:
             - title: Overview
               slug: reference/sdk
-            - title: Neon TypeScript SDK
+            - title: Neon Auth and Data API SDK
               slug: reference/javascript-sdk
-            - title: Neon API TypeScript SDK
+            - title: Neon Management SDK
               slug: reference/typescript-sdk
             - title: Python SDK (Neon API)
               slug: reference/python-sdk
-            - title: Go SDK (Neon API)
-              slug: https://github.com/kislerdm/neon-sdk-go
-              tag: community
-            - title: Node.js / Deno SDK (Neon API)
-              slug: https://github.com/paambaati/neon-js-sdk
-              tag: community
 
         - title: Local development
           icon: container

--- a/content/docs/reference/sdk.md
+++ b/content/docs/reference/sdk.md
@@ -6,12 +6,11 @@ summary: >-
   for programmatically creating and controlling projects, branches, databases,
   endpoints, and roles via the Neon API. Client SDKs target app developers who
   need database queries and user authentication; Management SDKs target platform
-  automation and DevOps workflows. Community-maintained Go and Node.js/Deno API
-  wrappers are listed here but are not officially supported by Neon.
+  automation and DevOps workflows.
 enableTableOfContents: true
 redirectFrom:
   - /docs/reference/neondatabase-toolkit
-updatedOn: '2026-07-06T16:27:57.937Z'
+updatedOn: '2026-07-09T23:12:37.869Z'
 ---
 
 Neon provides two categories of SDKs to support different use cases:
@@ -25,7 +24,7 @@ Use these SDKs to build applications with the Data API and optional authenticati
 
 <DetailIconCards>
 
-<a href="/docs/reference/javascript-sdk" description="Build apps with the Data API using database queries and authentication methods" icon="neon">Neon TypeScript SDK</a>
+<a href="/docs/reference/javascript-sdk" description="Build apps with the Data API using database queries and authentication methods" icon="neon">Neon Auth and Data API SDK</a>
 
 </DetailIconCards>
 
@@ -35,22 +34,8 @@ Use these SDKs to programmatically manage your Neon infrastructure (projects, br
 
 <DetailIconCards>
 
-<a href="/docs/reference/typescript-sdk" description="Programmatically manage Neon projects, branches, databases, and other platform resources" icon="neon">Neon API TypeScript SDK</a>
+<a href="/docs/reference/typescript-sdk" description="The official TypeScript SDK for the Neon API. Manage projects, branches, Postgres, storage, functions, and auth from one typed client" icon="neon">Neon Management SDK</a>
 
 <a href="/docs/reference/python-sdk" description="Programmatically manage Neon projects, branches, databases, and other platform resources" icon="neon">Python SDK (Neon API)</a>
-
-</DetailIconCards>
-
-## Community SDKs
-
-<Admonition type="note">
-Community SDKs are not maintained or officially supported by Neon. Some features may be out of date, so use these SDKs at your own discretion. If you have questions about these SDKs, please contact the project maintainers.
-</Admonition>
-
-<DetailIconCards>
-
-<a href="https://github.com/kislerdm/neon-sdk-go" description="A Go SDK for the Neon API" icon="github">Go SDK (Neon API)</a>
-
-<a href="https://github.com/paambaati/neon-js-sdk" description="A Node.js and Deno SDK for the Neon API" icon="github">Node.js / Deno SDK (Neon API)</a>
 
 </DetailIconCards>

--- a/content/docs/reference/typescript-sdk.md
+++ b/content/docs/reference/typescript-sdk.md
@@ -1,544 +1,512 @@
 ---
-title: Neon API TypeScript SDK
-subtitle: Programmatically manage Neon projects, branches, databases, and other platform
-  resources
+title: Neon Management SDK
+subtitle: The official TypeScript SDK for the Neon API. Projects, branches, Postgres, storage, functions, and auth in one typed client.
 summary: >-
-  The Neon TypeScript SDK (`@neondatabase/api-client` on npm) is a typed
-  wrapper around the Neon REST API. It lets you programmatically create,
-  update, and delete projects, branches, databases, endpoints, roles,
-  organizations, and consumption metrics. It provides TypeScript type safety,
-  IDE autocompletion, and structured Axios error handling. Install via npm,
-  yarn, or pnpm and authenticate with a Neon API key.
+  @neon/sdk is the official TypeScript SDK for the Neon API, a modern,
+  fetch-based replacement for @neondatabase/api-client. It exposes every
+  platform resource through ergonomic namespaces on a single client
+  (neon.projects, neon.branches, neon.postgres, neon.storage, neon.functions,
+  neon.snapshots, neon.auth, and more), with one result contract, typed errors,
+  automatic retries, readiness polling, and auto-pagination built in. A raw
+  1:1 layer exposes every endpoint and is generated from the Neon OpenAPI spec.
 enableTableOfContents: true
-updatedOn: '2026-07-06T16:27:57.937Z'
+updatedOn: '2026-07-09T23:12:37.869Z'
 ---
 
 <InfoBlock>
-
 <DocsList title="What you will learn:">
-<p>What is the Neon TypeScript SDK</p>
-<p>How to get started</p>
+<p>The one result contract every method shares</p>
+<p>Which namespaces and methods exist</p>
+<p>How pagination and async workflows work</p>
 </DocsList>
 
 <DocsList title="Related resources" theme="docs">
-  <a href="/docs/reference/api">Neon API Reference</a>
+<a href="/docs/reference/api">Neon API reference</a>
+<a href="/docs/cli">Neon CLI</a>
 </DocsList>
 
 <DocsList title="Source code" theme="repo">
-  <a href="https://www.npmjs.com/package/@neondatabase/api-client">@neondatabase/api-client on npm</a>
+<a href="https://www.npmjs.com/package/@neon/sdk">@neon/sdk on npm</a>
+<a href="/api_spec/release/v2.json">OpenAPI spec</a>
 </DocsList>
-
 </InfoBlock>
 
-## About the SDK
+`@neon/sdk` wraps the entire Neon API in one typed, fetch-based client. You authenticate once, then reach every resource through a namespace on `neon.*`: projects, branches, the Postgres data plane, object storage, functions, and Neon Auth. Retries, readiness polling, auto-pagination, and typed errors are built in.
 
-Neon supports the [@neondatabase/api-client](https://www.npmjs.com/package/@neondatabase/api-client) library, which is a wrapper for the [Neon API](/docs/reference/api). The SDK provides a convenient way to interact with the Neon API using TypeScript.
-
-You can use the Neon TypeScript SDK to manage your Neon projects, branches, databases, compute endpoints, roles, and more programmatically. The SDK abstracts the underlying API requests, authentication, and error handling, allowing you to focus on building applications that interact with Neon resources.
-
-The Neon TypeScript SDK allows you to manage:
-
-- [**API Keys:**](/docs/manage/api-keys) Create, list, and revoke API keys for secure access to the Neon API.
-- [**Projects:**](/docs/manage/projects) Create, list, update, and delete Neon projects.
-- [**Branches:**](/docs/manage/branches) Manage branches, including creation, deletion, restoration, and schema management.
-- [**Databases:**](/docs/manage/databases) Create, list, update, and delete databases within your branches.
-- [**Compute Endpoints:**](/docs/manage/computes) Manage compute endpoints, including creation, scaling, suspension, and restart.
-- [**Roles:**](/docs/manage/roles) Create, list, update, and delete Postgres roles within your branches.
-- [**Operations:**](/docs/manage/operations) Monitor and track the status of asynchronous operations performed on your Neon resources.
-- [**Organizations:**](/docs/manage/orgs-api) Manage organization settings, API keys, and members (for Neon organizational accounts).
-- [**Consumption Metrics:**](/docs/guides/consumption-metrics) Retrieve usage metrics for your account and projects to monitor resource consumption.
-
-<AgentSkillsTip skill_topic="the Neon TypeScript SDK for managing resources programmatically" />
-
-## Quick Start
-
-This guide walks you through installing the SDK, setting up authentication, and executing your first API call to retrieve a list of your Neon projects.
-
-### Installation
-
-Install the `@neondatabase/api-client` package into your project using your preferred package manager:
-
-<CodeTabs labels={["npm", "yarn", "pnpm"]}>
+It replaces [`@neondatabase/api-client`](https://www.npmjs.com/package/@neondatabase/api-client), the deprecated Axios-based SDK. New projects should use `@neon/sdk`.
 
 ```bash
-npm install @neondatabase/api-client
+npm install @neon/sdk
 ```
 
-```bash
-yarn add @neondatabase/api-client
+```ts
+import { createNeonClient } from "@neon/sdk";
+
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+
+const { data, error } = await neon.projects.list().all();
+if (error) throw error; // typed NeonError
+data; // ProjectListItem[]
 ```
 
-```bash
-pnpm add @neondatabase/api-client
-```
+Every method follows this shape: select a namespace, call a method, and receive a `{ data, error }` result. The reference below documents each namespace and method against that single contract.
 
-</CodeTabs>
+In the reference tables, the **Returns** column names the resolved resource, the type of `data` on success (or the value returned directly when `throwOnError` is set). A method resolving to `void` has no resource body; [`Paginated`](#lazy-auto-paginated-lists)`<T>` is the lazy, auto-paginated list described below. Every method also accepts an optional trailing options argument (`{ throwOnError?, waitForReadiness?, signal? }`), omitted from the tables for brevity.
 
-### Authentication Setup
+Nearly every method needs a `projectId`, and branch-scoped methods also need a `branchId`. Get these from `neon.projects.list()` and `neon.branches.list(projectId)` (or `neon.branches.getDefault(projectId)` for the default branch), reading `.id` off each result.
 
-Authentication with the Neon API is handled through API keys. Follow these steps to obtain and configure your API key:
+## Client configuration
 
-- Log in to the [Neon Console](https://console.neon.tech/)
-- Navigate to [Account settings > API keys](https://console.neon.tech/app/settings/api-keys).
-- Click Generate new API key.
-- Enter a descriptive Name (for example, "neon-typescript-sdk-demo") for your key and click Create.
+`createNeonClient(config)` accepts:
 
-For this quick start, we'll set the API key as an environment variable:
+| Option             | Type                                        | Default                            | Purpose                                                                                                      |
+| ------------------ | ------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `apiKey`           | `string \| () => string \| Promise<string>` | required                           | Bearer credential. A function is called per request, for short-lived tokens                                  |
+| `throwOnError`     | `boolean`                                   | `false`                            | Throw a `NeonError` instead of returning `{ data, error }`. Overridable per call                             |
+| `waitForReadiness` | `boolean`                                   | `false`                            | Poll provisioning operations to completion before resolving. Overridable per call                            |
+| `wait`             | `{ pollIntervalMs?, timeoutMs? }`           | `1000` / `300000`                  | Tuning for the readiness poller                                                                              |
+| `retries`          | `number`                                    | `2`                                | Automatic retries on safe statuses (423, 429, 503)                                                           |
+| `baseUrl`          | `string`                                    | `https://console.neon.tech/api/v2` | Override the API base URL                                                                                    |
+| `fetch`            | `typeof fetch`                              | global `fetch`                     | Custom fetch, for proxies, tests, or non-global runtimes                                                     |
+| `orgId`            | `string`                                    | none                               | Default organization id, applied to project create/list and as the transfer source org. Overridable per call |
 
-```bash
-export NEON_API_KEY="YOUR_API_KEY_FROM_NEON_CONSOLE"
-```
-
-Replace `YOUR_API_KEY_FROM_NEON_CONSOLE` with the API key you copied from the Neon Console.
-
-## Examples
-
-Let's create a simple TypeScript file to list your Neon projects using the SDK.
-
-### List Projects
-
-All Neon accounts are organization-based. To list projects, first retrieve the user's organization, then pass `org_id`:
-
-```typescript
-import { createApiClient } from '@neondatabase/api-client';
-
-const apiClient = createApiClient({
+```ts
+const neon = createNeonClient({
   apiKey: process.env.NEON_API_KEY!,
+  orgId: "org-cool-forest-12345678",
+  throwOnError: true,
 });
+```
 
-async function listNeonProjects() {
-  try {
-    // Get the user's organizations
-    const orgsResponse = await apiClient.getCurrentUserOrganizations();
-    const orgId = orgsResponse.data.organizations[0].id;
+## Core model
 
-    // List projects within the org
-    const response = await apiClient.listProjects({ org_id: orgId });
-    console.log(response.data.projects);
-  } catch (error) {
-    console.error('Error listing projects:', error);
-  }
+Four behaviors are shared by every method: the result envelope, typed errors, pagination, and async workflows.
+
+### The result envelope
+
+By default, no `try/catch`. Each call resolves to a discriminated `{ data, error }` envelope; check `error`, then `data` is narrowed:
+
+```ts
+const { data, error } = await neon.projects.get("late-frost-12345");
+if (error) return; // error: typed NeonError union
+data; // narrowed to Project
+```
+
+To throw instead, set `throwOnError` on the client (or per call). The return type narrows to the bare resource:
+
+```ts
+const neon = createNeonClient({ apiKey, throwOnError: true });
+const project = await neon.projects.get("my-project"); // Project (throws on error)
+const { data } = await neon.projects.get("my-project", { throwOnError: false }); // opt out per call
+```
+
+### Typed errors
+
+The error channel, and what `throwOnError` throws, is one hierarchy of `Error` subclasses, discriminated on `kind`:
+
+| kind         | Class                | Raised when                                                     |
+| ------------ | -------------------- | --------------------------------------------------------------- |
+| `api`        | `NeonApiError`       | Non-2xx response; carries `status`, `code`, `requestId`, `body` |
+| `not_found`  | `NeonNotFoundError`  | 404 (extends `NeonApiError`)                                    |
+| `auth`       | `NeonAuthError`      | 401 or 403                                                      |
+| `rate_limit` | `NeonRateLimitError` | 429, after retries                                              |
+| `operation`  | `NeonOperationError` | An awaited operation failed; carries `operationId`, `status`    |
+| `timeout`    | `NeonTimeoutError`   | A readiness or wait deadline was exceeded                       |
+| `network`    | `NeonNetworkError`   | Transport failure, no response received                         |
+| `client`     | `NeonError`          | SDK-side error, such as ambiguous connection-string selection   |
+
+```ts
+const { error } = await neon.branches.get(projectId, "nope");
+if (error?.kind === "not_found") {
+  // handle the 404
 }
-
-listNeonProjects();
 ```
 
-Execute the TypeScript file using [`tsx`](https://tsx.is) (or compile to JavaScript and run with `node`)
+### Lazy, auto-paginated lists
 
-```bash
-tsx list-projects.ts
-```
+Methods labeled Paginated return a [`Paginated`](#lazy-auto-paginated-lists)`<T>`; the cursor is managed for you:
 
-If your API key is correctly configured, you should see a list of your Neon projects printed to your console, similar to this:
-
-```json
-[
-  {
-    "id": "wandering-heart-70814840",
-    "platform_id": "aws",
-    "region_id": "aws-sa-east-1",
-    "name": "test-project",
-    "provisioner": "k8s-neonvm",
-    "default_endpoint_settings": {
-      "autoscaling_limit_min_cu": 0.25,
-      "autoscaling_limit_max_cu": 0.25,
-      "suspend_timeout_seconds": 0
-    },
-    "settings": {
-      "allowed_ips": [Object],
-      "enable_logical_replication": false,
-      "maintenance_window": [Object],
-      "block_public_connections": false,
-      "block_vpc_connections": false
-    },
-    "pg_version": 16,
-    "proxy_host": "sa-east-1.aws.neon.tech",
-    "branch_logical_size_limit": 512,
-    "branch_logical_size_limit_bytes": 536870912,
-    "store_passwords": true,
-    "active_time": 304,
-    "cpu_used_sec": 78,
-    "creation_source": "console",
-    "created_at": "2025-02-28T07:14:35Z",
-    "updated_at": "2025-02-28T07:54:53Z",
-    "synthetic_storage_size": 34149464,
-    "quota_reset_at": "2025-03-01T00:00:00Z",
-    "owner_id": "91cbdacd-06c2-49f5-bacf-78b9463c81ca",
-    "compute_last_active_at": "2025-02-28T07:54:49Z"
-  }, ..
-]
-```
-
-### Create a Project
-
-You can use the SDK to create a new Neon project. Here's an example of how to create a project and retrieve the connection string:
-
-```typescript
-import { createApiClient } from '@neondatabase/api-client';
-
-const apiClient = createApiClient({
-  apiKey: process.env.NEON_API_KEY!,
-});
-
-async function createNeonProject(projectName: string) {
-  try {
-    const response = await apiClient.createProject({
-      project: {
-        name: projectName,
-        region_id: 'aws-us-east-1',
-        pg_version: 17,
-      },
-    });
-    console.log('Project created:', response.data.project);
-    console.log('Project ID:', response.data.project.id);
-    console.log('Database connection string:', response.data.connection_uris[0].connection_uri);
-  } catch (error) {
-    console.error('Error creating project:', error);
-    throw error;
-  }
+```ts
+const { data: all } = await neon.projects.list().all(); // every page
+const { data: one } = await neon.projects.list().page(); // just the first page
+for await (const project of neon.projects.list()) {
+  // stream item by item
 }
-
-// Example usage: Create a project named "test-project"
-createNeonProject('test-project').catch((error) => {
-  console.error('Error creating project:', error.message);
-});
 ```
 
-#### Key points:
+### Async workflows
 
-- The `region_id` parameter specifies the cloud region where the project will be hosted. You can find the list of supported regions at [Neon Regions](/docs/introduction/regions).
-- The `pg_version` parameter specifies the major supported version of Postgres to use in the project.
+Neon mutations return operations that complete in the background. A few convenience methods, noted as "creates, then polls until ready" in the reference below (`projects.createAndConnect`, `branches.createWithCompute`), do this polling for you and hand back a ready-to-use result, such as a connection string, in a single call. The primitive underneath is `neon.operations.waitFor(operations)`.
 
-### Create a Branch
+## Namespaces
 
-You can use the SDK to create a new branch within a Neon project. Here's an example of how to create a branch:
+The client groups the API into resource namespaces. Projects and branches are the core surfaces: [`projects`](#neonprojects) create, manage, and share projects, and [`branches`](#neonbranches) branch a project's data and schema. The Postgres data plane lives under [`postgres`](#neonpostgres): compute endpoints, roles, databases, the Data API, and connection strings.
 
-```typescript
-import { createApiClient, EndpointType } from '@neondatabase/api-client';
+Branch-scoped platform services include [`storage`](#neonstorage) (S3-compatible object storage), [`functions`](#neonfunctions), [`credentials`](#neoncredentials), [`aiGateway`](#neonaigateway), and [`auth`](#neonauth) (Neon Auth, OAuth providers, and users). For data lifecycle and async work, use [`snapshots`](#neonsnapshots) for point-in-time snapshots and restore, and [`operations`](#neonoperations) to poll asynchronous operations.
 
-const apiClient = createApiClient({
-  apiKey: process.env.NEON_API_KEY!,
-});
+Account-level surfaces round out the client: [`consumption`](#neonconsumption) for billing metrics, [`apiKeys`](#neonapikeys), and [`regions` / `user`](#neonregions--user).
 
-async function createNeonBranch(projectId: string, branchName: string, parentBranchId?: string) {
-  try {
-    const response = await apiClient.createProjectBranch(projectId, {
-      branch: {
-        name: branchName,
-        parent_id: parentBranchId, // Optional: Specify a source branch. If omitted, the default branch will be used
-      },
-      endpoints: [
-        {
-          type: EndpointType.ReadWrite, // If you need read-only access, use EndpointType.ReadOnly,
-          // Optional: Specify the number of compute units (CU) for the endpoint. If omitted, the default value is 0.25 for both min and max.
-          // autoscaling_limit_min_cu: 0.25,
-          // autoscaling_limit_max_cu: 1,
-        },
-      ],
-    });
-    console.log('Branch created:', response.data.branch);
-  } catch (error) {
-    console.error('Error creating branch:', error);
-    throw error;
-  }
-}
+## neon.projects
 
-// Example usage: Create a branch named "dev-1" in the project with ID "your-project-id"
-createNeonBranch('your-project-id', 'dev-1').catch((error) => {
-  console.error('Error creating branch:', error.message);
-});
-```
+Create, manage, and share Neon projects. One API call per method; `list` is paginated. <small>REST: [Projects API](/docs/reference/api/projects)</small>
 
-#### Key points:
+| Method                            | Returns                                                      | Arguments                                                                                                               |
+| --------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `list(query?)`                    | [`Paginated`](#lazy-auto-paginated-lists)`<ProjectListItem>` | `query`: `{ search?, org_id?, limit? }`                                                                                 |
+| `get(id)`                         | `Project`                                                    |                                                                                                                         |
+| `create(input?)`                  | `Project`                                                    | `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
+| `createAndConnect(input?, opts?)` | `{ project: Project, connectionString: string }`             | Creates, then polls until ready. `opts`: `{ pooled? }` (default `true`)                                                 |
+| `update(id, input)`               | `Project`                                                    | `input`: `{ name?, settings? }`                                                                                         |
+| `delete(id)`                      | `Project`                                                    |                                                                                                                         |
+| `recover(id)`                     | `Project`                                                    | Recover a soft-deleted project within its retention window                                                              |
+| `transfer(input)`                 | `void`                                                       | `input`: `{ fromOrgId?, toOrgId, projectIds }` (`fromOrgId` defaults to the client `orgId`)                             |
+| `transferFromUser(input)`         | `void`                                                       | `input`: `{ toOrgId, projectIds }`                                                                                      |
 
-- `name` (optional): The branch name. If not provided, defaults to the branch ID. If specified, must be unique within the project and can be up to 256 characters. Cannot be empty or consist only of whitespace. See [Branch naming requirements](/docs/manage/branches#branch-naming-requirements) for details.
-- `parent_id` (optional): Specifies the branch to branch from. If omitted, the project's default branch is used.
-- `EndpointType`: Enum to define endpoint type (`ReadWrite` or `ReadOnly`).
-- Compute Unit (CU) customization (optional): Control compute size using `autoscaling_limit_min_cu` and `autoscaling_limit_max_cu`. Refer to [Compute size and autoscaling configuration](/docs/manage/computes#compute-size-and-autoscaling-configuration) for available options.
-
-### List Branches
-
-You can use the SDK to list branches within a Neon project. Here's an example of how to list branches:
-
-```typescript
-import { createApiClient } from '@neondatabase/api-client';
-
-const apiClient = createApiClient({
-  apiKey: process.env.NEON_API_KEY!,
-});
-
-async function listNeonBranches(projectId: string) {
-  try {
-    const response = await apiClient.listProjectBranches({ projectId });
-    console.log('Branches:', response.data.branches);
-  } catch (error) {
-    console.error('Error listing branches:', error);
-    throw error;
-  }
-}
-
-// Example usage: List branches in the project with ID "your-project-id"
-listNeonBranches('your-project-id').catch((error) => {
-  console.error('Error listing branches:', error.message);
-});
-```
-
-#### Key points:
-
-- The `projectId` parameter specifies the ID of the project for which you want to list branches.
-- The `listProjectBranches` method returns a list of branches within the specified project. Each branch object contains details like `id`, `name`, `created_at`, and more.
-
-### Create a Database
-
-You can use the SDK to create a new database within a Neon branch. Here's an example of how to create a database:
-
-```typescript
-import { createApiClient } from '@neondatabase/api-client';
-
-const apiClient = createApiClient({
-  apiKey: process.env.NEON_API_KEY!,
-});
-
-async function createNeonDatabase(
-  projectId: string,
-  branchId: string,
-  databaseName: string,
-  databaseOwner: string
-) {
-  try {
-    const response = await apiClient.createProjectBranchDatabase(projectId, branchId, {
-      database: {
-        name: databaseName,
-        owner_name: databaseOwner,
-      },
-    });
-    console.log('Database created:', response.data.database);
-  } catch (error) {
-    console.error('Error creating database:', error);
-    throw error;
-  }
-}
-
-// Example usage: In the project with ID "your-project-id", create a database named "mydatabase" in the branch with ID "your-branch-id" and owner "neondb_owner"
-createNeonDatabase('your-project-id', 'your-branch-id', 'mydatabase', 'neondb_owner').catch(
-  (error) => {
-    console.error('Error creating database:', error.message);
-  }
+```ts
+// Provision a project and get a pooled connection string in one call
+const { data } = await neon.projects.createAndConnect(
+  { name: "tenant-42", region_id: "aws-us-east-1" },
+  { pooled: true }
 );
+// data: { project, connectionString }
 ```
 
-- The `owner_name` parameter specifies the owner of the database. Ensure this role exists in the branch beforehand.
-- Branch & Project IDs: You can obtain these IDs from the [Neon Console](/docs/manage/branches#view-branches) or using SDK methods (for example, [listProjectBranches](#list-branches), [listProjects](#list-projects)).
+### neon.projects.permissions
 
-### Create a Role
+Share a project with additional users by email.
 
-You can use the SDK to create a new Postgres role within a Neon branch. Here's an example of how to create a role:
+| Method                            | Returns               |
+| --------------------------------- | --------------------- |
+| `list(projectId)`                 | `ProjectPermission[]` |
+| `grant(projectId, email)`         | `ProjectPermission`   |
+| `revoke(projectId, permissionId)` | `ProjectPermission`   |
 
-```typescript
-import { createApiClient } from '@neondatabase/api-client';
+## neon.branches
 
-const apiClient = createApiClient({
-  apiKey: process.env.NEON_API_KEY!,
+Branch a project's data and schema; optionally attach compute in one workflow. <small>REST: [Branches API](/docs/reference/api/branches)</small>
+
+| Method                                         | Returns                                                            | Arguments                                                                                                              |
+| ---------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `list(projectId, query?)`                      | [`Paginated`](#lazy-auto-paginated-lists)`<Branch>`                | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }`                                                        |
+| `get(projectId, branchId)`                     | `Branch`                                                           |                                                                                                                        |
+| `create(projectId, input?)`                    | `Branch`                                                           | `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected? }`                                           |
+| `createWithCompute(projectId, input, opts?)`   | `{ branch: Branch, endpoint: Endpoint, connectionString: string }` | Creates, then polls until ready. `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
+| `update(projectId, branchId, input)`           | `Branch`                                                           | `input`: `{ name?, protected?, expires_at? }`                                                                          |
+| `delete(projectId, branchId)`                  | `void`                                                             |                                                                                                                        |
+| `getDefault(projectId)`                        | `Branch`                                                           | Resolve the project's default branch by flag, not by name                                                              |
+| `setDefault(projectId, branchId)`              | `Branch`                                                           |                                                                                                                        |
+| `recover(projectId, branchId)`                 | `Branch`                                                           | Recover a soft-deleted branch within the 7-day window                                                                  |
+| `finalizeRestore(projectId, branchId, input?)` | `void`                                                             | Commit a restore previewed with `snapshots.restore({ finalize: false })`                                               |
+
+```ts
+// Branch off the default ("production") branch with its own compute
+const { data: prod } = await neon.branches.getDefault(projectId);
+const { data } = await neon.branches.createWithCompute(projectId, {
+  name: "preview/pr-123",
+  parentId: prod?.id,
+  compute: { minCu: 0.25, maxCu: 2 },
 });
+// data: { branch, endpoint, connectionString }
+```
 
-async function createNeonRole(projectId: string, branchId: string, roleName: string) {
-  try {
-    const response = await apiClient.createProjectBranchRole(projectId, branchId, {
-      role: { name: roleName },
-    });
-    console.log('Role created:', response.data.role);
-  } catch (error) {
-    console.error('Error creating role:', error);
-    throw error;
-  }
+## neon.postgres
+
+The Postgres data plane of a branch: compute endpoints, roles, databases, the Data API, and a connection-string helper. <small>REST: [Endpoints](/docs/reference/api/endpoints), [Branches](/docs/reference/api/branches), [Data API](/docs/reference/api/dataapi)</small>
+
+| Method                     | Returns  | Arguments                                                                                                                                                                                                                                                                                    |
+| -------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connectionString(params)` | `string` | `params`: `{ projectId, branchId?, endpointId?, databaseName?, roleName?, pooled? }`. Only `projectId` is required; branch defaults to the project default, endpoint to the read-write one, and role/database are auto-selected when the branch has exactly one. `pooled` defaults to `true` |
+
+```ts
+const { data: uri } = await neon.postgres.connectionString({ projectId });
+```
+
+### neon.postgres.endpoints
+
+Compute endpoints, scoped to a project.
+
+| Method                                 | Returns      | Arguments                                                                                                                                                               |
+| -------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list(projectId)`                      | `Endpoint[]` |                                                                                                                                                                         |
+| `listByBranch(projectId, branchId)`    | `Endpoint[]` |                                                                                                                                                                         |
+| `get(projectId, endpointId)`           | `Endpoint`   |                                                                                                                                                                         |
+| `create(projectId, input)`             | `Endpoint`   | `input`: `{ branch_id, type, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, suspend_timeout_seconds?, provisioner? }`. `type` is `"read_write"` \| `"read_only"` |
+| `update(projectId, endpointId, input)` | `Endpoint`   |                                                                                                                                                                         |
+| `delete(projectId, endpointId)`        | `void`       |                                                                                                                                                                         |
+| `start(projectId, endpointId)`         | `Endpoint`   |                                                                                                                                                                         |
+| `suspend(projectId, endpointId)`       | `Endpoint`   |                                                                                                                                                                         |
+| `restart(projectId, endpointId)`       | `Endpoint`   |                                                                                                                                                                         |
+
+### neon.postgres.roles
+
+Postgres roles, scoped to a branch.
+
+| Method                                     | Returns  | Arguments                                      |
+| ------------------------------------------ | -------- | ---------------------------------------------- |
+| `list(projectId, branchId)`                | `Role[]` |                                                |
+| `get(projectId, branchId, name)`           | `Role`   |                                                |
+| `create(projectId, branchId, input)`       | `Role`   | `input`: `{ name, no_login? }`                 |
+| `delete(projectId, branchId, name)`        | `void`   |                                                |
+| `password(projectId, branchId, name)`      | `string` | Reveals the current password                   |
+| `resetPassword(projectId, branchId, name)` | `Role`   | The returned `Role` carries the new `password` |
+
+```ts
+// Reveal a role's password, or rotate it
+const { data: password } = await neon.postgres.roles.password(projectId, branchId, "neondb_owner");
+const { data: role } = await neon.postgres.roles.resetPassword(projectId, branchId, "neondb_owner");
+// role.password holds the new secret
+```
+
+### neon.postgres.databases
+
+Databases, scoped to a branch.
+
+| Method                                     | Returns      | Arguments                         |
+| ------------------------------------------ | ------------ | --------------------------------- |
+| `list(projectId, branchId)`                | `Database[]` |                                   |
+| `get(projectId, branchId, name)`           | `Database`   |                                   |
+| `create(projectId, branchId, input)`       | `Database`   | `input`: `{ name, owner_name }`   |
+| `update(projectId, branchId, name, input)` | `Database`   | `input`: `{ name?, owner_name? }` |
+| `delete(projectId, branchId, name)`        | `void`       |                                   |
+
+### neon.postgres.dataApi
+
+The Neon Data API, scoped to a branch and database.
+
+| Method                                              | Returns                 |
+| --------------------------------------------------- | ----------------------- |
+| `get(projectId, branchId, databaseName)`            | `DataApiResponse`       |
+| `create(projectId, branchId, databaseName, input?)` | `DataApiCreateResponse` |
+| `update(projectId, branchId, databaseName, input?)` | `void`                  |
+| `delete(projectId, branchId, databaseName)`         | `void`                  |
+
+## neon.storage
+
+Branch-scoped, S3-compatible object storage. `get` returns whether storage is enabled and the branch's S3 endpoint metadata; buckets and objects are nested underneath. <small>REST: [Storage](/docs/reference/api/storage), [Buckets](/docs/reference/api/buckets)</small>
+
+| Method                     | Returns         |
+| -------------------------- | --------------- |
+| `get(projectId, branchId)` | `BranchStorage` |
+
+### neon.storage.buckets
+
+| Method                                    | Returns    | Arguments                                                                                  |
+| ----------------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `list(projectId, branchId)`               | `Bucket[]` |                                                                                            |
+| `create(projectId, branchId, input)`      | `Bucket`   | `input`: `{ name, access_level? }`, where `access_level` is `"private"` \| `"public_read"` |
+| `delete(projectId, branchId, bucketName)` | `void`     |                                                                                            |
+
+### neon.storage.objects
+
+| Method                                                       | Returns                     | Arguments                                                                                                    |
+| ------------------------------------------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `list(projectId, branchId, bucketName, query?)`              | `BucketObjectsListResponse` | `query`: `{ prefix?, delimiter?, cursor?, limit? }`. Returns one page of `folders`, `objects`, `next_cursor` |
+| `get(projectId, branchId, bucketName, objectKey)`            | `Blob`                      | Raw object bytes                                                                                             |
+| `delete(projectId, branchId, bucketName, objectKey)`         | `void`                      |                                                                                                              |
+| `deleteByPrefix(projectId, branchId, bucketName, prefix)`    | `{ deleted: number }`       | `prefix` must end with `/`                                                                                   |
+| `presign(projectId, branchId, bucketName, objectKey, input)` | `PresignResponse`           | `input`: `{ operation: "upload" \| "download", content_type?, expires_in_seconds? }`                         |
+
+```ts
+// Upload via a presigned PUT
+const { data: presign } = await neon.storage.objects.presign(
+  projectId, branchId, "avatars", "user-1.png",
+  { operation: "upload", content_type: "image/png" }
+);
+if (!presign) throw new Error("presign failed");
+
+await fetch(presign.url, {
+  method: "PUT",
+  headers: { ...presign.headers, "Content-Length": String(bytes.length) },
+  body: bytes,
+});
+```
+
+## neon.functions
+
+Branch-scoped Neon Functions. <small>REST: [Functions API](/docs/reference/api/functions)</small>
+
+| Method                                      | Returns                                                   | Arguments                                                                                                                                                |
+| ------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list(projectId, branchId, query?)`         | [`Paginated`](#lazy-auto-paginated-lists)`<NeonFunction>` | `query`: `{ limit? }`                                                                                                                                    |
+| `get(projectId, branchId, slug)`            | `NeonFunction`                                            |                                                                                                                                                          |
+| `update(projectId, branchId, slug, input)`  | `NeonFunction`                                            | `input`: `{ name? }`                                                                                                                                     |
+| `delete(projectId, branchId, slug)`         | `void`                                                    |                                                                                                                                                          |
+| `deploy(projectId, branchId, slug, input?)` | `NeonFunctionDeployment`                                  | Multipart. `input`: `{ zip?: Blob \| File, runtime?: "nodejs24", environment?: string }`, where `environment` is a JSON-encoded `Record<string, string>` |
+
+```ts
+// Deploy a bundled index.mjs inside a zip (first deploy must include the zip)
+const zip = await Bun.file("bundle.zip").arrayBuffer();
+const { data: deployment } = await neon.functions.deploy(projectId, branchId, "api", {
+  zip: new File([zip], "bundle.zip", { type: "application/zip" }),
+  runtime: "nodejs24",
+});
+// Poll neon.functions.get until current_deployment.status is "completed"
+```
+
+## neon.credentials
+
+Branch-scoped credentials with explicit scopes. Secrets (`api_token`, `s3_secret_access_key`) are returned once, on `create`. <small>REST: [Credentials API](/docs/reference/api/credentials)</small>
+
+| Method                                 | Returns                    | Arguments                                                                                                                              |
+| -------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `list(projectId, branchId)`            | `CredentialMeta[]`         |                                                                                                                                        |
+| `create(projectId, branchId, input)`   | `CreateCredentialResponse` | `input`: `{ name?, scopes, principal_type: "user" }`. Scopes: `storage:read`, `storage:write`, `ai_gateway:invoke`, `functions:invoke` |
+| `revoke(projectId, branchId, tokenId)` | `void`                     |                                                                                                                                        |
+
+## neon.aiGateway
+
+Branch-scoped AI Gateway endpoint metadata. <small>REST: [AI Gateway API](/docs/reference/api/ai-gateway)</small>
+
+| Method                     | Returns           | Arguments                                                |
+| -------------------------- | ----------------- | -------------------------------------------------------- |
+| `get(projectId, branchId)` | `BranchAiGateway` | Returns 404 when AI Gateway is not enabled on the branch |
+
+## neon.snapshots
+
+Point-in-time snapshots, restore, and backup schedules. <small>REST: [Snapshots API](/docs/reference/api/snapshots)</small>
+
+| Method                                       | Returns          | Arguments                                                                           |
+| -------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------- |
+| `list(projectId)`                            | `Snapshot[]`     |                                                                                     |
+| `create(projectId, branchId, input?)`        | `Snapshot`       | `input`: `{ name?, timestamp?, lsn?, expiresAt? }`                                  |
+| `update(projectId, snapshotId, input)`       | `Snapshot`       | `input`: `{ name? }`                                                                |
+| `delete(projectId, snapshotId)`              | `void`           |                                                                                     |
+| `restore(projectId, snapshotId, input?)`     | `Branch`         | `input`: `{ name?, targetBranchId?, finalize?, preview?, keepOnAbort? }`. See below |
+| `getSchedule(projectId, branchId)`           | `BackupSchedule` |                                                                                     |
+| `setSchedule(projectId, branchId, schedule)` | `void`           |                                                                                     |
+
+`restore` behaves differently depending on the target:
+
+- As a new branch (no `targetBranchId`), it finalizes by default and is ready to use immediately.
+- Onto an existing branch, it does not finalize by default, so you can preview first.
+- Transaction-style with `preview`: it restores un-finalized, runs your callback against the restored branch, then commits if the callback returns `true` or aborts (deletes the preview branch) if `false`, unless `keepOnAbort` is set:
+
+```ts
+await neon.snapshots.restore(projectId, snapshotId, {
+  targetBranchId,
+  preview: async (branch) => (await checks(branch)) === "ok", // true commits, false aborts
+});
+```
+
+## neon.operations
+
+Read operations and wait for them to finish. <small>REST: [Operations API](/docs/reference/api/operations)</small>
+
+| Method                          | Returns                                                | Arguments                                             |
+| ------------------------------- | ------------------------------------------------------ | ----------------------------------------------------- |
+| `list(projectId)`               | [`Paginated`](#lazy-auto-paginated-lists)`<Operation>` |                                                       |
+| `get(projectId, operationId)`   | `Operation`                                            |                                                       |
+| `waitFor(operations, options?)` | `void`                                                 | `options`: `{ pollIntervalMs?, timeoutMs?, signal? }` |
+
+```ts
+// Wait on operations from a raw call (or when readiness polling is off)
+const { data } = await raw.createProjectBranch({
+  client: neon.client,
+  path: { project_id: projectId },
+  body: { branch: { name: "wip" } },
+});
+const { error } = await neon.operations.waitFor(data!.operations, { timeoutMs: 120_000 });
+```
+
+## neon.auth
+
+Branch-scoped Neon Auth. The legacy project-scoped endpoints are deprecated and remain raw-only. <small>REST: [Authentication API](/docs/reference/api/auth)</small>
+
+| Method                                     | Returns                             | Arguments                  |
+| ------------------------------------------ | ----------------------------------- | -------------------------- |
+| `get(projectId, branchId)`                 | `NeonAuthIntegration`               |                            |
+| `create(projectId, branchId, input)`       | `NeonAuthCreateIntegrationResponse` | Enable the integration     |
+| `disable(projectId, branchId, input?)`     | `void`                              | `input`: `{ deleteData? }` |
+| `updateConfig(projectId, branchId, input)` | `NeonAuthConfigResponse`            |                            |
+
+### neon.auth.oauthProviders
+
+OAuth providers (Google, GitHub, and others).
+
+| Method                                           | Returns                   |
+| ------------------------------------------------ | ------------------------- |
+| `list(projectId, branchId)`                      | `NeonAuthOauthProvider[]` |
+| `add(projectId, branchId, input)`                | `NeonAuthOauthProvider`   |
+| `update(projectId, branchId, providerId, input)` | `NeonAuthOauthProvider`   |
+| `delete(projectId, branchId, providerId)`        | `void`                    |
+
+### neon.auth.trustedDomains
+
+The redirect-URI whitelist.
+
+| Method                               | Returns                                |
+| ------------------------------------ | -------------------------------------- |
+| `list(projectId, branchId)`          | `NeonAuthRedirectUriWhitelistDomain[]` |
+| `add(projectId, branchId, input)`    | `void`                                 |
+| `delete(projectId, branchId, input)` | `void`                                 |
+
+### neon.auth.users
+
+| Method                                               | Returns                          |
+| ---------------------------------------------------- | -------------------------------- |
+| `create(projectId, branchId, input)`                 | `NeonAuthCreateNewUserResponse`  |
+| `delete(projectId, branchId, authUserId)`            | `void`                           |
+| `updateRole(projectId, branchId, authUserId, roles)` | `UpdateNeonAuthUserRoleResponse` |
+
+## neon.consumption
+
+Cursor-paginated billing metrics. Each method takes `{ from, to, granularity, org_id, project_ids? }`, where `from`/`to` are ISO timestamps, `granularity` is `"hourly"` \| `"daily"` \| `"monthly"`, and `org_id` names the org to report on; `perBranchV2` also requires `project_ids`. Consumption requires a Scale plan or above. <small>REST: [Consumption API](/docs/reference/api/consumption)</small>
+
+| Method                | Returns                                                                     |
+| --------------------- | --------------------------------------------------------------------------- |
+| `perProject(query)`   | [`Paginated`](#lazy-auto-paginated-lists)`<ConsumptionHistoryPerProject>`   |
+| `perProjectV2(query)` | [`Paginated`](#lazy-auto-paginated-lists)`<ConsumptionHistoryPerProjectV2>` |
+| `perBranchV2(query)`  | [`Paginated`](#lazy-auto-paginated-lists)`<ConsumptionHistoryPerBranchV2>`  |
+
+```ts
+// Stream every project's daily usage across a range
+for await (const project of neon.consumption.perProject({
+  from: "2026-06-01T00:00:00Z",
+  to: "2026-06-30T00:00:00Z",
+  granularity: "daily",
+  org_id: "org-...", // the org to report on; consumption requires a Scale plan or above
+})) {
+  console.log(project);
 }
+```
 
-// Example usage: In the project with ID "your-project-id", create a role named "new_user_role" in the branch with ID "your-branch-id"
-createNeonRole('your-project-id', 'your-branch-id', 'new_user_role').catch((error) => {
-  console.error('Error creating role:', error.message);
+## neon.apiKeys
+
+Manage account-level API keys. <small>REST: [API Keys API](/docs/reference/api/api-keys)</small>
+
+| Method            | Returns                     | Arguments                     |
+| ----------------- | --------------------------- | ----------------------------- |
+| `list()`          | `ApiKeysListResponseItem[]` |                               |
+| `create(keyName)` | `ApiKeyCreateResponse`      | The `key` token is shown once |
+| `revoke(keyId)`   | `ApiKeyRevokeResponse`      |                               |
+
+## neon.regions / neon.user
+
+Active regions and the current account. <small>REST: [Regions](/docs/reference/api/regions), [Users](/docs/reference/api/users)</small>
+
+| Method                 | Returns                   |
+| ---------------------- | ------------------------- |
+| `regions.list()`       | `RegionResponse[]`        |
+| `user.me()`            | `CurrentUserInfoResponse` |
+| `user.organizations()` | `Organization[]`          |
+
+## Raw layer
+
+Anything not wrapped above is available as a raw, 1:1 function. Pass `neon.client` to reuse the client's auth and base URL:
+
+```ts
+import { raw } from "@neon/sdk";
+// or, for guaranteed tree-shaking: import { getProjectBranchSchema } from "@neon/sdk/raw";
+
+const { data, error } = await raw.getProjectBranchSchema({
+  client: neon.client,
+  path: { project_id, branch_id },
+  query: { db_name: "neondb" }, // db_name is required
 });
 ```
 
-#### Key points:
+The raw layer speaks the same result contract as the ergonomic client: `{ data, error }` by default, or the bare resource (throwing the typed `NeonError`) with `throwOnError: true`. There is no `responseStyle` switch. Every request, response, and error type is re-exported flat from `@neon/sdk` for `import type { Project, Branch }` and the rest.
 
-- `role.name`: Specifies the name of the Postgres role to be created.
-- Branch & Project IDs: You can obtain these IDs from the [Neon Console](/docs/manage/branches#view-branches) or using SDK methods (for example, [listProjectBranches](#list-branches), [listProjects](#list-projects))
+## How this SDK is built
 
-## TypeScript Types
-
-The Neon TypeScript SDK provides comprehensive type definitions for all request and response objects, enums, and interfaces. Leveraging these types enhances your development experience by enabling:
-
-- **Type Safety**: TypeScript types ensure that you are using the SDK methods and data structures correctly, catching type-related errors during development rather than at runtime.
-- **Improved Code Completion**: Modern IDEs and code editors use TypeScript types to provide intelligent code completion and suggestions, making it easier to discover and use SDK features.
-
-### Using SDK Types
-
-The `@neondatabase/api-client` package exports all the TypeScript types you need to interact with the Neon API in a type-safe manner. You can import these types directly into your TypeScript files.
-
-For example, when listing projects, you can use the `ProjectsResponse` type to explicitly define the structure of the API response:
-
-```typescript
-import { createApiClient, ProjectsResponse } from '@neondatabase/api-client';
-import { AxiosResponse } from 'axios';
-
-const apiClient = createApiClient({
-  apiKey: process.env.NEON_API_KEY!,
-});
-
-async function listNeonProjects(): Promise<void> {
-  try {
-    const orgsResponse = await apiClient.getCurrentUserOrganizations();
-    const orgId = orgsResponse.data.organizations[0].id;
-
-    const response: AxiosResponse<ProjectsResponse> = await apiClient.listProjects({ org_id: orgId });
-    const projects = response.data.projects;
-    console.log('Projects:', projects);
-  } catch (error) {
-    console.error('Error listing projects:', error);
-  }
-}
-
-listNeonProjects();
-```
-
-In this example:
-
-- We import `ProjectsResponse` type from `@neondatabase/api-client`.
-- We explicitly type the `response` variable as `AxiosResponse<ProjectsResponse>`. This tells TypeScript that we expect the `apiClient.listProjects()` method to return a response from Axios, where the `data` property conforms to the structure defined by `ProjectsResponse`.
-
-Similarly, when creating a project, you can use types like `ProjectCreateRequest` for the request body and `ProjectResponse` for the expected response:
-
-By using TypeScript types, you ensure that your code interacts with the Neon API in a predictable and type-safe manner, reducing potential errors and improving code quality. You can explore all available types in the `@neondatabase/api-client` package to get the full benefits of TypeScript in your Neon SDK integrations.
-
-## Key SDK Method Signatures
-
-To give you a better overview of the SDK, here are some of the key methods available, categorized by their resource. For complete details and parameters for each method, please refer to the full [Neon API Reference](/docs/reference/api).
-
-### Manage API keys
-
-- `listApiKeys()`: Retrieves a list of API keys for your account.
-- `createApiKey(data: ApiKeyCreateRequest)`: Creates a new API key.
-- `revokeApiKey(keyId: number)`: Revokes an existing API key.
-
-### Manage projects
-
-- `listProjects(query?: ListProjectsParams)`: Retrieves a list of projects in your Neon account.
-- `listSharedProjects(query?: ListSharedProjectsParams)`: Retrieves a list of projects shared with your account.
-- `createProject(data: ProjectCreateRequest)`: Creates a new Neon project.
-- `getProject(projectId: string)`: Retrieves details for a specific project.
-- `updateProject(projectId: string, data: ProjectUpdateRequest)`: Updates settings for a specific project.
-- `deleteProject(projectId: string)`: Deletes a Neon project.
-- `listProjectOperations(projectId: string, query?: ListProjectOperationsParams)`: Retrieves operations for a project.
-- `getProjectOperation(projectId: string, operationId: string)`: Retrieves details for a specific operation.
-- `getConnectionUri(projectId: string, query: GetConnectionUriParams)`: Retrieves a connection URI for a project.
-- `listProjectPermissions(projectId: string)`: Retrieves project access permissions.
-- `grantPermissionToProject(projectId: string, data: GrantPermissionToProjectRequest)`: Grants project access to a user.
-- `revokePermissionFromProject(projectId: string, permissionId: string)`: Revokes project access from a user.
-- `getProjectJwks(projectId: string)`: Retrieves JWKS URLs for a project.
-- `addProjectJwks(projectId: string, data: AddProjectJWKSRequest)`: Adds a JWKS URL to a project.
-- `deleteProjectJwks(projectId: string, jwksId: string)`: Deletes a JWKS URL from a project.
-
-### Manage branches
-
-- `listProjectBranches(projectId: string, query?: ListProjectBranchesParams)`: Retrieves a list of branches within a project.
-- `countProjectBranches(projectId: string, query?: CountProjectBranchesParams)`: Retrieves the number of branches in a project.
-- `createProjectBranch(projectId: string, data?: BranchCreateRequest)`: Creates a new branch within a project.
-- `getProjectBranch(projectId: string, branchId: string)`: Retrieves details for a specific branch.
-- `updateProjectBranch(projectId: string, branchId: string, data: BranchUpdateRequest)`: Updates settings for a specific branch.
-- `deleteProjectBranch(projectId: string, branchId: string)`: Deletes a branch from a project.
-- `restoreProjectBranch(projectId: string, branchId: string, data: BranchRestoreRequest)`: Restores a branch to a point in time.
-- `setDefaultProjectBranch(projectId: string, branchId: string)`: Sets a branch as the default for the project.
-- `getProjectBranchSchema(projectId: string, branchId: string, query?: GetProjectBranchSchemaParams)`: Retrieves the schema for a branch database.
-- `getProjectBranchSchemaComparison(projectId: string, branchId: string, query?: GetProjectBranchSchemaComparisonParams)`: Compares branch schemas.
-- `listProjectBranchEndpoints(projectId: string, branchId: string)`: Retrieves endpoints for a branch.
-- `listProjectBranchDatabases(projectId: string, branchId: string)`: Retrieves databases for a branch.
-- `createProjectBranchDatabase(projectId: string, branchId: string, data: DatabaseCreateRequest)`: Creates a database in a branch.
-- `getProjectBranchDatabase(projectId: string, branchId: string, databaseName: string)`: Retrieves details for a branch database.
-- `updateProjectBranchDatabase(projectId: string, branchId: string, databaseName: string, data: DatabaseUpdateRequest)`: Updates a branch database.
-- `deleteProjectBranchDatabase(projectId: string, branchId: string, databaseName: string)`: Deletes a database from a branch.
-- `listProjectBranchRoles(projectId: string, branchId: string)`: Retrieves roles for a branch.
-- `createProjectBranchRole(projectId: string, branchId: string, data: RoleCreateRequest)`: Creates a role in a branch.
-- `getProjectBranchRole(projectId: string, branchId: string, roleName: string)`: Retrieves details for a branch role.
-- `deleteProjectBranchRole(projectId: string, branchId: string, roleName: string)`: Deletes a role from a branch.
-- `resetProjectBranchRolePassword(projectId: string, branchId: string, roleName: string)`: Resets a branch role password.
-
-### Manage Compute Endpoints
-
-- `listProjectEndpoints(projectId: string)`: Retrieves a list of endpoints within a project.
-- `createProjectEndpoint(projectId: string, data: EndpointCreateRequest)`: Creates a new endpoint within a project.
-- `getProjectEndpoint(projectId: string, endpointId: string)`: Retrieves details for a specific endpoint.
-- `updateProjectEndpoint(projectId: string, endpointId: string, data: EndpointUpdateRequest)`: Updates settings for a specific endpoint.
-- `deleteProjectEndpoint(projectId: string, endpointId: string)`: Deletes an endpoint from a project.
-- `startProjectEndpoint(projectId: string, endpointId: string)`: Starts an endpoint.
-- `suspendProjectEndpoint(projectId: string, endpointId: string)`: Suspends an endpoint.
-- `restartProjectEndpoint(projectId: string, endpointId: string)`: Restarts an endpoint.
-
-### Retrieve Consumption Metrics
-
-- `getConsumptionHistoryPerProject(query: GetConsumptionHistoryPerProjectParams)`: Retrieves project consumption metrics.
-
-### Manage Organizations
-
-- `getOrganization(orgId: string)`: Retrieves organization details.
-- `getOrganizationMembers(orgId: string)`: Retrieves members of an organization.
-- `getOrganizationMember(orgId: string, memberId: string)`: Retrieves details for a specific organization member.
-- `getOrganizationInvitations(orgId: string)`: Retrieves invitations for an organization.
-- `listOrgApiKeys(orgId: string)`: Lists API keys for an organization.
-- `createOrgApiKey(orgId: string, data: OrgApiKeyCreateRequest)`: Creates an API key for an organization.
-- `revokeOrgApiKey(orgId: string, keyId: number)`: Revokes an organization API key.
-- `createOrganizationInvitations(orgId: string, data: OrganizationInvitesCreateRequest)`: Creates organization invitations.
-- `updateOrganizationMember(orgId: string, memberId: string, data: OrganizationMemberUpdateRequest)`: Updates an organization member's role.
-- `removeOrganizationMember(orgId: string, memberId: string)`: Removes a member from an organization.
-- `transferProjectsFromOrgToOrg(sourceOrgId: string, data: TransferProjectsToOrganizationRequest)`: Transfers projects between organizations.
-- `listOrganizationVpcEndpoints(orgId: string, regionId: string)`: Lists VPC endpoints for an organization.
-- `getOrganizationVpcEndpointDetails(orgId: string, regionId: string, vpcEndpointId: string)`: Retrieves VPC endpoint details for an organization.
-- `assignOrganizationVpcEndpoint(orgId: string, regionId: string, vpcEndpointId: string, data: VPCEndpointAssignment)`: Assigns/updates a VPC endpoint for an organization.
-- `deleteOrganizationVpcEndpoint(orgId: string, regionId: string, vpcEndpointId: string)`: Deletes a VPC endpoint from an organization.
-
-### Manage Users
-
-- `getCurrentUserInfo()`: Retrieves details for the current user.
-- `getCurrentUserOrganizations()`: Retrieves organizations for the current user.
-- `transferProjectsFromUserToOrg(data: TransferProjectsToOrganizationRequest)`: Transfers projects from a user to an organization.
-
-### Regions
-
-- `getActiveRegions()`: Retrieves a list of active Neon regions.
-
-### Manage Auth Integrations
-
-- `createProjectIdentityIntegration(data: IdentityCreateIntegrationRequest)`: Creates Neon Auth integration.
-- `createProjectIdentityAuthProviderSdkKeys(data: IdentityCreateAuthProviderSDKKeysRequest)`: Creates Auth Provider SDK keys.
-- `transferProjectIdentityAuthProviderProject(data: IdentityTransferAuthProviderProjectRequest)`: Transfers Neon-managed Auth project ownership.
-- `listProjectIdentityIntegrations(projectId: string)`: Lists Auth Provider integrations for a project.
-- `deleteProjectIdentityIntegration(projectId: string, authProvider: IdentitySupportedAuthProvider)`: Deletes an Auth Provider integration.
-
-### General
-
-- `getProjectOperation(projectId: string, operationId: string)`: Retrieves details for a specific operation.
-
-## Error Handling
-
-When working with APIs, handling errors gracefully is crucial for building robust applications. The Neon TypeScript SDK provides mechanisms to capture and inspect errors that may occur during API requests.
-
-### General Error Structure
-
-When an error occurs during an API request, the SDK throws an `AxiosError` object, which extends the standard JavaScript `Error` object. The `AxiosError` object contains additional properties that provide details about the error, including:
-
-**`error.response`**: This property (if present) is an Axios response object containing details from the API error response.
-
-- **`error.response.status`**: The HTTP status code of the error response (for example, 400, 401, 404, 500).
-- **`error.response.data`**: The response body, which, for Neon API errors, often follows a consistent structure, including an `error` object with `code` and `message` properties.
-
-### Common Error Scenarios and Debugging
-
-- **Invalid API Key (401 Unauthorized):** Ensure your `NEON_API_KEY` environment variable is correctly set with a valid API key from the Neon Console.
-- **Project or Branch Not Found (404 Not Found):** Verify that the `projectId` and `branchId` values you are using are correct and that the resources exist in your Neon account. Double-check IDs in the Neon Console.
-- **Rate Limiting (429 Too Many Requests):** If you are making requests too frequently, the API might rate-limit you. Implement retry mechanisms with exponential backoff or reduce the frequency of your API calls.
-- **Request Body Validation Errors (400 Bad Request):** If you receive 400 errors, carefully review the request body you are sending, ensuring it conforms to the expected schema for the API endpoint. Refer to the [Neon API Reference](/docs/reference/api) for request body structures.
-
-## References
-
-- [Neon API Reference](/docs/reference/api): Comprehensive documentation for the Neon API, including detailed descriptions of resources, endpoints, request/response structures, and error codes.
-
-<NeedHelp />
+The raw layer and all request, response, and error types are generated from the [Neon OpenAPI spec](/api_spec/release/v2.json) using [`@hey-api/openapi-ts`](https://heyapi.dev). The ergonomic namespaces documented above are hand-written on top of that generated layer. When the API adds an endpoint, it appears in the raw layer automatically; the namespace wrappers are added deliberately. The source lives in [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/sdk).


### PR DESCRIPTION
Rewrites the Management SDK reference for `@neon/sdk`, the fetch-based replacement for the deprecated `@neondatabase/api-client`. Reuses the `typescript-sdk` slug so existing inbound links keep working.

## What changed
- **New reference** for `@neon/sdk`: client config, the `{ data, error }` contract, typed error kinds, pagination, workflows, and a per-namespace method reference with argument shapes and a REST link per resource.
- **Naming** — disambiguates the two TypeScript SDKs:
  - `typescript-sdk` → **Neon Management SDK** (`@neon/sdk`)
  - `javascript-sdk` → **Neon Auth and Data API SDK** (`@neondatabase/neon-js`)
  - Updated in the SDK hub and sidebar.
- **Removed** unsupported community SDKs (Go, Node/Deno) from hub and sidebar.

## Verification
- Every code example run against the live SDK; fixed two bugs carried over from the source README (`getProjectBranchSchema` needs `db_name`; consumption needs `org_id`).
- `vitest run` (569) and `check:docs` (43) pass.

This pull request and its description were written by Isaac.