### PR TITLE
docs: clarify service.name applies to logs, not metrics

### DIFF
--- a/content/docs/guides/opentelemetry.md
+++ b/content/docs/guides/opentelemetry.md
@@ -12,7 +12,7 @@ summary: >-
   signal-specific paths (/v1/metrics, /v1/logs) and collects data from all
   computes in a project.
 enableTableOfContents: true
-updatedOn: '2026-06-16T14:29:15.394Z'
+updatedOn: '2026-07-20T22:03:00.289Z'
 ---
 
 <FeatureBetaProps feature_name="OpenTelemetry integration" />
@@ -208,11 +208,19 @@ You can enable either or both options based on your monitoring needs.
 
 ## Configure resource attributes
 
-Neon automatically organizes your data into separate service entities: your configured service name will receive Postgres logs, while metrics are split into `compute-host-metrics` (infrastructure metrics) and `sql-metrics` (database metrics).
+In the **Resource** section, set the `service.name` attribute to the name your Postgres logs should appear under in your observability platform, such as `neon-postgres-production`.
 
-1. In the **Resource** section, configure the `service.name` attribute to identify your Neon project in your observability platform. For example, you might use "neon-postgres-test" or your actual project name.
+Logs are event messages; metrics are numeric values sampled over time. This name labels your logs only. Metrics are not tagged with it; they arrive under fixed, Neon-assigned service names. Your data appears as follows:
 
-2. Optionally, you can add additional resource attributes by providing a value in the second field to further categorize or filter your data in your observability platform.
+| Data             | Service name                   | Includes                                                            |
+| ---------------- | ------------------------------ | ------------------------------------------------------------------- |
+| Postgres logs    | Your configured `service.name` | Errors, warnings, connection events, and other Postgres activity    |
+| Database metrics | `sql-metrics`                  | Connections, database size, replication delay, and other statistics |
+| Compute metrics  | `compute-host-metrics`         | CPU, memory, and load                                               |
+
+The metric service names are also exposed as the `job` label on each metric.
+
+`service.name` is the only resource attribute Neon exports. Custom resource attributes and custom request headers are not currently supported.
 
 ## Complete the setup
 
@@ -258,8 +266,8 @@ _Postgres logs flowing into New Relic_
 **Find your data under APM & Services**
 ![Multiple Neon services in New Relic APM & Services](/docs/guides/new_relic_services.png)
 
-- **Logs**: Check your configured service name in APM & Services (for example, `neon-postgres-test`)
-- **Metrics**: Look for the auto-created `compute-host-metrics` and `sql-metrics` services
+- **Logs**: Check your configured service name in APM & Services (for example, `neon-postgres-production`)
+- **Metrics**: Look for the auto-created `compute-host-metrics` and `sql-metrics` services. Metrics are not tagged with your configured `service.name`; see [Configure resource attributes](#configure-resource-attributes).
 
 </Steps>
 


### PR DESCRIPTION
Update the "Configure resource attributes" section:
- Remove the incorrect claim that a second field adds arbitrary resource attributes, Neon only exports `service.name`.
- Explain that `service.name` labels Postgres logs only, and that metrics arrive under fixed service names (sql-metrics, compute-host-metrics).
- Add a table mapping each data type to its service name and contents.
- Note custom resource attributes and request headers are unsupported.
- Did not yet add `compute-pgbouncer-metrics` as it isn't live, but expect a future update.

Addresses a customer concern as kindly reported by Jason Fane.