### PR TITLE
feat(ai-gateway): interactive model catalog on the docs models page

### DIFF
--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -21,6 +21,8 @@ Models are hosted by Databricks and served through Neon AI Gateway. By using the
 Model availability may vary by region. The catalog expands over time, so check back for new additions.
 </Admonition>
 
+The full catalog is published as the [`neon` provider on models.dev](https://models.dev/providers/neon) — the machine-readable source of truth — and served as JSON at [`neon.com/models.json`](https://neon.com/models.json).
+
 ## Quick picks
 
 Not sure which model to use? Start here.
@@ -56,79 +58,11 @@ Inference is free during the private preview. See [Pricing](/docs/ai-gateway/ove
 
 ## Available models
 
-Endpoints are shown in short form. See [Which endpoint to use](#which-endpoint-to-use) for full paths and when to prefer each one.
+Browse the full catalog below. Switch between the **Text** and **Image** tabs, filter by provider or open weights, sort any column, and click a model for a copy-paste quickstart (AI SDK, Mastra, Python, TypeScript, or cURL). The endpoint each snippet targets is baked into its base URL — `/v1` for chat completions, `/openai/v1` for the Responses API (image generation).
 
-### Anthropic
+<AiGatewayModelIndex/>
 
-| Model ID            | Inputs      | Context | Endpoints                                 | Notes                                    |
-| ------------------- | ----------- | ------- | ----------------------------------------- | ---------------------------------------- |
-| `claude-opus-4-8`   | text, image | —       | `chat/completions` · `anthropic/messages` | Most capable Claude model                |
-| `claude-opus-4-7`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Extended thinking available              |
-| `claude-opus-4-6`   | text, image | 1M      | `chat/completions` · `anthropic/messages` | Adaptive thinking with max effort level  |
-| `claude-opus-4-5`   | text, image | 200K    | `chat/completions` · `anthropic/messages` | Extended thinking available              |
-| `claude-opus-4-1`   | text, image | 200K    | `chat/completions` · `anthropic/messages` |                                          |
-| `claude-sonnet-4-6` | text, image | —       | `chat/completions` · `anthropic/messages` | Recommended. Instant + extended thinking |
-| `claude-sonnet-4-5` | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
-| `claude-sonnet-4`   | text, image | —       | `chat/completions` · `anthropic/messages` | Instant + extended thinking              |
-| `claude-haiku-4-5`  | text, image | —       | `chat/completions` · `anthropic/messages` | Fast and cost-effective                  |
-
-### Google
-
-| Model ID                | Inputs                    | Context | Endpoints                     | Notes                 |
-| ----------------------- | ------------------------- | ------- | ----------------------------- | --------------------- |
-| `gemini-3-5-flash`      | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
-| `gemini-3-1-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
-| `gemini-3-1-flash-lite` | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
-| `gemini-3-pro`          | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
-| `gemini-3-flash`        | text, image, video, audio | —       | `chat/completions` · `gemini` |                       |
-| `gemini-2-5-pro`        | text, image, video, audio | 1M      | `chat/completions` · `gemini` | Deep Think Mode       |
-| `gemini-2-5-flash`      | text, image, video, audio | 1M      | `chat/completions` · `gemini` |                       |
-| `gemma-3-12b`           | text, image               | 128K    | `chat/completions`            | Chat completions only |
-
-### Databricks
-
-Open-weight models hosted by Databricks. Text input only. Chat completions only.
-
-| Model ID                  | Context | Endpoints          | Notes                                    |
-| ------------------------- | ------- | ------------------ | ---------------------------------------- |
-| `databricks-gpt-oss-120b` | 128K    | `chat/completions` | Recommended. Adjustable reasoning effort |
-| `databricks-gpt-oss-20b`  | 128K    | `chat/completions` |                                          |
-
-### Meta
-
-| Model ID                                 | Inputs      | Context | Endpoints          | Notes                                                                                                                                                                                                              |
-| ---------------------------------------- | ----------- | ------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `databricks-llama-4-maverick`            | text, image | —       | `chat/completions` | Recommended. [Llama 4 Community License](https://www.llama.com/llama4/license) · [Acceptable Use](https://www.llama.com/llama4/use-policy)                                                                         |
-| `databricks-meta-llama-3-3-70b-instruct` | text        | 128K    | `chat/completions` | [Llama 3.3 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE) · [Acceptable Use](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/USE_POLICY.md) |
-| `databricks-meta-llama-3-1-8b-instruct`  | text        | 128K    | `chat/completions` | [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/) · [Acceptable Use](https://www.llama.com/llama3_1/use-policy/)                                                                              |
-
-### Alibaba
-
-Text input only. Chat completions only.
-
-| Model ID                                 | Context | Endpoints          | Notes                            |
-| ---------------------------------------- | ------- | ------------------ | -------------------------------- |
-| `databricks-qwen3-next-80b-a3b-instruct` | —       | `chat/completions` |                                  |
-| `databricks-qwen35-122b-a10b`            | 256K    | `chat/completions` | Always reasons before responding |
-
-### OpenAI
-
-All OpenAI models have a 400K token context window and accept text and image inputs.
-
-| Model ID             | Endpoints                               | Notes                                                              |
-| -------------------- | --------------------------------------- | ------------------------------------------------------------------ |
-| `gpt-5-4`            | `chat/completions` · `openai/responses` |                                                                    |
-| `gpt-5-4-mini`       | `chat/completions` · `openai/responses` |                                                                    |
-| `gpt-5-4-nano`       | `chat/completions` · `openai/responses` |                                                                    |
-| `gpt-5-3-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `gpt-5-2-codex`      | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `gpt-5-2`            | `chat/completions` · `openai/responses` |                                                                    |
-| `gpt-5-1-codex-max`  | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `gpt-5-1-codex-mini` | `openai/responses`                      | Requires [OpenAI Responses API](/docs/ai-gateway/openai-responses) |
-| `gpt-5-1`            | `chat/completions` · `openai/responses` | Instant + Thinking modes                                           |
-| `gpt-5`              | `chat/completions` · `openai/responses` |                                                                    |
-| `gpt-5-mini`         | `chat/completions` · `openai/responses` |                                                                    |
-| `gpt-5-nano`         | `chat/completions` · `openai/responses` |                                                                    |
+For full request paths and when to prefer each endpoint, see [Which endpoint to use](#which-endpoint-to-use).
 
 ## Which endpoint to use
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -68,14 +68,16 @@ For full request paths and when to prefer each endpoint, see [Which endpoint to 
 
 Most models work with the [Chat completions](/docs/ai-gateway/chat-completions) endpoint. It is the recommended starting point and works with all providers. Use a provider-specific endpoint when required:
 
-| Provider                  | Recommended endpoint                     | Notes                                                                                    |
-| ------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Anthropic                 | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/anthropic/v1/messages` for extended thinking and prompt caching         |
-| OpenAI (most models)      | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/openai/v1/responses` for Responses API features                         |
-| OpenAI (codex variants)   | `/ai-gateway/openai/v1/responses`        | These models require the Responses API and don't work with chat/completions              |
-| Google Gemini             | `/ai-gateway/mlflow/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
-| Google Gemma 3 12B        | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                           |
-| Meta, Databricks, Alibaba | `/ai-gateway/mlflow/v1/chat/completions` | Chat completions only                                                                    |
+All paths below are appended to your branch's bare AI Gateway host (`NEON_AI_GATEWAY_BASE_URL`).
+
+| Provider                  | Recommended endpoint   | Notes                                                                                    |
+| ------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| Anthropic                 | `/v1/chat/completions` | Use `/anthropic/v1/messages` for extended thinking and prompt caching                    |
+| OpenAI (most models)      | `/v1/chat/completions` | Use `/openai/v1/responses` for Responses API features                                    |
+| OpenAI (codex variants)   | `/openai/v1/responses` | These models require the Responses API and don't work with chat/completions              |
+| Google Gemini             | `/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
+| Google Gemma 3 12B        | `/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                           |
+| Meta, Databricks, Alibaba | `/v1/chat/completions` | Chat completions only                                                                    |
 
 ## Provider terms
 

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -3,7 +3,7 @@
     "id": "neon",
     "name": "Neon",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1",
+    "api": "${NEON_AI_GATEWAY_BASE_URL}/v1",
     "env": [
       "NEON_AI_GATEWAY_BASE_URL",
       "NEON_AI_GATEWAY_TOKEN"

--- a/src/components/pages/doc/ai-gateway-model-index/ai-gateway-model-index.jsx
+++ b/src/components/pages/doc/ai-gateway-model-index/ai-gateway-model-index.jsx
@@ -1,0 +1,23 @@
+// Server wrapper for the interactive AI Gateway model catalog. Reads the
+// committed /models.json data (synced from the models.dev `neon` provider) and
+// the vendored console quickstart snippets at build time, derives table rows,
+// and hands trimmed data to the client component — so the raw catalog/snippet
+// JSON never has to be authored by hand in the page.
+//
+// The llms .md mirror renders the same rows as static grouped tables (see the
+// AiGatewayModelIndex handler in src/scripts/process-md-for-llms.js), so the web
+// table and the agent-facing markdown can never disagree.
+import modelsData from '../../../../app/models.json/data.json';
+
+import ModelIndexClient from './model-index-client';
+import * as modelRows from './model-rows';
+import snippets from './snippets.json';
+
+const AiGatewayModelIndex = () => {
+  const provider = modelsData.neon;
+  const rows = modelRows.buildRows(provider);
+
+  return <ModelIndexClient rows={rows} snippets={snippets} />;
+};
+
+export default AiGatewayModelIndex;

--- a/src/components/pages/doc/ai-gateway-model-index/index.js
+++ b/src/components/pages/doc/ai-gateway-model-index/index.js
@@ -1,0 +1,1 @@
+export { default } from './ai-gateway-model-index';

--- a/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
+++ b/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
@@ -5,6 +5,9 @@ import PropTypes from 'prop-types';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 
 import CodeBlockWrapper from 'components/shared/code-block-wrapper';
+import CheckIcon from 'components/shared/code-block-wrapper/images/check.inline.svg';
+import CopyIcon from 'components/shared/code-block-wrapper/images/copy.inline.svg';
+import useCopyToClipboard from 'hooks/use-copy-to-clipboard';
 import highlight from 'lib/shiki';
 import { cn } from 'utils/cn';
 
@@ -110,6 +113,37 @@ const Badge = ({ children, tone = 'neutral' }) => (
 Badge.propTypes = {
   children: PropTypes.node.isRequired,
   tone: PropTypes.string,
+};
+
+// Click-to-copy model id. Stops propagation so copying doesn't also toggle the
+// row's expand/collapse.
+const CopyableModelId = ({ id }) => {
+  const { isCopied, handleCopy } = useCopyToClipboard(2000);
+  return (
+    <button
+      type="button"
+      className="group/copy inline-flex items-center gap-1.5 rounded text-left transition-colors"
+      aria-label={isCopied ? 'Copied' : `Copy ${id}`}
+      title={isCopied ? 'Copied' : 'Copy model ID'}
+      onClick={(event) => {
+        event.stopPropagation();
+        handleCopy(id);
+      }}
+    >
+      <code className="font-mono text-[13px] whitespace-nowrap text-gray-new-30 group-hover/copy:text-gray-new-10 dark:text-gray-new-80 dark:group-hover/copy:text-white">
+        {id}
+      </code>
+      {isCopied ? (
+        <CheckIcon className="size-3 shrink-0 text-green-45" />
+      ) : (
+        <CopyIcon className="size-3 shrink-0 text-gray-new-50 opacity-0 transition-opacity group-hover/copy:opacity-100 dark:text-gray-new-60" />
+      )}
+    </button>
+  );
+};
+
+CopyableModelId.propTypes = {
+  id: PropTypes.string.isRequired,
 };
 
 // The expanded quickstart panel under a selected row.
@@ -426,9 +460,7 @@ const ModelIndexClient = ({ rows, snippets }) => {
                       </span>
                     </td>
                     <td className="px-3 py-2.5">
-                      <code className="font-mono text-[13px] whitespace-nowrap text-gray-new-30 dark:text-gray-new-80">
-                        {row.id}
-                      </code>
+                      <CopyableModelId id={row.id} />
                     </td>
                     <td className="px-3 py-2.5 text-gray-new-30 dark:text-gray-new-80">
                       {row.providerName}

--- a/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
+++ b/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
@@ -2,7 +2,7 @@
 
 import parse from 'html-react-parser';
 import PropTypes from 'prop-types';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 
 import CodeBlockWrapper from 'components/shared/code-block-wrapper';
 import CheckIcon from 'components/shared/code-block-wrapper/images/check.inline.svg';
@@ -95,6 +95,116 @@ const SortArrow = ({ active, dir }) => (
 SortArrow.propTypes = {
   active: PropTypes.bool.isRequired,
   dir: PropTypes.string.isRequired,
+};
+
+const CheckMark = () => (
+  <svg viewBox="0 0 10 10" className="size-2.5" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M2 5 L4 7 L8 3" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+// Provider filter as a compact multi-select dropdown — stays a single control
+// no matter how many providers the catalog grows to.
+const ProviderMultiSelect = ({ providers, selected, onToggle, onClear }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocMouseDown = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) setOpen(false);
+    };
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const label = selected.size === 0 ? 'All providers' : `Providers (${selected.size})`;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={cn(
+          'flex h-10 items-center gap-2 rounded-md border bg-white px-3 text-sm transition-colors dark:bg-gray-new-8',
+          selected.size > 0
+            ? 'border-secondary-8/50 text-secondary-8 dark:border-primary-1/50 dark:text-primary-1'
+            : 'border-gray-new-80 text-gray-new-40 hover:border-gray-new-60 dark:border-gray-new-20 dark:text-gray-new-60'
+        )}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {label}
+        <svg
+          viewBox="0 0 12 12"
+          className={cn('size-3 shrink-0 transition-transform', open && 'rotate-180')}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          aria-hidden
+        >
+          <path d="M3 4.5 L6 7.5 L9 4.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-multiselectable="true"
+          className="absolute left-0 z-20 mt-1 min-w-[190px] rounded-md border border-gray-new-80 bg-white p-1 shadow-lg dark:border-gray-new-20 dark:bg-gray-new-10"
+        >
+          {providers.map((providerId) => {
+            const checked = selected.has(providerId);
+            return (
+              <button
+                key={providerId}
+                type="button"
+                role="option"
+                aria-selected={checked}
+                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-gray-new-30 transition-colors hover:bg-gray-new-98 dark:text-gray-new-80 dark:hover:bg-gray-new-8"
+                onClick={() => onToggle(providerId)}
+              >
+                <span
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded border transition-colors',
+                    checked
+                      ? 'border-secondary-8 bg-secondary-8 text-white dark:border-primary-1 dark:bg-primary-1'
+                      : 'border-gray-new-70 dark:border-gray-new-30'
+                  )}
+                >
+                  {checked && <CheckMark />}
+                </span>
+                {providerLabel(providerId)}
+              </button>
+            );
+          })}
+          {selected.size > 0 && (
+            <button
+              type="button"
+              className="mt-1 w-full border-t border-gray-new-90 px-2 pt-2 pb-1 text-left text-xs font-medium text-secondary-8 dark:border-gray-new-20 dark:text-primary-1"
+              onClick={onClear}
+            >
+              Clear selection
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+ProviderMultiSelect.propTypes = {
+  providers: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selected: PropTypes.instanceOf(Set).isRequired,
+  onToggle: PropTypes.func.isRequired,
+  onClear: PropTypes.func.isRequired,
 };
 
 // Click-to-copy model id. Stops propagation so copying doesn't also toggle the
@@ -346,27 +456,12 @@ const ModelIndexClient = ({ rows, snippets }) => {
 
         {mode === 'text' && (
           <>
-            <div className="flex flex-wrap items-center gap-1.5">
-              {providers.map((providerId) => {
-                const active = providerFilter.has(providerId);
-                return (
-                  <button
-                    key={providerId}
-                    type="button"
-                    className={cn(
-                      'rounded-md border px-2.5 py-1.5 text-[13px] font-medium transition-colors',
-                      active
-                        ? 'border-secondary-8/50 bg-secondary-8/5 text-secondary-8 dark:border-primary-1/50 dark:bg-primary-1/10 dark:text-primary-1'
-                        : 'border-gray-new-80 bg-white text-gray-new-40 hover:border-gray-new-60 dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-60'
-                    )}
-                    aria-pressed={active}
-                    onClick={() => toggleProvider(providerId)}
-                  >
-                    {providerLabel(providerId)}
-                  </button>
-                );
-              })}
-            </div>
+            <ProviderMultiSelect
+              providers={providers}
+              selected={providerFilter}
+              onToggle={toggleProvider}
+              onClear={() => setProviderFilter(new Set())}
+            />
             <label className="flex cursor-pointer items-center gap-2 text-[13px] text-gray-new-40 dark:text-gray-new-60">
               <input
                 type="checkbox"

--- a/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
+++ b/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
@@ -97,24 +97,6 @@ SortArrow.propTypes = {
   dir: PropTypes.string.isRequired,
 };
 
-const Badge = ({ children, tone = 'neutral' }) => (
-  <span
-    className={cn(
-      'inline-flex items-center rounded border px-1.5 py-0.5 text-[11px] leading-none font-medium',
-      tone === 'open'
-        ? 'border-gray-new-80 bg-gray-new-98 text-gray-new-40 dark:border-gray-new-30 dark:bg-gray-new-15 dark:text-gray-new-70'
-        : 'border-transparent text-gray-new-50 dark:text-gray-new-60'
-    )}
-  >
-    {children}
-  </span>
-);
-
-Badge.propTypes = {
-  children: PropTypes.node.isRequired,
-  tone: PropTypes.string,
-};
-
 // Click-to-copy model id. Stops propagation so copying doesn't also toggle the
 // row's expand/collapse.
 const CopyableModelId = ({ id }) => {
@@ -480,8 +462,8 @@ const ModelIndexClient = ({ rows, snippets }) => {
                     <td className="px-3 py-2.5 text-right font-mono text-[13px] text-gray-new-30 dark:text-gray-new-80">
                       {row.costOutputLabel}
                     </td>
-                    <td className="py-2.5 pr-5 pl-3">
-                      {row.openWeights ? <Badge tone="open">Open weights</Badge> : <Badge>—</Badge>}
+                    <td className="py-2.5 pr-5 pl-3 whitespace-nowrap text-gray-new-40 dark:text-gray-new-60">
+                      {row.openWeights ? 'Open weights' : '—'}
                     </td>
                   </tr>
                   {expanded && (

--- a/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
+++ b/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
@@ -477,7 +477,7 @@ const ModelIndexClient = ({ rows, snippets }) => {
 
       {/* Table */}
       <div className="overflow-x-auto rounded-lg border border-gray-new-90 dark:border-gray-new-20">
-        <table className="my-0! w-full min-w-[860px] border-collapse text-sm">
+        <table className="ai-gateway-model-table my-0! w-full min-w-[860px] border-collapse text-sm">
           <thead>
             <tr className="border-b border-gray-new-90 bg-gray-new-98 dark:border-gray-new-20 dark:bg-gray-new-8">
               {COLUMNS.map((column, index) => (

--- a/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
+++ b/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
@@ -1,0 +1,494 @@
+'use client';
+
+import parse from 'html-react-parser';
+import PropTypes from 'prop-types';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+
+import CodeBlockWrapper from 'components/shared/code-block-wrapper';
+import highlight from 'lib/shiki';
+import { cn } from 'utils/cn';
+
+import { PROVIDER_ORDER, providerLabel } from './model-rows';
+
+const COLUMNS = [
+  { key: 'name', label: 'Model', sortable: true, align: 'left' },
+  { key: 'id', label: 'Model ID', sortable: true, align: 'left' },
+  { key: 'provider', label: 'Provider', sortable: true, align: 'left' },
+  { key: 'inputs', label: 'Inputs', sortable: false, align: 'left' },
+  { key: 'contextWindow', label: 'Context', sortable: true, align: 'right' },
+  { key: 'releaseDate', label: 'Released', sortable: true, align: 'right' },
+  { key: 'costInput', label: 'Input /M', sortable: true, align: 'right' },
+  { key: 'costOutput', label: 'Output /M', sortable: true, align: 'right' },
+  { key: 'openWeights', label: 'License', sortable: true, align: 'left' },
+];
+
+const compareRows = (a, b, key) => {
+  switch (key) {
+    case 'contextWindow':
+    case 'costInput':
+    case 'costOutput': {
+      const av = a[key];
+      const bv = b[key];
+      if (av === undefined && bv === undefined) return 0;
+      if (av === undefined) return 1;
+      if (bv === undefined) return -1;
+      return av - bv;
+    }
+    case 'openWeights':
+      return Number(a.openWeights) - Number(b.openWeights);
+    case 'releaseDate':
+      return (a.releaseDate ?? '').localeCompare(b.releaseDate ?? '');
+    default:
+      return String(a[key]).localeCompare(String(b[key]));
+  }
+};
+
+// Client-side syntax highlighting with a graceful <pre> fallback — the same
+// pattern the API reference / MCP configurator use (lib/shiki in useEffect).
+const HighlightedCode = ({ code, language }) => {
+  const [html, setHtml] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    highlight(code, language).then((result) => {
+      if (!cancelled) setHtml(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language]);
+
+  if (!html) {
+    return (
+      <pre
+        className="my-0 overflow-x-auto !bg-gray-new-98 p-4 text-sm leading-relaxed dark:!bg-gray-new-10"
+        data-language={language}
+      >
+        <code>{code}</code>
+      </pre>
+    );
+  }
+
+  return <>{parse(html)}</>;
+};
+
+HighlightedCode.propTypes = {
+  code: PropTypes.string.isRequired,
+  language: PropTypes.string.isRequired,
+};
+
+const SortArrow = ({ active, dir }) => (
+  <span
+    className={cn(
+      'ml-1 inline-block text-[10px] transition-opacity',
+      active ? 'opacity-100' : 'opacity-0 group-hover:opacity-40'
+    )}
+    aria-hidden
+  >
+    {active && dir === 'asc' ? '▲' : '▼'}
+  </span>
+);
+
+SortArrow.propTypes = {
+  active: PropTypes.bool.isRequired,
+  dir: PropTypes.string.isRequired,
+};
+
+const Badge = ({ children, tone = 'neutral' }) => (
+  <span
+    className={cn(
+      'inline-flex items-center rounded border px-1.5 py-0.5 text-[11px] leading-none font-medium',
+      tone === 'open'
+        ? 'border-gray-new-80 bg-gray-new-98 text-gray-new-40 dark:border-gray-new-30 dark:bg-gray-new-15 dark:text-gray-new-70'
+        : 'border-transparent text-gray-new-50 dark:text-gray-new-60'
+    )}
+  >
+    {children}
+  </span>
+);
+
+Badge.propTypes = {
+  children: PropTypes.node.isRequired,
+  tone: PropTypes.string,
+};
+
+// The expanded quickstart panel under a selected row.
+const RowDetail = ({ row, snippets, mode }) => {
+  const languages = useMemo(() => {
+    const all = snippets.tabs[mode]?.languages ?? [];
+    // Mastra can't reach Responses-only (Codex) models through the
+    // OpenAI-compatible endpoint yet, so drop it for those in the text tab.
+    if (mode === 'text' && row.isResponsesOnly) {
+      return all.filter((lang) => lang.key !== 'mastra');
+    }
+    return all;
+  }, [snippets, mode, row.isResponsesOnly]);
+
+  const [langKey, setLangKey] = useState(languages[0]?.key);
+  const [view, setView] = useState('code');
+
+  useEffect(() => {
+    setLangKey(languages[0]?.key);
+    setView('code');
+  }, [languages]);
+
+  const activeLang = languages.find((lang) => lang.key === langKey) ?? languages[0];
+  if (!activeLang) return null;
+
+  const placeholder = snippets.modelIdPlaceholder;
+  const codeForModel = activeLang.code.split(placeholder).join(row.id);
+  const isEnv = view === 'env';
+  const shownCode = isEnv ? snippets.envExample : codeForModel;
+  const shownLang = isEnv ? 'bash' : activeLang.lang;
+  // The code sub-tab always shows the language's filename; only the `.env` tab
+  // is fixed. (Computing it from `isEnv` would mislabel the code tab as `.env`.)
+  const codeFilename =
+    { typescript: 'index.ts', python: 'main.py', bash: 'request.sh' }[activeLang.lang] || 'snippet';
+
+  const specs = [
+    { label: 'Context', value: row.contextLabel },
+    { label: 'Input', value: `${row.costInputLabel}/M` },
+    { label: 'Output', value: `${row.costOutputLabel}/M` },
+    { label: 'Knowledge', value: row.knowledge || '—' },
+    { label: 'Endpoints', value: row.endpoints.join(' · ') },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4 border-t border-gray-new-90 bg-gray-new-98 p-4 dark:border-gray-new-20 dark:bg-gray-new-8">
+      <dl className="flex flex-wrap gap-x-6 gap-y-2">
+        {specs.map((spec) => (
+          <div key={spec.label} className="flex flex-col gap-0.5">
+            <dt className="text-[10px] font-semibold tracking-wide text-gray-new-50 uppercase dark:text-gray-new-60">
+              {spec.label}
+            </dt>
+            <dd className="m-0 font-mono text-[13px] text-gray-new-20 dark:text-gray-new-90">
+              {spec.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2">
+          <span className="text-[11px] font-semibold tracking-wide text-gray-new-50 uppercase dark:text-gray-new-60">
+            Language
+          </span>
+          <select
+            className="h-8 rounded-md border border-gray-new-80 bg-white px-2 text-sm text-gray-new-20 outline-none focus:border-secondary-8 dark:border-gray-new-20 dark:bg-gray-new-10 dark:text-gray-new-90 dark:focus:border-primary-1"
+            value={activeLang.key}
+            onChange={(event) => {
+              setLangKey(event.target.value);
+              setView('code');
+            }}
+          >
+            {languages.map((lang) => (
+              <option key={lang.key} value={lang.key}>
+                {lang.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {activeLang.install && (
+          <code className="rounded bg-gray-new-94 px-2 py-1 text-[12px] text-gray-new-30 dark:bg-gray-new-15 dark:text-gray-new-80">
+            {activeLang.install}
+          </code>
+        )}
+      </div>
+
+      <div>
+        <div className="flex items-center gap-1 border border-b-0 border-gray-new-80 bg-gray-new-98 px-1 pt-1 dark:border-gray-new-20 dark:bg-gray-new-8">
+          {[
+            { key: 'code', label: codeFilename },
+            { key: 'env', label: '.env' },
+          ].map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              className={cn(
+                'rounded-t-md px-3 py-1.5 text-[13px] font-medium transition-colors',
+                (tab.key === 'env') === isEnv
+                  ? 'bg-white text-gray-new-10 dark:bg-gray-new-10 dark:text-white'
+                  : 'text-gray-new-50 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:text-gray-new-80'
+              )}
+              onClick={() => setView(tab.key)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <CodeBlockWrapper
+          className="overflow-hidden rounded-b-md border border-gray-new-80 dark:border-gray-new-20 [&>pre]:my-0 [&>pre]:!bg-gray-new-98 [&>pre]:dark:!bg-gray-new-10"
+          as="div"
+          copyCode={shownCode}
+        >
+          <HighlightedCode code={shownCode} language={shownLang} />
+        </CodeBlockWrapper>
+      </div>
+    </div>
+  );
+};
+
+RowDetail.propTypes = {
+  row: PropTypes.object.isRequired,
+  snippets: PropTypes.object.isRequired,
+  mode: PropTypes.string.isRequired,
+};
+
+const ModelIndexClient = ({ rows, snippets }) => {
+  const [mode, setMode] = useState('text');
+  const [search, setSearch] = useState('');
+  const [providerFilter, setProviderFilter] = useState(() => new Set());
+  const [openWeightsOnly, setOpenWeightsOnly] = useState(false);
+  const [sort, setSort] = useState({ key: 'releaseDate', dir: 'desc' });
+  const [expandedId, setExpandedId] = useState(null);
+
+  const providers = useMemo(() => {
+    const present = new Set(rows.map((row) => row.provider));
+    return [
+      ...PROVIDER_ORDER.filter((p) => present.has(p)),
+      ...[...present].filter((p) => !PROVIDER_ORDER.includes(p)),
+    ];
+  }, [rows]);
+
+  const visibleRows = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    let list = rows.filter((row) => (mode === 'image' ? row.isImageCapable : true));
+    if (mode === 'text') {
+      if (providerFilter.size > 0) list = list.filter((row) => providerFilter.has(row.provider));
+      if (openWeightsOnly) list = list.filter((row) => row.openWeights);
+    }
+    if (query) {
+      list = list.filter(
+        (row) =>
+          row.name.toLowerCase().includes(query) ||
+          row.id.toLowerCase().includes(query) ||
+          row.providerName.toLowerCase().includes(query)
+      );
+    }
+    const sorted = [...list].sort((a, b) => compareRows(a, b, sort.key));
+    return sort.dir === 'desc' ? sorted.reverse() : sorted;
+  }, [rows, mode, providerFilter, openWeightsOnly, search, sort]);
+
+  const changeMode = (next) => {
+    if (next === mode) return;
+    setMode(next);
+    setExpandedId(null);
+  };
+
+  const onSort = (key) => {
+    setSort((prev) =>
+      prev.key === key ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }
+    );
+  };
+
+  const toggleProvider = (providerId) => {
+    setProviderFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(providerId)) next.delete(providerId);
+      else next.add(providerId);
+      return next;
+    });
+  };
+
+  return (
+    <div className="not-prose my-6">
+      {/* Text / Image tabs */}
+      <div className="mb-4 inline-flex rounded-lg border border-gray-new-90 bg-gray-new-98 p-1 dark:border-gray-new-20 dark:bg-gray-new-8">
+        {[
+          { key: 'text', label: 'Text' },
+          { key: 'image', label: 'Image' },
+        ].map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            className={cn(
+              'rounded-md px-4 py-1.5 text-sm font-medium transition-colors',
+              mode === tab.key
+                ? 'bg-white text-gray-new-10 shadow-sm dark:bg-gray-new-10 dark:text-white'
+                : 'text-gray-new-50 hover:text-gray-new-30 dark:text-gray-new-60 dark:hover:text-gray-new-80'
+            )}
+            onClick={() => changeMode(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Controls */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <label className="relative min-w-[200px] flex-1">
+          <span className="sr-only">Search models</span>
+          <input
+            className="h-10 w-full rounded-md border border-gray-new-80 bg-white px-3 text-sm text-gray-new-15 outline-none placeholder:text-gray-new-50 focus:border-secondary-8 dark:border-gray-new-20 dark:bg-black-pure dark:text-white dark:placeholder:text-gray-new-60 dark:focus:border-primary-1"
+            type="search"
+            value={search}
+            placeholder="Search model, ID, or provider..."
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        </label>
+
+        {mode === 'text' && (
+          <>
+            <div className="flex flex-wrap items-center gap-1.5">
+              {providers.map((providerId) => {
+                const active = providerFilter.has(providerId);
+                return (
+                  <button
+                    key={providerId}
+                    type="button"
+                    className={cn(
+                      'rounded-md border px-2.5 py-1.5 text-[13px] font-medium transition-colors',
+                      active
+                        ? 'border-secondary-8/50 bg-secondary-8/5 text-secondary-8 dark:border-primary-1/50 dark:bg-primary-1/10 dark:text-primary-1'
+                        : 'border-gray-new-80 bg-white text-gray-new-40 hover:border-gray-new-60 dark:border-gray-new-20 dark:bg-gray-new-8 dark:text-gray-new-60'
+                    )}
+                    aria-pressed={active}
+                    onClick={() => toggleProvider(providerId)}
+                  >
+                    {providerLabel(providerId)}
+                  </button>
+                );
+              })}
+            </div>
+            <label className="flex cursor-pointer items-center gap-2 text-[13px] text-gray-new-40 dark:text-gray-new-60">
+              <input
+                type="checkbox"
+                className="size-4 rounded border-gray-new-70 accent-secondary-8 dark:accent-primary-1"
+                checked={openWeightsOnly}
+                onChange={(event) => setOpenWeightsOnly(event.target.checked)}
+              />
+              Open weights only
+            </label>
+          </>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-gray-new-90 dark:border-gray-new-20">
+        <table className="my-0! w-full min-w-[860px] border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-gray-new-90 bg-gray-new-98 dark:border-gray-new-20 dark:bg-gray-new-8">
+              {COLUMNS.map((column) => (
+                <th
+                  key={column.key}
+                  scope="col"
+                  className={cn(
+                    'px-3 py-2.5 font-medium text-gray-new-40 dark:text-gray-new-60',
+                    column.align === 'right' ? 'text-right' : 'text-left'
+                  )}
+                >
+                  {column.sortable ? (
+                    <button
+                      type="button"
+                      className={cn(
+                        'group inline-flex items-center transition-colors hover:text-gray-new-20 dark:hover:text-white',
+                        column.align === 'right' && 'flex-row-reverse'
+                      )}
+                      onClick={() => onSort(column.key)}
+                    >
+                      {column.label}
+                      <SortArrow active={sort.key === column.key} dir={sort.dir} />
+                    </button>
+                  ) : (
+                    column.label
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visibleRows.map((row) => {
+              const expanded = expandedId === row.id;
+              return (
+                <Fragment key={row.id}>
+                  <tr
+                    className={cn(
+                      'cursor-pointer border-t border-gray-new-90 transition-colors first:border-t-0 hover:bg-gray-new-98 dark:border-gray-new-20 dark:hover:bg-gray-new-8',
+                      expanded && 'bg-gray-new-98 dark:bg-gray-new-8'
+                    )}
+                    onClick={() => setExpandedId(expanded ? null : row.id)}
+                  >
+                    <td className="px-3 py-2.5 font-medium text-gray-new-10 dark:text-white">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span
+                          className={cn(
+                            'inline-block text-[9px] text-gray-new-50 transition-transform',
+                            expanded && 'rotate-90'
+                          )}
+                          aria-hidden
+                        >
+                          ▶
+                        </span>
+                        {row.name}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <code className="font-mono text-[13px] whitespace-nowrap text-gray-new-30 dark:text-gray-new-80">
+                        {row.id}
+                      </code>
+                    </td>
+                    <td className="px-3 py-2.5 text-gray-new-30 dark:text-gray-new-80">
+                      {row.providerName}
+                    </td>
+                    <td className="px-3 py-2.5 text-gray-new-40 dark:text-gray-new-60">
+                      {row.inputsLabel}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-mono text-[13px] text-gray-new-30 dark:text-gray-new-80">
+                      {row.contextLabel}
+                    </td>
+                    <td className="px-3 py-2.5 text-right text-gray-new-40 dark:text-gray-new-60">
+                      {row.releaseLabel}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-mono text-[13px] text-gray-new-30 dark:text-gray-new-80">
+                      {row.costInputLabel}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-mono text-[13px] text-gray-new-30 dark:text-gray-new-80">
+                      {row.costOutputLabel}
+                    </td>
+                    <td className="px-3 py-2.5">
+                      {row.openWeights ? <Badge tone="open">Open weights</Badge> : <Badge>—</Badge>}
+                    </td>
+                  </tr>
+                  {expanded && (
+                    <tr>
+                      <td colSpan={COLUMNS.length} className="p-0">
+                        <RowDetail row={row} snippets={snippets} mode={mode} />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+            {visibleRows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={COLUMNS.length}
+                  className="px-3 py-8 text-center text-gray-new-40 dark:text-gray-new-60"
+                >
+                  No models match your filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-3 text-[13px] text-gray-new-40 dark:text-gray-new-60">
+        Prices are provider list prices per million tokens. Inference is free during the private
+        preview. Click a model for a copy-paste quickstart.
+      </p>
+    </div>
+  );
+};
+
+ModelIndexClient.propTypes = {
+  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  snippets: PropTypes.shape({
+    modelIdPlaceholder: PropTypes.string.isRequired,
+    tabs: PropTypes.object.isRequired,
+    envExample: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default ModelIndexClient;

--- a/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
+++ b/src/components/pages/doc/ai-gateway-model-index/model-index-client.jsx
@@ -369,12 +369,14 @@ const ModelIndexClient = ({ rows, snippets }) => {
         <table className="my-0! w-full min-w-[860px] border-collapse text-sm">
           <thead>
             <tr className="border-b border-gray-new-90 bg-gray-new-98 dark:border-gray-new-20 dark:bg-gray-new-8">
-              {COLUMNS.map((column) => (
+              {COLUMNS.map((column, index) => (
                 <th
                   key={column.key}
                   scope="col"
                   className={cn(
                     'px-3 py-2.5 font-medium text-gray-new-40 dark:text-gray-new-60',
+                    index === 0 && 'pl-5',
+                    index === COLUMNS.length - 1 && 'pr-5',
                     column.align === 'right' ? 'text-right' : 'text-left'
                   )}
                 >
@@ -409,7 +411,7 @@ const ModelIndexClient = ({ rows, snippets }) => {
                     )}
                     onClick={() => setExpandedId(expanded ? null : row.id)}
                   >
-                    <td className="px-3 py-2.5 font-medium text-gray-new-10 dark:text-white">
+                    <td className="py-2.5 pr-3 pl-5 font-medium text-gray-new-10 dark:text-white">
                       <span className="inline-flex items-center gap-1.5">
                         <span
                           className={cn(
@@ -446,7 +448,7 @@ const ModelIndexClient = ({ rows, snippets }) => {
                     <td className="px-3 py-2.5 text-right font-mono text-[13px] text-gray-new-30 dark:text-gray-new-80">
                       {row.costOutputLabel}
                     </td>
-                    <td className="px-3 py-2.5">
+                    <td className="py-2.5 pr-5 pl-3">
                       {row.openWeights ? <Badge tone="open">Open weights</Badge> : <Badge>—</Badge>}
                     </td>
                   </tr>

--- a/src/components/pages/doc/ai-gateway-model-index/model-rows.js
+++ b/src/components/pages/doc/ai-gateway-model-index/model-rows.js
@@ -1,0 +1,157 @@
+/**
+ * Pure derivation + formatting helpers for the AI Gateway model catalog.
+ *
+ * Shared (CommonJS) so BOTH the interactive component (model-index-client.jsx)
+ * and the llms markdown mirror (src/scripts/process-md-for-llms.js) build rows
+ * the same way — the web table and the agent-facing markdown can never disagree.
+ *
+ * Input is the `neon` provider object from /models.json (models.dev-shaped);
+ * each model already carries its underlying maker in `provider`.
+ */
+
+const PROVIDER_ORDER = ['anthropic', 'openai', 'google', 'meta', 'alibaba'];
+
+const PROVIDER_LABELS = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  google: 'Google',
+  meta: 'Meta',
+  alibaba: 'Alibaba',
+};
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+const providerLabel = (id) => PROVIDER_LABELS[id] || (id ? id[0].toUpperCase() + id.slice(1) : '—');
+
+// e.g. 200000 -> "200K", 1000000 -> "1M".
+const formatContextWindow = (tokens) => {
+  if (!tokens) return '—';
+  if (tokens >= 1000000) {
+    const millions = Math.round((tokens / 1000000) * 10) / 10;
+    return `${millions}M`;
+  }
+  return `${Math.round(tokens / 1000)}K`;
+};
+
+// Price per million tokens: 0.4 -> "$0.40", 15 -> "$15", 0 -> "Free".
+const formatPrice = (pricePerMillion) => {
+  if (pricePerMillion === undefined || pricePerMillion === null) return '—';
+  if (pricePerMillion === 0) return 'Free';
+  const fixed = pricePerMillion.toFixed(2);
+  const trimmed = fixed.endsWith('.00') ? fixed.slice(0, -3) : fixed;
+  return `$${trimmed}`;
+};
+
+// "2026-02-17" -> "Feb 2026". Stable across server/client (no Intl locale drift).
+const formatDate = (iso) => {
+  if (!iso) return '—';
+  const [year, month] = iso.split('-');
+  const monthIndex = Number(month) - 1;
+  if (!year || Number.isNaN(monthIndex) || !MONTHS[monthIndex]) return iso;
+  return `${MONTHS[monthIndex]} ${year}`;
+};
+
+const isResponsesOnly = (model) => model.id.toLowerCase().includes('codex');
+
+// Image tab: OpenAI GPT models that support the Responses image_generation
+// tool. Only open-weight gpt-oss is excluded (routes to MLflow, no Responses
+// tools); Codex models ARE image-capable (verified live against the gateway).
+const isImageCapable = (model) =>
+  model.provider === 'openai' && !model.id.toLowerCase().startsWith('gpt-oss');
+
+// The gateway routes a model reaches. Conveyed to users mainly through the
+// quickstart snippet's base URL; surfaced here for the markdown mirror.
+const deriveEndpoints = (model) => {
+  const { provider, id } = model;
+  if (provider === 'openai') {
+    if (isResponsesOnly(model)) return ['openai/responses'];
+    if (id.toLowerCase().startsWith('gpt-oss')) return ['chat/completions'];
+    return ['chat/completions', 'openai/responses'];
+  }
+  if (provider === 'anthropic') return ['chat/completions', 'anthropic/messages'];
+  if (provider === 'google') {
+    return id.toLowerCase().startsWith('gemma')
+      ? ['chat/completions']
+      : ['chat/completions', 'gemini'];
+  }
+  return ['chat/completions'];
+};
+
+const toRow = (model) => {
+  const inputs = model.modalities?.input ?? [];
+  const contextWindow = model.limit?.context;
+  const costInput = model.cost?.input;
+  const costOutput = model.cost?.output;
+  return {
+    id: model.id,
+    name: model.name,
+    provider: model.provider,
+    providerName: providerLabel(model.provider),
+    inputs,
+    inputsLabel: inputs.length ? inputs.join(', ') : '—',
+    contextWindow,
+    contextLabel: formatContextWindow(contextWindow),
+    reasoning: Boolean(model.reasoning),
+    costInput,
+    costOutput,
+    costInputLabel: formatPrice(costInput),
+    costOutputLabel: formatPrice(costOutput),
+    knowledge: model.knowledge || null,
+    releaseDate: model.release_date || null,
+    releaseLabel: formatDate(model.release_date),
+    openWeights: Boolean(model.open_weights),
+    license: model.open_weights ? 'Open weights' : 'Proprietary',
+    endpoints: deriveEndpoints(model),
+    isImageCapable: isImageCapable(model),
+    isResponsesOnly: isResponsesOnly(model),
+  };
+};
+
+// All rows, sorted by provider order then release date (newest first).
+const buildRows = (neonProvider) => {
+  const models = neonProvider?.models ?? {};
+  return Object.values(models)
+    .map(toRow)
+    .sort((a, b) => {
+      const pa = PROVIDER_ORDER.indexOf(a.provider);
+      const pb = PROVIDER_ORDER.indexOf(b.provider);
+      const oa = pa === -1 ? 99 : pa;
+      const ob = pb === -1 ? 99 : pb;
+      if (oa !== ob) return oa - ob;
+      return (b.releaseDate ?? '').localeCompare(a.releaseDate ?? '');
+    });
+};
+
+// Rows grouped into ordered provider sections (used by the markdown mirror).
+const groupByProvider = (rows) => {
+  const byProvider = new Map();
+  for (const row of rows) {
+    if (!byProvider.has(row.provider)) byProvider.set(row.provider, []);
+    byProvider.get(row.provider).push(row);
+  }
+  const present = [...byProvider.keys()];
+  const ordered = [
+    ...PROVIDER_ORDER.filter((p) => byProvider.has(p)),
+    ...present.filter((p) => !PROVIDER_ORDER.includes(p)),
+  ];
+  return ordered.map((providerId) => ({
+    providerId,
+    label: providerLabel(providerId),
+    rows: byProvider.get(providerId),
+  }));
+};
+
+module.exports = {
+  PROVIDER_ORDER,
+  PROVIDER_LABELS,
+  providerLabel,
+  formatContextWindow,
+  formatPrice,
+  formatDate,
+  isResponsesOnly,
+  isImageCapable,
+  deriveEndpoints,
+  toRow,
+  buildRows,
+  groupByProvider,
+};

--- a/src/components/shared/content/content.jsx
+++ b/src/components/shared/content/content.jsx
@@ -3,6 +3,7 @@ import { MDXRemote } from 'next-mdx-remote/rsc';
 import PropTypes from 'prop-types';
 import remarkGfm from 'remark-gfm';
 
+import AiGatewayModelIndex from 'components/pages/doc/ai-gateway-model-index';
 import ApiMethodBadge from 'components/pages/doc/api-method-badge';
 import ApiParam from 'components/pages/doc/api-param';
 import ApiResourceGrid from 'components/pages/doc/api-resource-grid/api-resource-grid';
@@ -230,6 +231,7 @@ const getComponents = (withoutAnchorHeading, isReleaseNote, isPostgres, isTempla
   CopyPrompt,
   McpSetupConfigurator,
   SqlToRestConverter,
+  AiGatewayModelIndex,
   ...sharedComponents,
 });
 

--- a/src/scripts/process-md-for-llms.js
+++ b/src/scripts/process-md-for-llms.js
@@ -44,7 +44,44 @@ const jsYaml = require('js-yaml');
 // web page and this llms mirror can never disagree on the generated tables.
 const cliDocs = require('../../scripts/docs-checks/neonctl/generate-docs');
 const cliSchema = require('../../scripts/docs-checks/neonctl/schema.json');
+const aiGatewayModelsData = require('../app/models.json/data.json');
+const aiGatewayModelRows = require('../components/pages/doc/ai-gateway-model-index/model-rows');
 const { isUnusedOrSharedContent } = require('../constants/content');
+
+// AI Gateway model catalog: <AiGatewayModelIndex/> renders an interactive table
+// on the web page; here it degrades to static per-provider markdown tables built
+// from the SAME committed /models.json data + derivation helpers, so the two can
+// never disagree.
+
+function renderAiGatewayModelIndex() {
+  const rows = aiGatewayModelRows.buildRows(aiGatewayModelsData.neon);
+  const groups = aiGatewayModelRows.groupByProvider(rows);
+  const header =
+    '| Model | Model ID | Inputs | Context | Reasoning | Input /M | Output /M | Endpoints | License |\n' +
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |';
+  const sections = groups.map((group) => {
+    const body = group.rows
+      .map((row) =>
+        [
+          '',
+          row.name,
+          `\`${row.id}\``,
+          row.inputsLabel,
+          row.contextLabel,
+          row.reasoning ? 'Yes' : '—',
+          row.costInputLabel,
+          row.costOutputLabel,
+          row.endpoints.join(' · '),
+          row.license,
+          '',
+        ].join(' | ')
+      )
+      .map((line) => line.replace(/^ \| /, '| ').replace(/ \| $/, ' |'))
+      .join('\n');
+    return `### ${group.label}\n\n${header}\n${body}`;
+  });
+  return sections.join('\n\n');
+}
 
 const TOC_ONLY_PATTERN = /\s*\[toc-only\]\s*$/i;
 
@@ -564,6 +601,12 @@ const componentHandlers = {
     // The interactive index on the web page degrades to the full static
     // command tree for agents reading the .md mirror.
     return parseMarkdownToNodes(cliDocs.renderCommandIndex(cliSchema));
+  },
+
+  AiGatewayModelIndex() {
+    // The interactive model table degrades to static per-provider tables built
+    // from the same /models.json data for agents reading the .md mirror.
+    return parseMarkdownToNodes(renderAiGatewayModelIndex());
   },
 
   /**

--- a/src/scripts/process-md-for-llms.js
+++ b/src/scripts/process-md-for-llms.js
@@ -46,40 +46,102 @@ const cliDocs = require('../../scripts/docs-checks/neonctl/generate-docs');
 const cliSchema = require('../../scripts/docs-checks/neonctl/schema.json');
 const aiGatewayModelsData = require('../app/models.json/data.json');
 const aiGatewayModelRows = require('../components/pages/doc/ai-gateway-model-index/model-rows');
+const aiGatewayModelSnippets = require('../components/pages/doc/ai-gateway-model-index/snippets.json');
 const { isUnusedOrSharedContent } = require('../constants/content');
 
 // AI Gateway model catalog: <AiGatewayModelIndex/> renders an interactive table
-// on the web page; here it degrades to static per-provider markdown tables built
-// from the SAME committed /models.json data + derivation helpers, so the two can
-// never disagree.
+// with Text/Image tabs and per-model copy-paste quickstarts on the web page.
+// Here it degrades to static markdown built from the SAME committed /models.json
+// data + the vendored quickstart snippets.json, so the web page and the
+// agent-facing markdown can never disagree. Both tab contents are rendered:
+// Text (every catalog model) and Image (image-generation-capable models only).
+//
+// The quickstart snippets differ across models ONLY by the model id, so instead
+// of repeating each snippet once per model, we emit each language snippet a
+// single time per tab with the `__MODEL_ID__` placeholder intact — the model
+// tables directly above each quickstart are the list of IDs to drop in.
+
+const MODEL_TABLE_HEADER =
+  '| Model | Model ID | Inputs | Context | Reasoning | Input /M | Output /M | Endpoints | License |\n' +
+  '| --- | --- | --- | --- | --- | --- | --- | --- | --- |';
+
+function renderModelTableRows(rows) {
+  return rows
+    .map((row) =>
+      [
+        row.name,
+        `\`${row.id}\``,
+        row.inputsLabel,
+        row.contextLabel,
+        row.reasoning ? 'Yes' : '—',
+        row.costInputLabel,
+        row.costOutputLabel,
+        row.endpoints.join(' · '),
+        row.license,
+      ].join(' | ')
+    )
+    .map((line) => `| ${line} |`)
+    .join('\n');
+}
+
+// Per-provider tables under a shared heading depth (e.g. '####').
+function renderProviderTables(rows, headingDepth) {
+  return aiGatewayModelRows
+    .groupByProvider(rows)
+    .map(
+      (group) =>
+        `${headingDepth} ${group.label}\n\n${MODEL_TABLE_HEADER}\n${renderModelTableRows(group.rows)}`
+    )
+    .join('\n\n');
+}
+
+// One fenced code block per language (model id left as the placeholder), plus the
+// shared `.env` when requested. Emitted once per tab — not once per model.
+function renderSnippetQuickstart(tab, { includeEnv }) {
+  const blocks = tab.languages.map((lang) => {
+    const install = lang.install ? ` — install: \`${lang.install}\`` : '';
+    return `**${lang.label}**${install}\n\n\`\`\`${lang.lang}\n${lang.code.trimEnd()}\n\`\`\``;
+  });
+  if (includeEnv) {
+    blocks.push(`**.env**\n\n\`\`\`bash\n${aiGatewayModelSnippets.envExample.trimEnd()}\n\`\`\``);
+  }
+  return blocks.join('\n\n');
+}
 
 function renderAiGatewayModelIndex() {
   const rows = aiGatewayModelRows.buildRows(aiGatewayModelsData.neon);
-  const groups = aiGatewayModelRows.groupByProvider(rows);
-  const header =
-    '| Model | Model ID | Inputs | Context | Reasoning | Input /M | Output /M | Endpoints | License |\n' +
-    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |';
-  const sections = groups.map((group) => {
-    const body = group.rows
-      .map((row) =>
-        [
-          '',
-          row.name,
-          `\`${row.id}\``,
-          row.inputsLabel,
-          row.contextLabel,
-          row.reasoning ? 'Yes' : '—',
-          row.costInputLabel,
-          row.costOutputLabel,
-          row.endpoints.join(' · '),
-          row.license,
-          '',
-        ].join(' | ')
-      )
-      .map((line) => line.replace(/^ \| /, '| ').replace(/ \| $/, ' |'))
-      .join('\n');
-    return `### ${group.label}\n\n${header}\n${body}`;
-  });
+  const placeholder = aiGatewayModelSnippets.modelIdPlaceholder;
+  const responsesOnly = rows.filter((row) => row.isResponsesOnly).map((row) => `\`${row.id}\``);
+  const imageRows = rows.filter((row) => row.isImageCapable);
+
+  const sections = [];
+
+  // Text tab — every catalog model.
+  sections.push('### Text models');
+  sections.push(renderProviderTables(rows, '####'));
+  const mastraNote = responsesOnly.length
+    ? ` Mastra can't reach Responses-only models through the OpenAI-compatible endpoint — use another language for ${responsesOnly.join(', ')}.`
+    : '';
+  sections.push(
+    `**Quickstart (text).** These snippets work for every model above — replace \`${placeholder}\` with any model ID from the tables.${mastraNote}`
+  );
+  sections.push(renderSnippetQuickstart(aiGatewayModelSnippets.tabs.text, { includeEnv: true }));
+
+  // Image tab — image-generation-capable models only.
+  if (imageRows.length > 0) {
+    sections.push('### Image models');
+    sections.push(
+      'These models support image generation through the Responses API (base URL `/openai/v1`):'
+    );
+    sections.push(renderProviderTables(imageRows, '####'));
+    sections.push(
+      `**Quickstart (image).** Replace \`${placeholder}\` with any image model ID above. Environment variables are the same as the Text quickstart.`
+    );
+    sections.push(
+      renderSnippetQuickstart(aiGatewayModelSnippets.tabs.image, { includeEnv: false })
+    );
+  }
+
   return sections.join('\n\n');
 }
 

--- a/src/scripts/process-md-for-llms.test.js
+++ b/src/scripts/process-md-for-llms.test.js
@@ -115,6 +115,35 @@ describe('MDX to Markdown Conversion', () => {
       // Should NOT have raw TwoColumnLayout
       expect(result).not.toContain('<TwoColumnLayout');
     });
+
+    it('should render both AI Gateway tabs and quickstart snippets', async () => {
+      const inputPath = 'content/docs/ai-gateway/models.md';
+      const pageUrl = 'https://neon.com/docs/ai-gateway/models';
+      const projectRoot = process.cwd();
+
+      const { content: result } = await processFile(inputPath, pageUrl, projectRoot);
+
+      // Both tabs are served as static sections (not just the interactive widget)
+      expect(result).toContain('### Text models');
+      expect(result).toContain('### Image models');
+      expect(result).not.toContain('<AiGatewayModelIndex');
+
+      // Per-provider tables render under each tab
+      expect(result).toContain('#### Anthropic');
+      expect(result).toContain('| `claude-sonnet-4-6` |');
+
+      // Quickstart snippets are served, once per language, with the model-id
+      // placeholder rather than duplicated per model
+      expect(result).toContain('**Quickstart (text).**');
+      expect(result).toContain('**Quickstart (image).**');
+      expect(result).toContain('__MODEL_ID__');
+      expect(result).toContain('import { generateText } from "ai";');
+      expect(result).toContain('image_generation');
+
+      // Each language snippet appears exactly once per tab (no per-model repeat)
+      const aiSdkImportCount = result.split('import { generateText } from "ai";').length - 1;
+      expect(aiSdkImportCount).toBe(1);
+    });
   });
 
   // Test specific component conversions with inline MDX

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -273,6 +273,19 @@
       }
     }
 
+    /* AI Gateway model table (AiGatewayModelIndex): the model-id chips are long
+       hyphenated slugs (e.g. qwen3-next-80b-a3b-instruct). The global inline-code
+       rule's `overflow-wrap: anywhere` would break them across many lines; keep
+       each id on one line (the table wrapper scrolls horizontally if needed). */
+    .ai-gateway-model-table {
+      td code,
+      th code {
+        overflow-wrap: normal;
+        word-break: normal;
+        white-space: nowrap;
+      }
+    }
+
     .sticky-table {
       @apply relative lg:[--docs-header-height:0px];
     }


### PR DESCRIPTION
## Summary

PR 2/2 (stacked on #5242). Replaces the hand-maintained per-provider model tables on **[/docs/ai-gateway/models](https://neon.com/docs/ai-gateway/models)** with an interactive `<AiGatewayModelIndex/>` component — mirroring the Neon Console's AI Gateway model table.

- **One data source, two renderings.** The component reads the committed `/models.json` data (synced from the models.dev `neon` provider) + the vendored `snippets.json` (#5242). On the web it renders an interactive table; the **llms `.md` mirror** renders the same rows as static per-provider tables from the same data — so the page and the agent-facing markdown can never drift (same pattern as `CliCommandIndex`).
- **Table:** Model · Model ID · Provider · Inputs · Context · Released · Input/M · Output/M · License. Sortable columns, search, provider multi-select, open-weights filter, and **Text / Image** tabs (Image lists only image-capable OpenAI GPT models; Codex included, gpt-oss excluded).
- **Console-parity quickstart:** clicking a model expands specs (context, pricing, knowledge, endpoints) + a language dropdown (AI SDK · Mastra · Python · TypeScript · cURL) over `index.*` / `.env` tabs, with the selected model id substituted. **The endpoint is conveyed by each snippet's base URL** (`/v1` chat, `/openai/v1` Responses/image) — no separate endpoints column. Mastra is hidden for Responses-only (Codex) models.
- Adds a link to the **[models.dev `neon` provider](https://models.dev/providers/neon)** and keeps the editorial sections (Quick picks, Rate limits, Pricing, Which endpoint to use, Provider terms).

## Screenshots

Text tab (default), expanded Claude Opus 4.8 quickstart, and the Image tab were verified live via agent-browser on `next dev`.

## Test plan

- [x] `next dev` — page renders 200; table, sort, search, provider/open-weights filters, Text/Image tabs, row expand, language switch, `index.*`↔`.env` toggle, model-id substitution all verified via agent-browser
- [x] Image tab lists only image-capable GPT models (Codex incl., gpt-oss excl.); languages limited to AI SDK / TypeScript / Python
- [x] `npx vitest run src/scripts/process-md-for-llms.test.js` — 67 passed (mirror handler wired)
- [x] eslint + prettier clean (pre-commit)
- [ ] Review the llms `.md` mirror output on the deployed preview