### PR TITLE
chore: update topbar to promote neon inspect db

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'Neon is expanding into a backend: Object Storage, Functions, and AI Gateway now in beta'
+text: 'Just shipped: Use neon inspect db to debug your Neon database from your agent/CLI'
 link:
-  url: 'https://neon.com/blog/neon-backend-is-beta'
+  url: 'https://neon.com/blog/neon-inspect-db'
   target: '_blank'


### PR DESCRIPTION


- Updates the site topbar announcement to: "Just shipped: Use neon inspect db to debug your Neon database from your agent/CLI"
- Links to https://neon.com/blog/neon-inspect-db
