### PR TITLE
docs: redirect .md URLs for moved docs pages

### DIFF
--- a/scripts/test-markdown-urls.js
+++ b/scripts/test-markdown-urls.js
@@ -1125,6 +1125,34 @@ function buildTests() {
     { note: 'HTML content routes should still have X-LLMs-Txt' }
   );
 
+  // ── 11. redirectFrom for .md URLs ─────────────────────────────────────
+  // A moved doc's .md URL must 308 to the target .md, matching the HTML redirect
+  // (see src/proxy.js). /docs/cli/login is a redirectFrom of content/docs/cli/auth.md.
+
+  add(
+    'redirectFrom .md',
+    '/docs/cli/login.md',
+    'browser',
+    [
+      (r) => expectStatus(r.status, 308),
+      (r) => expectHeader(r.headers, 'location', '/docs/cli/auth.md'),
+    ],
+    { note: 'redirectFrom source .md → 308 to target .md' }
+  );
+
+  // The HTML counterpart should still redirect (sanity check that the .md
+  // variant did not displace the original redirect).
+  add(
+    'redirectFrom HTML',
+    '/docs/cli/login',
+    'browser',
+    [
+      (r) => expectStatus(r.status, 308),
+      (r) => expectHeader(r.headers, 'location', '/docs/cli/auth'),
+    ],
+    { note: 'redirectFrom source → 308 to target' }
+  );
+
   return tests;
 }
 

--- a/src/middleware.test.js
+++ b/src/middleware.test.js
@@ -68,6 +68,18 @@ describe('Middleware - AI Agent Integration Tests', () => {
       .mockResolvedValueOnce({ ok: true }); // analytics (trackLLMPageview, second call)
   };
 
+  // Route fetches by URL instead of by call order, so tests don't depend on the
+  // exact sequence of markdown fetch / analytics / redirect probe. `md` is the
+  // response for the /md/... static fetch; `probe` is the response for the HTML
+  // sibling redirect probe. Analytics (/t.js) always resolves ok.
+  const mockFetchByUrl = ({ md, probe }) => {
+    global.fetch.mockImplementation((url, opts) => {
+      if (url === 'https://neonapi.io/t.js') return Promise.resolve({ ok: true });
+      if (opts?.redirect === 'manual') return Promise.resolve(probe);
+      return Promise.resolve(md);
+    });
+  };
+
   describe('Content routes - AI Agents should get markdown', () => {
     const testCases = [
       { name: 'Docs', path: '/docs/introduction' },
@@ -212,9 +224,9 @@ describe('Middleware - AI Agent Integration Tests', () => {
     it('should return agent-friendly 404 markdown when markdown fetch returns 404', async () => {
       const req = createMockRequest('/docs/non-existent', 'Claude/1.0', 'text/html');
 
-      global.fetch
-        .mockResolvedValueOnce({ ok: false, status: 404 }) // markdown 404
-        .mockResolvedValueOnce({ ok: true }); // analytics
+      // Non-.md path: markdown 404, no redirect probe (bare moved paths are
+      // handled by next.config before middleware).
+      mockFetchByUrl({ md: { ok: false, status: 404 } });
 
       const response = await middleware(req);
 
@@ -231,14 +243,112 @@ describe('Middleware - AI Agent Integration Tests', () => {
     it('should use shorter cache TTL for agent 404 responses', async () => {
       const req = createMockRequest('/docs/non-existent', 'Claude/1.0', 'text/html');
 
-      global.fetch
-        .mockResolvedValueOnce({ ok: false, status: 404 })
-        .mockResolvedValueOnce({ ok: true });
+      // Non-.md path: no redirect probe (bare moved paths are handled by
+      // next.config before middleware).
+      mockFetchByUrl({ md: { ok: false, status: 404 } });
 
       const response = await middleware(req);
 
       expect(response.status).toBe(404);
       expect(response.headers.get('Cache-Control')).toBe('public, max-age=60, s-maxage=300');
+    });
+
+    it('should track an agent .md request only once when the backend errors (5xx)', async () => {
+      const req = createMockRequest('/docs/cli/login.md', 'Claude/1.0', 'text/html');
+
+      // Markdown backend returns 500: the agent branch tracks once and falls
+      // through to the .md content branch, which must NOT track again.
+      mockFetchByUrl({ md: { ok: false, status: 500 } });
+
+      await middleware(req);
+
+      const analyticsCalls = global.fetch.mock.calls.filter(
+        ([url]) => url === 'https://neonapi.io/t.js'
+      );
+      expect(analyticsCalls).toHaveLength(1);
+    });
+
+    it('should redirect agents to the target .md when a moved page 404s', async () => {
+      const req = createMockRequest('/docs/cli/login.md', 'Claude/1.0', 'text/html');
+
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: { ok: false, status: 308, headers: new Headers({ location: '/docs/cli/auth' }) },
+      });
+
+      const response = await middleware(req);
+
+      expect(response.type).toBe('redirect');
+      expect(response.url.toString()).toBe('https://neon.com/docs/cli/auth.md');
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600, s-maxage=86400');
+      // The agent hit is still tracked before the redirect returns.
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://neonapi.io/t.js',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should not redirect when the moved page targets an off-origin URL', async () => {
+      const req = createMockRequest('/docs/legacy.md', 'Claude/1.0', 'text/html');
+
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: {
+          ok: false,
+          status: 308,
+          headers: new Headers({ location: 'https://example.com/somewhere' }),
+        },
+      });
+
+      const response = await middleware(req);
+
+      // Off-origin has no .md equivalent, so fall through to the agent 404.
+      expect(response.status).toBe(404);
+      expect(response.headers.get('X-Content-Source')).toBe('agent-404');
+    });
+
+    it('should not mirror a temporary (307) redirect as a permanent .md redirect', async () => {
+      const req = createMockRequest('/docs/temporary.md', 'Claude/1.0', 'text/html');
+
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: { ok: false, status: 307, headers: new Headers({ location: '/docs/elsewhere' }) },
+      });
+
+      const response = await middleware(req);
+
+      // Temporary redirects must not become a hard-cached 308, so fall through.
+      expect(response.status).toBe(404);
+      expect(response.headers.get('X-Content-Source')).toBe('agent-404');
+    });
+
+    it('should mirror a permanent 301 redirect (not just 308)', async () => {
+      const req = createMockRequest('/docs/cli/login.md', 'Claude/1.0', 'text/html');
+
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: { ok: false, status: 301, headers: new Headers({ location: '/docs/cli/auth' }) },
+      });
+
+      const response = await middleware(req);
+
+      expect(response.type).toBe('redirect');
+      expect(response.url.toString()).toBe('https://neon.com/docs/cli/auth.md');
+    });
+
+    it('should not redirect when the moved page targets the site root', async () => {
+      const req = createMockRequest('/docs/legacy.md', 'Claude/1.0', 'text/html');
+
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: { ok: false, status: 308, headers: new Headers({ location: '/' }) },
+      });
+
+      const response = await middleware(req);
+
+      // Root has no .md equivalent, so fall through to the agent 404.
+      expect(response.status).toBe(404);
+      expect(response.headers.get('X-Content-Source')).toBe('agent-404');
     });
 
     it('should fallback to next() when markdown fetch throws error', async () => {
@@ -257,7 +367,9 @@ describe('Middleware - AI Agent Integration Tests', () => {
     });
   });
 
-  describe('Direct .md URL handling for non-agent requests', () => {
+  // Direct .md URL requests (any UA). .md is agent-shaped traffic, so these are
+  // served as markdown and tracked as LLM pageviews regardless of User-Agent.
+  describe('Direct .md URL handling', () => {
     it('should serve markdown directly for existing .md URLs', async () => {
       const req = createMockRequest(
         '/docs/introduction/existing-doc.md',
@@ -265,9 +377,8 @@ describe('Middleware - AI Agent Integration Tests', () => {
         'text/html'
       );
 
-      global.fetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve('# Existing doc'),
+      mockFetchByUrl({
+        md: { ok: true, text: () => Promise.resolve('# Existing doc') },
       });
 
       const response = await middleware(req);
@@ -277,17 +388,24 @@ describe('Middleware - AI Agent Integration Tests', () => {
       expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
       expect(response.headers.get('X-Content-Source')).toBe('markdown');
       expect(await response.text()).toContain('# Existing doc');
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      // .md requests are treated as agent traffic, so a pageview is tracked.
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://neonapi.io/t.js',
+        expect.objectContaining({ method: 'POST' })
+      );
     });
 
-    it('should return markdown 404 page for non-agent .md URLs that do not exist', async () => {
+    it('should return markdown 404 page for .md URLs that do not exist', async () => {
       const req = createMockRequest(
         '/docs/introduction/foobar.md',
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
         'text/html'
       );
 
-      global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: { ok: false, status: 404, headers: new Headers() }, // no location → no redirect
+      });
 
       const response = await middleware(req);
 
@@ -296,7 +414,53 @@ describe('Middleware - AI Agent Integration Tests', () => {
       expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
       expect(response.headers.get('X-Content-Source')).toBe('md-404');
       expect(await response.text()).toContain('/docs/introduction/foobar.md');
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      // .md 404s are also tracked as agent traffic.
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://neonapi.io/t.js',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should redirect to the target .md when a moved .md page 404s', async () => {
+      const req = createMockRequest(
+        '/docs/cli/login.md',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        'text/html'
+      );
+
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: { ok: false, status: 308, headers: new Headers({ location: '/docs/cli/auth' }) },
+      });
+
+      const response = await middleware(req);
+
+      // Probe fired against the HTML sibling with a neutral (non-agent) UA.
+      expect(global.fetch).toHaveBeenCalledWith('https://neon.com/docs/cli/login', {
+        headers: { Accept: 'text/html', 'User-Agent': 'neon-md-redirect-probe' },
+        redirect: 'manual',
+      });
+      expect(response.type).toBe('redirect');
+      expect(response.url.toString()).toBe('https://neon.com/docs/cli/auth.md');
+    });
+
+    it('should append .md to a collapsing subpath redirect target', async () => {
+      // e.g. next.config: /docs/use-cases/:path* → /use-cases
+      const req = createMockRequest(
+        '/docs/use-cases/ai-agents.md',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        'text/html'
+      );
+
+      mockFetchByUrl({
+        md: { ok: false, status: 404 },
+        probe: { ok: false, status: 308, headers: new Headers({ location: '/use-cases' }) },
+      });
+
+      const response = await middleware(req);
+
+      expect(response.type).toBe('redirect');
+      expect(response.url.toString()).toBe('https://neon.com/use-cases.md');
     });
 
     it('should pass through static .md files under docs/ai/ without rewriting', async () => {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -63,6 +63,74 @@ function trackLLMPageview(req, { is404 = false } = {}) {
 
 const BLOG_CDN_BASE = process.env.BLOG_CDN_URL || 'https://blog.neonapi.io/blog';
 
+// Resolve where a moved `.md` page should redirect. next.config `redirectFrom`
+// rules match only the non-`.md` source, so we probe the HTML sibling (which
+// flows through those rules) and mirror its permanent redirect onto the `.md`.
+// Returns the target `.md` path, or null to fall through to the normal 404.
+async function resolveMarkdownRedirect(pathname, origin) {
+  const htmlPathname = pathname.endsWith('.md') ? pathname.slice(0, -3) : pathname;
+
+  try {
+    // Neutral UA so the probe isn't classified as an AI agent (isAIAgentRequest
+    // matches broad tokens like curl/got/axios) and gets the next.config 308.
+    const response = await fetch(`${origin}${htmlPathname}`, {
+      headers: { Accept: 'text/html', 'User-Agent': 'neon-md-redirect-probe' },
+      redirect: 'manual',
+    });
+
+    // Permanent redirects only; a 302/307 must not become a hard-cached 308.
+    if (response.status !== 301 && response.status !== 308) return null;
+
+    const location = response.headers.get('location');
+    if (!location) return null;
+
+    // Off-origin or root targets have no `.md` equivalent.
+    const url = new URL(location, origin);
+    if (url.origin !== origin) return null;
+
+    const targetPathname = url.pathname.replace(/\/$/, '');
+    if (!targetPathname) return null;
+
+    return `${targetPathname}.md`;
+  } catch (error) {
+    console.error('[.md] Error resolving markdown redirect', { pathname, error: error.message });
+    return null;
+  }
+}
+
+// Cacheable 308 to a moved `.md` page's target, or null if there's no redirect.
+// Doing this here (rather than adding `.md` variants to next.config) keeps the
+// route count under Next's 1000-route performance threshold.
+async function markdownRedirectResponse(req, pathname) {
+  if (!pathname.endsWith('.md')) return null;
+
+  const target = await resolveMarkdownRedirect(pathname, req.nextUrl.origin);
+  if (!target) return null;
+
+  const response = NextResponse.redirect(new URL(target, req.url), 308);
+  response.headers.set('Cache-Control', 'public, max-age=3600, s-maxage=86400');
+  return response;
+}
+
+// A 308 to the moved target if one exists, else the agent 404 body. `source`
+// sets X-Content-Source so logs distinguish the agent vs direct `.md` branch.
+async function markdownMovedOr404Response(req, pathname, source) {
+  const redirect = await markdownRedirectResponse(req, pathname);
+  if (redirect) return redirect;
+
+  return applyDocHeaders(
+    new NextResponse(buildAgent404Response(pathname), {
+      status: 404,
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=60, s-maxage=300',
+        'X-Content-Source': source,
+        'X-Robots-Tag': 'noindex',
+      },
+    })
+  );
+}
+
 export async function proxy(req) {
   try {
     const { pathname } = req.nextUrl;
@@ -159,17 +227,7 @@ export async function proxy(req) {
       trackLLMPageview(req, { is404: agentHit404 });
 
       if (agentHit404) {
-        return applyDocHeaders(
-          new NextResponse(buildAgent404Response(pathname), {
-            status: 404,
-            headers: {
-              'Content-Type': 'text/markdown; charset=utf-8',
-              'Cache-Control': 'public, max-age=60, s-maxage=300',
-              'X-Content-Source': 'agent-404',
-              'X-Robots-Tag': 'noindex',
-            },
-          })
-        );
+        return markdownMovedOr404Response(req, pathname, 'agent-404');
       }
     }
 
@@ -198,6 +256,14 @@ export async function proxy(req) {
             const markdownUrl = `${req.nextUrl.origin}${markdownPath}`;
             const response = await fetch(markdownUrl);
 
+            // Track .md as agent traffic, but only on outcomes handled here
+            // (200/404). A 5xx falls through untracked — the agent branch above
+            // already tracked it, so tracking again would double-count.
+            const isMarkdown404 = response.status === 404;
+            if (response.ok || isMarkdown404) {
+              trackLLMPageview(req, { is404: isMarkdown404 });
+            }
+
             if (response.ok) {
               const markdown = await response.text();
               return applyDocHeaders(
@@ -214,17 +280,7 @@ export async function proxy(req) {
             }
 
             if (response.status === 404) {
-              return applyDocHeaders(
-                new NextResponse(buildAgent404Response(pathname), {
-                  status: 404,
-                  headers: {
-                    'Content-Type': 'text/markdown; charset=utf-8',
-                    'Cache-Control': 'public, max-age=60, s-maxage=300',
-                    'X-Content-Source': 'md-404',
-                    'X-Robots-Tag': 'noindex',
-                  },
-                })
-              );
+              return markdownMovedOr404Response(req, pathname, 'md-404');
             }
           } catch (error) {
             console.error('[.md] Error serving markdown', { pathname, error: error.message });


### PR DESCRIPTION
The `redirectFrom` rules in `next.config` only match the non-.md source, so `.md` variants of moved pages 404 instead of redirecting like their HTML siblings. On a `.md` 404, the middleware now probes the HTML sibling and issues a cacheable 308 to the target `.md`. 

Also now tracks `.md` requests as agent traffic.

This approach supersedes #5221 which does a rewrite instead of redirect.