### PR TITLE
docs: backend service general updates

### DIFF
--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:22:11.599Z'
+updatedOn: '2026-07-14T20:35:24.380Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -123,6 +123,8 @@ When your code runs inside Neon Functions, both gateway env vars are injected au
 | -------------------------- | --------------------------------------------------- |
 | `NEON_AI_GATEWAY_TOKEN`    | Bearer token for the AI Gateway                     |
 | `NEON_AI_GATEWAY_BASE_URL` | Branch gateway host with `https://` prefix, no path |
+
+See [Environment variables](/docs/compute/functions/environment-variables) for the full list of variables Neon injects into a function.
 
 Configure an OpenAI SDK by setting `apiKey` and `baseURL` from these variables. Use the OpenAI Responses dialect for `responses.create()`:
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-06-15T19:57:08.490Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -15,7 +15,7 @@ updatedOn: '2026-06-15T19:57:08.490Z'
 
 ## Get access
 
-You need a new project in the AWS us-east-2 region, and foundation model access requires a paid Neon plan. When your account is enabled, you'll receive an email and a Discord invite.
+You need a project in the AWS us-east-2 region, and foundation model access requires a paid Neon plan. When your account is enabled, you'll receive an email and a Discord invite.
 
 ## Create a credential
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,10 +6,16 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-07-14T19:10:20.806Z'
 ---
 
 <PrivatePreviewEnquire/>
+
+To set up Neon AI Gateway with an AI coding assistant, install the Neon Platform (`neon`) and Neon AI Gateway skills:
+
+```bash
+npx skills add neondatabase/agent-skills -s neon -s neon-ai-gateway
+```
 
 <Steps>
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -6,7 +6,7 @@ summary: >-
   OpenAI, Google, Meta, Databricks, and Alibaba. Use short model IDs
   like claude-sonnet-4-6 or gpt-5-mini. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-07-13T13:28:24.776Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -22,6 +22,12 @@ Model availability may vary by region. The catalog expands over time, so check b
 </Admonition>
 
 The full catalog is published as the [`neon` provider on models.dev](https://models.dev/providers/neon) — the machine-readable source of truth — and served as JSON at [`neon.com/models.json`](https://neon.com/models.json).
+
+## Model access
+
+Every project with AI Gateway access can call open-weight models (Llama, Qwen, gpt-oss, and others) right away. Check **Open weights only** in the [model catalog](#available-models) to see the full list.
+
+Foundation models from Anthropic, OpenAI, and Google are being rolled out gradually as we expand capacity. Request access from the **AI Gateway** page in the Neon Console.
 
 ## Quick picks
 
@@ -90,5 +96,7 @@ Models are hosted by Databricks and served through Neon AI Gateway. You are resp
 | Google Gemini | [Google Cloud Acceptable Use Policy](https://cloud.google.com/terms/aup) · [Google Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy) |
 | Google Gemma  | [Gemma Terms of Use](https://ai.google.dev/gemma/terms) · [Gemma Prohibited Use Policy](https://ai.google.dev/gemma/prohibited_use_policy)                                          |
 | Meta          | Terms differ by Llama version. See the Notes column in the [Meta models table](#meta).                                                                                              |
+
+> AI Gateway doesn't currently log or store the prompts, completions, or other request content you send through it, though this isn't a formal guarantee and is subject to change during the private preview. Neon doesn't yet offer a zero-data-retention agreement, an opt-out from provider training on your requests, or regional data residency; all requests are routed through AWS us-east-2 regardless of your project's region.
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -6,7 +6,7 @@ summary: >-
   OpenAI, Google, Meta, Databricks, and Alibaba. Use short model IDs
   like claude-sonnet-4-6 or gpt-5-mini. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-07-14T20:34:24.495Z'
+updatedOn: '2026-07-15T11:08:18.153Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -45,16 +45,15 @@ Not sure which model to use? Start here.
 
 ## Rate limits
 
-During the private preview, the following limits apply:
+During the private preview, the following limit applies per account:
 
-| Limit                                   | Value         |
-| --------------------------------------- | ------------- |
-| Per model (tokens per minute)           | 200,000 TPM   |
-| All models combined (tokens per minute) | 1,100,000 TPM |
+| Limit                   | Value   |
+| ----------------------- | ------- |
+| Tokens per minute (TPM) | 200,000 |
 
-If you hit a limit, you'll receive a `429 Too Many Requests` response. Requests resume when the rate limit window resets.
+If you hit the limit, you'll receive a `429 Too Many Requests` response with a message like `ai gateway TPM limit exceeded for model "<model-id>"`. Requests resume when the rate limit window resets.
 
-These limits are counted against total tokens (input and output combined), not input alone. Upstream output token limits (20,000 OTPM for most models) apply independently, so you can hit a `429` on output tokens without reaching the gateway's TPM limit. See [Databricks Foundation Model API limits](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits) for details.
+The TPM limit is counted against total tokens (input and output combined), not input alone. Upstream output token limits (20,000 OTPM for most models) apply independently, so you can hit a `429` on output tokens without reaching the gateway's TPM limit. See [Databricks Foundation Model API limits](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits) for details.
 
 Once billing begins, usage will also be capped by your prepaid credit balance. See [Pricing](#pricing) below.
 
@@ -137,7 +136,5 @@ Models are hosted by Databricks and served through Neon AI Gateway. You are resp
 | Google Gemini | [Google Cloud Acceptable Use Policy](https://cloud.google.com/terms/aup) · [Google Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy) |
 | Google Gemma  | [Gemma Terms of Use](https://ai.google.dev/gemma/terms) · [Gemma Prohibited Use Policy](https://ai.google.dev/gemma/prohibited_use_policy)                                          |
 | Meta          | Terms differ by Llama version. See the Notes column in the [Meta models table](#meta).                                                                                              |
-
-> AI Gateway doesn't currently log or store the prompts, completions, or other request content you send through it, though this isn't a formal guarantee and is subject to change during the private preview. Neon doesn't yet offer a zero-data-retention agreement, an opt-out from provider training on your requests, or regional data residency; all requests are routed through AWS us-east-2 regardless of your project's region.
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -6,7 +6,7 @@ summary: >-
   OpenAI, Google, Meta, Databricks, and Alibaba. Use short model IDs
   like claude-sonnet-4-6 or gpt-5-mini. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-07-15T11:08:18.153Z'
+updatedOn: '2026-07-15T15:43:20.389Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -45,7 +45,7 @@ Not sure which model to use? Start here.
 
 ## Rate limits
 
-During the private preview, the following limit applies per account:
+During the beta, the following limit applies per account:
 
 | Limit                   | Value   |
 | ----------------------- | ------- |
@@ -59,7 +59,7 @@ Once billing begins, usage will also be capped by your prepaid credit balance. S
 
 ## Pricing
 
-Inference is free during the private preview. See [Pricing](/docs/ai-gateway/overview#pricing) for what to expect when billing begins.
+Inference is free during the beta. See [Pricing](/docs/ai-gateway/overview#pricing) for what to expect when billing begins.
 
 Independent of billing, Neon enforces an account-level daily spend cap on AI Gateway usage, separate from the per-minute rate limits above. If your account exceeds it, every AI Gateway endpoint returns `429 Too Many Requests` with error code `REQUEST_LIMIT_EXCEEDED` until the cap resets or the block is lifted. This can happen even though inference itself isn't billed yet. Neon hasn't published a fixed cap value; it isn't a flat number and can vary by account. See [Troubleshooting](/docs/ai-gateway/troubleshooting#429-account-quota-exceeded) if you hit this.
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,14 +6,14 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-07-14T20:34:24.495Z'
+updatedOn: '2026-07-15T15:43:20.389Z'
 ---
 
-<RequestForm type="backend-platform" title="Get early access to Neon AI Gateway" description="Neon AI Gateway is in private preview. Drop your email and we'll reach out with access." />
+<RequestForm type="backend-platform" title="Get early access to Neon AI Gateway" description="Neon AI Gateway is in beta. Drop your email and we'll reach out with access." />
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
 
-> During the private preview, AI Gateway is available in the **AWS us-east-2** region only, and requires a paid Neon plan. Inference is free during the preview. See [Pricing](#pricing) for what to expect when billing begins.
+> AI Gateway is in beta and available only in **AWS US East (Ohio) (`aws-us-east-2`)**, so create your project there to use it. It requires a paid Neon plan. Inference is free during beta. See [Pricing](#pricing) for what to expect when billing begins.
 
 <Admonition type="important">
 Participation in this Private Preview is subject to our Private Preview Terms. Access is not available to users, organizations, or entities located in or operating from regions restricted by Anthropic's [Supported Regions Policy](https://www.anthropic.com/supported-countries). This restriction also applies to entities that are majority owned, directly or indirectly, by companies headquartered in unsupported regions.
@@ -27,11 +27,11 @@ Participation in this Private Preview is subject to our Private Preview Terms. A
 
 ## Pricing
 
-AI Gateway pricing isn't finalized. Here's what to expect once it moves out of private preview:
+AI Gateway pricing isn't finalized. Here's what to expect once it moves out of beta:
 
 - **Paid plans only.** AI Gateway will be available on Neon's Launch and Scale plans. There's no difference in AI Gateway pricing or model access between the two plans.
 - **No markup.** Neon charges the same per-token rate as the model provider. Published provider prices are passed on to users with no additional markup.
-- **Free for now.** Inference remains free through the end of the private preview. Billing starts when AI Gateway reaches GA.
+- **Free for now.** Inference remains free through the end of the beta. Billing starts when AI Gateway reaches GA.
 
 We'll publish exact per-model rates on the [Neon pricing page](https://neon.com/pricing) and update this page before billing begins.
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,14 +6,14 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-07-13T15:15:20.992Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <RequestForm type="backend-platform" title="Get early access to Neon AI Gateway" description="Neon AI Gateway is in private preview. Drop your email and we'll reach out with access." />
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from Anthropic, OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI or Anthropic SDK works without code changes. Just point it at your branch endpoint.
 
-> During the private preview, AI Gateway is available for **new projects** in the **AWS us-east-2** region only, and requires a paid Neon plan. Inference is free during the preview. See [Pricing](#pricing) for what to expect when billing begins.
+> During the private preview, AI Gateway is available in the **AWS us-east-2** region only, and requires a paid Neon plan. Inference is free during the preview. See [Pricing](#pricing) for what to expect when billing begins.
 
 <Admonition type="important">
 Participation in this Private Preview is subject to our Private Preview Terms. Access is not available to users, organizations, or entities located in or operating from regions restricted by Anthropic's [Supported Regions Policy](https://www.anthropic.com/supported-countries). This restriction also applies to entities that are majority owned, directly or indirectly, by companies headquartered in unsupported regions.

--- a/content/docs/ai-gateway/troubleshooting.md
+++ b/content/docs/ai-gateway/troubleshooting.md
@@ -5,7 +5,7 @@ summary: >-
   Solutions for common errors when using Neon AI Gateway, including
   authentication failures, model errors, quota limits, and upstream issues.
 enableTableOfContents: true
-updatedOn: '2026-07-14T20:34:24.495Z'
+updatedOn: '2026-07-15T11:08:18.153Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -117,7 +117,7 @@ Your account's AI Gateway quota is blocked. This can happen if you exceed the to
 }
 ```
 
-If the block is due to the per-minute token limit specifically rather than the daily cap, the message reads `ai gateway per-minute token limit exceeded...` instead.
+If the block is due to the per-minute token limit specifically rather than the daily cap, the message reads `ai gateway TPM limit exceeded for model "<model-id>"` instead.
 
 **Fix:** Check the `Retry-After` header. If present, the block is temporary and will lift at that time. If absent, the block is permanent until resolved. Contact support for a quota increase or to resolve a permanent block. See [Rate limits](/docs/ai-gateway/models#rate-limits) for current per-minute quota values.
 

--- a/content/docs/compute/functions/authentication.md
+++ b/content/docs/compute/functions/authentication.md
@@ -6,12 +6,16 @@ summary: >-
   Auth JWT against the injected JWKS, check an API key, and add CORS when the
   browser calls the function directly.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T20:35:24.380Z'
 ---
 
 <PrivatePreviewEnquire/>
 
 A Neon Function has a public HTTPS URL, so anyone who knows it can reach it. There's no platform gate in front of your handler. Authenticate the caller yourself, at the top of the handler, and reject anything that doesn't check out.
+
+<Callout title="Looking for credentials to call Neon services?">
+This page covers verifying inbound requests to your function. For the credentials Neon injects into a function to call Object Storage or AI Gateway, see [Environment variables](/docs/compute/functions/environment-variables), [Object Storage authentication](/docs/storage/authentication#credentials-in-neon-functions), or [AI Gateway authentication](/docs/ai-gateway/authentication#credentials-in-neon-functions).
+</Callout>
 
 How you authenticate depends on who calls the function:
 

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -7,7 +7,7 @@ summary: >-
   neon deploy. The function gets a public HTTPS URL with DATABASE_URL
   injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-07-02T22:08:19.260Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -22,7 +22,7 @@ A function takes a request and returns a web response, running on long-lived Nod
 - The latest `neon`, installed and authenticated. Functions commands are new and change often during the preview, so upgrade before you start (`npm install -g neon@latest`).
 - Node.js 20 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
-Functions are available on new projects in AWS us-east-2 only, created on or after June 15, 2026.
+Functions are available in AWS us-east-2 only.
 
 `neon init --preview` is designed to be run by your AI coding assistant. It outputs structured instructions that guide the agent through setup. To install the Neon Platform (`neon`) and Neon Functions skills separately:
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -6,7 +6,7 @@ summary: >-
   API, AI agent, real-time server, or webhook handler that runs next to your
   Postgres data, with DATABASE_URL injected automatically.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-07-14T19:13:13.774Z'
 ---
 
 Neon Functions are serverless compute you deploy onto a Neon branch, so your backend code runs right next to your database. Use them to host an API, an AI agent, a real-time server, or a webhook handler without standing up separate infrastructure.
@@ -47,7 +47,7 @@ A [Hono](https://hono.dev) app exports the object shape, so `export default app`
 
 ## When to use Neon Functions
 
-- **REST APIs and CRUD backends**: request in, JSON out, queries running next to Postgres. See [Get started](/docs/compute/functions/get-started).
+- **REST APIs and CRUD backends**: request in, JSON out, queries running next to Postgres. See [Quickstart](/docs/compute/functions/get-started).
 - **AI agents**: stream tokens back across multiple model calls and tool invocations without a short execution limit cutting the run off. See [AI agents](/docs/compute/functions/agents).
 - **Real-time apps**: WebSocket servers for chat and presence, or SSE for live updates. See [WebSockets and SSE](/docs/compute/functions/websockets).
 - **MCP servers**: expose database-backed tools to AI clients over a single `fetch` endpoint. See the [with-mcp example](https://github.com/neondatabase/examples/tree/main/with-mcp).
@@ -61,13 +61,13 @@ Functions are backend primitives, not full-stack app hosting. Host your app on V
 - **Add a function to a full-stack app.** Your Next.js or TanStack Start app owns the UI, auth, and most routes. When one workload outgrows the host's short serverless limit (a WebSocket or SSE server, or a long-running agent), move only that piece onto a function and call it directly from the client. See [Authentication](/docs/compute/functions/authentication) for the direct-call pattern.
 - **Run the backend on functions.** When the frontend is client-only (a React or TanStack SPA), the client calls functions directly: REST APIs, request/response agents, MCP servers, and anything stateful that belongs close to Postgres and Object Storage.
 
-## Get started
+## Quickstart
 
 <DetailIconCards>
 
 <a href="/docs/compute/functions/preview-access" description="Request access and learn what's included in the private preview." icon="screen">Preview access</a>
 
-<a href="/docs/compute/functions/get-started" description="Deploy your first function and call it over HTTP in under 5 minutes." icon="code">Get started</a>
+<a href="/docs/compute/functions/get-started" description="Deploy your first function and call it over HTTP in under 5 minutes." icon="code">Quickstart</a>
 
 <a href="/docs/compute/functions/agents" description="Run streaming, tool-calling AI agents next to your data." icon="openai">AI agents</a>
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -6,7 +6,7 @@ summary: >-
   API, AI agent, real-time server, or webhook handler that runs next to your
   Postgres data, with DATABASE_URL injected automatically.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:13:13.774Z'
+updatedOn: '2026-07-14T20:35:24.380Z'
 ---
 
 Neon Functions are serverless compute you deploy onto a Neon branch, so your backend code runs right next to your database. Use them to host an API, an AI agent, a real-time server, or a webhook handler without standing up separate infrastructure.
@@ -83,7 +83,7 @@ Functions are backend primitives, not full-stack app hosting. Host your app on V
 
 </DetailIconCards>
 
-## Examples and templates
+## Starter templates
 
 Each example is a complete, runnable build. Read the source on GitHub, or scaffold one with `neon bootstrap --template <id>` (it copies the files, links a Neon project, and pulls env vars). You can also browse them at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/).
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -6,7 +6,7 @@ summary: >-
   API, AI agent, real-time server, or webhook handler that runs next to your
   Postgres data, with DATABASE_URL injected automatically.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 Neon Functions are serverless compute you deploy onto a Neon branch, so your backend code runs right next to your database. Use them to host an API, an AI agent, a real-time server, or a webhook handler without standing up separate infrastructure.
@@ -19,7 +19,7 @@ What makes Neon Functions different from lambda-style serverless?
 
 Functions run on Neon's own compute platform, the same infrastructure that runs your Postgres, so they sit in the same region as your data.
 
-> During the private preview, Functions are available for **new projects** in the **AWS us-east-2** region only, created on or after June 15, 2026. See [Preview access](/docs/compute/functions/preview-access) for what's included.
+> During the private preview, Functions are available in the **AWS us-east-2** region only. See [Preview access](/docs/compute/functions/preview-access) for what's included.
 
 ## Request/response, not background jobs
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -5,7 +5,7 @@ summary: >-
   Neon Functions is in private preview in the AWS us-east-2 region. Learn how
   to request access, what's included, and the current limitations.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-07-14T20:35:24.380Z'
 ---
 
 ## Request access
@@ -14,15 +14,15 @@ Sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-bui
 
 ## What's included
 
-- Deploy Node.js 24 HTTP handlers to Neon branches
-- Web Fetch API handler interface (`fetch(request)` export)
-- Long-running compute: WebSocket servers, SSE endpoints, AI agents
+- [Deploy Node.js 24 HTTP handlers](/docs/compute/functions/get-started) to Neon branches
+- [Web Fetch API handler interface](/docs/compute/functions/overview#request-response-not-background-jobs) (`fetch(request)` export)
+- Long-running compute: [WebSocket servers, SSE endpoints](/docs/compute/functions/websockets), [AI agents](/docs/compute/functions/agents)
 - Postgres, [AI Gateway](/docs/ai-gateway/overview), and [Object Storage](/docs/storage/overview) credentials injected automatically when the service is enabled
-- `neon dev` for local development with hot reload
-- `neon.ts` config with `neon deploy` for declarative branch setup
-- `neon functions deploy` for direct CLI deployment
-- Neon API for programmatic deployment
-- Branch-scoped functions: each branch runs its own version at its own URL
+- [`neon dev`](/docs/cli/dev) for local development with hot reload
+- [`neon.ts`](/docs/reference/neon-ts) config with [`neon deploy`](/docs/cli/deploy) for declarative branch setup
+- [`neon functions deploy`](/docs/cli/functions#deploy) for direct CLI deployment
+- [Neon API](/docs/compute/functions/deploy#deploy-with-the-api) for programmatic deployment
+- [Branch-scoped functions](/docs/compute/functions/overview): each branch runs its own version at its own URL
 
 ## What's not included
 

--- a/content/docs/compute/functions/preview-access.md
+++ b/content/docs/compute/functions/preview-access.md
@@ -2,16 +2,15 @@
 title: Neon Functions preview access
 subtitle: What's included in the Neon Functions private preview.
 summary: >-
-  Neon Functions is in private preview for new projects in the AWS us-east-2
-  region. Learn how to request access, what's included, and the current
-  limitations.
+  Neon Functions is in private preview in the AWS us-east-2 region. Learn how
+  to request access, what's included, and the current limitations.
 enableTableOfContents: true
-updatedOn: '2026-06-24T23:12:20.545Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 ## Request access
 
-Sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends#access). The team will reach out with access details. Functions are available on new projects in AWS us-east-2 only, created on or after June 15, 2026.
+Sign up at [neon.com/blog/were-building-backends](https://neon.com/blog/were-building-backends#access). The team will reach out with access details. Functions are available in AWS us-east-2 only.
 
 ## What's included
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-06-26T10:41:58.102Z'
+updatedOn: '2026-07-15T11:08:18.153Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -53,18 +53,21 @@ Because each isolate is its own process and handles concurrent requests, module-
 - **Not shared across isolates**: every isolate holds its own module state. Keep `max` small on `pg` pools (for example, 5). The effective connection count is `max` × the number of live isolates. Any module-scope setup (seeding, migrations) runs once per isolate, so make it safe to repeat or guard it with a Postgres advisory lock.
 - **Lost on eviction**: in-memory state disappears when an isolate is evicted. Persist anything that matters in Postgres.
 
+To prevent abusive use, Neon also enforces an account-wide limit of **100 concurrent invocations** across all your functions. This is a default, not a hard ceiling tied to your plan; due to internal load balancing, the effective ceiling can run modestly higher. Exceeding it returns a `429 Too Many Requests` with the plain-text body `per-account concurrency limit reached` and a `Retry-After` header (in seconds). A slot frees up as soon as one of your in-flight requests completes, so a near-term retry is usually enough.
+
 ## Slug constraints
 
 Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment. See [Slugs](/docs/compute/functions/deploy#slugs) for the full rules.
 
 ## Runtime
 
-| Property    | Value                                                                                                                                           |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Runtime     | Node.js 24                                                                                                                                      |
-| Isolation   | microVM per isolate                                                                                                                             |
-| Concurrency | Multiple requests in flight per isolate (interleaved on the event loop), scaling out with additional isolates. See [Concurrency](#concurrency). |
-| Memory      | 2048 MiB (fixed during the private preview, not configurable)                                                                                   |
+| Property          | Value                                                                                                                                           |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime           | Node.js 24                                                                                                                                      |
+| Isolation         | microVM per isolate                                                                                                                             |
+| Concurrency       | Multiple requests in flight per isolate (interleaved on the event loop), scaling out with additional isolates. See [Concurrency](#concurrency). |
+| Concurrency limit | 100 concurrent invocations per account (default). See [Concurrency](#concurrency).                                                              |
+| Memory            | 2048 MiB (fixed during the private preview, not configurable)                                                                                   |
 
 ## Environment variables
 

--- a/content/docs/get-started/platform-private-preview.md
+++ b/content/docs/get-started/platform-private-preview.md
@@ -24,9 +24,9 @@ You declare all of it in one `neon.ts` file, and it branches together: fork a br
 
 ## Check your access
 
-Access is a flag on your Neon account. If you received the invite email, your flag should already be set. Preview services work on **new projects** in **AWS us-east-2** only. They can't be enabled on existing projects. All usage during the preview is free, subject to fair usage. See [AI Gateway pricing](/docs/ai-gateway/overview#pricing) for what to expect once billing begins.
+Access is a flag on your Neon account. If you received the invite email, your flag should already be set. Preview services work in **AWS us-east-2** only. All usage during the preview is free, subject to fair usage. See [AI Gateway pricing](/docs/ai-gateway/overview#pricing) for what to expect once billing begins.
 
-To confirm your access, go to [console.neon.tech](https://console.neon.tech), create a new project in **US East (Ohio)** (`us-east-2`), and check the left navigation for **Storage**, **Credentials**, **AI Gateway**, and **Functions**. If those don't appear, post in [#neon-platform-private-preview](https://discord.com/channels/1176467419317940276/1514002115024916643) on Discord and we'll fix your flag.
+To confirm your access, go to [console.neon.tech](https://console.neon.tech), open a project in **US East (Ohio)** (`us-east-2`), and check the left navigation for **Storage**, **Credentials**, **AI Gateway**, and **Functions**. If those don't appear, post in [#neon-platform-private-preview](https://discord.com/channels/1176467419317940276/1514002115024916643) on Discord and we'll fix your flag.
 
 ![Neon app backend navigation](/docs/get-started/neon_app_backend.png)
 
@@ -171,7 +171,7 @@ For inspiration, see [Build on Neon](https://build-on-neon.vercel.app/): an inde
 
 ## Known limitations
 
-- New projects in AWS us-east-2 only. Existing projects don't work.
+- AWS us-east-2 only.
 - Functions: memory is fixed at 2048 MiB.
 - Logs from deployed functions can't be retrieved yet. Use `neon dev` during development, and have deployed functions write diagnostics to Postgres. Error trackers work today: `@sentry/node` bundles and runs fine; set `SENTRY_DSN` as a deploy-time env var.
 

--- a/content/docs/guides/astro.md
+++ b/content/docs/guides/astro.md
@@ -9,7 +9,7 @@ summary: >-
   node-postgres, postgres.js, and the Neon serverless driver, and shows query
   patterns for both .astro page components and server endpoint API routes.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/astro-serverless-prompt.md" 
@@ -230,5 +230,12 @@ When you run `npm run dev` you can expect to see something like the following wh
 ```
 
 </Steps>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/branching-intro.md
+++ b/content/docs/guides/branching-intro.md
@@ -8,7 +8,7 @@ summary: >-
   GitHub Actions, or Githooks, and for connecting branches to Vercel preview
   deployments or restoring data with Time Travel.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 Find detailed information and instructions about Neon's branching feature and how you can integrate branching with your development workflows.
@@ -28,6 +28,12 @@ Learn about branching and how you can apply it in your development workflows.
 <a href="/docs/guides/branching-schema-only" description="Learn how you can protect sensitive data with schema-only branches" icon="split-branch">Schema-only branches</a>
 
 <a href="/docs/auth/branching-authentication" description="Test sign-in, OAuth, and permissions in isolated branches without touching production" icon="lock-landscape">Branching authentication</a>
+
+<a href="/docs/storage/overview" description="Each branch gets its own isolated Object Storage namespace" icon="data">Neon Object Storage</a>
+
+<a href="/docs/compute/functions/overview" description="Each branch runs its own Neon Functions deployment at its own URL" icon="code">Neon Functions</a>
+
+<a href="/docs/ai-gateway/overview" description="Each branch gets its own Neon AI Gateway endpoint" icon="sparkle">Neon AI Gateway</a>
 
 </DetailIconCards>
 

--- a/content/docs/guides/django.md
+++ b/content/docs/guides/django.md
@@ -15,7 +15,7 @@ redirectFrom:
   - /docs/integrations/
   - /docs/quickstart/django/
   - /docs/cloud/integrations/django/
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/django-prompt.md" 
@@ -207,6 +207,7 @@ Learn how to use Django with Neon Postgres with this blog post and the accompany
 
 ## Next steps
 
-- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database.
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database.
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential.
 
 <NeedHelp/>

--- a/content/docs/guides/dotnet-entity-framework.md
+++ b/content/docs/guides/dotnet-entity-framework.md
@@ -12,7 +12,7 @@ summary: >-
   `Microsoft.EntityFrameworkCore.Design`, and `dotnet-ef`, then applying the
   initial schema with `dotnet ef database update`.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/dotnet-ef-prompt.md"
@@ -207,5 +207,10 @@ If you do not have one already, create a Neon project.
 
 - [.NET Documentation](https://learn.microsoft.com/en-us/dotnet/)
 - [Entity Framework Core](https://learn.microsoft.com/en-us/ef/)
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/dotnet-npgsql.md
+++ b/content/docs/guides/dotnet-npgsql.md
@@ -9,7 +9,7 @@ summary: >-
   injection, and credential storage in appsettings.json. For ORM-based
   alternatives, see the Entity Framework guide.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/dotnet-prompt.md" 
@@ -442,6 +442,11 @@ While this guide demonstrates how to connect to Neon using raw SQL queries, for 
 Explore the following resources to learn how to integrate ORMs with Neon:
 
 - [Connect an Entity Framework application to Neon](/docs/guides/dotnet-entity-framework)
+
+## Next steps: Neon backend services
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Resources
 

--- a/content/docs/guides/drizzle.md
+++ b/content/docs/guides/drizzle.md
@@ -10,7 +10,7 @@ summary: >-
   guide also shows how to point Drizzle at different Neon branches per
   environment by selecting a connection string based on NODE_ENV.
 enableTableOfContents: true
-updatedOn: '2026-07-02T16:34:30.445Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/drizzle-prompt.md" 
@@ -383,5 +383,12 @@ Each branch has its own connection string, available in the Neon Console or via 
 - [Drizzle with Neon Postgres](https://orm.drizzle.team/docs/tutorials/drizzle-with-neon)
 - [Schema migration with Neon Postgres and Drizzle ORM](/docs/guides/drizzle-migrations)
 - [Todo App with Neon Postgres and Drizzle ORM](https://orm.drizzle.team/docs/tutorials/drizzle-nextjs-neon)
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/elixir-ecto.md
+++ b/content/docs/guides/elixir-ecto.md
@@ -9,7 +9,7 @@ summary: >-
   Postgrex idle_interval defaults that can prevent Neon's scale-to-zero
   autosuspend from triggering.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/elixir-ecto-prompt.md" 
@@ -204,6 +204,11 @@ You can find the application code for the example above on GitHub.
 ## Next steps
 
 The [Ecto Getting Started Guide](https://hexdocs.pm/ecto/getting-started.html#content) provides additional steps that you can follow to create a schema, insert data, and run queries. See [Creating the schema](https://hexdocs.pm/ecto/getting-started.html#creating-the-schema) in the _Ecto Getting Started Guide_ to pick up where the steps in this guide leave off.
+
+## Next steps: Neon backend services
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Usage notes
 

--- a/content/docs/guides/elixir.md
+++ b/content/docs/guides/elixir.md
@@ -8,7 +8,7 @@ summary: >-
   when you want direct Postgrex access without an ORM; for Ecto-based
   integration see the Elixir Ecto guide.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/elixir-prompt.md" 
@@ -365,6 +365,11 @@ While this guide demonstrates how to connect to Neon using raw SQL queries, for 
 Explore the following resources to learn how to integrate ORMs with Neon:
 
 - [Connect an Elixir Ecto application to Neon](/docs/guides/elixir-ecto)
+
+## Next steps: Neon backend services
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Resources
 

--- a/content/docs/guides/encore.md
+++ b/content/docs/guides/encore.md
@@ -8,7 +8,7 @@ summary: >-
   guide when you want Encore to create and manage your Neon database, including
   per-pull-request Neon branch preview environments for safe schema testing.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 [Encore](https://encore.dev) is a backend development framework that uses static analysis and type-safe primitives to provide automatic infrastructure provisioning, distributed tracing, and API documentation. This guide shows you how to use Neon with Encore for production deployments.
@@ -221,5 +221,12 @@ You can find a complete Encore + Neon example application on GitHub:
 - [Encore SQL Databases](https://encore.dev/docs/ts/primitives/databases)
 - [Encore Cloud + Neon Integration](https://encore.dev/docs/platform/infrastructure/neon)
 - [Blog post: Building Production API Services with Encore and Neon](https://neon.tech/blog/building-production-api-services-with-encore-typescript-and-neon-serverless-postgres)
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/express.md
+++ b/content/docs/guides/express.md
@@ -11,7 +11,7 @@ summary: >-
   covers project creation, `DATABASE_URL` setup via `dotenv`, and connection
   pool initialization outside route handlers.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/express-prompt.md"
@@ -193,5 +193,12 @@ Run `node index.js` to view the result on [localhost:4242](localhost:4242) as fo
 - Choose the right driver for your platform. `@neondatabase/serverless` is for serverless/edge platforms without TCP support. For long-running Express servers, use `pg` or `postgres`. See [Choosing your connection method](/docs/connect/choose-connection).
 
 </details>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/go.md
+++ b/content/docs/guides/go.md
@@ -11,7 +11,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/go
   - /docs/integrations/go
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/golang-prompt.md" 
@@ -560,6 +560,11 @@ While this guide demonstrates how to connect to Neon using raw SQL queries, for 
 Explore the following resources to learn how to integrate ORMs with Neon:
 
 - [Connect a Go application to Neon using GORM](/guides/golang-gorm-postgres)
+
+## Next steps: Neon backend services
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Resources
 

--- a/content/docs/guides/hono.md
+++ b/content/docs/guides/hono.md
@@ -8,7 +8,7 @@ summary: >-
   Deno, and Edge runtimes. Each driver option includes a complete TypeScript
   route handler with Postgres query examples.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/hono-prompt.md"
@@ -156,5 +156,12 @@ Navigate to your application's URL ([localhost:3000](http://localhost:3000)). Yo
 > The specific version may vary depending on the PostgreSQL version you are using.
 
 </Steps>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/java.md
+++ b/content/docs/guides/java.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/java
   - /docs/integrations/java
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/java-prompt.md" 
@@ -499,6 +499,11 @@ While this guide demonstrates how to connect to Neon using raw SQL queries, for 
 Explore the following resources to learn how to integrate ORMs with Neon:
 
 - [Database Schema Changes with Hibernate, Spring Boot, and Neon](/guides/spring-boot-hibernate)
+
+## Next steps: Neon backend services
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Resources
 

--- a/content/docs/guides/javascript.md
+++ b/content/docs/guides/javascript.md
@@ -10,7 +10,7 @@ summary: >-
   suits serverless and edge runtimes. Bun and Deno users are directed to
   separate guides.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/javascript-prompt.md" 
@@ -678,6 +678,13 @@ Explore these guides to integrate popular data tools with Neon:
 - [Connect with Drizzle ORM](/docs/guides/drizzle)
 - [Connect with TypeORM](/docs/guides/typeorm)
 - [Connect with Sequelize](/docs/guides/sequelize)
+
+## Next steps: Neon backend services
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Using Bun or Deno
 

--- a/content/docs/guides/kysely.md
+++ b/content/docs/guides/kysely.md
@@ -10,7 +10,7 @@ summary: >-
   interface-based schema definitions, client initialization per driver,
   optional migrations via FileMigrationProvider, and CRUD query examples.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/kysely-prompt.md" 
@@ -428,3 +428,10 @@ For more advanced use cases, such as complex filters, joins, transactions, and s
 - [Kysely Documentation](https://kysely.dev/docs/intro)
 - [kysely-neon GitHub Repository](https://github.com/kysely-org/kysely-neon)
 - [Neon serverless driver](/docs/serverless/serverless-driver)
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential

--- a/content/docs/guides/laravel.md
+++ b/content/docs/guides/laravel.md
@@ -8,7 +8,7 @@ summary: >-
   that affects older PDO_PGSQL or libpq drivers, with workarounds for passing
   the endpoint ID as a URL option or in the password field.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/laravel-prompt.md" 
@@ -78,5 +78,10 @@ For schema migration with Laravel, see our guide:
 <a href="/docs/guides/laravel-migrations" description="Schema migration with Neon Postgres and Laravel" icon="app-store" icon="app-store">Laravel Migrations</a>
 
 </DetailIconCards>
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/medusajs.md
+++ b/content/docs/guides/medusajs.md
@@ -11,7 +11,7 @@ summary: >-
   and self-hosted environments such as DigitalOcean, AWS EC2, Render, and
   Fly.io.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 [Medusa](https://medusajs.com/) is an open-source headless e-commerce platform that provides a flexible backend for building modern e-commerce applications. It uses Postgres as its primary database to store all product, order, and customer data.
@@ -150,5 +150,12 @@ You can optionally enable IP whitelisting in the Neon Console to restrict databa
 - [Neon Documentation](/docs/introduction)
 - [Medusa Official Documentation](https://docs.medusajs.com/)
 - [Medusa Application Deployment Guide](https://docs.medusajs.com/learn/deployment/general)
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/micronaut-kotlin.md
+++ b/content/docs/guides/micronaut-kotlin.md
@@ -10,7 +10,7 @@ summary: >-
   The setup uses the micronaut-data-jdbc, jdbc-hikari, and flyway Micronaut
   features alongside the org.postgresql JDBC driver.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/micronaut-kotlin-prompt.md"
@@ -271,5 +271,10 @@ You have successfully connected a Micronaut Kotlin application to your Neon Post
 - [Micronaut Data JDBC documentation](https://micronaut-projects.github.io/micronaut-data/latest/guide/index.html#jdbc)
 - [Micronaut Hikari JDBC Connection Pool documentation](https://micronaut-projects.github.io/micronaut-sql/latest/guide/index.html#jdbc)
 - [Flyway](https://www.red-gate.com/products/flyway/community/)
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/nestjs.md
+++ b/content/docs/guides/nestjs.md
@@ -9,7 +9,7 @@ summary: >-
   cover Neon project creation, DATABASE_URL configuration in .env, and wiring
   a service and GET controller endpoint to query the database.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/nestjs-prompt.md"
@@ -236,5 +236,12 @@ When you run `npm run start` you can expect to see output similar to the followi
 ```
 
 </Steps>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/nextjs.md
+++ b/content/docs/guides/nextjs.md
@@ -14,7 +14,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/vercel
   - /docs/integrations/vercel
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/nextjs-prompt.md"
@@ -442,5 +442,8 @@ Neon does not provide a built-in file storage service. For managing binary file 
 ## Next steps
 
 - [Set up Managed BetterAuth](/docs/auth/quick-start/nextjs-api-only): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/node.md
+++ b/content/docs/guides/node.md
@@ -13,7 +13,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/node
   - /docs/integrations/node
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/javascript-prompt.md" 
@@ -270,5 +270,12 @@ getPgVersion();
 ## Community resources
 
 - [Serverless Node.js Tutorial – Neon Serverless Postgres, AWS Lambda, Next.js, Vercel](https://youtu.be/cxgAN7T3rq8)
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/nuxt.md
+++ b/content/docs/guides/nuxt.md
@@ -10,7 +10,7 @@ summary: >-
   node-postgres, or postgres.js), `.env` credential storage, and
   `nuxt.config.js` setup.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/nuxt-neon-prompt.md"
@@ -107,5 +107,12 @@ PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1
 ```
 
 </Steps>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/phoenix.md
+++ b/content/docs/guides/phoenix.md
@@ -9,7 +9,7 @@ summary: >-
   creation, DATABASE_URL credential storage, and config updates for dev, test,
   and runtime environments.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/phoenix-prompt.md"
@@ -149,5 +149,10 @@ mix phx.server
 ```
 
 </Steps>
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -16,7 +16,7 @@ redirectFrom:
   - /docs/integrations/prisma
   - /docs/guides/prisma-guide
   - /docs/guides/prisma-migrate
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/prisma-prompt.md" 
@@ -267,6 +267,13 @@ The `directUrl` property is available in Prisma 4.10.0 and higher.
 
 - [Schema migrations with Prisma](/docs/guides/prisma-migrations): Full tutorial for building an app with migrations
 - [Neon serverless driver](/docs/serverless/serverless-driver): Learn more about the driver powering the adapter
+
+## Next steps: Neon backend services
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Resources
 

--- a/content/docs/guides/python.md
+++ b/content/docs/guides/python.md
@@ -10,7 +10,7 @@ summary: >-
   the SQLAlchemy or Django guides when you need raw SQL driver code rather than
   an ORM.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/python-prompt.md" 
@@ -721,6 +721,11 @@ Explore the following resources to learn how to integrate ORMs with Neon:
 
 - [Connect an SQLAlchemy application to Neon](/docs/guides/sqlalchemy)
 - [Connect a Django application to Neon](/docs/guides/django)
+
+## Next steps: Neon backend services
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 ## Resources
 

--- a/content/docs/guides/quarkus-jdbc.md
+++ b/content/docs/guides/quarkus-jdbc.md
@@ -10,7 +10,7 @@ summary: >-
   datasource configuration with SSL required, and a working HTTP endpoint that
   queries the Postgres version.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/quarkus-jdbc-prompt.md"
@@ -118,5 +118,10 @@ PostgreSQL 17.5 (6bc9ef8) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0
 ```
 
 </Steps>
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/quarkus-reactive.md
+++ b/content/docs/guides/quarkus-reactive.md
@@ -9,7 +9,7 @@ summary: >-
   configuring QUARKUS_DATASOURCE_REACTIVE_URL with sslmode=require, and
   exposing a REST endpoint that queries Neon asynchronously using Mutiny.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/quarkus-reactive-prompt.md"
@@ -108,5 +108,10 @@ PostgreSQL 17.5 (6bc9ef8) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0
 ```
 
 </Steps>
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/react.md
+++ b/content/docs/guides/react.md
@@ -8,7 +8,7 @@ summary: >-
   meta-framework, since Neon must be accessed server-side in React apps. Neon
   Auth quick starts for Next.js and TanStack Router are also linked here.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 React by Facebook is an open-source front-end JavaScript library for building user interfaces based on components.
@@ -44,5 +44,11 @@ After you connect your database, add managed authentication with [Managed Better
 </TechCards>
 
 For React Router, follow the [React Auth quick start](/docs/auth/quick-start/react).
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/redwoodsdk.md
+++ b/content/docs/guides/redwoodsdk.md
@@ -10,7 +10,7 @@ summary: >-
   TypeScript to query Postgres on Neon. Use this page when building a RedwoodSDK
   app on Cloudflare that needs a serverless Postgres backend.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/redwood-sdk-prompt.md"
@@ -135,5 +135,12 @@ PostgreSQL 17.5 (6bc9ef8) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 
 
 - [RedwoodSDK Documentation](https://docs.rwsdk.com/)
 - [Connect to a PostgreSQL database with Cloudflare Workers](https://developers.cloudflare.com/workers/tutorials/postgres/)
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/reflex.md
+++ b/content/docs/guides/reflex.md
@@ -9,7 +9,7 @@ summary: >-
   covering virtual environment setup, psycopg2-binary installation, schema
   migrations, and a working CRUD example.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/reflex-prompt.md"
@@ -471,5 +471,10 @@ You should see the Customer Data App interface, where you can add, view, and del
 ![Reflex Customer Data App](/docs/guides/reflex_customer_data_app.png)
 
 </Steps>
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/remix.md
+++ b/content/docs/guides/remix.md
@@ -8,7 +8,7 @@ summary: >-
   creating a Neon project, storing the DATABASE_URL in `.env`, and wiring up a
   loader route using node-postgres, postgres.js, or the Neon serverless driver.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <Admonition type="note">
@@ -170,5 +170,12 @@ PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1
 ```
 
 </Steps>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/ruby-on-rails.md
+++ b/content/docs/guides/ruby-on-rails.md
@@ -8,7 +8,7 @@ summary: >-
   page when setting up a new or existing Rails project against Neon. A separate
   sibling page covers Rails schema migrations.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/ruby-on-rails-prompt.md" 
@@ -134,6 +134,7 @@ For schema migration with Ruby on Rails, see our guide:
 
 ## Next steps
 
-- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database.
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database.
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential.
 
 <NeedHelp/>

--- a/content/docs/guides/rust.md
+++ b/content/docs/guides/rust.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/rust
   - /docs/integrations/rust
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/rust-prompt.md" 
@@ -674,5 +674,10 @@ ID: 4, Title: Dune, Author: Frank Herbert, Year: 1965, In Stock: true
 - [rust-postgres crate documentation](https://docs.rs/postgres/latest/postgres/)
 - [tokio-postgres crate documentation](https://docs.rs/tokio-postgres/latest/tokio_postgres/)
 - [Tokio async runtime](https://tokio.rs/)
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/sequelize.md
+++ b/content/docs/guides/sequelize.md
@@ -11,7 +11,7 @@ summary: >-
   connection string is required for migrations, as pooled connections via
   PgBouncer cause migration errors.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 [Sequelize](https://sequelize.org/) is a promise-based Node.js ORM that supports multiple relational databases. In this guide, we'll explore how to use `Sequelize` ORM with a Neon Postgres database in a JavaScript project.
@@ -362,5 +362,12 @@ For more information on the tools used in this guide, refer to the following res
 
 - [Sequelize](https://sequelize.org/)
 - [Express.js](https://expressjs.com/)
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/solid-start.md
+++ b/content/docs/guides/solid-start.md
@@ -7,7 +7,7 @@ summary: >-
   Covers server-side data loading and API routes using node-postgres,
   postgres.js, or the Neon serverless driver.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/solidstart-prompt.md"
@@ -206,5 +206,12 @@ PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1
 ```
 
 </Steps>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/sqlalchemy.md
+++ b/content/docs/guides/sqlalchemy.md
@@ -13,7 +13,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/sqlalchemy
   - /docs/integrations/sqlalchemy
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/sqlalchemy-prompt.md" 
@@ -125,5 +125,10 @@ For schema migration with SQLAlchemy, see our guide:
 <a href="/docs/guides/sqlalchemy-migrations" description="Schema migration with Neon Postgres and SQLAlchemy" icon="app-store" icon="app-store">SQLAlchemy Migrations</a>
 
 </DetailIconCards>
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/sveltekit.md
+++ b/content/docs/guides/sveltekit.md
@@ -10,7 +10,7 @@ summary: >-
   function. Requires a DATABASE_URL connection string with sslmode=require and
   channel_binding=require.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/sveltekit-prompt.md"
@@ -184,5 +184,12 @@ PostgreSQL 17.2 on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.
 ```
 
 </Steps>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/symfony.md
+++ b/content/docs/guides/symfony.md
@@ -10,7 +10,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/symfony
   - /docs/integrations/symfony
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/symfony-prompt.md" 
@@ -41,5 +41,10 @@ DATABASE_URL="postgresql://[user]:[password]@[neon_hostname]/[dbname]?charset=ut
 You can find the connection string for your database by clicking the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
 
 </Steps>
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/tanstack-start.md
+++ b/content/docs/guides/tanstack-start.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/quickstart/tanstack-start
   - /docs/integrations/tanstack-start
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/tanstack-start-prompt.md"
@@ -274,5 +274,8 @@ You can find the source code for the applications described in this guide on Git
 ## Next steps
 
 - [Set up Managed BetterAuth](/docs/auth/quick-start/tanstack-router): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/tortoise-orm.md
+++ b/content/docs/guides/tortoise-orm.md
@@ -12,7 +12,7 @@ summary: >-
   python-dotenv, and avoiding hanging processes by calling
   Tortoise.close_connections() or using run_async().
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/tortoise-orm-prompt.md" 
@@ -214,5 +214,10 @@ The `in_transaction()` block ensures an all-or-nothing execution. Because the si
 
 - [Tortoise ORM documentation](https://tortoise.github.io/)
 - [asyncpg documentation](https://magicstack.github.io/asyncpg/current/)
+
+## Next steps
+
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/typeorm.md
+++ b/content/docs/guides/typeorm.md
@@ -9,7 +9,7 @@ summary: >-
   connections. To prevent timeouts from Neon's idle-compute cold start (default
   5 minutes), add `connect_timeout=10` to the connection string.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <CopyPrompt src="/prompts/typeorm-prompt.md" 
@@ -89,5 +89,12 @@ DATABASE_URL="postgresql://[user]:[password]@[neon_hostname]/[dbname]?sslmode=re
 <Admonition type="note">
 A `connect_timeout` setting of 0 means no timeout.
 </Admonition>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/guides/vue.md
+++ b/content/docs/guides/vue.md
@@ -7,7 +7,7 @@ summary: >-
   Use a Vue meta-framework such as Nuxt.js or Quasar Framework to run database
   queries on the server and expose data to your Vue frontend.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 Vue.js is a progressive JavaScript framework for building user interfaces.
@@ -23,5 +23,12 @@ Find detailed instructions for connecting to Neon from various Vue.js meta-frame
 <a href="/docs/guides/nuxt" title="Nuxt.js" description="Connect a Nuxt.js application to Neon" icon="nuxt"></a>
 
 </TechCards>
+
+## Next steps
+
+- [Set up Managed BetterAuth](/docs/auth/overview): Add managed authentication that branches with your database
+- [Add Object Storage](/docs/storage/overview): S3-compatible file storage that branches with your database
+- [Deploy a Function](/docs/compute/functions/overview): Run backend compute next to your database, no separate hosting needed
+- [Call an LLM with AI Gateway](/docs/ai-gateway/overview): Access foundation models from Anthropic, OpenAI, Google, and more with one credential
 
 <NeedHelp/>

--- a/content/docs/introduction/branching.md
+++ b/content/docs/introduction/branching.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /docs/conceptual-guides/branching
   - /docs/concepts/branching
   - /docs/introduction/point-in-time-restore
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 With Neon, you can quickly branch your data for development, testing, and various other purposes, enabling you to improve developer productivity and optimize continuous integration and delivery (CI/CD) pipelines.
@@ -38,6 +38,10 @@ Each Neon project is created with a [root branch](/docs/reference/glossary#root-
 
 <Admonition type="tip" title="Using Managed BetterAuth?">
 Users, sessions, and auth configuration in the `neon_auth` schema branch with your data, so preview and test environments get isolated authentication state. See [Managed BetterAuth](/docs/auth/overview) and [Branching authentication](/docs/auth/branching-authentication).
+</Admonition>
+
+<Admonition type="tip" title="Using Neon backend services?">
+Object Storage, Functions, and AI Gateway all branch with your data too: each branch gets its own storage namespace, function deployment, and gateway endpoint, isolated from its parent. See [Neon Object Storage](/docs/storage/overview), [Neon Functions](/docs/compute/functions/overview), and [Neon AI Gateway](/docs/ai-gateway/overview).
 </Admonition>
 
 ## Branching workflows

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -22,7 +22,7 @@ redirectFrom:
   - /docs/reference/billing-sample
   - /docs/introduction/legacy-plans
   - /docs/introduction/extra-usage
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 Neon offers plans to support you at every stage, from your first prototype to production at scale.
@@ -38,30 +38,32 @@ Compare Neon's **Free**, **Launch**, and **Scale** plans.
 For AI agent platforms that provision thousands of databases, Neon offers an **Agent Plan** with custom resource limits and credits for **your** free tier. [Learn more](/docs/introduction/agent-plan)
 </Admonition>
 
-| Plan feature                                          | **Free**                                   | **Launch**                           | **Scale**                                                                                         |
-| ----------------------------------------------------- | ------------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| [Price](#price)                                       | $0/month                                   | Pay for what you use                 | Pay for what you use                                                                              |
-| [Who it's for](#who-its-for)                          | Prototypes, side projects, and small teams | Startups and growing teams           | Production-grade workloads and larger companies                                                   |
-| [Organization members](#organization-members)         | Unlimited                                  | Unlimited                            | Unlimited                                                                                         |
-| [Projects](#projects)                                 | 100                                        | 100                                  | 1,000 (can be increased on request)                                                               |
-| [Branches](#branches)                                 | 10/project                                 | 10/project                           | 25/project                                                                                        |
-| [Extra branches](#extra-branches)                     | —                                          | $1.50/branch-month (prorated hourly) | $1.50/branch-month (prorated hourly)                                                              |
-| [Compute](#compute)                                   | 100 CU-hours/project                       | $0.106/CU-hour                       | $0.222/CU-hour                                                                                    |
-| [Autoscaling](#autoscaling)                           | Up to 2 CU (8 GB RAM)                      | Up to 16 CU (64 GB RAM)              | Up to 16 CU autoscaling, or fixed sizes up to 56 CU (224 GB RAM)                                  |
-| [Scale to zero](#scale-to-zero)                       | After 5 min                                | After 5 min, can be disabled         | Configurable (1 minute to always on)                                                              |
-| [Storage](#storage)                                   | 0.5 GB/project                             | $0.35/GB-month                       | $0.35/GB-month                                                                                    |
-| [Public network transfer](#public-network-transfer)   | 5 GB included                              | 500 GB included, then $0.10/GB       | 500 GB included, then $0.10/GB                                                                    |
-| [Monitoring](#monitoring)                             | 1 day                                      | 3 days                               | 14 days                                                                                           |
-| [Metrics/logs export](#metricslogs-export)            | —                                          | —                                    | ✅                                                                                                |
-| [Instant restore](#instant-restore)                   | —                                          | $0.20/GB-month                       | $0.20/GB-month                                                                                    |
-| [History window](#history-window)                     | 6 hours, up to 1 GB-month                  | Up to 7 days                         | Up to 30 days                                                                                     |
-| [Snapshots](#snapshots)                               | 1 manual snapshot                          | 100 manual snapshots                 | 100 manual snapshots                                                                              |
-| [Auth](#auth) (Beta)                                  | Up to 60k MAU                              | Up to 1M MAU                         | Up to 1M MAU                                                                                      |
-| [AI Gateway](#ai-gateway) (Private Preview)           | —                                          | Free during preview                  | Free during preview                                                                               |
-| [Private network transfer](#private-network-transfer) | —                                          | —                                    | $0.01/GB                                                                                          |
-| [Compliance and security](#compliance-and-security)   | —                                          | Protected branches                   | SOC 2, ISO, GDPR, [HIPAA](/docs/security/hipaa), Protected branches, IP Allow, Private Networking |
-| [Uptime SLA](#uptime-sla)                             | —                                          | —                                    | ✅                                                                                                |
-| [Support](#support)                                   | Community                                  | Billing support                      | Standard, Business, or Production                                                                 |
+| Plan feature                                          | **Free**                                   | **Launch**                                | **Scale**                                                                                         |
+| ----------------------------------------------------- | ------------------------------------------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [Price](#price)                                       | $0/month                                   | Pay for what you use                      | Pay for what you use                                                                              |
+| [Who it's for](#who-its-for)                          | Prototypes, side projects, and small teams | Startups and growing teams                | Production-grade workloads and larger companies                                                   |
+| [Organization members](#organization-members)         | Unlimited                                  | Unlimited                                 | Unlimited                                                                                         |
+| [Projects](#projects)                                 | 100                                        | 100                                       | 1,000 (can be increased on request)                                                               |
+| [Branches](#branches)                                 | 10/project                                 | 10/project                                | 25/project                                                                                        |
+| [Extra branches](#extra-branches)                     | —                                          | $1.50/branch-month (prorated hourly)      | $1.50/branch-month (prorated hourly)                                                              |
+| [Compute](#compute)                                   | 100 CU-hours/project                       | $0.106/CU-hour                            | $0.222/CU-hour                                                                                    |
+| [Autoscaling](#autoscaling)                           | Up to 2 CU (8 GB RAM)                      | Up to 16 CU (64 GB RAM)                   | Up to 16 CU autoscaling, or fixed sizes up to 56 CU (224 GB RAM)                                  |
+| [Scale to zero](#scale-to-zero)                       | After 5 min                                | After 5 min, can be disabled              | Configurable (1 minute to always on)                                                              |
+| [Storage](#storage)                                   | 0.5 GB/project                             | $0.35/GB-month                            | $0.35/GB-month                                                                                    |
+| [Public network transfer](#public-network-transfer)   | 5 GB included                              | 500 GB included, then $0.10/GB            | 500 GB included, then $0.10/GB                                                                    |
+| [Monitoring](#monitoring)                             | 1 day                                      | 3 days                                    | 14 days                                                                                           |
+| [Metrics/logs export](#metricslogs-export)            | —                                          | —                                         | ✅                                                                                                |
+| [Instant restore](#instant-restore)                   | —                                          | $0.20/GB-month                            | $0.20/GB-month                                                                                    |
+| [History window](#history-window)                     | 6 hours, up to 1 GB-month                  | Up to 7 days                              | Up to 30 days                                                                                     |
+| [Snapshots](#snapshots)                               | 1 manual snapshot                          | 100 manual snapshots                      | 100 manual snapshots                                                                              |
+| [Auth](#auth) (Beta)                                  | Up to 60k MAU                              | Up to 1M MAU                              | Up to 1M MAU                                                                                      |
+| [Object Storage](#object-storage) (Beta)              | No charge during beta, usage limits apply  | No charge during beta, usage limits apply | No charge during beta, usage limits apply                                                         |
+| [Functions](#functions) (Beta)                        | No charge during beta, usage limits apply  | No charge during beta, usage limits apply | No charge during beta, usage limits apply                                                         |
+| [AI Gateway](#ai-gateway) (Beta)                      | —                                          | Free during beta                          | Free during beta                                                                                  |
+| [Private network transfer](#private-network-transfer) | —                                          | —                                         | $0.01/GB                                                                                          |
+| [Compliance and security](#compliance-and-security)   | —                                          | Protected branches                        | SOC 2, ISO, GDPR, [HIPAA](/docs/security/hipaa), Protected branches, IP Allow, Private Networking |
+| [Uptime SLA](#uptime-sla)                             | —                                          | —                                         | ✅                                                                                                |
+| [Support](#support)                                   | Community                                  | Billing support                           | Standard, Business, or Production                                                                 |
 
 ## Plan features
 
@@ -320,11 +322,27 @@ Monthly Active User (MAU) limits per plan:
 
 See [Managed BetterAuth](/docs/auth/overview) for more information.
 
+### Object Storage
+
+Neon Object Storage is S3-compatible object storage that branches with your Neon project. It's available on all plans, including Free, during the beta.
+
+There's no charge for Object Storage during the beta, but usage limits apply.
+
+See [Neon Object Storage](/docs/storage/overview) for more information.
+
+### Functions
+
+Neon Functions are serverless Node.js compute you deploy onto a Neon branch, so your backend code runs next to your database. They're available on all plans, including Free, during the beta.
+
+There's no charge for Functions during the beta, but usage limits apply.
+
+See [Neon Functions](/docs/compute/functions/overview) and [Preview access](/docs/compute/functions/preview-access) for what's included and current limitations.
+
 ### AI Gateway
 
-Neon AI Gateway provides access to foundation models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba through a single Neon credential. It is available on paid plans during the private preview.
+Neon AI Gateway provides access to foundation models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba through a single Neon credential. It is available on paid plans (Launch and Scale) during the beta.
 
-Inference is free during the preview. When billing begins, prices will match each provider's published list prices.
+Inference is free during the beta. When billing begins, prices will match each provider's published list prices, with no additional markup.
 
 See [AI Gateway models](/docs/ai-gateway/models#pricing) for details.
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -788,7 +788,7 @@
           slug: compute/functions/overview
         - title: Preview access
           slug: compute/functions/preview-access
-        - title: Get started
+        - title: Quickstart
           slug: compute/functions/get-started
         - title: Deploy and manage
           slug: compute/functions/deploy

--- a/content/docs/reference/neon-ts.md
+++ b/content/docs/reference/neon-ts.md
@@ -9,7 +9,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/compute/functions/reference/neon-ts/
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 `neon.ts` is a TypeScript config file you commit to your repository. It declares which Neon services exist on your project and how each branch is configured.
@@ -244,7 +244,7 @@ The key list autocompletes from your config, so selecting a variable from a serv
 ## Preview services
 
 <Admonition type="info" title="Private preview">
-Functions, Storage, and AI Gateway are in private preview. They require a new project in AWS us-east-2. See [Preview access](/docs/compute/functions/preview-access) to request access.
+Functions, Storage, and AI Gateway are in private preview. They require a project in AWS us-east-2. See [Preview access](/docs/compute/functions/preview-access) to request access.
 </Admonition>
 
 Preview services are declared under the `preview` block. All three are optional and independent:

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-07-10T13:57:31.917Z'
+updatedOn: '2026-07-14T20:35:24.380Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -158,6 +158,8 @@ When your code runs inside Neon Functions, Neon injects storage credentials auto
 | `AWS_SECRET_ACCESS_KEY` | S3 Secret Access Key                     |
 | `AWS_ENDPOINT_URL_S3`   | Branch S3 endpoint URL                   |
 | `AWS_REGION`            | Object storage region (e.g. `us-east-2`) |
+
+See [Environment variables](/docs/compute/functions/environment-variables) for the full list of variables Neon injects into a function.
 
 Credentials are branch-scoped and tied to the function's serving branch. User-supplied environment variables with the same name can't override the injected values (the injected secret access key always wins). Because the credentials use AWS-standard names, the AWS SDK picks them up automatically. Only `forcePathStyle` needs explicit configuration:
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -1,12 +1,12 @@
 ---
-title: Get started with Neon Object Storage
+title: Get started with Object Storage
 subtitle: Upload your first file in minutes
 summary: >-
   This quickstart walks you through creating a storage credential, configuring
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-07-14T20:35:24.380Z'
 ---
 
 <PrivatePreviewEnquire/>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-07-10T13:57:31.917Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -20,7 +20,7 @@ npx skills add neondatabase/agent-skills -s neon -s neon-object-storage
 To follow this guide, you need:
 
 - Early access to the Neon Object Storage private preview
-- A new Neon project in the AWS `us-east-2` region
+- A Neon project in the AWS `us-east-2` region
 - The Neon CLI installed and authenticated if you use the recommended `neon.ts` flow
 - A Neon API key in `NEON_API_KEY` if you use the manual API flow
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-07-15T14:53:00.836Z'
 ---
 
 <RequestForm type="backend-platform" title="Get early access to Neon Object Storage" description="Neon Object Storage is in private preview. Drop your email and we'll reach out with access." />
@@ -20,6 +20,19 @@ Neon Object Storage is S3-compatible object storage built into the Neon backend 
 - **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, the [Files SDK](https://files-sdk.dev), and any other S3-compatible tool works out of the box.
 - **Two access modes.** `private` buckets require authentication for all operations. `public_read` buckets allow anonymous reads with authenticated writes.
 - **One credential system.** The same Neon credential system used by AI Gateway and Functions.
+
+## Rate limits
+
+Neon Object Storage rate-limits S3 API requests at two tiers: **pre-auth**, before Neon checks your credential (limited by source IP), and **post-auth**, after your credential is verified (limited by API key or project):
+
+| Tier                               | Limit                                       |
+| ---------------------------------- | ------------------------------------------- |
+| Per source IP (pre-auth)           | 500 requests/second, 20,000 requests/minute |
+| Per API key or project (post-auth) | 100 requests/second, 3,000 requests/minute  |
+
+These limits are enforced independently by each running instance of the storage service, not globally. Neon runs multiple instances behind a load balancer for availability and capacity; each instance tracks its own request counts. Since your requests are typically spread across more than one instance, your practical ceiling is somewhat higher than the per-instance numbers above.
+
+If you exceed a limit, you'll get an `HTTP 503` response with the S3 error code `SlowDown` and a `Retry-After` header. `OPTIONS`/CORS preflight requests are never rate-limited. See [Troubleshooting](/docs/storage/troubleshooting#503-service-unavailable-slowdown) for how to handle it.
 
 ## Quickstart
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-07-15T14:53:00.836Z'
+updatedOn: '2026-07-15T15:03:54.666Z'
 ---
 
 <RequestForm type="backend-platform" title="Get early access to Neon Object Storage" description="Neon Object Storage is in private preview. Drop your email and we'll reach out with access." />
@@ -20,19 +20,6 @@ Neon Object Storage is S3-compatible object storage built into the Neon backend 
 - **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, the [Files SDK](https://files-sdk.dev), and any other S3-compatible tool works out of the box.
 - **Two access modes.** `private` buckets require authentication for all operations. `public_read` buckets allow anonymous reads with authenticated writes.
 - **One credential system.** The same Neon credential system used by AI Gateway and Functions.
-
-## Rate limits
-
-Neon Object Storage rate-limits S3 API requests at two tiers: **pre-auth**, before Neon checks your credential (limited by source IP), and **post-auth**, after your credential is verified (limited by API key or project):
-
-| Tier                               | Limit                                       |
-| ---------------------------------- | ------------------------------------------- |
-| Per source IP (pre-auth)           | 500 requests/second, 20,000 requests/minute |
-| Per API key or project (post-auth) | 100 requests/second, 3,000 requests/minute  |
-
-These limits are enforced independently by each running instance of the storage service, not globally. Neon runs multiple instances behind a load balancer for availability and capacity; each instance tracks its own request counts. Since your requests are typically spread across more than one instance, your practical ceiling is somewhat higher than the per-instance numbers above.
-
-If you exceed a limit, you'll get an `HTTP 503` response with the S3 error code `SlowDown` and a `Retry-After` header. `OPTIONS`/CORS preflight requests are never rate-limited. See [Troubleshooting](/docs/storage/troubleshooting#503-service-unavailable-slowdown) for how to handle it.
 
 ## Quickstart
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,14 +7,14 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-07-10T13:57:31.917Z'
+updatedOn: '2026-07-14T19:04:57.024Z'
 ---
 
 <RequestForm type="backend-platform" title="Get early access to Neon Object Storage" description="Neon Object Storage is in private preview. Drop your email and we'll reach out with access." />
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
 
-> During the private preview, object storage is available for **new projects** in the **AWS us-east-2** region only.
+> During the private preview, object storage is available in the **AWS us-east-2** region only.
 
 - **Branches with your database.** Each branch has its own view of storage. Test file uploads and deletions in preview branches without touching production data.
 - **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, the [Files SDK](https://files-sdk.dev), and any other S3-compatible tool works out of the box.

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-07-10T13:57:31.917Z'
+updatedOn: '2026-07-15T14:53:00.836Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -114,7 +114,7 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 
 ### `503 Service Unavailable` (SlowDown)
 
-The request exceeded the per-IP or per-tenant rate limit. The S3 error code is `SlowDown`. This is a rate limit signal, not a server error. The storage service is healthy.
+The request exceeded the per-IP or per-tenant rate limit. The S3 error code is `SlowDown`. This is a rate limit signal, not a server error. The storage service is healthy. See [Rate limits](/docs/storage/overview#rate-limits) for the current limit values.
 
 **Fix:** Implement exponential backoff and retry. Don't treat `SlowDown` as a fatal error. The response may include a `Retry-After` header indicating how long to wait. AWS SDKs handle this automatically when retry logic is enabled.
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-07-15T14:53:00.836Z'
+updatedOn: '2026-07-15T15:03:54.666Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -114,9 +114,9 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 
 ### `503 Service Unavailable` (SlowDown)
 
-The request exceeded the per-IP or per-tenant rate limit. The S3 error code is `SlowDown`. This is a rate limit signal, not a server error. The storage service is healthy. See [Rate limits](/docs/storage/overview#rate-limits) for the current limit values.
+The request exceeded a rate limit. The S3 error code is `SlowDown`. This is a rate limit signal, not a server error. The storage service is healthy.
 
-**Fix:** Implement exponential backoff and retry. Don't treat `SlowDown` as a fatal error. The response may include a `Retry-After` header indicating how long to wait. AWS SDKs handle this automatically when retry logic is enabled.
+**Fix:** Implement exponential backoff and retry. Don't treat `SlowDown` as a fatal error. The response may include a `Retry-After` header indicating how long to wait. AWS SDKs handle this automatically when retry logic is enabled. If you're hitting this consistently, [let us know](/docs/introduction/support) and we can look into raising your limit.
 
 ### Large downloads timing out mid-stream
 


### PR DESCRIPTION
## Summary

- Updated pricing page: added Object Storage & Functions rows/sections, relabeled AI Gateway to Beta
- Removed "new projects only" restriction from Storage/Functions/AI Gateway docs (region limit still applies)
- Added "Model access" section to AI Gateway models page (open-weight vs. foundation model access)
- Added data-handling note (no prompt/data retention guarantees yet) to AI Gateway models page
- Added backend-services branching note to Branching page + resource cards to Branching intro hub
- Added "Next steps" section (Auth/Storage/Functions/AI Gateway) to 42 framework/language/ORM guides
- Fixed Django & Ruby on Rails guides to drop broken Auth recommendation, point to Storage/AI Gateway instead