### PR TITLE
docs: fix Lakebase Search operator table + preload/tuning gaps

### DIFF
--- a/content/docs/ai/lakebase-search-get-started.md
+++ b/content/docs/ai/lakebase-search-get-started.md
@@ -7,7 +7,7 @@ summary: >-
   BM25 full-text index, and running vector and keyword searches from a
   TypeScript application using @neondatabase/serverless and OpenAI.
 enableTableOfContents: true
-updatedOn: '2026-06-29T20:34:27.614Z'
+updatedOn: '2026-07-14T23:16:53.813Z'
 ---
 
 This guide sets up Lakebase Search on a Neon project: enabling both extensions, creating a schema that supports vector and full-text search, inserting documents with embeddings, and querying from TypeScript.
@@ -32,7 +32,8 @@ SHOW shared_preload_libraries;
 If the list already includes `lakebase_vector` and `lakebase_text`, skip to [Install the extensions](#install-the-extensions). If not, you'll add them with the Neon API, using a [Neon API key](/docs/manage/api-keys) and your project ID.
 
 <Admonition type="note">
-The Neon CLI does not support enabling preloaded libraries. You must use the API steps below.
+The `curl` examples below use a [Neon API key](/docs/manage/api-keys). If you'd rather not manage a key, the `neon api` command (an authenticated passthrough that reuses your existing CLI login) calls the same endpoints. For example, `neon api /projects/$PROJECT_ID/available_preload_libraries` replaces the first `curl` below; the `PATCH` and `restart` calls map the same way, passing the request body with `-d`.
+
 </Admonition>
 
 First, confirm the libraries are available to your project:
@@ -48,7 +49,7 @@ curl -sS \
 | jq '.libraries[] | select(.library_name | test("lakebase"))'
 ```
 
-If that returns the two libraries, enable them. The Neon API replaces the preload list rather than appending, so the command below reads your current libraries (plus the defaults) and re-sends them with the Lakebase Search libraries added, leaving your existing preloads in place:
+If that returns the two libraries, enable them. The Neon API replaces the preload list rather than appending, so the command below reads your current libraries (plus the defaults) and re-sends them with the Lakebase Search libraries added, leaving your existing preloads in place. The `split(",")` guards against a default `library_name` that packs several names into one comma-separated string. Note that experimental or beta libraries may remain in `enabled_libraries` without loading into `shared_preload_libraries`; confirm what actually loaded with `SHOW shared_preload_libraries` after the restart.
 
 ```bash
 AVAILABLE="$(curl -sS \
@@ -63,7 +64,7 @@ CURRENT="$(curl -sS \
 
 BODY="$(jq -n --argjson avail "$AVAILABLE" --argjson cur "$CURRENT" '
   { project: { settings: { preload_libraries: { enabled_libraries: (
-    [$avail.libraries[] | select(.is_default == true) | .library_name]
+    [$avail.libraries[] | select(.is_default == true) | .library_name | split(",")[]]
     + ($cur.project.settings.preload_libraries.enabled_libraries // [])
     + ["lakebase_vector", "lakebase_text"]
     | unique
@@ -82,7 +83,7 @@ For more on how Neon handles preloaded libraries, see [Extensions with preloaded
 
 ## Restart the compute
 
-The new `shared_preload_libraries` setting applies after the compute restarts, which drops current connections. Restart it with your `endpoint_id`, or let an idle compute pick up the change when it next wakes:
+The new `shared_preload_libraries` setting applies the next time the compute starts. If the compute is idle (suspended), you don't need to do anything: the next connection wakes it and picks up the change. If it's active, restart it to apply the setting, which drops current connections:
 
 ```bash
 export ENDPOINT_ID=...
@@ -92,6 +93,10 @@ curl -sS -X POST \
   -H "accept: application/json" \
   "https://console.neon.tech/api/v2/projects/$PROJECT_ID/endpoints/$ENDPOINT_ID/restart"
 ```
+
+<Admonition type="note">
+The restart call requires an **active** compute. On an idle compute it returns `endpoint is not active, could not restart`. That's expected; skip the restart and just connect, and the compute picks up the new setting when it wakes.
+</Admonition>
 
 ## Enable the extensions
 

--- a/content/docs/extensions/lakebase-vector.md
+++ b/content/docs/extensions/lakebase-vector.md
@@ -9,7 +9,7 @@ summary: >-
   index, configure build_mode, tune search with the lakebase_ann.probes and
   lakebase_ann.epsilon GUCs, and reference all operator classes and index options.
 enableTableOfContents: true
-updatedOn: '2026-06-26T12:58:36.951Z'
+updatedOn: '2026-07-14T23:16:53.813Z'
 ---
 
 The `lakebase_vector` extension adds the `lakebase_ann` index type to Postgres for approximate nearest-neighbor (ANN) vector search. It is a drop-in companion to `pgvector`: the same `vector` types, distance operators, and query syntax work unchanged; only the index type changes.
@@ -69,6 +69,10 @@ CREATE INDEX ON items USING lakebase_ann (embedding vector_l2_ops) WITH (build_m
 
 Before tuning search, call `lakebase_ann_index_info(index_name)` to get the index's `lists`, `default_probes`, and `default_epsilon` values.
 
+<Admonition type="note">
+The `probes` and `epsilon` GUCs apply only once the index has built IVF lists, which happens above a corpus-size threshold. On a small dataset, `lakebase_ann` uses exact (flat) search instead: `lakebase_ann_index_info` returns empty `lists` and `default_probes`, `SET lakebase_ann.probes` fails with `usage: need 0 probes, but N provided`, and `epsilon` has no effect. This is expected, since the index is already returning exact results, so there is nothing to tune. These GUCs become relevant as your data grows and the index switches to IVF partitioning.
+</Admonition>
+
 Use the `lakebase_ann.probes` GUC to control how many IVF partitions are searched at query time. Higher values improve recall at the cost of speed.
 
 ```sql
@@ -81,6 +85,8 @@ SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 10;
 ```sql
 SET lakebase_ann.epsilon TO '1.5';
 ```
+
+When you set these GUCs from application code, the `SET` and the query must run on the same session. With a connection pool or the [Neon serverless driver](/docs/serverless/serverless-driver), where each statement can use a different connection, issue both in a single transaction so the `SET` applies to the query.
 
 ### Concurrent index updates
 
@@ -97,22 +103,37 @@ REINDEX INDEX CONCURRENTLY items_embedding_ann;
 
 ### Operator classes
 
-`lakebase_ann` supports the following operator classes. The `<->`, `<#>`, and `<=>` operators are defined by `pgvector`. The `<<->>`, `<<#>>`, and `<<=>>` operators are defined by `lakebase_vector` for similarity filtering.
+`lakebase_ann` supports the following operator classes. Each class provides two operators:
 
-| Operator class       | Operator 1              | Operator 2                |
-| :------------------- | :---------------------- | :------------------------ |
-| `vector_l2_ops`      | `<->(vector, vector)`   | `<<->>(vector, vector)`   |
-| `vector_ip_ops`      | `<#>(vector, vector)`   | `<<#>>(vector, vector)`   |
-| `vector_cosine_ops`  | `<=>(vector, vector)`   | `<<=>>(vector, vector)`   |
-| `halfvec_l2_ops`     | `<->(halfvec, halfvec)` | `<<->>(halfvec, halfvec)` |
-| `halfvec_ip_ops`     | `<#>(halfvec, halfvec)` | `<<#>>(halfvec, halfvec)` |
-| `halfvec_cosine_ops` | `<=>(halfvec, halfvec)` | `<<=>>(halfvec, halfvec)` |
-| `rabitq8_l2_ops`     | `<->(rabitq8, rabitq8)` | `<<->>(rabitq8, rabitq8)` |
-| `rabitq8_ip_ops`     | `<#>(rabitq8, rabitq8)` | `<<#>>(rabitq8, rabitq8)` |
-| `rabitq8_cosine_ops` | `<=>(rabitq8, rabitq8)` | `<<=>>(rabitq8, rabitq8)` |
-| `rabitq4_l2_ops`     | `<->(rabitq4, rabitq4)` | `<<->>(rabitq4, rabitq4)` |
-| `rabitq4_ip_ops`     | `<#>(rabitq4, rabitq4)` | `<<#>>(rabitq4, rabitq4)` |
-| `rabitq4_cosine_ops` | `<=>(rabitq4, rabitq4)` | `<<=>>(rabitq4, rabitq4)` |
+- A **pgvector distance operator** (`<->`, `<#>`, `<=>`) that returns a distance and is used in `ORDER BY` for nearest-neighbor search.
+- A **`lakebase_vector` range operator** (`<<->>`, `<<#>>`, `<<=>>`) that takes a `sphere_*` value on its right side and returns a `boolean`: true when the vector falls within the sphere's radius. Use it in a `WHERE` clause to filter by similarity. Build the sphere with the `sphere(vector, radius)` function.
+
+| Operator class       | Distance operator (`ORDER BY`) | Range operator (`WHERE`)         |
+| :------------------- | :----------------------------- | :------------------------------- |
+| `vector_l2_ops`      | `<->(vector, vector)`          | `<<->>(vector, sphere_vector)`   |
+| `vector_ip_ops`      | `<#>(vector, vector)`          | `<<#>>(vector, sphere_vector)`   |
+| `vector_cosine_ops`  | `<=>(vector, vector)`          | `<<=>>(vector, sphere_vector)`   |
+| `halfvec_l2_ops`     | `<->(halfvec, halfvec)`        | `<<->>(halfvec, sphere_halfvec)` |
+| `halfvec_ip_ops`     | `<#>(halfvec, halfvec)`        | `<<#>>(halfvec, sphere_halfvec)` |
+| `halfvec_cosine_ops` | `<=>(halfvec, halfvec)`        | `<<=>>(halfvec, sphere_halfvec)` |
+| `rabitq8_l2_ops`     | `<->(rabitq8, rabitq8)`        | `<<->>(rabitq8, sphere_rabitq8)` |
+| `rabitq8_ip_ops`     | `<#>(rabitq8, rabitq8)`        | `<<#>>(rabitq8, sphere_rabitq8)` |
+| `rabitq8_cosine_ops` | `<=>(rabitq8, rabitq8)`        | `<<=>>(rabitq8, sphere_rabitq8)` |
+| `rabitq4_l2_ops`     | `<->(rabitq4, rabitq4)`        | `<<->>(rabitq4, sphere_rabitq4)` |
+| `rabitq4_ip_ops`     | `<#>(rabitq4, rabitq4)`        | `<<#>>(rabitq4, sphere_rabitq4)` |
+| `rabitq4_cosine_ops` | `<=>(rabitq4, rabitq4)`        | `<<=>>(rabitq4, sphere_rabitq4)` |
+
+To filter by similarity, wrap the query vector in `sphere(vector, radius)` and use the range operator in a `WHERE` clause. Rank the matches with the corresponding distance operator:
+
+```sql
+-- Rows within cosine radius 0.5 of the query vector, closest first
+SELECT * FROM items
+WHERE embedding <<=>> sphere('[3,1,2]'::vector, 0.5)
+ORDER BY embedding <=> '[3,1,2]'
+LIMIT 5;
+```
+
+The range operator returns a `boolean`, so it belongs in `WHERE`, not `ORDER BY`. Use the distance operator (`<=>` here) to order results.
 
 The `rabitq8` and `rabitq4` types are quantization types defined by `lakebase_vector`. They offer reduced memory footprint at the cost of some precision.
 


### PR DESCRIPTION
Fixes issues found while building a live demo end-to-end against the Lakebase Search docs. All claims verified against live `lakebase_vector` 1.0.0-dev / `lakebase_text` 0.1.0-dev.

## extensions/lakebase-vector.md
- **Operator table (main fix):** the `<<->>` / `<<#>>` / `<<=>>` column showed `(vector, vector)`. The real signature is `(vector, sphere_vector) -> boolean` — these are `WHERE` range filters, not distance operators. `vector <<=>> vector` errors with `operator does not exist`. Corrected all rows, split the prose into distance-op (`ORDER BY`) vs range-op (`WHERE`), and added a working `sphere()` example.
- Noted `probes` / `epsilon` only take effect once the index builds IVF lists; on small data it uses exact search (`SET probes` errors, `epsilon` is inert).
- Noted `SET` and the query must share a session (serverless driver).

## ai/lakebase-search-get-started.md
- The CLI *can* drive the preload flow via `neon api` (no API key to export).
- `jq`: `split(",")` guards a default `library_name` returned as a comma-joined string.
- `restart` errors on an idle compute; skip it and just connect.
- Experimental preloads can stay in `enabled_libraries` without loading.