### PR TITLE
Update AI Gateway pricing table copy for beta

### DIFF
--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -185,8 +185,8 @@ export default {
         tag: { label: 'Beta', theme: 'orange-muted' },
       },
       free: false,
-      launch: 'Pricing matches model provider list prices',
-      scale: 'Pricing matches model provider list prices',
+      launch: 'No charges applied during beta. After it, pricing will match model provider (no markup)',
+      scale: 'No charges applied during beta. After it, pricing will match model provider (no markup)',
     },
     {
       rows: '1',

--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -185,8 +185,8 @@ export default {
         tag: { label: 'Beta', theme: 'orange-muted' },
       },
       free: false,
-      launch: 'No charges applied during beta. After it, pricing will match model provider (no markup)',
-      scale: 'No charges applied during beta. After it, pricing will match model provider (no markup)',
+      launch: 'No charges applied during beta. After beta, pricing will match model provider (no markup)',
+      scale: 'No charges applied during beta. After beta, pricing will match model provider (no markup)',
     },
     {
       rows: '1',


### PR DESCRIPTION
## Summary
- Updates the AI Gateway row in the pricing comparison table (Launch and Scale columns)
- New copy clarifies that there are no charges during beta, and that post-beta pricing will match model provider rates with no markup

## Test plan
- [ ] Open `/pricing` and confirm the AI Gateway row shows the updated text for Launch and Scale plans