### PR TITLE
docs(functions): fix reserved-prefix claim and invocation URL trailing slash

### DIFF
--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -190,7 +190,7 @@ GET /projects/{project_id}/branches/{branch_id}/functions/{slug}
 The response includes `invocation_url`, the public URL for your function:
 
 ```
-https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech
+https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech/
 ```
 
 ### List functions

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -169,13 +169,13 @@ neon functions get hello
 The `invocation_url` field contains the public URL for your function:
 
 ```
-https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech
+https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech/
 ```
 
 Call it with curl:
 
 ```bash shouldWrap
-curl https://<branch_id>-hello.compute.<cell>.us-east-2.aws.neon.tech
+curl https://<branch_id>-hello.compute.<cell>.us-east-2.aws.neon.tech/
 ```
 
 The response is a JSON object with your branch's Postgres version:

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -69,6 +69,6 @@ Slugs must match `^[a-z0-9]{1,20}$` and are immutable after the first deployment
 
 ## Environment variables
 
-See [Environment variables](/docs/compute/functions/environment-variables#constraints) for limits on variable count, total size, and the reserved `NEON_` prefix.
+See [Environment variables](/docs/compute/functions/environment-variables#constraints) for limits on variable count and total size.
 
 <NeedHelp/>


### PR DESCRIPTION
Doc-only fixes from the neon-docs-drift audit (docs vs. current product behavior). Two independent corrections across 3 files. **Not auto-merged** — awaiting your review.

## What changed and why

### 1. False "reserved `NEON_` prefix" claim (`runtime-limits.md`)
No env-var name is actually reserved.

- **Before:** "…limits on variable count, total size, and the reserved `NEON_` prefix."
- **After:** "…limits on variable count and total size."
- **Why the new text is right:** platform variables (`DATABASE_URL`, `AWS_*`, `NEON_*`, …) are injected as *defaults* — a user variable with the same name simply overrides them, so nothing is reserved. You can confirm by setting a `NEON_`-prefixed variable on a function and seeing it accepted. This is the same fix already merged for the sibling pages in #5210; this is the one file that PR missed.

### 2. Invocation URL examples missing the trailing slash
The public API guarantees a trailing slash so paths concatenate cleanly.

- **Before:** `https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech`
- **After:** `https://<branch_id>-<slug>.compute.<cell>.us-east-2.aws.neon.tech/`
- **Why the new text is right:** the `invocation_url` returned by the public API always ends with a trailing slash so request paths concatenate onto it — you can confirm by deploying a function and inspecting the `invocation_url` the API returns. Applied to all 3 examples (the URL line and the curl line in get-started, and the deploy example).

## Files
| File | Change |
|------|--------|
| `content/docs/compute/functions/reference/runtime-limits.md` | drop the false "reserved `NEON_` prefix" clause |
| `content/docs/compute/functions/get-started.md` | trailing slash on URL + curl examples |
| `content/docs/compute/functions/deploy.md` | trailing slash on invocation URL example |

## Verified against live Neon ✅

Both fixes were tested against a real Neon Functions deployment (production, Postgres 17.10, nodejs24 runtime). Anyone can reproduce:

**The `NEON_` prefix is not reserved.** Deploy a function with an env var named `NEON_LIVE_TEST_VALUE`. What happens: the deploy is accepted, the variable shows up in the function's environment, and calling the function returns the exact value you set. So a `NEON_`-prefixed name is accepted *and* readable at runtime — nothing reserves it.

**The invocation URL ends with a trailing slash.** Deploy a function and read the `invocation_url` the API returns. What happens: it ends in `/` — confirmed for two function slugs, including the `hello` slug from the get-started example.

A second, independent reviewer (a different AI tool) checked that these tests actually prove the doc's claims — both PASS. Text-only change; no build or deploy behavior is affected.

## Notes
- Tracked in LKB-15130 and LKB-15131. Cross-vendor reviewed: PASS. Live-tested against production Neon: PASS (both claims).
