### PR TITLE
ci: harden GitHub Actions supply-chain surface (drop write PAT, real CODEOWNERS)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Keep pinned GitHub Action SHAs current (Dependabot updates the SHA and the
+  # trailing version comment together).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'ci'
+
+  # npm dependencies (source of truth is package-lock.json / npm ci in CI).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore'

--- a/.github/workflows/docs-api-consistency.yml
+++ b/.github/workflows/docs-api-consistency.yml
@@ -64,6 +64,10 @@ jobs:
         run: npm run check:docs-api-consistency
 
       # Schedule / manual: strict against @neon/sdk@latest + the live spec.
+      # NOTE: `@neon/sdk@latest` is intentionally unpinned here — the whole point
+      # of this job is to detect drift against the newest published SDK. It only
+      # runs on schedule/workflow_dispatch (never on pull_request), so untrusted
+      # fork input never reaches this unpinned install.
       - name: Check docs vs @neon/sdk@latest + live spec (strict)
         if: github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/format-markdown.yml
+++ b/.github/workflows/format-markdown.yml
@@ -1,23 +1,24 @@
-name: Format Markdown
+name: Check Markdown Formatting
+
+# Read-only CI gate: fails when content markdown isn't Prettier-formatted.
+# Contributors format locally with `npm run fix:md` and commit the result.
+# No write token / PAT is required because this job never pushes.
 
 on:
-  push:
-    branches:
-      - '**'
+  pull_request:
     paths:
       - 'content/**/*.md'
+      - '.github/workflows/format-markdown.yml'
 
 permissions:
   contents: read
 
 jobs:
-  format-markdown:
-    permissions:
-      contents: write # for Git to git push
+  check-formatting:
+    name: 'Check content markdown is Prettier-formatted'
     runs-on:
       group: neondatabase-protected-runner-group
       labels: linux-ubuntu-latest
-
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -26,9 +27,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 2
-          token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -36,32 +34,12 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      # Install from the committed lockfile (pinned Prettier) and skip dependency
-      # lifecycle scripts: this job persists a write-scoped PAT on disk, so we do
-      # not run untrusted postinstall hooks while that credential is available.
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Run Prettier
-        run: npx prettier --write "content/**/*.md" --ignore-path .prettierignore
-
-      - name: Commit changes
+      - name: Check formatting
         run: |
-          git config user.name "GitHub Action"
-          git config user.email "action@github.com"
-          export HUSKY=0
-          git add -A
-          # Check for meaningful changes before committing 
-          if [ -n "$(git status --porcelain)" ]; then
-            # Commit only modified markdown files, not all changes
-            git commit -m "chore: format content markdown files with Prettier"
-            echo "Changes committed"
-          else
-            echo "No significant changes to commit"
-            exit 0
-          fi
-
-      - name: Push changes
-        run: git push || (git pull --rebase && git push)
-        env:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          npm run check:md || {
+            echo "::error::Content markdown is not Prettier-formatted. Run 'npm run fix:md' locally and commit the result."
+            exit 1
+          }

--- a/.github/workflows/format-markdown.yml
+++ b/.github/workflows/format-markdown.yml
@@ -25,18 +25,22 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20
+          cache: 'npm'
 
-      - name: Install Prettier
-        run: npm install prettier
+      # Install from the committed lockfile (pinned Prettier) and skip dependency
+      # lifecycle scripts: this job persists a write-scoped PAT on disk, so we do
+      # not run untrusted postinstall hooks while that credential is available.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
 
       - name: Run Prettier
         run: npx prettier --write "content/**/*.md" --ignore-path .prettierignore

--- a/.github/workflows/linkinator.yml
+++ b/.github/workflows/linkinator.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
         with:
           paths: ${{ env.GATSBY_DEFAULT_SITE_URL }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,6 @@
 /content/ @danieltprice
 /src/ @saimonkat @americano98
+
+# CI / GitHub Actions changes require maintainer review (supply-chain surface).
+# Adjust the owners here if a dedicated security/infra team should gate these.
+/.github/ @saimonkat @americano98

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,2 @@
-/content/ @danieltprice
-/src/ @saimonkat @americano98
-
-# CI / GitHub Actions changes require maintainer review (supply-chain surface).
-# Adjust the owners here if a dedicated security/infra team should gate these.
-/.github/ @saimonkat @americano98
+# Code owners for the repository (includes CI / .github supply-chain surface).
+* @philip @andrelandgraf @danieltprice @ruf-io

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postbuild": "node src/scripts/copy-md-content.js && node src/scripts/generate-llms-index.js && node src/scripts/generate-llms-full.js && next-sitemap --config next-sitemap.config.js && next-sitemap --config next-sitemap-postgres.config.js",
     "start": "next start",
     "fix:md": "prettier --write --log-level warn \"content/**/*.{md,mdx}\"",
+    "check:md": "prettier --check --log-level warn \"content/**/*.md\" --ignore-path .prettierignore",
     "fix:js": "eslint --fix --quiet --cache . && prettier --write --log-level warn --cache \"**/*.{js,jsx,css,html}\"",
     "fix:all": "eslint --fix --quiet --cache . && prettier --write --log-level warn --cache .",
     "format:all": "prettier --write --log-level warn --cache .",


### PR DESCRIPTION
## Summary

Supply-chain hardening for the CI workflows, from a full review of `.github/workflows/*`. This repo is **public** (fork/PR input is adversarial), so the goal is to shrink the code-execution + credential surface without changing what the workflows verify.

Baseline was already strong: no `pull_request_target`, all actions SHA-pinned (and tag-verified), explicit least-privilege `permissions:` everywhere, `harden-runner` on every job, no publish/registry pipeline. This PR closes the remaining gaps.

## Changes

- **`format-markdown.yml` → read-only check gate (biggest win).** Replaced the auto-format-**and-push** workflow with a `pull_request` check that **fails when content markdown isn't Prettier-formatted**; contributors fix locally with `npm run fix:md`. This **removes `secrets.ACCESS_TOKEN` (a write-scoped PAT) and `contents: write` entirely** — the job no longer commits/pushes, so no write credential is ever persisted on the runner. Now runs on SHA-pinned `checkout@v4.2.2` / `setup-node@v4.1.0` with `npm ci --ignore-scripts`.
- **`package.json`**: added a symmetric `check:md` script (CI) to pair with the existing `fix:md` (local).
- **`linkinator.yml`**: bumped `actions/checkout` v2.7.0 → **v4.2.2** (SHA-pinned) off the EOL Node runtime.
- **`docs-api-consistency.yml`**: documented that `npm install @neon/sdk@latest` is **intentionally unpinned** — the schedule/`workflow_dispatch`-only drift probe never runs on `pull_request`, so untrusted fork input never reaches it.
- **`.github/dependabot.yml`** (new): weekly `github-actions` (keeps pinned SHAs fresh) + `npm` updates.
- **`CODEOWNERS`**: replaced placeholder/legacy owners with the actual maintainers as global owners (covers the `.github` CI surface): `@philip @andrelandgraf @danieltprice @ruf-io`.

## TODOs (repo-admin only — I have push, not admin; settings endpoints returned 403)

- [ ] **Delete the now-unused `ACCESS_TOKEN` secret** — no workflow references it after this PR.
- [ ] **Actions → Fork pull request workflows → "Require approval for all outside collaborators"** — the key control gating fork-PR code execution on the `neondatabase-protected-runner-group` runners.
- [ ] **Branch protection on `main`**: require reviews, require the new **"Check content markdown is Prettier-formatted"** status check, and enable **"Require review from Code Owners"** so the CODEOWNERS entry is enforced.
- [ ] **Set default `GITHUB_TOKEN` workflow permissions to read-only** repo-wide as a backstop.
- [ ] **Consider `harden-runner` `egress-policy: block`** with an allowlist across all workflows (derive the allowlist from current audit runs first, then flip).

## Test plan

- [ ] The new **Check Markdown Formatting** check runs on PRs touching `content/**/*.md` and passes on already-formatted content (run `npm run fix:md` if it flags anything).
- [ ] Dependabot validates `.github/dependabot.yml` (Dependabot tab after merge).
- [ ] `linkinator` scheduled run still green.