### PR TITLE
Add frame_clause to the syntax of window function calls

### DIFF
--- a/content/postgresql/window-function.md
+++ b/content/postgresql/window-function.md
@@ -142,7 +142,8 @@ PostgreSQL has a sophisticated [syntax for window function call](https://www.pos
 ```sql
 window_function(arg1, arg2,..) OVER (
    [PARTITION BY partition_expression]
-   [ORDER BY sort_expression [ASC | DESC] [NULLS {FIRST | LAST }])
+   [ORDER BY sort_expression [ASC | DESC] [NULLS {FIRST | LAST }]
+   [frame_clause])
 ```
 
 In this syntax:


### PR DESCRIPTION
### Detail 

- Add `frame_clause` to the syntax of window function calls.

#### Related documentation

https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS