### PR TITLE
docs: standardize on `neon` CLI over `neonctl`

### DIFF
--- a/content/docs/reference/api.md
+++ b/content/docs/reference/api.md
@@ -39,7 +39,7 @@ If you don't need to call the REST API directly, use one of these interfaces ins
 
 <DetailIconCards>
 
-<a href="/docs/cli" description="Use neonctl for terminal, CI/CD, and agent workflows." icon="cli">CLI</a>
+<a href="/docs/cli" description="Use the neon CLI for terminal, CI/CD, and agent workflows." icon="cli">CLI</a>
 
 <a href="/docs/ai/neon-mcp-server" description="Connect AI assistants to Neon with MCP." icon="sparkle">MCP server</a>
 

--- a/public/agentic-provisioning-llm-context.md
+++ b/public/agentic-provisioning-llm-context.md
@@ -81,8 +81,8 @@ Neon is the backend for apps and agents. Use the API key from Part 1 for all Neo
 | Connection Methods & Drivers | Choosing transport/driver (TCP, HTTP, WebSocket, edge, serverless) | [connection-methods.md](https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md) |
 | Serverless Driver | `@neondatabase/serverless`, HTTP/WebSocket, runtime optimizations | [neon-serverless.md](https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md) |
 | Neon JS SDK | Neon Auth + Data API, PostgREST-style queries, typed client | [neon-js.md](https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md) |
-| Developer Tools | `npx neonctl@latest init`, VSCode, Neon MCP server | [devtools.md](https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md) |
-| Neon CLI | Terminal/scripts/CI with `neonctl` | [neon-cli.md](https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md) |
+| Developer Tools | `npx neon@latest init`, VSCode, Neon MCP server | [devtools.md](https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md) |
+| Neon CLI | Terminal/scripts/CI with `neon` | [neon-cli.md](https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md) |
 | Neon REST API | Direct HTTP automation, API key auth, rate limits, polling | [neon-rest-api.md](https://neon.com/docs/ai/skills/neon-postgres/references/neon-rest-api.md) |
 | Neon TypeScript SDK | Typed Neon control in TypeScript (`@neon/sdk`) | [neon-typescript-sdk.md](https://neon.com/docs/ai/skills/neon-postgres/references/neon-typescript-sdk.md) |
 | Neon Python SDK | Programmatic Neon management in Python (`neon-api`) | [neon-python-sdk.md](https://neon.com/docs/ai/skills/neon-postgres/references/neon-python-sdk.md) |

--- a/src/components/pages/cli/hero/code-tabs/code-tabs.jsx
+++ b/src/components/pages/cli/hero/code-tabs/code-tabs.jsx
@@ -16,13 +16,13 @@ const codeSnippets = [
     name: 'Windows',
     iconName: 'windows',
     language: 'text',
-    code: `npm install -g neonctl`,
+    code: `npm install -g neon`,
   },
   {
     name: 'Linux',
     iconName: 'linux',
     language: 'text',
-    code: `npm install -g neonctl`,
+    code: `npm install -g neon`,
   },
 ];
 

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -15,7 +15,7 @@ const META = {
   auth: { desc: 'Browser OAuth; stores credentials locally.', examples: ['neon auth'] },
   init: {
     desc: 'Wire up MCP, agent skills, and editor (Cursor/VS Code/Claude).',
-    examples: ['npx neonctl@latest init'],
+    examples: ['npx neon@latest init'],
   },
   link: {
     desc: 'Bind the directory to a project; writes .neon and pulls env.',

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.test.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.test.js
@@ -20,7 +20,7 @@ describe('cli-command-index meta', () => {
     }
     for (const example of meta.examples || []) {
       const tokens = example
-        .replace(/^npx neonctl@latest\s+/, '')
+        .replace(/^npx neon(ctl)?@latest\s+/, '')
         .replace(/^neonctl\s+/, '')
         .replace(/^neon\s+/, '')
         .split(/\s+/);

--- a/src/components/pages/doc/neon-init-modal/neon-init-modal.jsx
+++ b/src/components/pages/doc/neon-init-modal/neon-init-modal.jsx
@@ -14,8 +14,8 @@ import CheckIcon from './images/check.inline.svg';
 import CopyIcon from './images/copy.inline.svg';
 
 const TABS = [
-  { id: 'npm', label: 'npm', command: 'npx neonctl@latest init' },
-  { id: 'brew', label: 'brew', command: 'neonctl init' },
+  { id: 'npm', label: 'npm', command: 'npx neon@latest init' },
+  { id: 'brew', label: 'brew', command: 'neon init' },
 ];
 
 const NeonInitModal = ({ isOpen, onClose }) => {

--- a/src/components/pages/home/ai/ai.jsx
+++ b/src/components/pages/home/ai/ai.jsx
@@ -51,7 +51,7 @@ const AI = () => (
             <p className="sm::text-[15px] ml-3 text-[20px] leading-snug tracking-tight text-white lg:text-[18px] sm:ml-0">
               Try for yourself, start building <br className="hidden md:block" /> with Neon now.
             </p>
-            <CopyCodeButton code="npx neonctl init" copyText="npx neonctl@latest init" />
+            <CopyCodeButton code="npx neon init" copyText="npx neon@latest init" />
           </div>
         </div>
 

--- a/src/components/pages/home/cta/cta.jsx
+++ b/src/components/pages/home/cta/cta.jsx
@@ -32,8 +32,8 @@ const CTA = () => (
             </Button>
             <CopyCodeButton
               className="inline-flex items-center gap-x-3 font-mono font-medium!"
-              code="npx neonctl init"
-              copyText="npx neonctl@latest init"
+              code="npx neon init"
+              copyText="npx neon@latest init"
             />
           </div>
         </div>

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -41,7 +41,7 @@ module.exports = {
       url: 'https://neon.com/docs/reference/api.md',
     },
     {
-      label: 'Neon CLI reference (neonctl commands, options, and usage)',
+      label: 'Neon CLI reference (neon commands, options, and usage)',
       url: 'https://neon.com/docs/cli.md',
     },
   ],
@@ -85,7 +85,7 @@ module.exports = {
     {
       name: 'Neon CLI',
       description:
-        'Install: `npm i -g neonctl`. Use this for terminal-first workflows, scripts, and CI/CD automation with `neonctl`.',
+        'Install: `npm i -g neon`. Use this for terminal-first workflows, scripts, and CI/CD automation with `neon`.',
     },
     {
       name: 'AI & Agents',

--- a/src/utils/ai-agent-detection.js
+++ b/src/utils/ai-agent-detection.js
@@ -131,7 +131,7 @@ const DEFAULT_404_LINKS = [
   {
     label: 'Neon CLI',
     href: '/docs/cli.md',
-    description: 'neonctl commands, options, and usage',
+    description: 'neon commands, options, and usage',
   },
 ];
 

--- a/src/utils/get-table-of-contents.js
+++ b/src/utils/get-table-of-contents.js
@@ -34,16 +34,17 @@ const buildNestedToc = (headings, currentLevel, currentIndex = 0) => {
     const title = stripTocOnlyMarker(currentHeading.title.replace(/(#+)\s/, ''));
     const customId = extractCustomId(title);
     const cleanedTitle = title.replace(/\(#[^)]+\)$/, '').trim();
-    // CLI reference pages use full-path headings ("### neonctl branches
+    // CLI reference pages use full-path headings ("### neon branches
     // restore (#restore)") for unambiguous, copy-pasteable anchors. Keep the
     // right-rail label short: drop the binary and top-level command, leaving
     // "restore" (or "oauth-provider add" on nested pages). Double-gated on a
-    // custom ID so ordinary headings that merely mention neonctl (e.g.
-    // "### neonctl init" in prose docs) keep their full text.
+    // custom ID so ordinary headings that merely mention the CLI (e.g.
+    // "### neon init" in prose docs) keep their full text. The legacy
+    // `neonctl` binary name is still matched for older/back-compat headings.
     let displayTitle = cleanedTitle;
-    if (customId && /^neonctl\s+\S+/.test(cleanedTitle)) {
-      const rest = cleanedTitle.replace(/^neonctl\s+\S+\s*/, '').trim();
-      displayTitle = rest || cleanedTitle.replace(/^neonctl\s+/, '');
+    if (customId && /^neon(ctl)?\s+\S+/.test(cleanedTitle)) {
+      const rest = cleanedTitle.replace(/^neon(ctl)?\s+\S+\s*/, '').trim();
+      displayTitle = rest || cleanedTitle.replace(/^neon(ctl)?\s+/, '');
     }
     const titleWithInlineCode = displayTitle.replace(/`([^`]+)`/g, '<code>$1</code>');
 

--- a/src/utils/get-table-of-contents.test.js
+++ b/src/utils/get-table-of-contents.test.js
@@ -27,9 +27,9 @@ describe('getTableOfContents', () => {
     const content = [
       '## Subcommands',
       '',
-      '### neonctl branches restore (#restore)',
+      '### neon branches restore (#restore)',
       '',
-      '### neonctl neon-auth oauth-provider add (#oauth-provider-add)',
+      '### neon neon-auth oauth-provider add (#oauth-provider-add)',
       '',
     ].join('\n');
     const toc = getTableOfContents(content);
@@ -40,14 +40,20 @@ describe('getTableOfContents', () => {
     expect(subItems[1].id).toBe('oauth-provider-add');
   });
 
+  it('still shortens legacy neonctl full-path headings with custom ids', () => {
+    const toc = getTableOfContents('## Subcommands\n\n### neonctl branches restore (#restore)\n');
+    expect(toc[0].items[0].title).toBe('restore');
+    expect(toc[0].items[0].id).toBe('restore');
+  });
+
   it('falls back to dropping only the binary for single-command headings', () => {
-    const toc = getTableOfContents('## neonctl connection-string (#connection-string)\n');
+    const toc = getTableOfContents('## neon connection-string (#connection-string)\n');
     expect(toc[0].title).toBe('connection-string');
   });
 
-  it('leaves neonctl headings without custom ids untouched', () => {
-    const toc = getTableOfContents('## neonctl init\n');
-    expect(toc[0].title).toBe('neonctl init');
+  it('leaves CLI headings without custom ids untouched', () => {
+    const toc = getTableOfContents('## neon init\n');
+    expect(toc[0].title).toBe('neon init');
   });
 
   it('ignores headings inside code blocks', () => {


### PR DESCRIPTION
## Summary

The Neon CLI is now published as `neon` (`npm i -g neon`, `npx neon@latest`). `neonctl` still works as an alias for the exact same CLI — nothing breaks, no migration or re-auth needed — but docs and user-facing examples should reference the cleaner `neon` command going forward.

Changes:
- **Homepage**: CTA + AI section copy buttons → `npx neon init` / `npx neon@latest init`
- **CLI install hero tabs**: `npm install -g neon` (Windows/Linux)
- **`neon init` modal**: npm tab `npx neon@latest init`, brew tab `neon init`
- **CLI command index** example + **API reference** interface card copy
- **LLM index / agent-detection** descriptions and **agentic provisioning** context table
- **ToC label shortener** now matches `neon` (and legacy `neonctl`) full-path CLI headings — fixes the right-rail labels for the reference pages, whose headings were already renamed to `neon …` on `main` (they were no longer being shortened). Test coverage added for both `neon` and legacy `neonctl` headings.

## Intentionally left as-is

These are real identifiers, not command references, so changing them would break things or be inaccurate:
- Homebrew formula name `neonctl` (`brew install neonctl`)
- Release binary asset names (`neonctl-macos-x64`, `neonctl-win-x64.exe`, …)
- Config path `~/.config/neonctl/credentials.json`
- The `neonctl-init-{timestamp}` API-key name the CLI generates
- Redirect slugs (`/docs/neonctl`) and the `neonctl_auth.png` image
- The intentional "`neonctl` is an alias for `neon`" explanations
- Internal docs-check pipeline folder/schema (`scripts/docs-checks/neonctl/`, `neonctlVersion`)

## Test plan

- [x] `vitest run` for `get-table-of-contents.test.js` and `cli-command-index/meta.test.js` (9 passed)
- [ ] Visual check: homepage CTA, `/cli` install tabs, `neon init` modal render `neon`
- [ ] Visual check: CLI reference right-rail ToC labels are shortened (e.g. `enable`, `oauth-provider add`)