### PR TITLE
fix: restore unique keys for docs sidebar submenu items

### DIFF
--- a/src/components/pages/doc/menu/item/item.jsx
+++ b/src/components/pages/doc/menu/item/item.jsx
@@ -207,10 +207,10 @@ const Item = ({
             transition={{ duration: 0.2 }}
           >
             <ul className="border-l border-gray-new-80 pl-3 dark:border-gray-new-20">
-              {items.map((item) => (
+              {items.map((item, index) => (
                 <Item
                   {...item}
-                  key={item.slug ?? item.title}
+                  key={item.slug ?? item.title ?? item.section ?? index}
                   basePath={basePath}
                   closeMobileMenu={closeMobileMenu}
                   isHidden={isCollapsed}


### PR DESCRIPTION
## Problem

Rendering certain docs pages logs a repeated React warning:

> Each child in a list should have a unique \"key\" prop. Check the render method of \`Item\`.

## Cause

\`src/components/pages/doc/menu/item/item.jsx\` keyed submenu items with \`key={item.slug ?? item.title}\` (introduced in #5165). Section-group nav entries carry a \`section\` field but no \`slug\` or \`title\`, so those siblings all resolved to \`key={undefined}\` — non-unique. This is why the warning was intermittent and page-specific: it only fired on menus containing section groups (e.g. \`/docs/cli/*\`, \`/docs/community/*\`).

## Fix

\`key={item.slug ?? item.title ?? item.section ?? index}\` — keeps stable identity where a slug/title exists, and guarantees uniqueness otherwise.

This pull request and its description were written by Isaac.