### PR TITLE
docs: add @neon/sdk migration guide and cross-links

### DIFF
--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /docs/cloud/roadmap
   - /docs/conceptual-guides/roadmap
   - /docs/reference/roadmap
-updatedOn: '2026-06-27T13:07:31.581Z'
+updatedOn: '2026-07-10T10:36:04.593Z'
 ---
 
 This roadmap describes what's in flight, what we delivered recently, and what's on the horizon.
@@ -203,7 +203,6 @@ We're accelerating work on improving and scaling the core database on Neon as we
 - **Read replicas on the Free plan**: Read Replicas are now available to all Neon users. [Read the announcement](/blog/create-read-replicas-in-the-free-plan)
 - **ISO27110 & ISO27701 compliance**: These new certifications add to our growing list of compliance achievements. For more about Neon's compliance milestones, see [Compliance](/docs/security/compliance).
 - **Increased limits for Neon projects**: We increased the number of projects included in all our paid plans: Launch (100 projects), Scale (1000 projects), and Business (5000 projects). More projects supports use cases such as database-per-tenant and AI agents. [Read the announcement](/blog/thousands-of-neon-projects-now-included-in-your-pricing-plan).
-- **A new Postgres toolkit for AI agents and test environments**: We recently announced an experimental release of the [@neondatabase/toolkit](https://github.com/neondatabase/toolkit). This toolkit lets you spin up a Postgres database in seconds and run SQL queries. It includes both the [Neon API Client](https://www.npmjs.com/package/@neondatabase/api-client) and the [Neon Serverless Driver](https://github.com/neondatabase/serverless), making it an excellent choice for AI agents that need to quickly set up an SQL database, or for test environments where manually deploying a new database isn't practical. To learn more, see [Why we built @neondatabase/toolkit](/blog/why-neondatabase-toolkit).
 - **Postgres 17**: You can now run the very latest version of Postgres on Neon. [Read the announcement](/blog/postgres-17).
 - **SQL Editor AI features**: We added AI features to the Neon SQL Editor, including SQL generation, AI-generated query names, and an AI assistant that will fix your queries. [Learn more](/docs/get-started/query-with-neon-sql-editor#ai-features).
 - **Data migration support with inbound logical replication**: We've introduced inbound logical replication as the first step toward enabling seamless, low-downtime migrations from your current database provider to Neon. This feature allows you to use Neon as your development environment, taking advantage of developer-friendly tools like branching and our [GitHub integration](/docs/guides/neon-github-integration), even if you keep production with your existing provider. To get started, explore our guides for replicating data from AlloyDB, CloudSQL, and RDS. See [Replicate data to Neon](/docs/guides/logical-replication-guide#replicate-data-to-neon). Inbound logical replication also supports migrating data between Neon projects, useful for version, region, or account migrations. See [Replicate data from one Neon project to another](/docs/guides/logical-replication-neon-to-neon).

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -829,6 +829,8 @@
               slug: reference/javascript-sdk
             - title: Neon Management SDK
               slug: reference/typescript-sdk
+            - title: Migrate to @neon/sdk
+              slug: reference/migrate-api-client-to-sdk
             - title: Python SDK (Neon API)
               slug: reference/python-sdk
 

--- a/content/docs/reference/migrate-api-client-to-sdk.md
+++ b/content/docs/reference/migrate-api-client-to-sdk.md
@@ -1,0 +1,256 @@
+---
+title: Migrate from @neondatabase/api-client to @neon/sdk
+subtitle: Move Platform API automation from the legacy Axios client to the official fetch-based SDK
+summary: >-
+  Step-by-step migration from @neondatabase/api-client to @neon/sdk: package
+  install, createNeonClient, namespace method mapping, error handling, and raw
+  layer 1.0 breaking changes. Use this page when updating scripts, CI jobs, or
+  apps that call the Neon Platform API with TypeScript.
+enableTableOfContents: true
+updatedOn: '2026-07-10T10:36:04.593Z'
+---
+
+<Admonition type="note" title="@neondatabase/api-client still works">
+The legacy [`@neondatabase/api-client`](https://www.npmjs.com/package/@neondatabase/api-client) package continues to work. [`@neon/sdk`](https://www.npmjs.com/package/@neon/sdk) is the recommended replacement for new projects and for teams that want fetch-based, zero-dependency Platform API access with ergonomic workflows.
+</Admonition>
+
+This guide maps common `@neondatabase/api-client` patterns to [`@neon/sdk`](/docs/reference/typescript-sdk). For full method reference, see the [Neon Management SDK](/docs/reference/typescript-sdk) documentation.
+
+## What changes
+
+|               | `@neondatabase/api-client`                      | `@neon/sdk`                                                              |
+| ------------- | ----------------------------------------------- | ------------------------------------------------------------------------ |
+| HTTP client   | Axios                                           | `fetch` (zero runtime dependencies)                                      |
+| Factory       | `createApiClient({ apiKey })`                   | `createNeonClient({ apiKey })`                                           |
+| Method layout | Flat (`listProjects`, `createProjectBranch`, …) | Namespaced (`neon.projects.list()`, `neon.branches.create()`, …)         |
+| Success path  | `response.data` on Axios responses              | `{ data, error }` by default, or bare resource with `throwOnError: true` |
+| Errors        | `AxiosError` + `error.response`                 | Typed `NeonError` hierarchy (`kind`: `api`, `not_found`, `auth`, …)      |
+| Node.js       | Broader support                                 | **≥ 20.19** (or any runtime with global `fetch`)                         |
+| Low-level API | Generated methods on the client                 | `raw.*` functions + `neon.client`                                        |
+
+## Install and swap the package
+
+```bash
+npm uninstall @neondatabase/api-client
+npm install @neon/sdk
+```
+
+Update imports:
+
+```typescript
+// Before
+import { createApiClient } from '@neondatabase/api-client';
+
+// After
+import { createNeonClient } from '@neon/sdk';
+```
+
+## Client setup
+
+```typescript
+// Before
+const apiClient = createApiClient({
+  apiKey: process.env.NEON_API_KEY!,
+});
+
+// After — check { data, error } on each call
+const neon = createNeonClient({
+  apiKey: process.env.NEON_API_KEY!,
+});
+
+// After — throw on error (closer to try/catch style)
+const neon = createNeonClient({
+  apiKey: process.env.NEON_API_KEY!,
+  throwOnError: true,
+});
+```
+
+`createNeonClient` also supports `orgId`, `waitForReadiness`, `retries`, `baseUrl`, and a custom `fetch` implementation. See [Neon Management SDK](/docs/reference/typescript-sdk#client-configuration).
+
+## Method mapping
+
+Common Platform API calls and their `@neon/sdk` equivalents:
+
+| `@neondatabase/api-client`             | `@neon/sdk`                                                                      |
+| -------------------------------------- | -------------------------------------------------------------------------------- |
+| `getCurrentUserOrganizations()`        | `neon.user.organizations()`                                                      |
+| `getCurrentUserInfo()`                 | `neon.user.me()`                                                                 |
+| `listProjects({ org_id })`             | `neon.projects.list({ org_id }).page()` or `.all()`                              |
+| `createProject({ project })`           | `neon.projects.create({ name, region_id, … })`                                   |
+| `getProject(projectId)`                | `neon.projects.get(projectId)`                                                   |
+| `deleteProject(projectId)`             | `neon.projects.delete(projectId)`                                                |
+| `listProjectBranches({ projectId })`   | `neon.branches.list(projectId).page()` or `.all()`                               |
+| `createProjectBranch(projectId, body)` | `neon.branches.create(projectId, input)` or `neon.branches.createWithCompute(…)` |
+| `getConnectionUri(projectId, query)`   | `neon.postgres.connectionString({ projectId, … })`                               |
+| `listProjectBranchDatabases(…)`        | `neon.postgres.databases.list(…)`                                                |
+| `createProjectBranchDatabase(…)`       | `neon.postgres.databases.create(…)`                                              |
+| `listProjectBranchRoles(…)`            | `neon.postgres.roles.list(…)`                                                    |
+| `createProjectBranchRole(…)`           | `neon.postgres.roles.create(…)`                                                  |
+| `listProjectEndpoints(projectId)`      | `neon.postgres.endpoints.list(projectId)`                                        |
+| `listApiKeys()`                        | `neon.apiKeys.list()`                                                            |
+| `getActiveRegions()`                   | `neon.regions.list()`                                                            |
+
+Endpoints that are not wrapped in an ergonomic namespace remain available through [`raw`](/docs/reference/typescript-sdk#raw-layer).
+
+## Error handling
+
+**Before** — Axios throws; inspect `error.response`:
+
+```typescript
+try {
+  const response = await apiClient.getProject(projectId);
+  console.log(response.data.project);
+} catch (error) {
+  // AxiosError — error.response?.status, error.response?.data
+}
+```
+
+**After** — default `{ data, error }` envelope:
+
+```typescript
+const { data: project, error } = await neon.projects.get(projectId);
+if (error) {
+  if (error.kind === 'not_found') {
+    // handle 404
+  }
+  throw error;
+}
+console.log(project);
+```
+
+**After** — `throwOnError: true` on the client or per call:
+
+```typescript
+const neon = createNeonClient({ apiKey, throwOnError: true });
+const project = await neon.projects.get(projectId); // throws NeonError on failure
+```
+
+## Side-by-side examples
+
+### List projects
+
+```typescript
+// Before
+const orgs = await apiClient.getCurrentUserOrganizations();
+const orgId = orgs.data.organizations[0].id;
+const response = await apiClient.listProjects({ org_id: orgId });
+console.log(response.data.projects);
+
+// After
+const { data: orgs, error: orgsError } = await neon.user.organizations();
+if (orgsError) throw orgsError;
+
+const { data: page, error } = await neon.projects.list({ org_id: orgs[0].id }).page();
+if (error) throw error;
+console.log(page.items);
+```
+
+### Create a project with a connection string
+
+```typescript
+// Before
+const response = await apiClient.createProject({
+  project: { name: 'my-app', region_id: 'aws-us-east-1', pg_version: 17 },
+});
+const uri = response.data.connection_uris[0].connection_uri;
+
+// After — waits for provisioning and returns a ready connection string
+const { data, error } = await neon.projects.createAndConnect({
+  name: 'my-app',
+  region_id: 'aws-us-east-1',
+  pg_version: 17,
+});
+if (error) throw error;
+const { project, connectionString } = data;
+```
+
+### Create a branch with compute
+
+```typescript
+// Before
+import { EndpointType } from '@neondatabase/api-client';
+
+await apiClient.createProjectBranch(projectId, {
+  branch: { name: 'dev-1', parent_id: parentBranchId },
+  endpoints: [{ type: EndpointType.ReadWrite }],
+});
+
+// After
+const { data, error } = await neon.branches.createWithCompute(projectId, {
+  name: 'dev-1',
+  parentId: parentBranchId,
+});
+if (error) throw error;
+const { branch, endpoint, connectionString } = data;
+```
+
+### Create a database
+
+```typescript
+// Before
+await apiClient.createProjectBranchDatabase(projectId, branchId, {
+  database: { name: 'mydb', owner_name: 'neondb_owner' },
+});
+
+// After
+const { error } = await neon.postgres.databases.create(projectId, branchId, {
+  name: 'mydb',
+  owner_name: 'neondb_owner',
+});
+if (error) throw error;
+```
+
+## Raw layer changes in 1.0
+
+If you adopted `@neon/sdk` **0.x** and used `raw.*` directly, **1.0 changes the raw contract**:
+
+| 0.x                                            | 1.0                                               |
+| ---------------------------------------------- | ------------------------------------------------- |
+| hey-api `{ data, request, response }` envelope | `{ data, error }` `NeonResult`                    |
+| `responseStyle: "data"`                        | **Removed**                                       |
+| `throwOnError: true` needed workarounds        | Returns the bare resource; types narrow correctly |
+
+```typescript
+// Before (0.x)
+const project = await raw.getProject({
+  client: neon.client,
+  path: { project_id: projectId },
+  throwOnError: true,
+  responseStyle: 'data',
+});
+
+// After (1.0)
+const project = await raw.getProject({
+  client: neon.client,
+  path: { project_id: projectId },
+  throwOnError: true,
+});
+```
+
+Drop any `unwrapRaw` helpers or `responseStyle` usage.
+
+## Types
+
+Import request/response types from `@neon/sdk` instead of `@neondatabase/api-client`:
+
+```typescript
+import type { Project, Branch } from '@neon/sdk';
+```
+
+Some generated type names changed (for example, `DataAPI*` → `DataApi*`). Endpoint types are string unions (`"read_write"` / `"read_only"`) rather than enums.
+
+## What you gain
+
+- **Workflow helpers** such as `projects.createAndConnect` and `branches.createWithCompute` that poll operations and return connection strings
+- **Readiness polling** via `waitForReadiness` and `neon.operations.waitFor`
+- **Automatic retries** on safe statuses (`423`, `429`, `503`)
+- **Ergonomic beta APIs** for storage, functions, credentials, AI gateway, snapshots, and branch-scoped Neon Auth (`neon.auth`, `neon.storage`, …)
+- **Tree-shakeable raw imports** from `@neon/sdk/raw`
+
+## Next steps
+
+- [Neon Management SDK](/docs/reference/typescript-sdk) — install, configuration, examples, and namespace reference
+- [Neon API Reference](https://api-docs.neon.tech/reference/getting-started-with-neon-api) — REST endpoint details
+- [`@neon/sdk` on GitHub](https://github.com/neondatabase/neon-pkgs/tree/main/packages/sdk) — full method tables and regeneration notes
+
+<NeedHelp />

--- a/content/docs/reference/sdk.md
+++ b/content/docs/reference/sdk.md
@@ -10,7 +10,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/reference/neondatabase-toolkit
-updatedOn: '2026-07-09T23:12:37.869Z'
+updatedOn: '2026-07-10T10:36:04.593Z'
 ---
 
 Neon provides two categories of SDKs to support different use cases:
@@ -35,6 +35,8 @@ Use these SDKs to programmatically manage your Neon infrastructure (projects, br
 <DetailIconCards>
 
 <a href="/docs/reference/typescript-sdk" description="The official TypeScript SDK for the Neon API. Manage projects, branches, Postgres, storage, functions, and auth from one typed client" icon="neon">Neon Management SDK</a>
+
+<a href="/docs/reference/migrate-api-client-to-sdk" description="Migrate from @neondatabase/api-client to @neon/sdk" icon="neon">Migrate to @neon/sdk</a>
 
 <a href="/docs/reference/python-sdk" description="Programmatically manage Neon projects, branches, databases, and other platform resources" icon="neon">Python SDK (Neon API)</a>
 

--- a/content/docs/reference/typescript-sdk.md
+++ b/content/docs/reference/typescript-sdk.md
@@ -10,7 +10,7 @@ summary: >-
   automatic retries, readiness polling, and auto-pagination built in. A raw
   1:1 layer exposes every endpoint and is generated from the Neon OpenAPI spec.
 enableTableOfContents: true
-updatedOn: '2026-07-09T23:12:37.869Z'
+updatedOn: '2026-07-10T10:36:04.593Z'
 ---
 
 <InfoBlock>
@@ -22,6 +22,7 @@ updatedOn: '2026-07-09T23:12:37.869Z'
 
 <DocsList title="Related resources" theme="docs">
 <a href="/docs/reference/api">Neon API reference</a>
+<a href="/docs/reference/migrate-api-client-to-sdk">Migrate from @neondatabase/api-client</a>
 <a href="/docs/cli">Neon CLI</a>
 </DocsList>
 
@@ -33,7 +34,11 @@ updatedOn: '2026-07-09T23:12:37.869Z'
 
 `@neon/sdk` wraps the entire Neon API in one typed, fetch-based client. You authenticate once, then reach every resource through a namespace on `neon.*`: projects, branches, the Postgres data plane, object storage, functions, and Neon Auth. Retries, readiness polling, auto-pagination, and typed errors are built in.
 
-It replaces [`@neondatabase/api-client`](https://www.npmjs.com/package/@neondatabase/api-client), the deprecated Axios-based SDK. New projects should use `@neon/sdk`.
+It replaces [`@neondatabase/api-client`](https://www.npmjs.com/package/@neondatabase/api-client), the deprecated Axios-based SDK. New projects should use `@neon/sdk`. See the [migration guide](/docs/reference/migrate-api-client-to-sdk) for method mapping and error-handling changes.
+
+<Admonition type="note" title="Not every endpoint has an ergonomic wrapper">
+`createNeonClient` namespaces cover common workflows (projects, branches, Postgres resources, snapshots, and more). They do **not** wrap every Platform API operation. For endpoints without a namespace method, use the [`raw` layer](#raw-layer) below or the [Neon API reference](/docs/reference/api).
+</Admonition>
 
 ```bash
 npm install @neon/sdk


### PR DESCRIPTION
Adds the api-client → `@neon/sdk` migration path on top of #5233 (Neon Management SDK reference, merged).

## What this PR adds

Philip's PR (#5233) rewrote the Management SDK reference (`typescript-sdk.md`). This PR adds the pieces that were not in that merge:

- **New:** [`migrate-api-client-to-sdk.md`](/docs/reference/migrate-api-client-to-sdk) — package swap, method mapping, error handling, side-by-side examples, raw 0.x → 1.0 notes
- **Cross-links:** migration guide in SDK hub, sidebar, and Management SDK related resources
- **Management SDK:** upfront note that ergonomic namespaces do not wrap every Platform API endpoint (use `raw` or the API reference)
- **Roadmap:** remove deprecated `@neondatabase/toolkit` shipped-features bullet

## What this PR does not change

- `typescript-sdk.md` body (Philip's per-namespace reference stays as merged in #5233)
- Integration guides still using `@neondatabase/api-client` (separate follow-up after validation)
- Agent context page (separate branch: `docs/platform-api-agent-context`)

## Preview

- https://neon-next-git-docs-neon-sdk-v1-neondatabase.vercel.app/docs/reference/migrate-api-client-to-sdk
- https://neon-next-git-docs-neon-sdk-v1-neondatabase.vercel.app/docs/reference/sdk
- https://neon-next-git-docs-neon-sdk-v1-neondatabase.vercel.app/docs/reference/typescript-sdk
- https://neon-next-git-docs-neon-sdk-v1-neondatabase.vercel.app/docs/introduction/roadmap

## Changelog

`changelog-2026-07-10` links to the migration guide and Management SDK docs. Merge this PR before or with that changelog.

## Test plan

- [x] Pre-push unit tests pass
- [ ] Migration guide renders; links to Management SDK and API reference resolve
- [ ] SDK hub shows "Migrate to @neon/sdk" card
- [ ] Sidebar SDKs section lists migration guide