### PR TITLE
docs: correct AI Gateway injected env vars

### DIFF
--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-07-10T13:57:31.917Z'
+updatedOn: '2026-07-14T19:22:11.599Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -97,42 +97,42 @@ client = OpenAI(
 
 ## Environment variables
 
-Neon provides four gateway env vars. Two follow OpenAI's standard naming so existing SDKs pick them up automatically. Two use `NEON_`-prefixed names that survive a user overriding the `OPENAI_*` variables with their own provider keys.
+Neon provides two gateway env vars. `NEON_AI_GATEWAY_BASE_URL` is the bare branch host, so you append the dialect path yourself when configuring an SDK.
 
-| Variable                   | Value                                                                                                   |
-| -------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `OPENAI_API_KEY`           | Bearer token (`nt_live_...`)                                                                            |
-| `OPENAI_BASE_URL`          | Full OpenAI Responses dialect URL: `https://<branch-host>/ai-gateway/openai/v1` — **includes the path** |
-| `NEON_AI_GATEWAY_TOKEN`    | Same bearer token as `OPENAI_API_KEY`                                                                   |
-| `NEON_AI_GATEWAY_BASE_URL` | Bare branch host: `https://<branch-host>` — **no path**; append `/ai-gateway/<dialect>/v1` yourself     |
+| Variable                   | Value                                                                                               |
+| -------------------------- | --------------------------------------------------------------------------------------------------- |
+| `NEON_AI_GATEWAY_TOKEN`    | Bearer token (`nt_live_...`)                                                                        |
+| `NEON_AI_GATEWAY_BASE_URL` | Bare branch host: `https://<branch-host>`, with no path. Append `/ai-gateway/<dialect>/v1` yourself |
 
-`OPENAI_BASE_URL` and `NEON_AI_GATEWAY_BASE_URL` point at different URLs. `OPENAI_BASE_URL` already includes `/ai-gateway/openai/v1`, so `new OpenAI()` picks it up with zero config and calls the Responses API. `NEON_AI_GATEWAY_BASE_URL` is the bare host — append the dialect path yourself:
+Append the dialect path for the endpoint you need:
 
 ```
 NEON_AI_GATEWAY_BASE_URL + /ai-gateway/mlflow/v1   → chat completions (all providers)
-NEON_AI_GATEWAY_BASE_URL + /ai-gateway/openai/v1   → OpenAI Responses API (= OPENAI_BASE_URL)
+NEON_AI_GATEWAY_BASE_URL + /ai-gateway/openai/v1   → OpenAI Responses API
 NEON_AI_GATEWAY_BASE_URL + /ai-gateway/anthropic   → Anthropic Messages API
 NEON_AI_GATEWAY_BASE_URL + /ai-gateway/gemini      → Gemini generateContent API
 ```
 
+To use an OpenAI SDK, set its `apiKey` and `baseURL` from these variables (see the examples below).
+
 ## Credentials in Neon Functions
 
-When your code runs inside Neon Functions, all four env vars are injected automatically. No credential creation step required:
+When your code runs inside Neon Functions, both gateway env vars are injected automatically. No credential creation step required:
 
-| Variable                   | Value                                                   |
-| -------------------------- | ------------------------------------------------------- |
-| `NEON_AI_GATEWAY_TOKEN`    | Bearer token for the AI Gateway                         |
-| `NEON_AI_GATEWAY_BASE_URL` | Branch gateway host with `https://` prefix, no path     |
-| `OPENAI_API_KEY`           | Same value as `NEON_AI_GATEWAY_TOKEN`                   |
-| `OPENAI_BASE_URL`          | Branch gateway host including the OpenAI Responses path |
+| Variable                   | Value                                               |
+| -------------------------- | --------------------------------------------------- |
+| `NEON_AI_GATEWAY_TOKEN`    | Bearer token for the AI Gateway                     |
+| `NEON_AI_GATEWAY_BASE_URL` | Branch gateway host with `https://` prefix, no path |
 
-`new OpenAI()` works with zero configuration because `OPENAI_API_KEY` and `OPENAI_BASE_URL` are already set:
+Configure an OpenAI SDK by setting `apiKey` and `baseURL` from these variables. Use the OpenAI Responses dialect for `responses.create()`:
 
 ```typescript
 import OpenAI from 'openai';
 
-// Reads OPENAI_API_KEY + OPENAI_BASE_URL from the environment automatically.
-const client = new OpenAI();
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1`,
+});
 
 const response = await client.responses.create({
   model: 'gpt-5-mini',
@@ -140,7 +140,7 @@ const response = await client.responses.create({
 });
 ```
 
-For the chat completions endpoint or when you need credentials that survive a user overriding `OPENAI_*` with their own keys, use the `NEON_AI_GATEWAY_*` vars:
+For the chat completions endpoint, point the base URL at the `mlflow` dialect instead:
 
 ```typescript
 import OpenAI from 'openai';

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -6,7 +6,7 @@ summary: >-
   functions automatically. Set your own variables with --env at deploy time or
   in neon.ts, and pull branch variables locally with neon env pull.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:22:11.599Z'
 ---
 
 <PrivatePreviewEnquire/>
@@ -17,25 +17,23 @@ Neon injects connection strings, credentials, and service URLs automatically at 
 
 Each variable is present only when its service is enabled on the branch. `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, for example, are undefined on a functions-only branch with no Postgres database.
 
-| Variable                                     | Service            | Description                                                                                                                                        |
-| -------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                               | Postgres           | Pooled connection string. Use this for most queries.                                                                                               |
-| `DATABASE_URL_UNPOOLED`                      | Postgres           | Direct connection string. Use for migrations, `LISTEN`/`NOTIFY`, and multi-round-trip transactions.                                                |
-| `NEON_BRANCH`                                | Core               | Branch name (e.g. `main`, `preview/foo`). Present on all branches.                                                                                 |
-| `NEON_AUTH_BASE_URL`                         | Managed BetterAuth | Base URL for Managed BetterAuth.                                                                                                                   |
-| `NEON_AUTH_JWKS_URL`                         | Managed BetterAuth | JWKS endpoint for verifying Managed BetterAuth JWTs. See [Authentication](/docs/compute/functions/authentication).                                 |
-| `NEON_DATA_API_URL`                          | Data API           | Base URL for the Neon Data API (PostgREST). Present when the Data API is provisioned on the branch.                                                |
-| `OPENAI_API_KEY`                             | AI Gateway         | Gateway key, under the OpenAI-standard name so the OpenAI SDKs pick it up automatically.                                                           |
-| `OPENAI_BASE_URL`                            | AI Gateway         | OpenAI **Responses API** endpoint (`/ai-gateway/openai/v1`). An OpenAI SDK reading these two variables reaches `responses.create()` with no setup. |
-| `NEON_AI_GATEWAY_TOKEN`                      | AI Gateway         | Gateway token. Same value as `OPENAI_API_KEY`.                                                                                                     |
-| `NEON_AI_GATEWAY_BASE_URL`                   | AI Gateway         | Gateway host root. Append a dialect route, e.g. `/ai-gateway/mlflow/v1` for Chat Completions.                                                      |
-| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Object Storage     | S3-compatible credentials for the branch's buckets.                                                                                                |
-| `AWS_ENDPOINT_URL_S3`, `AWS_REGION`          | Object Storage     | S3 endpoint and region. The `AWS_*` names mean the AWS SDKs work with no setup.                                                                    |
+| Variable                                     | Service            | Description                                                                                                                                           |
+| -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                               | Postgres           | Pooled connection string. Use this for most queries.                                                                                                  |
+| `DATABASE_URL_UNPOOLED`                      | Postgres           | Direct connection string. Use for migrations, `LISTEN`/`NOTIFY`, and multi-round-trip transactions.                                                   |
+| `NEON_BRANCH`                                | Core               | Branch name (e.g. `main`, `preview/foo`). Present on all branches.                                                                                    |
+| `NEON_AUTH_BASE_URL`                         | Managed BetterAuth | Base URL for Managed BetterAuth.                                                                                                                      |
+| `NEON_AUTH_JWKS_URL`                         | Managed BetterAuth | JWKS endpoint for verifying Managed BetterAuth JWTs. See [Authentication](/docs/compute/functions/authentication).                                    |
+| `NEON_DATA_API_URL`                          | Data API           | Base URL for the Neon Data API (PostgREST). Present when the Data API is provisioned on the branch.                                                   |
+| `NEON_AI_GATEWAY_TOKEN`                      | AI Gateway         | Gateway bearer token.                                                                                                                                 |
+| `NEON_AI_GATEWAY_BASE_URL`                   | AI Gateway         | Gateway host root. Append a dialect route, e.g. `/ai-gateway/mlflow/v1` for Chat Completions or `/ai-gateway/openai/v1` for the OpenAI Responses API. |
+| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Object Storage     | S3-compatible credentials for the branch's buckets.                                                                                                   |
+| `AWS_ENDPOINT_URL_S3`, `AWS_REGION`          | Object Storage     | S3 endpoint and region. The `AWS_*` names mean the AWS SDKs work with no setup.                                                                       |
 
 These variables are branch-scoped: each branch injects its own values. A function deployed to a preview branch connects to that branch's database, not the default branch's.
 
 <Admonition type="note" title="Two AI Gateway endpoints">
-`OPENAI_BASE_URL` targets the gateway's OpenAI **Responses API** (`/ai-gateway/openai/v1`). The **Chat Completions** endpoint is at a different path: point the SDK's base URL at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1` (see [Chat completions](/docs/ai-gateway/chat-completions)). The [`@neon/ai-sdk-provider`](/docs/compute/functions/agents) handles this routing for you.
+`NEON_AI_GATEWAY_BASE_URL` is the bare gateway host: append a dialect path yourself. Use `/ai-gateway/openai/v1` for the OpenAI **Responses API** and `/ai-gateway/mlflow/v1` for **Chat Completions** (see [Chat completions](/docs/ai-gateway/chat-completions)). The [`@neon/ai-sdk-provider`](/docs/compute/functions/agents) handles this routing for you.
 </Admonition>
 
 <Admonition type="note" title="Local pull vs. deployed runtime">
@@ -69,7 +67,7 @@ Pass `--env KEY=VALUE` to `neon functions deploy`. The flag is repeatable:
 neon functions deploy hello --src functions/hello.ts --env RESEND_API_KEY=re_...
 ```
 
-Don't define variables under the names Neon injects (`DATABASE_URL`, `OPENAI_*`, `AWS_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
+Don't define variables under the names Neon injects (`DATABASE_URL`, `AWS_*`). Those are provided by the platform when the matching service is enabled on the branch, and setting your own collides with the injected values. The `NEON_` prefix is reserved (see [Constraints](#constraints)).
 
 A deploy doesn't wipe variables set by earlier deploys. The `--env` flags you pass are merged into the existing set:
 
@@ -123,7 +121,7 @@ neon env pull --file .env.preview
 
 To pull from a different branch, switch with `neon checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, plus the variables for each service **declared in `neon.ts`**: the Managed BetterAuth URLs, the Neon Data API URL, the AI Gateway credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_*`), and the Object Storage credentials (`AWS_*`). Neon mints the AI Gateway key itself and uses the OpenAI-standard names, so the OpenAI SDKs pick it up from the environment.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's `DATABASE_URL` and `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, plus the variables for each service **declared in `neon.ts`**: the Managed BetterAuth URLs, the Neon Data API URL, the AI Gateway credentials (`NEON_AI_GATEWAY_TOKEN`, `NEON_AI_GATEWAY_BASE_URL`), and the Object Storage credentials (`AWS_*`).
 
 ## Constraints
 

--- a/content/docs/reference/neon-ts.md
+++ b/content/docs/reference/neon-ts.md
@@ -9,7 +9,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/compute/functions/reference/neon-ts/
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T19:22:11.599Z'
 ---
 
 `neon.ts` is a TypeScript config file you commit to your repository. It declares which Neon services exist on your project and how each branch is configured.
@@ -249,11 +249,11 @@ Functions, Storage, and AI Gateway are in private preview. They require a new pr
 
 Preview services are declared under the `preview` block. All three are optional and independent:
 
-| Field               | Type                                 | What it enables                                                                                                   |
-| ------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `preview.functions` | Record of slug → function def        | Neon Functions. Long-running Node.js compute on the branch                                                        |
-| `preview.buckets`   | Record of name → bucket def          | Neon Object Storage. S3-compatible object storage, branched with your database                                    |
-| `preview.aiGateway` | `true`, `false`, `{ enabled: bool }` | Neon AI Gateway. Injects `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEON_AI_GATEWAY_TOKEN`, `NEON_AI_GATEWAY_BASE_URL` |
+| Field               | Type                                 | What it enables                                                                |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------------ |
+| `preview.functions` | Record of slug → function def        | Neon Functions. Long-running Node.js compute on the branch                     |
+| `preview.buckets`   | Record of name → bucket def          | Neon Object Storage. S3-compatible object storage, branched with your database |
+| `preview.aiGateway` | `true`, `false`, `{ enabled: bool }` | Neon AI Gateway. Injects `NEON_AI_GATEWAY_TOKEN`, `NEON_AI_GATEWAY_BASE_URL`   |
 
 ### `preview.functions`
 


### PR DESCRIPTION
Neon injects only `NEON_AI_GATEWAY_TOKEN` and `NEON_AI_GATEWAY_BASE_URL`, not `OPENAI_*`. This removes the incorrect `OPENAI_*` injection claims and zero-config `new OpenAI()` examples, and shows building the client from the `NEON_` vars instead.

Files: AI Gateway authentication, Functions env vars, and the neon.ts reference.

Verified live against a gateway branch: both the Responses API and chat completions snippets return 200.

This pull request and its description were written by Isaac.