### PR TITLE
docs: add inspect CLI command reference (neonctl 2.36.0)

### DIFF
--- a/content/docs/cli/inspect.md
+++ b/content/docs/cli/inspect.md
@@ -25,7 +25,7 @@ Run a single diagnostic query against a branch's Postgres. Pick the query with a
 
 By default the command resolves the project, branch, database, and role from your [context](/docs/cli/set-context) and connects through the Neon API. Pass `--db-url` to inspect any Postgres directly from a connection string, which bypasses API resolution and lets you point `inspect` at a database outside Neon.
 
-Some queries read from Postgres statistics extensions. `outliers` and `calls` need [`pg_stat_statements`](/docs/extensions/pg_stat_statements), and `lfc-hit-rate` and `working-set` need the `neon` extension. If a required extension is not installed, the command reports it instead of returning rows.
+Some queries read from Postgres statistics extensions. `outliers` and `calls` need [`pg_stat_statements`](/docs/extensions/pg_stat_statements), and `lfc-hit-rate` and `working-set` need the [`neon`](/docs/extensions/neon) extension. If a required extension is not installed, the command reports it instead of returning rows.
 
 <CliSubcommands command="inspect db" anchorParts="db" />
 
@@ -35,6 +35,18 @@ Size of each table, including TOAST, largest first.
 
 ```bash
 neon inspect db table-sizes
+```
+
+```text
+┌────────┬───────────┬─────────┐
+│ Schema │ Name      │ Size    │
+├────────┼───────────┼─────────┤
+│ public │ events    │ 16 MB   │
+├────────┼───────────┼─────────┤
+│ public │ orders    │ 4752 kB │
+├────────┼───────────┼─────────┤
+│ public │ customers │ 1616 kB │
+└────────┴───────────┴─────────┘
 ```
 
 ### neon inspect db index-sizes (#db-index-sizes)
@@ -47,15 +59,29 @@ neon inspect db index-sizes
 
 ### neon inspect db unused-indexes (#db-unused-indexes)
 
-Non-unique indexes with few scans. These are candidates for removal.
+Non-unique, non-primary-key indexes with fewer than 50 scans, largest first. These are candidates for removal. Check the `Index Scans` column: an index that has never been scanned (`0`) while taking up space is a strong candidate to drop.
 
 ```bash
 neon inspect db unused-indexes
 ```
 
+```text
+┌──────────────────┬────────────────────────┬────────────┬─────────────┐
+│ Table            │ Index                  │ Index Size │ Index Scans │
+├──────────────────┼────────────────────────┼────────────┼─────────────┤
+│ public.events    │ events_created_at_idx  │ 1368 kB    │ 0           │
+├──────────────────┼────────────────────────┼────────────┼─────────────┤
+│ public.orders    │ orders_customer_id_idx │ 1024 kB    │ 2           │
+├──────────────────┼────────────────────────┼────────────┼─────────────┤
+│ public.customers │ customers_email_idx    │ 808 kB     │ 0           │
+├──────────────────┼────────────────────────┼────────────┼─────────────┤
+│ public.orders    │ orders_status_idx      │ 560 kB     │ 20          │
+└──────────────────┴────────────────────────┴────────────┴─────────────┘
+```
+
 ### neon inspect db seq-scans (#db-seq-scans)
 
-Number of sequential scans recorded against each table. A high count on a large table often points to a missing index.
+Number of sequential scans recorded against each table, highest first. A high count on a large table often points to a missing index.
 
 ```bash
 neon inspect db seq-scans
@@ -63,39 +89,81 @@ neon inspect db seq-scans
 
 ### neon inspect db long-running-queries (#db-long-running-queries)
 
-Queries that have been running longer than five minutes.
+Queries that have been running longer than five minutes. Run it to catch a runaway statement. When nothing qualifies, it says so instead of printing an empty table:
 
 ```bash
 neon inspect db long-running-queries
 ```
 
+```text
+No long-running queries.
+```
+
 ### neon inspect db locks (#db-locks)
 
-Locks currently held, with the query that acquired each one and its age.
+Locks currently held, with the query that acquired each one and its age. When writes are blocked, run this to find what is holding the lock.
 
 ```bash
 neon inspect db locks
 ```
 
+```text
+No locks held.
+```
+
 ### neon inspect db outliers (#db-outliers)
 
-Queries that take the most cumulative execution time. Needs the `pg_stat_statements` extension.
+The top 25 queries by cumulative execution time (`Total Exec Time`), with each query's share of the total (`Prop Exec Time`) and how often it ran (`Ncalls`). This ranks by total time spent, so a cheap query that runs constantly can outrank an expensive one that runs rarely. Needs the [`pg_stat_statements`](/docs/extensions/pg_stat_statements) extension.
 
 ```bash
 neon inspect db outliers
 ```
 
+<details>
+<summary>Show output</summary>
+
+```text
+┌─────────────────┬────────────────┬────────┬───────────────────────────────────────────────────────────────────────┐
+│ Total Exec Time │ Prop Exec Time │ Ncalls │ Query                                                                 │
+├─────────────────┼────────────────┼────────┼───────────────────────────────────────────────────────────────────────┤
+│ 00:00:00.875831 │ 57.0%          │ 250    │ SELECT * FROM orders WHERE customer_id = $1                           │
+├─────────────────┼────────────────┼────────┼───────────────────────────────────────────────────────────────────────┤
+│ 00:00:00.439406 │ 28.6%          │ 400    │ SELECT * FROM customers WHERE email = $1                              │
+├─────────────────┼────────────────┼────────┼───────────────────────────────────────────────────────────────────────┤
+│ 00:00:00.220669 │ 14.4%          │ 15     │ SELECT status, count(*), sum(total_cents) FROM orders GROUP BY status │
+└─────────────────┴────────────────┴────────┴───────────────────────────────────────────────────────────────────────┘
+```
+
+</details>
+
 ### neon inspect db calls (#db-calls)
 
-Most frequently called queries. Needs the `pg_stat_statements` extension.
+The top 25 queries by call count (`Ncalls`). Where `outliers` ranks by total time, this ranks by how often a query runs, so it highlights hot paths worth caching or batching even when each individual call is cheap. Needs the [`pg_stat_statements`](/docs/extensions/pg_stat_statements) extension.
 
 ```bash
 neon inspect db calls
 ```
 
+<details>
+<summary>Show output</summary>
+
+```text
+┌────────┬─────────────────┬────────────────┬───────────────────────────────────────────────────────────────────────┐
+│ Ncalls │ Total Exec Time │ Prop Exec Time │ Query                                                                 │
+├────────┼─────────────────┼────────────────┼───────────────────────────────────────────────────────────────────────┤
+│ 400    │ 00:00:00.439406 │ 59.8%          │ SELECT * FROM customers WHERE email = $1                              │
+├────────┼─────────────────┼────────────────┼───────────────────────────────────────────────────────────────────────┤
+│ 250    │ 00:00:00.875831 │ 37.4%          │ SELECT * FROM orders WHERE customer_id = $1                           │
+├────────┼─────────────────┼────────────────┼───────────────────────────────────────────────────────────────────────┤
+│ 15     │ 00:00:00.220669 │ 2.2%           │ SELECT status, count(*), sum(total_cents) FROM orders GROUP BY status │
+└────────┴─────────────────┴────────────────┴───────────────────────────────────────────────────────────────────────┘
+```
+
+</details>
+
 ### neon inspect db lfc-hit-rate (#db-lfc-hit-rate)
 
-Local File Cache hit rate. Needs the `neon` extension.
+Local File Cache hit rate, the share of reads served from Neon's Local File Cache instead of storage. A low or falling ratio means your working set no longer fits in the cache. Read it after the compute has handled some traffic, not on a freshly resumed one. Needs the [`neon`](/docs/extensions/neon) extension.
 
 ```bash
 neon inspect db lfc-hit-rate
@@ -103,23 +171,41 @@ neon inspect db lfc-hit-rate
 
 ### neon inspect db working-set (#db-working-set)
 
-Estimated working set size compared with the Local File Cache size. Needs the `neon` extension.
+Estimated working set size over several time windows, compared with the Local File Cache size. When `Exceeds Lfc` is `no`, your recent data fits in cache. A `yes` means the working set has outgrown the cache, and a larger compute may help. Needs the [`neon`](/docs/extensions/neon) extension.
 
 ```bash
 neon inspect db working-set
 ```
 
+```text
+┌────────┬─────────────┬──────────┬─────────────┐
+│ Window │ Working Set │ Lfc Size │ Exceeds Lfc │
+├────────┼─────────────┼──────────┼─────────────┤
+│ 1m     │ 48 MB       │ 607 MB   │ no          │
+├────────┼─────────────┼──────────┼─────────────┤
+│ 5m     │ 48 MB       │ 607 MB   │ no          │
+├────────┼─────────────┼──────────┼─────────────┤
+│ 15m    │ 48 MB       │ 607 MB   │ no          │
+├────────┼─────────────┼──────────┼─────────────┤
+│ 1h     │ 48 MB       │ 607 MB   │ no          │
+└────────┴─────────────┴──────────┴─────────────┘
+```
+
 ### neon inspect db vacuum-stats (#db-vacuum-stats)
 
-Autovacuum status per table: last (auto)vacuum time, dead tuples, and the autovacuum threshold.
+Autovacuum status per table: last (auto)vacuum time, dead tuples, and the autovacuum threshold, ordered by dead tuples. Rising dead tuples with no recent autovacuum points at autovacuum falling behind.
 
 ```bash
 neon inspect db vacuum-stats
 ```
 
+<Admonition type="note" title="Vacuum stats reset on auto-suspend">
+Postgres resets these counters whenever the compute restarts, including after a scale-to-zero auto-suspend. On a freshly resumed compute they start near empty, so read them after the database has handled some real traffic.
+</Admonition>
+
 ### neon inspect db bloat (#db-bloat)
 
-Estimated table and index bloat. This is a statistical estimate and needs no extension.
+The top 25 tables by estimated wasted bytes. It needs no extension. The number is a statistical estimate, so use it to decide where to look, not as an exact measurement.
 
 ```bash
 neon inspect db bloat
@@ -127,7 +213,7 @@ neon inspect db bloat
 
 ### neon inspect db replication-slots (#db-replication-slots)
 
-Replication slots with their kind, status, client, restart and confirmed-flush LSNs, and lag.
+Replication slots with their kind, status, client, restart and confirmed-flush LSNs, and lag. Check the lag and status columns to see how far each replica or subscriber is behind the primary.
 
 ```bash
 neon inspect db replication-slots
@@ -135,7 +221,7 @@ neon inspect db replication-slots
 
 ### neon inspect db subscriptions (#db-subscriptions)
 
-Per-table logical replication progress on this subscriber.
+Per-table logical replication progress on this subscriber. Run it on a database with a subscription to see which tables are still copying and which have caught up. On other databases it reports that no subscriptions were found.
 
 ```bash
 neon inspect db subscriptions

--- a/content/docs/cli/inspect.md
+++ b/content/docs/cli/inspect.md
@@ -1,0 +1,142 @@
+---
+title: 'Neon CLI command: inspect'
+subtitle: Run diagnostic queries against a branch's Postgres to check its health and configuration
+summary: >-
+  The Neon CLI `neon inspect` command runs read-only diagnostic queries
+  against a branch's Postgres, reporting on table and index sizes, unused
+  indexes, locks, long-running and expensive queries, cache hit rates,
+  autovacuum status, bloat, and replication. Use it to troubleshoot
+  performance and understand what a database is doing without leaving the
+  terminal.
+enableTableOfContents: true
+---
+
+The `inspect` command runs a set of read-only diagnostic queries against a branch's Postgres and prints the results. Each query targets a common operational question, such as which tables are largest, which indexes go unused, what is holding locks, or how the cache is performing. Nothing is modified, so the command is safe to run against any branch.
+
+<CliSubcommands command="inspect" />
+
+## neon inspect db (#db)
+
+Run a single diagnostic query against a branch's Postgres. Pick the query with a subcommand, for example `neon inspect db table-sizes`.
+
+<CliUsage command="inspect db" />
+
+<CliOptions command="inspect db" />
+
+By default the command resolves the project, branch, database, and role from your [context](/docs/cli/set-context) and connects through the Neon API. Pass `--db-url` to inspect any Postgres directly from a connection string, which bypasses API resolution and lets you point `inspect` at a database outside Neon.
+
+Some queries read from Postgres statistics extensions. `outliers` and `calls` need [`pg_stat_statements`](/docs/extensions/pg_stat_statements), and `lfc-hit-rate` and `working-set` need the `neon` extension. If a required extension is not installed, the command reports it instead of returning rows.
+
+<CliSubcommands command="inspect db" anchorParts="db" />
+
+### neon inspect db table-sizes (#db-table-sizes)
+
+Size of each table, including TOAST, largest first.
+
+```bash
+neon inspect db table-sizes
+```
+
+### neon inspect db index-sizes (#db-index-sizes)
+
+Size of each index, largest first.
+
+```bash
+neon inspect db index-sizes
+```
+
+### neon inspect db unused-indexes (#db-unused-indexes)
+
+Non-unique indexes with few scans. These are candidates for removal.
+
+```bash
+neon inspect db unused-indexes
+```
+
+### neon inspect db seq-scans (#db-seq-scans)
+
+Number of sequential scans recorded against each table. A high count on a large table often points to a missing index.
+
+```bash
+neon inspect db seq-scans
+```
+
+### neon inspect db long-running-queries (#db-long-running-queries)
+
+Queries that have been running longer than five minutes.
+
+```bash
+neon inspect db long-running-queries
+```
+
+### neon inspect db locks (#db-locks)
+
+Locks currently held, with the query that acquired each one and its age.
+
+```bash
+neon inspect db locks
+```
+
+### neon inspect db outliers (#db-outliers)
+
+Queries that take the most cumulative execution time. Needs the `pg_stat_statements` extension.
+
+```bash
+neon inspect db outliers
+```
+
+### neon inspect db calls (#db-calls)
+
+Most frequently called queries. Needs the `pg_stat_statements` extension.
+
+```bash
+neon inspect db calls
+```
+
+### neon inspect db lfc-hit-rate (#db-lfc-hit-rate)
+
+Local File Cache hit rate. Needs the `neon` extension.
+
+```bash
+neon inspect db lfc-hit-rate
+```
+
+### neon inspect db working-set (#db-working-set)
+
+Estimated working set size compared with the Local File Cache size. Needs the `neon` extension.
+
+```bash
+neon inspect db working-set
+```
+
+### neon inspect db vacuum-stats (#db-vacuum-stats)
+
+Autovacuum status per table: last (auto)vacuum time, dead tuples, and the autovacuum threshold.
+
+```bash
+neon inspect db vacuum-stats
+```
+
+### neon inspect db bloat (#db-bloat)
+
+Estimated table and index bloat. This is a statistical estimate and needs no extension.
+
+```bash
+neon inspect db bloat
+```
+
+### neon inspect db replication-slots (#db-replication-slots)
+
+Replication slots with their kind, status, client, restart and confirmed-flush LSNs, and lag.
+
+```bash
+neon inspect db replication-slots
+```
+
+### neon inspect db subscriptions (#db-subscriptions)
+
+Per-table logical replication progress on this subscriber.
+
+```bash
+neon inspect db subscriptions
+```

--- a/content/docs/extensions/neon.md
+++ b/content/docs/extensions/neon.md
@@ -12,7 +12,7 @@ summary: >-
   ANALYZE` with the `FILECACHE` and `PREFETCH` options provides per-query LFC
   and prefetch metrics without requiring the extension.
 enableTableOfContents: true
-updatedOn: '2026-07-10T13:57:31.917Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 ---
 
 The `neon` extension provides functions and views designed to gather Neon-specific metrics.
@@ -32,7 +32,7 @@ When data is requested, Postgres checks shared buffers first, then the LFC. If t
 
 ## Monitoring Local File Cache usage
 
-You can monitor Local File Cache (LFC) usage by installing the `neon` extension on your database and querying the [neon_stat_file_cache](#the-neon_stat_file_cache-view) view or [using EXPLAIN ANALYZE](#view-lfc-metrics-with-explain-analyze). Additionally, you can monitor the [Local file cache hit rate](/docs/introduction/monitoring-page#local-file-cache-hit-rate) graph on the **Monitoring** page in the Neon console.
+You can monitor Local File Cache (LFC) usage by installing the `neon` extension on your database and querying the [neon_stat_file_cache](#the-neon_stat_file_cache-view) view or [using EXPLAIN ANALYZE](#view-lfc-metrics-with-explain-analyze). Additionally, you can monitor the [Local file cache hit rate](/docs/introduction/monitoring-page#local-file-cache-hit-rate) graph on the **Monitoring** page in the Neon console, or check it from the terminal with [`neon inspect db lfc-hit-rate`](/docs/cli/inspect#db-lfc-hit-rate) and [`neon inspect db working-set`](/docs/cli/inspect#db-working-set).
 
 ## neon_stat_file_cache view
 

--- a/content/docs/extensions/pg_stat_statements.md
+++ b/content/docs/extensions/pg_stat_statements.md
@@ -9,7 +9,7 @@ summary: >-
   scales to zero. Only `neon_superuser` roles can call
   `pg_stat_statements_reset()` to clear accumulated stats manually.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 ---
 
 The `pg_stat_statements` extension provides a detailed statistical view of SQL statement execution within a Postgres database. It tracks information such as execution counts, total and average execution times, and more, helping database administrators and developers analyze and optimize SQL query performance.
@@ -85,6 +85,8 @@ FROM pg_stat_statements
 ORDER BY 3 DESC
 LIMIT 10;
 ```
+
+As an alternative to writing SQL, the Neon CLI wraps these two queries as [`neon inspect db calls`](/docs/cli/inspect#db-calls) and [`neon inspect db outliers`](/docs/cli/inspect#db-outliers).
 
 ### Monitor slow queries
 

--- a/content/docs/extensions/pgstattuple.md
+++ b/content/docs/extensions/pgstattuple.md
@@ -12,7 +12,7 @@ summary: >-
   for B-tree fragmentation metrics. GIN and hash index stats are covered by
   `pgstatginindex()` and `pgstathashindex()`.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 ---
 
 The `pgstattuple` extension provides a suite of functions to inspect the physical storage of Postgres tables and indexes at a detailed, tuple (row) level. It offers insights into issues like table and index bloat, fragmentation, and overall space utilization, which are crucial for performance tuning and storage management.
@@ -279,6 +279,8 @@ LIMIT 10;
 <Admonition type="warning" title="Resource Intensive Query">
 Running `pgstattuple()` for every table can be very resource-intensive. For larger databases, consider using `pgstattuple_approx()` in the `CROSS JOIN LATERAL` subquery or filtering tables by size first (for example, adding `AND pg_total_relation_size(c.oid) > '1GB'` to the `WHERE` clause).
 </Admonition>
+
+For a lighter-weight estimate that needs no extension, [`neon inspect db bloat`](/docs/cli/inspect#db-bloat) reports the top bloated tables from the Neon CLI.
 
 ### Diagnosing and resolving index bloat and fragmentation
 

--- a/content/docs/guides/logical-replication-manage.md
+++ b/content/docs/guides/logical-replication-manage.md
@@ -11,7 +11,7 @@ summary: >-
   require manual intervention on the subscriber.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 ---
 
 This topic provides commands for managing publications, subscriptions, and replication slots.
@@ -213,6 +213,8 @@ SELECT * FROM pg_replication_slots;
 ```
 
 It's important to keep an eye on replication lag, which indicates how far behind the subscriber is from the publisher. A significant replication lag could mean that the subscriber isn't receiving updates in a timely manner, which could lead to data inconsistencies.
+
+From the Neon CLI, [`neon inspect db replication-slots`](/docs/cli/inspect#db-replication-slots) shows slot status and lag, and [`neon inspect db subscriptions`](/docs/cli/inspect#db-subscriptions) shows per-table progress on a subscriber.
 
 ## References
 

--- a/content/docs/introduction/monitor-query-performance.md
+++ b/content/docs/introduction/monitor-query-performance.md
@@ -10,7 +10,7 @@ summary: >-
   system-managed database. Query history resets whenever the Neon compute
   suspends or restarts, including after scaling to zero due to inactivity.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 redirectFrom:
   - /docs/introduction/monitor-query-history
 ---
@@ -34,3 +34,5 @@ In Neon, data collected by the `pg_stat_statements` extension is not retained wh
 ## Running your own queries
 
 To run your own queries on `pg_stat_statements` data, you can install the `pg_stat_statements` extension to your database and run your queries from the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or any SQL client, such as [psql](/docs/connect/query-with-psql-editor). For details on `pg_stat_statements`, including how to install it, what data it collects, and queries you can run, refer to our [pg_stat_statements](/docs/extensions/pg_stat_statements) extension guide.
+
+You can also get this data from the terminal with [`neon inspect db outliers`](/docs/cli/inspect#db-outliers) and [`neon inspect db calls`](/docs/cli/inspect#db-calls).

--- a/content/docs/introduction/monitoring-page.md
+++ b/content/docs/introduction/monitoring-page.md
@@ -7,7 +7,7 @@ summary: >-
   connection saturation, cache misses, or replication lag, and decide whether
   to scale up or enable pooling. Historical data retention depends on your plan.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 ---
 
 The **Monitoring** dashboard in the Neon console provides several graphs for monitoring system and database metrics. You can access the **Monitoring** dashboard from the sidebar in the Neon Console. Observable metrics include:
@@ -220,3 +220,5 @@ The **Working set size** graph visualizes the amount of data accessed (calculate
   If your working set size is larger than the LFC size it is recommended to increase the maximum size of the compute to improve the LFC hit rate and achieve good performance.
 
 If your workload pattern doesn't change much over time it is recommended to compare the 1h time interval working set size with the LFC size and make sure that working set size is smaller than LFC size.
+
+To read these values from the terminal, see [`neon inspect db working-set`](/docs/cli/inspect#db-working-set) and [`neon inspect db lfc-hit-rate`](/docs/cli/inspect#db-lfc-hit-rate).

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1266,6 +1266,10 @@
                   slug: cli/ip-allow
                 - title: vpc
                   slug: cli/vpc
+            - title: Debugging
+              items:
+                - title: inspect
+                  slug: cli/inspect
         - section: API
           icon: api
           items:

--- a/content/docs/postgresql/query-performance.md
+++ b/content/docs/postgresql/query-performance.md
@@ -14,7 +14,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/postgres/query-performance
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 ---
 
 Many factors can impact query performance in Postgres, ranging from insufficient indexing and database maintenance to poorly optimized queries or inadequate system resources. With such a wide range of factors, it can be difficult to know where to start. In this topic, we'll look at several strategies you can use to optimize query performance in Postgres.
@@ -37,6 +37,8 @@ Strategies in this category include:
 Gathering query statistics can aid in identifying performance issues and opportunities for optimization. Neon supports the [pg_stat_statements](/docs/extensions/pg_stat_statements) extension for monitoring and analyzing SQL query performance.
 
 The [pg_stat_statements](/docs/extensions/pg_stat_statements) extension provides aggregated query statistics for executed SQL statements. The data collected includes the number of query executions, total execution time, rows returned by the query, and more.
+
+As an alternative to writing SQL, run [`neon inspect db outliers`](/docs/cli/inspect#db-outliers) and [`neon inspect db calls`](/docs/cli/inspect#db-calls) from the terminal to see the slowest and most-frequent queries.
 
 This extension isn’t installed by default, so your first step is to install it and then allow some time for statistics collection. To install the extension, run the following `CREATE EXTENSION` statement.
 
@@ -212,6 +214,8 @@ Strategies in this category include:
 ### Use indexes
 
 Indexes are crucial for query performance, especially in applications with large tables. They significantly reduce the time required to access data, which can be the difference between a slow application and a fast one.
+
+To find indexes that are rarely scanned, run [`neon inspect db unused-indexes`](/docs/cli/inspect#db-unused-indexes); to find tables Postgres scans end to end, run [`neon inspect db seq-scans`](/docs/cli/inspect#db-seq-scans).
 
 Suppose that you have a large `users` table like this with millions of rows:
 
@@ -396,6 +400,8 @@ Remember that the local file cache statistics are for the entire compute, not sp
 The cache hit ratio query is based on statistics that represent the lifetime of your Postgres instance, from the last time you started it until the time you ran the query. Statistics are lost when your instance stops and gathered again from scratch when your instance restarts. In Neon, your compute runs Postgres, so starting and stopping a compute also starts and stops Postgres. Additionally, you'll only want to run the cache hit ratio query after a representative workload has been run. For example, say that you restart Postgres. In this case, you should run a representative workload before you try the cache hit ratio query again to see if your cache hit ratio improved.
 </Admonition>
 
+For the same numbers from the terminal, run [`neon inspect db lfc-hit-rate`](/docs/cli/inspect#db-lfc-hit-rate) and [`neon inspect db working-set`](/docs/cli/inspect#db-working-set).
+
 ### Use connection pooling
 
 Connection pooling improves performance by minimizing the overhead associated with creating and tearing down database connections. Neon uses PgBouncer to provide connection pooling support, enabling up to 10,000 concurrent connections.
@@ -434,6 +440,8 @@ There are SQL queries you can run to check for table and index bloat. There are 
 
 - [Show database bloat – PostgreSQL wiki](https://wiki.postgresql.org/wiki/Show_database_bloat)
 - [Index and table bloat check scripts from PostgreSQL Experts](https://github.com/pgexperts/pgx_scripts/tree/master/bloat)
+
+As an alternative to these queries, run [`neon inspect db bloat`](/docs/cli/inspect#db-bloat) from the Neon CLI for a quick estimate.
 
 #### Reducing bloat
 

--- a/content/docs/postgresql/query-reference.md
+++ b/content/docs/postgresql/query-reference.md
@@ -14,7 +14,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/postgres/query-reference
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-22T19:54:54.241Z'
 ---
 
 <CTA />
@@ -661,6 +661,8 @@ Functions are typically used to perform computations. For additional information
 ## Performance tuning
 
 To analyze query performance in Postgres, you can use a combination of built-in views, extensions, and commands that help identify performance bottlenecks and optimize query execution. Here are some examples:
+
+Many of the checks below are also available as one-line commands under [`neon inspect db`](/docs/cli/inspect) in the Neon CLI.
 
 ### Use pg_stat_statements
 

--- a/scripts/docs-checks/neonctl/scaffold-command.js
+++ b/scripts/docs-checks/neonctl/scaffold-command.js
@@ -40,6 +40,7 @@ const NAV_TITLE_BY_GROUP = {
   config: 'Config as code',
   surfaces: 'Functions, storage and data',
   network: 'Organizations and networking',
+  debugging: 'Debugging',
 };
 
 // Extract group ids from the GROUPS array literal in groups.js, so the list of

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "2.35.2",
+  "neonctlVersion": "2.36.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -1528,6 +1528,146 @@
       },
       "commands": {},
       "describe": "Initialize a project with Neon using your AI coding assistant"
+    },
+    "inspect": {
+      "aliases": [
+        "inspection"
+      ],
+      "positionals": [],
+      "options": {},
+      "commands": {
+        "db": {
+          "name": "db",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "branch": {
+              "type": "string",
+              "describe": "Branch ID or name"
+            },
+            "database-name": {
+              "type": "string",
+              "describe": "Database name"
+            },
+            "db-url": {
+              "type": "string",
+              "describe": "Inspect any Postgres via a connection string, bypassing the Neon API (project/branch resolution is skipped)"
+            },
+            "project-id": {
+              "type": "string",
+              "describe": "Project ID"
+            },
+            "role-name": {
+              "type": "string",
+              "describe": "Role name"
+            }
+          },
+          "commands": {
+            "bloat": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Estimated table/index bloat (statistical estimate, no extension needed)"
+            },
+            "calls": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Most frequently called queries (needs pg_stat_statements)"
+            },
+            "index-sizes": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Size of each index, largest first (pg_relation_size)"
+            },
+            "lfc-hit-rate": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Local File Cache hit rate (needs neon extension)"
+            },
+            "locks": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Locks held with the acquiring query and its age (pg_locks + pg_stat_activity)"
+            },
+            "long-running-queries": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Queries running longer than 5 minutes (pg_stat_activity)"
+            },
+            "outliers": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Queries taking the most cumulative execution time (needs pg_stat_statements)"
+            },
+            "replication-slots": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Replication slots: kind, status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)"
+            },
+            "seq-scans": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Number of sequential scans recorded against each table (pg_stat_user_tables)"
+            },
+            "subscriptions": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Per-table logical replication progress on this subscriber (pg_subscription_rel)"
+            },
+            "table-sizes": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Size of each table (including TOAST), largest first (pg_table_size)"
+            },
+            "unused-indexes": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Non-unique indexes with few scans — candidates for removal (pg_stat_user_indexes)"
+            },
+            "vacuum-stats": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Autovacuum status per table: last (auto)vacuum, dead tuples, threshold"
+            },
+            "working-set": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Estimated working set vs LFC size (needs neon extension)"
+            }
+          },
+          "describe": "Run a diagnostic query against a branch's Postgres",
+          "usage": "$0 inspect db <sub-command> [options]"
+        }
+      },
+      "describe": "Inspect a database's health and configuration",
+      "usage": "$0 inspect <sub-command> [options]"
     },
     "ip-allow": {
       "aliases": [],

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -9,6 +9,7 @@ const GROUPS = [
   { id: 'config', title: 'Config as code' },
   { id: 'surfaces', title: 'Functions, storage & data' },
   { id: 'network', title: 'Org & network' },
+  { id: 'debugging', title: 'Debugging' },
 ];
 
 const GROUP_OF = {
@@ -42,6 +43,7 @@ const GROUP_OF = {
   api: 'network',
   diff: 'core',
   snapshots: 'core',
+  inspect: 'debugging',
 };
 
 // Commands documented as a section of another command's page instead of a


### PR DESCRIPTION
Documents the `neon inspect` command (shipped in neon cli 2.36.0) and links to it from related doc pages.

## What's included

- **New page `content/docs/cli/inspect.md`** — documents `neon inspect db` and all 14 diagnostic subcommands (`table-sizes`, `index-sizes`, `unused-indexes`, `seq-scans`, `long-running-queries`, `locks`, `outliers`, `calls`, `lfc-hit-rate`, `working-set`, `vacuum-stats`, `bloat`, `replication-slots`, `subscriptions`). Each entry says what to run it for; several include real captured output.
- **Schema bump to 2.36.0** — `neon inspect` and its subcommands are picked up automatically by the dynamic-subcommand support from #5345.
- **New "Debugging" CLI group** — added to `groups.js`, `scaffold-command.js`, and `navigation.yaml`.
- **Cross-links from 8 related pages** — query-performance, pg_stat_statements, the neon extension, pgstattuple, logical-replication-manage, monitor-query-performance, the monitoring page, and query-reference each link to the relevant `inspect db` subcommand as a CLI alternative to writing the SQL by hand.

## Verification

- `npm run cli-docs -- check` — 47 tests pass (coverage, anchors, renderers).
- `npm run cli-docs -- verify-dynamic` — `OK: neon inspect db — 14 leaves match --help`.
- Markdown validation: 0 errors across 898 CLI examples.

This pull request and its description were written by Isaac.