### PR TITLE
docs: add neon snapshots cli docs added in v2.34.0

### DIFF
--- a/content/docs/cli/snapshots.md
+++ b/content/docs/cli/snapshots.md
@@ -1,0 +1,199 @@
+---
+title: 'Neon CLI command: snapshots'
+subtitle: 'Create, list, restore, and schedule branch snapshots from the terminal'
+summary: >-
+  The Neon CLI `snapshots` command provides subcommands (create, list, get,
+  update, delete, restore, finalize, schedule) to manage point-in-time
+  snapshots of your Neon branches. Use this reference for exact flags and
+  syntax: snapshot a branch at an LSN or timestamp, set an expiration, restore
+  a snapshot into a new or existing branch, and configure an automatic backup
+  schedule.
+enableTableOfContents: true
+updatedOn: '2026-07-17T17:50:54.830Z'
+---
+
+The `snapshots` command creates, lists, updates, deletes, and restores snapshots of your Neon branches, and manages the automatic backup schedule of a branch. A snapshot captures the state of a branch at a point in time, so you can restore it later. For background on the feature, plans, and limits, see [Backup and restore](/docs/guides/backup-restore).
+
+If `--project-id` is omitted, the CLI resolves it from your [context file](/docs/cli/set-context), auto-selects when your account has only one project, and prompts otherwise.
+
+<CliSubcommands command="snapshots" />
+
+## neon snapshots create (#create)
+
+Creates a snapshot from a branch. By default, it snapshots the head of the branch from your context or the project's default branch. Use `--lsn` or `--timestamp` to capture an earlier point within the branch's [restore window](/docs/introduction/history-window); the two options are mutually exclusive.
+
+<CliUsage command="snapshots create" />
+
+<CliOptions command="snapshots create" />
+
+Snapshot the head of a branch with a name:
+
+```bash
+neon snapshots create --branch main --name pre-migration
+```
+
+Snapshot a branch at a specific LSN and set an expiration:
+
+```bash
+neon snapshots create --branch main --lsn 0/1F3C8A0 --expires-at 2025-12-31T23:59:59Z
+```
+
+Snapshot a branch at a point in time:
+
+```bash
+neon snapshots create --branch main --timestamp 2025-01-01T00:00:00Z
+```
+
+Timestamps and expiration times use RFC 3339 format. Omit `--expires-at` to keep the snapshot indefinitely.
+
+## neon snapshots list (#list)
+
+Lists the snapshots in a project.
+
+<CliUsage command="snapshots list" />
+
+<CliOptions command="snapshots list" />
+
+```bash
+neon snapshots list
+```
+
+## neon snapshots get (#get)
+
+Retrieves a snapshot by ID or name.
+
+<CliUsage command="snapshots get" />
+
+<CliOptions command="snapshots get" />
+
+```bash
+neon snapshots get snap-1234
+```
+
+## neon snapshots update (#update)
+
+Renames a snapshot or changes its expiration. Use `--clear-expiration` to keep a snapshot indefinitely; it's mutually exclusive with `--expires-at`.
+
+<CliUsage command="snapshots update" />
+
+<CliOptions command="snapshots update" />
+
+Rename a snapshot:
+
+```bash
+neon snapshots update snap-1234 --name pre-migration
+```
+
+Clear a snapshot's expiration:
+
+```bash
+neon snapshots update snap-1234 --clear-expiration
+```
+
+## neon snapshots delete (#delete)
+
+Deletes a snapshot by ID or name.
+
+<CliUsage command="snapshots delete" />
+
+<CliOptions command="snapshots delete" />
+
+```bash
+neon snapshots delete snap-1234
+```
+
+## neon snapshots restore (#restore)
+
+Restores a snapshot into a branch. By default, the restore is left un-finalized so you can inspect the restored branch first, then swap it in with [snapshots finalize](#finalize). Pass `--finalize` to move computes onto the restored branch and swap it in for the target immediately.
+
+<CliUsage command="snapshots restore" />
+
+<CliOptions command="snapshots restore" />
+
+Restore a snapshot to a new branch:
+
+```bash
+neon snapshots restore snap-1234 --name recovered
+```
+
+Restore onto an existing branch un-finalized to preview, then finalize:
+
+```bash
+neon snapshots restore snap-1234 --target-branch main
+```
+
+Restore onto a branch and swap it in immediately:
+
+```bash
+neon snapshots restore snap-1234 --target-branch main --finalize
+```
+
+## neon snapshots finalize (#finalize)
+
+Finalizes a previewed snapshot restore, swapping the restored branch in for the target. Use this after running `snapshots restore` without `--finalize`. The argument is the ID of the restored branch that `snapshots restore` created, not the target branch. The `restore` command prints the exact `finalize` command to run.
+
+<CliUsage command="snapshots finalize" />
+
+<CliOptions command="snapshots finalize" />
+
+```bash
+neon snapshots finalize br-summer-water-au2msxjn
+```
+
+The replaced (old) branch is kept under an auto-generated name unless you set one with `--name`.
+
+## Snapshot schedule (#schedule)
+
+The `snapshots schedule` subcommands get and set the automatic snapshot (backup) schedule of a branch.
+
+<CliSubcommands command="snapshots schedule" anchorParts="schedule" />
+
+### neon snapshots schedule get (#schedule-get)
+
+Gets a branch's automatic snapshot schedule.
+
+<CliUsage command="snapshots schedule get" />
+
+<CliOptions command="snapshots schedule get" />
+
+```bash
+neon snapshots schedule get --branch main
+```
+
+### neon snapshots schedule set (#schedule-set)
+
+Sets a branch's automatic snapshot schedule. Build a single-entry schedule with `--frequency` and its companion flags, or pass a full JSON schedule with `--schedule` for a multi-entry schedule (this overrides the single-entry flags).
+
+Pick one `--frequency`; that choice determines which of `--day` and `--hour` you must also set. The supported frequencies are:
+
+| `--frequency` | Also required     | `--day` range       |
+| ------------- | ----------------- | ------------------- |
+| `daily`       | `--hour` (0-23)   | not used            |
+| `weekly`      | `--day`, `--hour` | 1-7 (Monday-Sunday) |
+| `monthly`     | `--day`, `--hour` | 1-31                |
+
+Use `--retention` with any frequency to set how long each snapshot is kept.
+
+<CliUsage command="snapshots schedule set" />
+
+<CliOptions command="snapshots schedule set" />
+
+Set a daily 03:00 snapshot kept for 7 days (604800 seconds):
+
+```bash
+neon snapshots schedule set --branch main --frequency daily --hour 3 --retention 604800
+```
+
+Set a weekly snapshot on Mondays at 04:00:
+
+```bash
+neon snapshots schedule set --branch main --frequency weekly --day 1 --hour 4
+```
+
+Set a multi-entry schedule with JSON:
+
+```bash
+neon snapshots schedule set --branch main --schedule '[{"frequency":"daily","hour":3},{"frequency":"weekly","day":1,"hour":4}]'
+```
+
+Retention is set in seconds (minimum 3600). Omit `--retention` to keep snapshots indefinitely.

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1216,6 +1216,8 @@
                   slug: cli/completion
             - title: Projects and branches
               items:
+                - title: snapshots
+                  slug: cli/snapshots
                 - title: diff
                   slug: cli/diff
                 - title: projects

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -130,6 +130,26 @@
           }
         }
       }
+    },
+    "snapshots": {
+      "commands": {
+        "schedule": {
+          "commands": {
+            "set": {
+              "options": {
+                "frequency": {
+                  "describe": "How often to take snapshots. Combine with --hour, --day, and --retention to build a single-entry schedule.",
+                  "choices": [
+                    "daily",
+                    "weekly",
+                    "monthly"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "2.32.0",
+  "neonctlVersion": "2.34.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -2645,6 +2645,266 @@
       "commands": {},
       "describe": "Deprecated: use `neonctl link`. Set the .neon context (raw write).",
       "usage": "$0 set-context [options]"
+    },
+    "snapshots": {
+      "aliases": [
+        "snapshot"
+      ],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string",
+          "describe": "Project ID"
+        }
+      },
+      "commands": {
+        "create": {
+          "name": "create",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "branch": {
+              "type": "string",
+              "describe": "Branch id or name to snapshot. Defaults to the branch in your context, or the project's default branch.",
+              "alias": "b"
+            },
+            "expires-at": {
+              "type": "string",
+              "describe": "When the snapshot is automatically deleted (RFC 3339, e.g. 2025-12-31T23:59:59Z). Omit to keep it indefinitely."
+            },
+            "lsn": {
+              "type": "string",
+              "describe": "Take the snapshot at this LSN (e.g. 0/1F3C8A0). Must fall within the branch's restore window. Mutually exclusive with --timestamp."
+            },
+            "name": {
+              "type": "string",
+              "describe": "A name for the snapshot"
+            },
+            "timestamp": {
+              "type": "string",
+              "describe": "Take the snapshot at this point in time (RFC 3339, e.g. 2025-01-01T00:00:00Z). Must fall within the branch's restore window. Mutually exclusive with --lsn."
+            }
+          },
+          "commands": {},
+          "describe": "Create a snapshot from a branch",
+          "examples": [
+            {
+              "command": "$0 snapshots create --branch main --lsn 0/1F3C8A0 --expires-at 2025-12-31T23:59:59Z",
+              "description": "Snapshot main at an LSN, auto-deleting at the given time"
+            },
+            {
+              "command": "$0 snapshots create --branch main --timestamp 2025-01-01T00:00:00Z",
+              "description": "Snapshot main at a point in time"
+            },
+            {
+              "command": "$0 snapshots create --branch main --name pre-migration",
+              "description": "Snapshot the head of main with a name"
+            },
+            {
+              "command": "$0 snapshots create",
+              "description": "Snapshot the head of the context/default branch"
+            }
+          ]
+        },
+        "delete": {
+          "name": "delete",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Delete a snapshot by id or name"
+        },
+        "finalize": {
+          "name": "finalize",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "branch",
+              "required": true
+            }
+          ],
+          "options": {
+            "name": {
+              "type": "string",
+              "describe": "Name to give the replaced (old) branch. Auto-generated when omitted."
+            }
+          },
+          "commands": {},
+          "describe": "Finalize a previewed snapshot restore (swap the restored branch in)"
+        },
+        "get": {
+          "name": "get",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Get a snapshot by id or name"
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {},
+          "describe": "List snapshots in the project"
+        },
+        "restore": {
+          "name": "restore",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ],
+          "options": {
+            "finalize": {
+              "type": "boolean",
+              "describe": "Finalize the restore immediately: move computes onto the restored branch and swap it in for the target. Without this, the restore is left un-finalized so you can inspect it first, then run `snapshots finalize <branch>`.",
+              "default": false
+            },
+            "name": {
+              "type": "string",
+              "describe": "Name for the newly restored branch. Auto-generated when omitted."
+            },
+            "target-branch": {
+              "type": "string",
+              "describe": "Branch id or name to restore the snapshot onto. Defaults to the snapshot's source branch. Recommended when you intend to finalize (replace an existing branch)."
+            }
+          },
+          "commands": {},
+          "describe": "Restore a snapshot into a branch",
+          "examples": [
+            {
+              "command": "$0 snapshots restore snap-1234 --target-branch main",
+              "description": "Restore onto main un-finalized to preview, then run `snapshots finalize`"
+            },
+            {
+              "command": "$0 snapshots restore snap-1234 --target-branch main --finalize",
+              "description": "Restore onto main and swap it in immediately"
+            },
+            {
+              "command": "$0 snapshots restore snap-1234 --name recovered",
+              "description": "Restore a snapshot to a new branch named 'recovered'"
+            }
+          ]
+        },
+        "schedule": {
+          "name": "schedule",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {
+            "get": {
+              "name": "get",
+              "aliases": [],
+              "positionals": [],
+              "options": {
+                "branch": {
+                  "type": "string",
+                  "describe": "Branch id or name. Defaults to the branch in your context, or the project's default branch.",
+                  "alias": "b"
+                }
+              },
+              "commands": {},
+              "describe": "Get a branch's automatic snapshot schedule"
+            },
+            "set": {
+              "name": "set",
+              "aliases": [],
+              "positionals": [],
+              "options": {
+                "branch": {
+                  "type": "string",
+                  "describe": "Branch id or name. Defaults to the branch in your context, or the project's default branch.",
+                  "alias": "b"
+                },
+                "day": {
+                  "type": "number",
+                  "describe": "Day of the week/month (1-31) to take the snapshot (used with --frequency)."
+                },
+                "frequency": {
+                  "type": "string",
+                  "describe": "How often to take snapshots. Combine with --hour, --day, and --retention to build a single-entry schedule.",
+                  "choices": [
+                    "daily",
+                    "weekly",
+                    "monthly"
+                  ]
+                },
+                "hour": {
+                  "type": "number",
+                  "describe": "Hour of the day (0-23) to take the snapshot (used with --frequency)."
+                },
+                "month": {
+                  "type": "number",
+                  "describe": "Month of the year (1-12) to take the snapshot (used with --frequency)."
+                },
+                "retention": {
+                  "type": "number",
+                  "describe": "How long to keep each snapshot, in seconds (min 3600). Omit to keep indefinitely."
+                },
+                "schedule": {
+                  "type": "string",
+                  "describe": "Full schedule as JSON, for multi-entry schedules, e.g. '[{\"frequency\":\"daily\",\"hour\":3,\"retention_seconds\":604800}]'. Overrides the single-entry flags."
+                }
+              },
+              "commands": {},
+              "describe": "Set a branch's automatic snapshot schedule",
+              "examples": [
+                {
+                  "command": "$0 snapshots schedule set --branch main --schedule '[{\"frequency\":\"hourly\"},{\"frequency\":\"daily\",\"hour\":3}]'",
+                  "description": "A multi-entry schedule via JSON"
+                },
+                {
+                  "command": "$0 snapshots schedule set --branch main --frequency daily --hour 3 --retention 604800",
+                  "description": "A daily 03:00 snapshot kept for 7 days"
+                }
+              ]
+            }
+          },
+          "describe": "Manage the automatic snapshot (backup) schedule of a branch",
+          "usage": "$0 snapshots schedule <sub-command> [options]"
+        },
+        "update": {
+          "name": "update",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ],
+          "options": {
+            "clear-expiration": {
+              "type": "boolean",
+              "describe": "Clear the expiration so the snapshot is kept indefinitely."
+            },
+            "expires-at": {
+              "type": "string",
+              "describe": "Set when the snapshot expires (RFC 3339). Mutually exclusive with --clear-expiration."
+            },
+            "name": {
+              "type": "string",
+              "describe": "Rename the snapshot"
+            }
+          },
+          "commands": {},
+          "describe": "Update a snapshot's name or expiration"
+        }
+      },
+      "describe": "Manage snapshots",
+      "usage": "$0 snapshots <sub-command> [options]"
     },
     "status": {
       "aliases": [],

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -41,6 +41,7 @@ const GROUP_OF = {
   vpc: 'network',
   api: 'network',
   diff: 'core',
+  snapshots: 'core',
 };
 
 // Commands documented as a section of another command's page instead of a


### PR DESCRIPTION
Document the new `neon snapshots` command group (create, list, get, update, delete, restore, finalize, schedule).

Narrow the schedule `--frequency` choices to daily/weekly/monthly via overrides.json to match what the API actually accepts. The hourly and yearly are in the spec but rejected. Will follow up to correct the spec.

Note: `neon snapshots update --expires-at` / `--clear-expiration` currently don't function, pending backend release. Until supported (soon), set a snapshot's expiration at creation time with `neon snapshots create --expires-at`.
