### PR TITLE
docs: credentials: 'include' for cross-origin Managed Better Auth clients

### DIFF
--- a/content/docs/auth/guides/plugins/jwt.md
+++ b/content/docs/auth/guides/plugins/jwt.md
@@ -11,7 +11,7 @@ summary: >-
   for session management in browser-based apps, and custom JWT claims are not
   supported.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T23:56:19.781Z'
 ---
 
 <FeatureBetaProps feature_name="Managed BetterAuth" />
@@ -54,6 +54,16 @@ export async function getJwtToken() {
   return data.token;
 }
 ```
+
+If your app is served from a different origin than your Managed Better Auth URL (for example a Vite or SPA dev server on `localhost` talking to auth on `*.neon.tech`), configure the auth client to send the session cookie on cross-origin requests. Otherwise `authClient.token()` returns `data.token` as `undefined` and calls to your API fail with 401.
+
+```ts filename="src/auth.ts"
+export const authClient = createAuthClient(NEON_AUTH_URL, {
+  fetchOptions: { credentials: 'include' },
+});
+```
+
+Cross-domain setups have further limitations, notably Safari ITP blocking third-party cookies, with reverse-proxy or shared-parent-domain workarounds. See [Better Auth: Safari, ITP, and Cross-Domain Setups](https://www.better-auth.com/docs/concepts/cookies#safari-itp-and-cross-domain-setups).
 
 ### Using the session header
 

--- a/content/docs/auth/quick-start/tanstack-router.md
+++ b/content/docs/auth/quick-start/tanstack-router.md
@@ -9,7 +9,7 @@ summary: >-
   auth UI. User profiles are stored automatically in the `neon_auth.user` table
   in your Neon Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-07-10T15:48:27.200Z'
+updatedOn: '2026-07-14T23:56:19.781Z'
 layout: wide
 ---
 
@@ -120,7 +120,12 @@ This quick start uses the standalone Auth client. For one `createClient()` insta
 import { createAuthClient } from '@neondatabase/neon-js/auth';
 import { BetterAuthReactAdapter } from '@neondatabase/neon-js/auth/react/adapters';
 
-export const authClient = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL, { adapter: BetterAuthReactAdapter() });
+// credentials: 'include' sends the session cookie on cross-origin requests.
+// Required if you later call authClient.token() from an origin other than your Managed Better Auth URL.
+export const authClient = createAuthClient(import.meta.env.VITE_NEON_AUTH_URL, {
+  adapter: BetterAuthReactAdapter(),
+  fetchOptions: { credentials: 'include' },
+});
 ```
 
 </TwoColumnLayout.Block>


### PR DESCRIPTION
## What

An SPA served from a different origin than its Managed Better Auth URL must set `fetchOptions: { credentials: 'include' }` on the auth client. Without it, `authClient.token()` returns an undefined token and API calls fail with 401.

## Changes

- **jwt.md**: document the requirement and symptom after the `token()` example; link to Better Auth's Safari ITP / cross-domain guidance
- **tanstack-router.md**: add `credentials: 'include'` to the auth client snippet

## Verification

Reproduced in-browser (Chromium, TanStack SPA on `localhost` → auth on `*.neon.tech`) calling a JWT-protected backend:
- without the flag: `authClient.token()` yields an undefined token, request returns 401
- with the flag: token is minted, request returns 200

This pull request and its description were written by Isaac.