### PR TITLE
fix: correct @neon/env import subpath and align auth API ref link in ai-skills

### DIFF
--- a/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/auth-users.ts
+++ b/public/docs/ai/skills/neon-postgres-agent-platforms/scripts/auth-users.ts
@@ -45,7 +45,7 @@ function printMeta(): void {
           "https://neon.com/docs/auth/guides/manage-auth-api",
           "https://neon.com/docs/auth/guides/user-management",
           "https://neon.com/docs/manage/roles",
-          "https://api-docs.neon.tech/reference/createbranchneonauthnewuser",
+          "https://neon.com/docs/reference/api/auth/create-branch-neon-auth-new-user",
         ],
         envForThisScript: {
           create: [

--- a/public/docs/ai/skills/neon/SKILL.md
+++ b/public/docs/ai/skills/neon/SKILL.md
@@ -245,7 +245,7 @@ npm i @neon/env
 ```
 
 ```typescript
-import { parseEnv } from "@neon/env/v1";
+import { parseEnv } from "@neon/env";
 import config from "./neon";
 
 const env = parseEnv(config);
@@ -257,7 +257,7 @@ console.log(env.auth.baseUrl);
 By default `parseEnv` requires _every_ variable your config implies. When a process only uses a subset — a common case in frameworks like Next.js, where you might read `DATABASE_URL` but never the unpooled URL — pass an array of env-var keys to require and return only those. The keys are typesafe: autocomplete only offers variables your config enables, and the returned shape is narrowed to exactly what you selected (so unselected variables are neither enforced nor present).
 
 ```typescript
-import { parseEnv } from "@neon/env/v1";
+import { parseEnv } from "@neon/env";
 import config from "./neon";
 
 // Only DATABASE_URL is required and returned; DATABASE_URL_UNPOOLED is not enforced.


### PR DESCRIPTION
## Summary

Two fact-checked corrections to the hosted AI skills corpus (`public/docs/ai/skills`), found while reconciling the hosted skills against the source repos (`neondatabase/agent-skills`, `neondatabase/neon-for-agent-platforms`).

- **`neon/SKILL.md`: `@neon/env/v1` → `@neon/env`** (2 occurrences). The `/v1` subpath does **not** exist in `@neon/env`'s package `exports` map — only `.` is exported (verified in `neondatabase/neon-pkgs/packages/env/package.json` and its README, which imports `from "@neon/env"`). Only `@neon/config` is versioned with `/v1`, so the convention was over-applied here. The documented import as written would fail to resolve.
- **`neon-postgres-agent-platforms/scripts/auth-users.ts`: auth API reference link.** Point the create-user reference at `https://neon.com/docs/reference/api/auth/create-branch-neon-auth-new-user` (canonical neon.com docs path) instead of `https://api-docs.neon.tech/reference/createbranchneonauthnewuser`. Both URLs currently return 200, but this aligns the hosted copy with the **later-updated** source of truth in `neondatabase/neon-for-agent-platforms` (PR #17, merged ~18 min after the hosted corpus fix PR #5238).

## Fact-check notes

- `@neon/env` has no `/v1` export → `/v1` import is broken. Fact-check overrides recency here.
- Both auth-ref hosts return real 404s on bad paths, so both are valid; tie broken by "later change wins" → source repo's neon.com path.

## Test plan

- [ ] Confirm `@neon/env` (no `/v1`) is the intended public import.
- [ ] Confirm the neon.com auth API reference path is preferred over `api-docs.neon.tech`.