### PR TITLE
docs(compatibility): correct superuser_reserved_connections and max_worker_processes formula

### DIFF
--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -84,7 +84,7 @@ If you are a Neon [Scale plan](/docs/introduction/plans) user and require a diff
 | `password_encryption`                 | scram-sha-256 |                                                                                                                                                                                                                                                                                |
 | `restart_after_crash`                 | off           |                                                                                                                                                                                                                                                                                |
 | `shared_buffers`                      | 128MB         | Neon uses a [Local File Cache (LFC)](/docs/extensions/neon#what-is-the-local-file-cache) in addition to `shared_buffers` to extend cache memory to 75% of your compute's RAM. The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size). |
-| `superuser_reserved_connections`      | 4             |                                                                                                                                                                                                                                                                                |
+| `superuser_reserved_connections`      | 7             |                                                                                                                                                                                                                                                                                |
 | `synchronous_standby_names`           | 'walproposer' |                                                                                                                                                                                                                                                                                |
 | `wal_level`                           | replica       | Support for `wal_level=logical` is coming soon. See [logical replication](/docs/introduction/logical-replication).                                                                                                                                                             |
 | `wal_log_hints`                       | off           |                                                                                                                                                                                                                                                                                |
@@ -185,10 +185,10 @@ _For most applications, we recommend using connection pooling, which supports up
 - The formula for `max_worker_processes` is:
 
   ```go
-  max_worker_processes := 12 + floor(2 * max_compute_size)
+  max_worker_processes := 13 + floor(2 * max_compute_size)
   ```
 
-  For example, if your `max_compute_size` is 4 CU, your `max_worker_processes` setting would be 20.
+  For example, if your `max_compute_size` is 4 CU, your `max_worker_processes` setting would be 21.
 
 - The formula for `shared_buffers` is:
 


### PR DESCRIPTION
Doc-only fixes from a docs-vs-product audit. Two related Postgres-parameter corrections in one file. **Not auto-merged** — awaiting your review.

## What changed and why

### 1. `superuser_reserved_connections` value
- **Before:** `4`
- **After:** `7`
- **Why the new text is right:** the running server reserves 7 connections, not 4. The connection-pooling doc already says "Seven connections are reserved", so this also removes a contradiction between two of our own pages. Verify on any instance with `SHOW superuser_reserved_connections;`.

### 2. `max_worker_processes` formula (off by one)
- **Before:** `12 + floor(2 * max_compute_size)`; example for 4 CU said `20`
- **After:** base constant `13`; 4 CU example → `21`
- **Why the new text is right:** the base constant is 13, not 12, so the documented formula and its worked example were each low by one. With 1 CU = 1 vCPU the value is `13 + 2 * CU`, so 4 CU → 21. Verify with `SHOW max_worker_processes;` on a 4-CU compute.

## Files
| File | Change |
|------|--------|
| `content/docs/reference/compatibility.md` | `superuser_reserved_connections` 4→7; formula base 12→13; example 20→21 |

## Scope / what's intentionally untouched
- The separate `max_connections` per-CU drift (the 419.66-per-CU numbers) is **deliberately NOT touched here** — it's a cross-cutting, needs-a-decision item. Tracked in LKB-15158.

## How to verify
- On a running compute, `SHOW superuser_reserved_connections;` returns 7; on a 4-CU compute, `SHOW max_worker_processes;` returns 21.
- Text-only change: no build or runtime behavior affected.

## Notes
- Tracked in LKB-15160 and LKB-15161. Cross-vendor reviewed: PASS.
