### PR TITLE
docs: bump cli docs from 2.34.0 to 2.35.2

### DIFF
--- a/content/docs/cli/branches.md
+++ b/content/docs/cli/branches.md
@@ -10,7 +10,7 @@ summary: >-
   any two branches or historical states, expiration timestamps, or adding
   read replica computes.
 enableTableOfContents: true
-updatedOn: '2026-07-14T22:23:35.340Z'
+updatedOn: '2026-07-22T13:42:19.210Z'
 redirectFrom:
   - /docs/reference/cli-branches
   - /docs/cli/branch
@@ -262,6 +262,12 @@ Create a schema-only branch:
 
 ```bash
 neon branches create --schema-only
+```
+
+Create a [protected branch](/docs/guides/protected-branches):
+
+```bash
+neon branches create --name production --protected
 ```
 
 ## neon branches reset (#reset)

--- a/content/docs/cli/projects.md
+++ b/content/docs/cli/projects.md
@@ -11,7 +11,7 @@ summary: >-
   18; use the Neon Console or API to create projects on earlier Postgres
   versions.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-07-22T13:42:19.210Z'
 redirectFrom:
   - /docs/reference/cli-projects
   - /docs/cli/project
@@ -86,7 +86,7 @@ Creates a Neon project.
 The `--region-id` value defaults to `aws-us-east-2` if not specified. `--block-public-connections` and `--block-vpc-connections` are part of [Private Networking](/docs/guides/neon-private-networking); `--hipaa` enables [HIPAA compliance](/docs/security/hipaa) for the project.
 
 <Admonition type="note">
-Neon projects created using the CLI use the default Postgres version, which is Postgres 18. To create a project with a different Postgres version, you can use the [Neon Console](/docs/manage/projects#create-a-project) or [Neon API](/docs/reference/api/projects/create-project).
+Projects created using the CLI use the default Postgres version (Postgres 18) unless you specify `--pg-version`.
 </Admonition>
 
 Create a project with a user-defined name in a specific region:
@@ -112,6 +112,12 @@ neon projects create --name mynewproject --region-id aws-us-west-2
 <Admonition type="tip">
 The Neon CLI provides a `neon connection-string` command you can use to extract a connection URI programmatically. See [the connection-string command](/docs/cli/connection-string).
 </Admonition>
+
+Create a project with a specific Postgres major version:
+
+```bash
+neon projects create --name mynewproject --pg-version 17
+```
 
 - Create a project with `--output json`, which returns the full project response data and is the recommended format for scripts and agents. The output below was captured on an earlier CLI version; new projects report `"pg_version": 18`.
 
@@ -213,6 +219,12 @@ Block connections from the public internet (see [restrict public internet access
 
 ```bash
 neon projects update orange-credit-12345678 --block-public-connections=true
+```
+
+Enable [logical replication](/docs/guides/logical-replication-neon) for the project. This suspends active endpoints and cannot be disabled, so `--yes` skips the confirmation prompt:
+
+```bash
+neon projects update orange-credit-12345678 --enable-logical-replication --yes
 ```
 
 ## neon projects delete (#delete)

--- a/content/docs/cli/projects.md
+++ b/content/docs/cli/projects.md
@@ -8,10 +8,9 @@ summary: >-
   connections, and filtering shared projects. Use this page when you need CLI
   automation for project lifecycle tasks or to recover a deleted project within
   its 7-day recovery window. Projects created via the CLI default to Postgres
-  18; use the Neon Console or API to create projects on earlier Postgres
-  versions.
+  18; use `--pg-version` to select a different major version.
 enableTableOfContents: true
-updatedOn: '2026-07-22T13:42:19.210Z'
+updatedOn: '2026-07-22T13:52:43.579Z'
 redirectFrom:
   - /docs/reference/cli-projects
   - /docs/cli/project

--- a/content/docs/guides/logical-replication-neon.md
+++ b/content/docs/guides/logical-replication-neon.md
@@ -11,7 +11,7 @@ summary: >-
   `pgoutput` and `wal2json`.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-07-22T13:42:19.210Z'
 ---
 
 This topic outlines information about logical replication specific to Neon, including important notices.
@@ -24,7 +24,7 @@ When replicating data from Neon, enable logical replication on your Neon project
 Enabling logical replication changes the PostgreSQL `wal_level` setting from `replica` to `logical` for all databases in your Neon project. This allows Postgres to record the row-level WAL detail required for logical decoding. Once changed, it cannot be reverted. Enabling logical replication also restarts all computes, so active connections will be dropped and have to reconnect.
 </Admonition>
 
-<Tabs labels={["Console", "API"]}>
+<Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
 
@@ -32,6 +32,16 @@ Enabling logical replication changes the PostgreSQL `wal_level` setting from `re
 2. On the **Project Dashboard**, select **Settings**.
 3. Select **Logical replication**.
 4. Click **Enable** to enable logical replication.
+
+</TabItem>
+
+<TabItem>
+
+Use the [Neon CLI](/docs/reference/neon-cli) `projects update` command with `--enable-logical-replication`. Replace `$PROJECT_ID` with your project ID. The `--yes` flag skips the confirmation prompt.
+
+```bash
+neon projects update $PROJECT_ID --enable-logical-replication --yes
+```
 
 </TabItem>
 

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "2.34.0",
+  "neonctlVersion": "2.35.2",
   "binaries": [
     "neonctl",
     "neon"
@@ -305,6 +305,10 @@
             "parent": {
               "type": "string",
               "describe": "Parent branch name or id or timestamp or LSN. Defaults to the default branch"
+            },
+            "protected": {
+              "type": "boolean",
+              "describe": "Whether the branch is protected"
             },
             "psql": {
               "type": "boolean",
@@ -2378,6 +2382,10 @@
               "type": "string",
               "describe": "The project's organization ID"
             },
+            "pg-version": {
+              "type": "number",
+              "describe": "Major PostgreSQL version (14–19). Version 19 is available only in regions where it has been enabled."
+            },
             "psql": {
               "type": "boolean",
               "describe": "Connect to a new project via psql",
@@ -2479,6 +2487,10 @@
               "type": "string",
               "describe": "The number of Compute Units. Could be a fixed size (e.g. \"2\") or a range delimited by a dash (e.g. \"0.5-3\")."
             },
+            "enable-logical-replication": {
+              "type": "boolean",
+              "describe": "Enable logical replication for all project endpoints. This suspends active endpoints and cannot be disabled."
+            },
             "hipaa": {
               "type": "boolean",
               "describe": "Enable HIPAA compliance for the project."
@@ -2486,6 +2498,11 @@
             "name": {
               "type": "string",
               "describe": "The project name"
+            },
+            "yes": {
+              "type": "boolean",
+              "describe": "Skip the confirmation prompt when enabling logical replication.",
+              "default": false
             }
           },
           "commands": {},


### PR DESCRIPTION
Refreshes the neon cli docs to 2.35.2 and documents the three new flags it adds:

- Create projects on a specific Postgres version: `projects create --pg-version`
- Enable logical replication from the CLI: `projects update --enable-logical-replication` (with `--yes` to skip the confirmation prompt), previously only possible via Console or API
- Create a branch as protected: `branches create --protected`

Adds usage examples for each, adds CLI tab to the logical replication docs, and related updates.

All three flags were verified against live projects.