### PR TITLE
docs(cli): support dynamically-registered CLI subcommands in schema parser

### DIFF
--- a/scripts/docs-checks/neonctl/README.md
+++ b/scripts/docs-checks/neonctl/README.md
@@ -17,6 +17,21 @@ The schema is parsed from the neonctl TypeScript source (not `--help`
 output, which has known per-subcommand bugs) and patched by `overrides.json`
 for values the parser can't resolve.
 
+## Dynamically-registered subcommands
+
+Most commands declare subcommands as literal `.command('name', ...)` chains the
+parser reads directly. `inspect db` instead registers its 14 leaves in a loop
+over `INSPECT_QUERIES` (in `src/utils/inspect_queries.ts`), which is invisible
+to a static parse. `dynamic-commands.json` declares which const to enumerate;
+`applyDynamicCommands` in `generate-schema.js` reads its keys + describes from
+source and injects the leaves (throwing if the const or parent can't be
+resolved, so drift fails the refresh loudly).
+
+Verify with `npm run cli-docs -- verify-dynamic`: it cross-checks the schema
+leaves against a local `neon <path> --help`. Local/manual (needs the `neon`
+binary) and version-gated — it skips if the installed binary doesn't match
+`schema.json`'s pin, rather than reporting spurious drift.
+
 ## Run
 
 All commands run through a single `cli-docs` dispatcher. Run it with no
@@ -29,6 +44,7 @@ npm run cli-docs -- refresh               # full refresh from the latest GitHub 
 npm run cli-docs -- schema --src <path>   # regenerate schema.json from a CLI checkout
 npm run cli-docs -- scaffold <name> --group <group-id>   # wire a new command
 npm run cli-docs -- preview               # emit fragments to fragments/ (local preview)
+npm run cli-docs -- verify-dynamic        # cross-check dynamic subcommands vs local `neon --help`
 ```
 
 For a local Markdown validation report:
@@ -96,6 +112,8 @@ override deletes a stale key.
 | `schema.json`                     | Committed schema. Canonical, version-pinned, the only refresh artifact. |
 | `generate-schema.js`              | Parses neonctl's TS source → `schema.json`.                   |
 | `overrides.json`                  | Hand-maintained patches for parser-unresolvable values.       |
+| `dynamic-commands.json`           | Declares loop-registered subcommands to enumerate from source (e.g. `inspect db`). |
+| `verify-dynamic.js`               | `verify-dynamic`: cross-checks dynamic subcommands vs a matching-version local `neon --help`. |
 | `generate-docs.js`                | Markdown renderers shared by components + llms mirror; `--fragments` preview. |
 | `cli.js`                          | The `npm run cli-docs` dispatcher; routes to the scripts below. |
 | `fragments/`                      | Local-only preview dump from `npm run cli-docs -- preview` (gitignored). |

--- a/scripts/docs-checks/neonctl/__tests__/units.test.js
+++ b/scripts/docs-checks/neonctl/__tests__/units.test.js
@@ -14,7 +14,17 @@ const {
   isLikelyCommand,
   buildTopLevelCommands,
 } = require('../extract-examples.js');
+const { parseCommandFile, enumerateConstEntries } = require('../generate-schema.js');
 const { loadSchema, resolvePath, resolveValidOptions } = require('../schema.js');
+
+// Writes `source` to a temp .ts file and returns its path, for exercising the
+// TypeScript-source parser without a full neonctl checkout.
+function writeTempSource(source) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'neonctl-units-'));
+  const file = path.join(dir, 'sample.ts');
+  fs.writeFileSync(file, source);
+  return file;
+}
 
 describe('tokenize', () => {
   it('splits on whitespace', () => {
@@ -231,5 +241,56 @@ describe('resolveValidOptions', () => {
     const opts = resolveValidOptions(schema, []);
     const maybe = [...opts.keys()].find((k) => k.startsWith('--no-'));
     expect(typeof maybe).toBe('string');
+  });
+});
+
+describe('parseCommandFile: builder passed as a bare identifier', () => {
+  it('walks a builder function referenced by name (like inspect db)', () => {
+    const file = writeTempSource(`
+      import type yargs from "yargs";
+      export const command = "inspect";
+      export const describe = "Inspect things";
+      const dbBuilder = (argv: yargs.Argv) =>
+        argv
+          .usage("$0 inspect db <sub-command> [options]")
+          .options({
+            "project-id": { describe: "Project ID", type: "string" },
+            "db-url": { describe: "Connection string", type: "string" },
+          });
+      export const builder = (argv: yargs.Argv) =>
+        argv.command("db", "Run a diagnostic query", dbBuilder);
+    `);
+    const parsed = parseCommandFile(file, new Map());
+    expect(parsed.name).toBe('inspect');
+    const db = parsed.commands.db;
+    expect(db).toBeDefined();
+    // Options and usage from the identifier-resolved builder are captured.
+    expect(Object.keys(db.options).sort()).toEqual(['db-url', 'project-id']);
+    expect(db.usage).toBe('$0 inspect db <sub-command> [options]');
+  });
+});
+
+describe('enumerateConstEntries', () => {
+  it('reads keys and describe from a const object literal', () => {
+    const file = writeTempSource(`
+      export const INSPECT_QUERIES = {
+        "table-sizes": { describe: "Size of each table", sql: "SELECT 1" },
+        "index-sizes": { describe: "Size of each index", sql: "SELECT 2" },
+      } as const;
+    `);
+    const entries = enumerateConstEntries(file, 'INSPECT_QUERIES', 'describe');
+    expect(entries).toEqual([
+      { name: 'table-sizes', describe: 'Size of each table' },
+      { name: 'index-sizes', describe: 'Size of each index' },
+    ]);
+  });
+
+  it('returns null when the const is missing (so callers fail loudly)', () => {
+    const file = writeTempSource(`export const SOMETHING_ELSE = {};`);
+    expect(enumerateConstEntries(file, 'INSPECT_QUERIES', 'describe')).toBeNull();
+  });
+
+  it('returns null when the source file does not exist', () => {
+    expect(enumerateConstEntries('/no/such/file.ts', 'X', 'describe')).toBeNull();
   });
 });

--- a/scripts/docs-checks/neonctl/cli.js
+++ b/scripts/docs-checks/neonctl/cli.js
@@ -8,6 +8,7 @@
 //   npm run cli-docs -- scaffold <name> --group <group-id>   # wire a new command
 //   npm run cli-docs -- check        # run the coverage + generation tests
 //   npm run cli-docs -- preview      # emit markdown fragments to fragments/ (dev only)
+//   npm run cli-docs -- verify-dynamic  # cross-check dynamic subcommands vs local `neon --help`
 //
 // Each subcommand forwards its remaining args to the underlying script with
 // stdio inherited, so per-script flags (--src, --group, ...) work unchanged.
@@ -45,6 +46,11 @@ const SUBCOMMANDS = {
   preview: {
     summary: 'Emit every rendered markdown fragment to fragments/ for local preview (dev only).',
     run: (args) => node(path.join(HERE, 'generate-docs.js'), args),
+  },
+  'verify-dynamic': {
+    summary:
+      'Cross-check dynamically-generated subcommands against a matching-version local `neon --help`.',
+    run: (args) => node(path.join(HERE, 'verify-dynamic.js'), args),
   },
 };
 

--- a/scripts/docs-checks/neonctl/dynamic-commands.json
+++ b/scripts/docs-checks/neonctl/dynamic-commands.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Declares subcommands that neonctl registers dynamically (in a loop over a const map) rather than as literal `.command('name', ...)` chains the static parser can read. For each entry, generate-schema.js reads the named const from the given source file, treats each top-level key as a leaf subcommand, and uses the key's `describeProp` as its description. `inspect db` is the only such command today. Verify with `npm run cli-docs -- verify-dynamic` (compares against a matching-version `neon <path> --help`). See README.md.",
+  "commands": {
+    "inspect.db": {
+      "sourceFile": "src/utils/inspect_queries.ts",
+      "enumerateConst": "INSPECT_QUERIES",
+      "describeProp": "describe"
+    }
+  }
+}

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -122,6 +122,26 @@ function collectModuleConsts(sf) {
   return consts;
 }
 
+// Builds a map of module-level `const name = (argv) => ...` / `const name =
+// function (argv) {...}` builder functions, so a `.command('db', 'desc',
+// dbBuilder)` that passes its builder as a bare identifier (rather than an
+// inline arrow) can still be walked. `inspect db` is the only command that
+// does this today, but the resolution is general.
+function collectFunctionConsts(sf) {
+  const fns = new Map();
+  sf.forEachChild((node) => {
+    if (!ts.isVariableStatement(node)) return;
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue;
+      const init = unwrapExpression(decl.initializer);
+      if (init && (ts.isArrowFunction(init) || ts.isFunctionExpression(init))) {
+        fns.set(decl.name.text, init);
+      }
+    }
+  });
+  return fns;
+}
+
 // Resolves an expression to an option-spec ObjectLiteralExpression, if
 // possible. Handles inline object literals and external references like
 // `projectCreateRequest['project.name']` where the referenced const (e.g.
@@ -401,11 +421,21 @@ function parseCommandCall(callArgs, consts) {
 // Walks an arrow-function / function builder body, collecting
 // `.options(...)` and `.command(...)` calls into the `node` accumulator.
 function walkBuilder(builderNode, node, consts) {
+  // A builder passed as a bare identifier (`.command('db', 'desc', dbBuilder)`)
+  // resolves to its module-level function const, whose body we then walk. Only
+  // `inspect db` does this today; the resolution is general.
+  let resolvedBuilder = builderNode;
+  if (builderNode && ts.isIdentifier(builderNode) && consts && consts.has(builderNode.text)) {
+    const target = consts.get(builderNode.text);
+    if (target && (ts.isArrowFunction(target) || ts.isFunctionExpression(target))) {
+      resolvedBuilder = target;
+    }
+  }
   let body;
-  if (ts.isArrowFunction(builderNode) || ts.isFunctionExpression(builderNode)) {
-    body = builderNode.body;
+  if (ts.isArrowFunction(resolvedBuilder) || ts.isFunctionExpression(resolvedBuilder)) {
+    body = resolvedBuilder.body;
   } else {
-    body = builderNode;
+    body = resolvedBuilder;
   }
   // The body is either a block (with a return and/or expression
   // statements) or a single expression. Collect every candidate so we
@@ -535,8 +565,14 @@ function walkBuilder(builderNode, node, consts) {
 
 function parseCommandFile(srcFile, externalConsts) {
   const sf = readSource(srcFile);
-  // File-local consts shadow external ones (parameters.gen.ts).
-  const consts = new Map([...(externalConsts || new Map()), ...collectModuleConsts(sf)]);
+  // File-local consts shadow external ones (parameters.gen.ts). Function
+  // consts (builder functions passed by identifier) live in the same map so
+  // walkBuilder can resolve `.command('db', 'desc', dbBuilder)`.
+  const consts = new Map([
+    ...(externalConsts || new Map()),
+    ...collectModuleConsts(sf),
+    ...collectFunctionConsts(sf),
+  ]);
   const result = {
     name: null,
     aliases: [],
@@ -631,6 +667,84 @@ function parseGlobalOptions(cliSrc) {
   return filtered;
 }
 
+// Reads the top-level keys (and their `describeProp` values) of a const
+// object literal declared in a source file. Used to enumerate subcommands
+// neonctl registers dynamically (see applyDynamicCommands). Returns an
+// ordered array of `{ name, describe }`, or null if the const can't be
+// resolved (source moved, const renamed) so the caller can fail loudly.
+function enumerateConstEntries(srcFile, constName, describeProp) {
+  if (!fs.existsSync(srcFile)) return null;
+  const sf = readSource(srcFile);
+  const consts = collectModuleConsts(sf);
+  const obj = consts.get(constName);
+  if (!obj || !ts.isObjectLiteralExpression(obj)) return null;
+  const entries = [];
+  for (const p of obj.properties) {
+    if (!ts.isPropertyAssignment(p)) continue;
+    let key;
+    if (ts.isIdentifier(p.name)) key = p.name.text;
+    else if (ts.isStringLiteral(p.name)) key = p.name.text;
+    if (!key) continue;
+    const entry = { name: key };
+    const spec = resolveSpecObject(p.initializer, consts);
+    if (spec) {
+      const descProp = getProp(spec, describeProp);
+      if (descProp && ts.isPropertyAssignment(descProp)) {
+        const d = resolveStringValue(descProp.initializer, consts);
+        if (d !== undefined) entry.describe = d.trim();
+      }
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+// Injects subcommands that neonctl registers dynamically (in a loop over a
+// const map) into the command tree. These are invisible to the static parser
+// — `dynamic-commands.json` names the const and source file to enumerate. The
+// parent node (e.g. `inspect db`) must already exist from the static walk;
+// its options and usage came through Gap-1 identifier-builder resolution.
+//
+// A configured parent that isn't in this CLI version is skipped (the config is
+// forward-compatible: it lies dormant until the command ships upstream). But a
+// parent that IS present with a const that can't be enumerated throws — that's
+// real drift (renamed/moved const) and must fail the refresh loudly rather
+// than silently emit an empty leaf list.
+function applyDynamicCommands(schema, src) {
+  const configPath = path.join(__dirname, 'dynamic-commands.json');
+  if (!fs.existsSync(configPath)) return schema;
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  for (const [cmdPath, spec] of Object.entries(config.commands || {})) {
+    const parts = cmdPath.split('.');
+    let node = { commands: schema.commands };
+    let missing = false;
+    for (const part of parts) {
+      node = node.commands && node.commands[part];
+      if (!node) {
+        missing = true;
+        break;
+      }
+    }
+    // Parent absent: this CLI version doesn't have the command yet. Skip.
+    if (missing) continue;
+    const srcFile = path.join(src, spec.sourceFile);
+    const entries = enumerateConstEntries(srcFile, spec.enumerateConst, spec.describeProp);
+    if (!entries || entries.length === 0) {
+      throw new Error(
+        `dynamic-commands.json: could not enumerate "${spec.enumerateConst}" in ${spec.sourceFile} ` +
+          `for "${cmdPath}". The const may have been renamed or moved upstream — update the config.`
+      );
+    }
+    node.commands = node.commands || {};
+    for (const entry of entries) {
+      const leaf = { aliases: [], positionals: [], options: {}, commands: {} };
+      if (entry.describe) leaf.describe = entry.describe;
+      node.commands[entry.name] = leaf;
+    }
+  }
+  return schema;
+}
+
 // Deep-merges `overrides.json` (if present) into the schema. Overrides are
 // the escape hatch for terse or missing upstream descriptions — same shape
 // as the schema itself, merged key-by-key with overrides winning.
@@ -712,15 +826,19 @@ function buildSchema({ src } = {}) {
     commands[parsed.name] = entry;
   }
 
-  return applyOverrides({
-    schemaVersion: 2,
-    neonctlVersion: pkg.version,
-    // The published binary names; `neon` is an alias of `neonctl`.
-    binaries: ['neonctl', 'neon'],
-    docsUrl: 'https://neon.com/docs/cli',
-    globalOptions,
-    commands,
-  });
+  const schema = applyDynamicCommands(
+    {
+      schemaVersion: 2,
+      neonctlVersion: pkg.version,
+      // The published binary names; `neon` is an alias of `neonctl`.
+      binaries: ['neonctl', 'neon'],
+      docsUrl: 'https://neon.com/docs/cli',
+      globalOptions,
+      commands,
+    },
+    src
+  );
+  return applyOverrides(schema);
 }
 
 const USAGE = [
@@ -815,6 +933,7 @@ module.exports = {
   parseGlobalOptions,
   parseOptionsObject,
   parseCommandCall,
+  enumerateConstEntries,
 };
 
 if (require.main === module) main();

--- a/scripts/docs-checks/neonctl/verify-dynamic.js
+++ b/scripts/docs-checks/neonctl/verify-dynamic.js
@@ -1,0 +1,161 @@
+// Cross-checks the dynamically-generated subcommands in schema.json against a
+// locally-installed `neon` binary's `--help` output. This is an independent
+// derivation path: schema.json builds these leaves by reading a const from the
+// neonctl TypeScript source (see applyDynamicCommands in generate-schema.js),
+// while this check reads them from the built CLI's help. If the two disagree,
+// the source-driven config has drifted from what the CLI actually ships.
+//
+//   npm run cli-docs -- verify-dynamic
+//
+// The check is local/manual, not part of CI: it needs the `neon` binary
+// installed, which CI boxes may not have. It also REQUIRES the installed
+// binary to match schema.json's pinned neonctlVersion — a mismatched version
+// would report spurious drift (the CLI added/removed leaves the pinned schema
+// hasn't caught up to). On a version mismatch it skips with a clear message
+// rather than failing.
+
+const { execFileSync, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Guard against shell metacharacters before interpolating into execSync. The
+// bin comes from --bin and command paths from dynamic-commands.json, so this
+// is defense-in-depth, not untrusted input.
+function assertShellSafe(token) {
+  if (!/^[A-Za-z0-9._-]+$/.test(token)) {
+    throw new Error(`Refusing to run: unsafe token ${JSON.stringify(token)}`);
+  }
+  return token;
+}
+
+const SCHEMA_PATH = path.join(__dirname, 'schema.json');
+const CONFIG_PATH = path.join(__dirname, 'dynamic-commands.json');
+
+// Which binary to probe. `neon` and `neonctl` are the same package; prefer
+// `neon` (the documented name) and let --bin override for odd setups.
+function parseArgs(argv) {
+  const out = { bin: 'neon' };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--bin') {
+      out.bin = argv[i + 1];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function installedVersion(bin) {
+  try {
+    return execFileSync(bin, ['--version'], { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Parse the leaf subcommand names out of `neon <path> --help`. yargs lists
+// each subcommand on its own line as `<bin> <path> <leaf>` under "Commands:".
+// We take the token right after the full command path.
+//
+// The CLI writes help straight to the terminal, bypassing execFile's piped
+// stdout (captured output comes back empty). A shell invocation with
+// `2>&1 </dev/null` reliably captures it; tokens are validated first so the
+// interpolation is safe.
+function leavesFromHelp(bin, cmdPath) {
+  const pathParts = cmdPath.split('.');
+  assertShellSafe(bin);
+  pathParts.forEach(assertShellSafe);
+  let help;
+  try {
+    help = execSync(`${bin} ${pathParts.join(' ')} --help 2>&1 </dev/null`, {
+      encoding: 'utf8',
+    });
+  } catch (err) {
+    // yargs exits non-zero for some help invocations but still prints the
+    // help; fall back to whatever it emitted.
+    help = (err.stdout && err.stdout.toString()) || '';
+  }
+  const prefix = `${bin} ${pathParts.join(' ')} `;
+  const leaves = new Set();
+  for (const line of help.split('\n')) {
+    const trimmed = line.trimEnd();
+    if (!trimmed.startsWith(prefix)) continue;
+    const rest = trimmed.slice(prefix.length).trim();
+    // A leaf line is just the subcommand name (possibly with a trailing
+    // positional/option hint); take the first token, and skip lines that are
+    // really the parent's own usage (`<sub-command>`) or option hints.
+    const name = rest.split(/\s+/)[0];
+    if (!name || name.startsWith('<') || name.startsWith('[') || name.startsWith('-')) continue;
+    leaves.add(name);
+  }
+  return leaves;
+}
+
+// Walk a dotted command path (`inspect.db`) into the schema and return its
+// child command names.
+function leavesFromSchema(schema, cmdPath) {
+  let node = { commands: schema.commands };
+  for (const part of cmdPath.split('.')) {
+    node = node.commands && node.commands[part];
+    if (!node) return null;
+  }
+  return new Set(Object.keys(node.commands || {}));
+}
+
+function main() {
+  const { bin } = parseArgs(process.argv.slice(2));
+  const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+  const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+  const version = installedVersion(bin);
+  if (!version) {
+    console.log(
+      `SKIP: \`${bin}\` is not installed or not runnable. This check needs the CLI ` +
+        `locally.\n  Install it with: npm i -g neonctl`
+    );
+    process.exit(0);
+  }
+  if (version !== schema.neonctlVersion) {
+    console.log(
+      `SKIP: installed ${bin} is ${version}, but schema.json is pinned to ` +
+        `${schema.neonctlVersion}.\n  Versions must match to compare leaves — a mismatch ` +
+        `reports spurious drift.\n  Align them (\`npm i -g neonctl@${schema.neonctlVersion}\` ` +
+        `or \`npm run cli-docs -- refresh\`) and re-run.`
+    );
+    process.exit(0);
+  }
+
+  let failed = false;
+  for (const cmdPath of Object.keys(config.commands || {})) {
+    const schemaLeaves = leavesFromSchema(schema, cmdPath);
+    if (!schemaLeaves) {
+      console.error(`FAIL: "${cmdPath}" not found in schema.json.`);
+      failed = true;
+      continue;
+    }
+    const helpLeaves = leavesFromHelp(bin, cmdPath);
+    const missingFromSchema = [...helpLeaves].filter((l) => !schemaLeaves.has(l));
+    const extraInSchema = [...schemaLeaves].filter((l) => !helpLeaves.has(l));
+    const label = cmdPath.replace(/\./g, ' ');
+    if (missingFromSchema.length === 0 && extraInSchema.length === 0) {
+      console.log(`OK: ${bin} ${label} — ${schemaLeaves.size} leaves match --help.`);
+      continue;
+    }
+    failed = true;
+    console.error(`FAIL: ${bin} ${label} leaves disagree with --help:`);
+    if (missingFromSchema.length) {
+      console.error(`  in --help but missing from schema: ${missingFromSchema.join(', ')}`);
+    }
+    if (extraInSchema.length) {
+      console.error(`  in schema but not in --help: ${extraInSchema.join(', ')}`);
+    }
+    console.error(
+      `  Regenerate: npm run cli-docs -- refresh (or fix dynamic-commands.json if the ` +
+        `enumerated const moved).`
+    );
+  }
+  process.exit(failed ? 1 : 0);
+}
+
+module.exports = { leavesFromHelp, leavesFromSchema };
+
+if (require.main === module) main();


### PR DESCRIPTION
## Problem

The CLI docs schema generator statically parses neonctl source and only captured subcommands declared as literal `.command('name', ...)` chains. `inspect db` is the only command that breaks this on two counts:

1. It passes `db`'s builder as a **bare identifier** (`dbBuilder`) instead of an inline arrow, so `db`'s options were lost.
2. Its 14 leaf subcommands are registered in a **`for` loop** over `Object.keys(INSPECT_QUERIES)`, with names/descriptions computed at runtime — invisible to a static parse.

Result: `neon inspect db` showed up with no options and none of its 14 leaves.

## Changes

- **Identifier-builder resolution** (`collectFunctionConsts`): the parser now follows a builder passed by name, recovering `db`'s options and usage. General to any command written this way.
- **`dynamic-commands.json` + `applyDynamicCommands`**: declares which const to enumerate (and its source file) for loop-registered subcommands, and injects the leaves with their descriptions read from source. Forward-compatible — skips an entry whose parent command isn't in the current CLI version (dormant until it ships), throws only on real drift (const renamed/moved).
- **`npm run cli-docs -- verify-dynamic`**: independent cross-check that parses leaves from a local `neon <path> --help` and asserts they match the schema. Local/manual and version-gated (skips if the installed binary doesn't match the schema pin, to avoid spurious drift).
- Unit tests for both new capabilities, and a trimmed README section.

## For the reviewer / follow-up

This PR is the enabling infra only. The config is dormant against the current `2.35.2` schema pin. Running `cli-docs -- refresh` to `2.36.0` activates it (produces `inspect` + `inspect db` + 14 leaves); the new `inspect` command then needs a group mapping, doc page, and nav entry (scaffold flow).

All checks pass (`npm run cli-docs -- check`: 47 tests).

This pull request and its description were written by Isaac.