### PR TITLE
Add public writing skills

### DIFF
--- a/.agents/skills/blog-authoring/SKILL.md
+++ b/.agents/skills/blog-authoring/SKILL.md
@@ -1,35 +1,97 @@
 ---
 name: blog-authoring
-description: Use when creating, editing, previewing, or publishing blog posts through the local working-copy flow, especially when the task involves `content/blog`, `npm run blog:*` commands, or `/blog-preview/...` URLs.
+description: Creates, edits, previews, and publishes Neon blog posts through the website repository's local working-copy flow. Use for content/blog posts, blog frontmatter, blog MDX components, cover images, object-storage uploads, and blog branch previews.
 ---
 
-# Neon Blog Authoring
+# Blog authoring
 
-Default editing workflow:
+Read `../neon-writing/SKILL.md` before drafting or editing a blog post.
 
-1. Work in the site repository.
-2. Edit the local working copy under `content/blog/`.
-3. Run the local site to visually inspect the result.
-4. Publish the snapshot into the configured remote blog-content branch with the provided CLI.
+Use the website repository as the editing surface. Blog content is materialized under the ignored `content/blog/` working copy and published to the configured blog-content repository with the built-in CLI.
 
 Do not default to editing the remote source-of-truth repository directly unless the user explicitly asks for it.
 
+## Choose the post shape
+
+Start with the subject, evidence, audience, and intended reader outcome. Choose a structure that fits the material:
+
+- **Technical tutorial:** Problem, prerequisites, implementation, verification, and tradeoffs.
+- **Technical explanation:** Concrete observation, mechanism, consequence, and examples.
+- **Product announcement:** What changed, who can use it, how it works, limits, and how to try it.
+- **Engineering story:** Problem, constraints, decisions, implementation, evidence, and lessons.
+- **Customer story:** Customer context, problem, decision, implementation, measured result, and attributable quotes.
+- **Opinion or analysis:** Clear thesis supported by evidence and technical reasoning.
+
+Don't force a standard outline onto material that needs a different shape. Build the reasoning before stating a broad conclusion.
+
+## Research
+
+1. Verify product claims, names, dates, measurements, feature status, and availability.
+2. Find primary sources for quotes, benchmarks, and comparisons.
+3. Read related Neon posts and docs. Link the source instead of repeating volatile details.
+4. Confirm code and commands in an environment that matches the post when possible.
+5. Preserve the named author's point of view. Don't invent personal experience or opinions.
+
+## Frontmatter
+
+Read [references/frontmatter.md](references/frontmatter.md) before creating or substantially editing a post. It includes the required schema and cover-image consistency rules.
+
+The filename is the URL slug:
+
+```text
+content/blog/posts/<slug>.md
+```
+
+Use existing slugs from:
+
+- `content/blog/authors/data.json`
+- `content/blog/categories/data.json`
+
+Don't create a new author or category when an existing entry applies.
+
+## Opening image
+
+The post-page Hero renders title, date, authors, and category only. It does not display `cover.image`.
+
+Start the post body with a relevant lead image immediately after frontmatter:
+
+```md
+![Descriptive alt text](https://cdn.neonapi.io/public/images/pages/blog/<slug>/<filename>)
+```
+
+The lead image may match `cover.image` or be a distinct content image. Set `cover.image` to the approved listing and social asset. Read [references/images.md](references/images.md) before uploading or replacing an image.
+
+## Write the post
+
+- Open with the concrete problem, change, observation, or result. Skip generic industry setup.
+- Give readers enough context to understand why the subject matters, but don't explain basics the intended audience already knows.
+- Connect sections logically. Each section should advance the argument or task.
+- Use code, diagrams, measurements, and examples as evidence, not decoration.
+- State constraints, tradeoffs, and failure modes.
+- Attribute quotes and opinions to named people or sources.
+- Use descriptive headings that help readers scan.
+- End on the last concrete implication or next action. Don't add a recap that repeats the post.
+
+## Components
+
+Read [references/components.md](references/components.md) before adding custom MDX. Blog posts support a smaller component set than docs. An unregistered docs component will fail or render incorrectly.
+
 ## Required checks
 
-Before changing content, verify the current state:
+Before changing content:
 
 ```bash
 git branch --show-current
 npm run blog:status
 ```
 
-If `content/blog` is missing, initialize it:
+If `content/blog` is missing:
 
 ```bash
 npm run blog:bootstrap
 ```
 
-If the user explicitly wants to refresh the working copy from remote state:
+Use this only when the user explicitly wants to replace the working copy with remote state:
 
 ```bash
 npm run blog:sync -- --force
@@ -45,7 +107,9 @@ Edit only:
 - `content/blog/authors/data.json`
 - `content/blog/categories/data.json`
 
-Then run:
+Don't edit generated snapshots or a separate clone by default.
+
+### 2. Review locally
 
 ```bash
 npm run dev
@@ -56,7 +120,9 @@ Use the local app to review:
 - `/blog`
 - `/blog/<slug>`
 
-### 2. Publish to a branch in `blog`
+Check the cover image, opening image, headings, code, links, responsive layout, and every custom component.
+
+### 3. Publish to a branch in `blog`
 
 Use the built-in CLI:
 
@@ -70,7 +136,7 @@ Defaults:
 - the command pushes the current `content/blog` snapshot into the configured remote content repository
 - the command prints preview URLs under `/blog-preview/...`
 
-### 3. Review branch preview
+### 4. Review the branch preview
 
 Open the generated preview URL, for example:
 
@@ -80,16 +146,34 @@ Open the generated preview URL, for example:
 
 If the preview returns `404`, treat that as “access denied or missing branch/slug”. Do not assume the route is public.
 
+Before publishing to production, set `draft: false`, confirm dates and metadata, and follow the blog repository's review and merge process.
+
 ## Guardrails
 
 - Prefer `content/blog` in the current repository as the editing surface.
 - Do not overwrite existing `content/blog` automatically; only use `blog:sync -- --force` when the user explicitly wants a refresh.
 - Do not push to the main source-of-truth remote accidentally. If you must work in a separate source repo directly, inspect `git remote -v` first and confirm which remote is safe to push to.
 - When credentials are missing, limit yourself to local editing and local preview; explain exactly which publish/preview actions are blocked.
+- Never print, commit, paste, or log object-storage credentials, GitHub tokens, or preview secrets.
+- Don't upload an image until its final slug and filename are confirmed.
+- Don't overwrite a cached CDN object in place. Use a new filename when replacing an existing asset.
 - Do not touch unrelated local files such as `src/scripts/compare-sites.js`.
+
+## Final review
+
+- Verify the post's claims, code, links, names, dates, and measurements.
+- Confirm frontmatter uses existing author and category slugs.
+- Confirm the lead image appears first in the body and all cover, lead, and SEO image URLs are correct.
+- Confirm all image alt text is useful and all embeds have written context.
+- Confirm every MDX component is supported by the blog renderer.
+- Check `npm run blog:status` after editing.
+- Review both the local page and branch preview before treating the post as ready.
 
 ## References
 
 Load only what you need:
 
 - Commands and environment expectations: `references/commands.md`
+- Frontmatter schema: `references/frontmatter.md`
+- Supported MDX components: `references/components.md`
+- Image preparation and R2 upload: `references/images.md`

--- a/.agents/skills/blog-authoring/references/commands.md
+++ b/.agents/skills/blog-authoring/references/commands.md
@@ -34,7 +34,7 @@ BLOG_PREVIEW_SECRET=...
 
 Notes:
 
-- `BLOG_GITHUB_TOKEN` is currently used for both branch fetches and `blog:publish-branch`, so it needs write access to the configured remote content repo.
+- `BLOG_GITHUB_TOKEN` is used for both branch fetches and `blog:publish-branch`, so it needs write access to the configured remote content repository.
 - Without the repo credentials, local editing still works, but publishing and branch-aware remote fetches do not.
 
 ## Useful git checks

--- a/.agents/skills/blog-authoring/references/components.md
+++ b/.agents/skills/blog-authoring/references/components.md
@@ -1,0 +1,124 @@
+# Blog components
+
+Blog posts support only the components registered in `src/components/pages/blog-post/blog-post-page/blog-post-page.jsx`. Don't assume a docs component is available.
+
+Ordinary Markdown headings, links, lists, tables, images, and fenced code blocks are supported. Use a custom component only when it improves the article.
+
+## Admonition
+
+Use when readers could miss a risk, requirement, correction, or time-sensitive status.
+
+```mdx
+<Admonition type="important" title="Update">
+This feature is now available to all users.
+</Admonition>
+```
+
+Types:
+
+- `note`: Information worth noticing.
+- `important`: Information required to interpret or use the post correctly.
+- `tip`: Optional practical advice.
+- `info`: Explanatory context.
+- `warning`: Risk or destructive behavior.
+- `comingSoon`: A capability that isn't available yet.
+
+Don't use admonitions for routine prose or promotional claims.
+
+## BlogQuote
+
+Use for a short attributed quotation. Verify the wording, speaker, role, and permission before publishing.
+
+```mdx
+<BlogQuote
+  quote="A verified quotation without surrounding quotation marks."
+  author="Dana Smith"
+  role="Staff engineer at Example"
+  photo="https://cdn.neonapi.io/public/images/people/dana-smith.jpg"
+/>
+```
+
+`quote` and `author` are required. `role` and `photo` are optional. Link the primary source in nearby prose when one exists.
+
+## CodeTabs
+
+Use for equivalent code in different languages, clients, package managers, or runtimes.
+
+````mdx
+<CodeTabs labels={["JavaScript", "Python"]}>
+
+```javascript
+const result = await client.query('SELECT 1');
+```
+
+```python
+cursor.execute("SELECT 1")
+```
+
+</CodeTabs>
+````
+
+Keep examples equivalent and labels aligned with code-block order. Use ordinary fenced code when only one example is needed.
+
+## CTA
+
+Use for one focused next action, usually near the end of the post.
+
+```mdx
+<CTA
+  title="Try Neon"
+  description="Create a project and connect your application."
+  buttonText="Create a project"
+  buttonUrl="https://console.neon.tech/signup"
+/>
+```
+
+All four props are required. Don't use multiple competing CTAs or send all readers to plan-gated support.
+
+## EmbedTweet
+
+Use when the original post on X is evidence or part of the story. Explain its relevance in nearby prose because the embed may be unavailable to some readers.
+
+```mdx
+<EmbedTweet url="https://x.com/example/status/1234567890" />
+```
+
+Don't use an embed as the only source for a factual claim that needs a durable citation.
+
+## RequestForm
+
+Use only for an approved request or early-access campaign already configured in `src/components/shared/request-form/data.js`.
+
+```mdx
+<RequestForm type="backend-platform" />
+```
+
+The `type` is required and must exist in the component data. Title, description, button text, and confirmation can be overridden, but the type still controls options and analytics. Don't invent a type in a post.
+
+## YoutubeIframe
+
+Use for a YouTube tutorial, talk, or demo that supports the written article.
+
+```mdx
+<YoutubeIframe embedId="IcoOpnAcO1Y" />
+```
+
+Use only the video ID. Introduce the video in prose and keep the essential information available in text.
+
+## Images and code blocks
+
+Markdown images are rendered with zoom:
+
+```md
+![Descriptive alt text](https://cdn.neonapi.io/public/images/pages/blog/<slug>/<filename>)
+```
+
+Fenced code blocks are highlighted by language:
+
+````md
+```sql
+SELECT now();
+```
+````
+
+Use a language identifier. Keep examples complete enough to understand and safe to copy.

--- a/.agents/skills/blog-authoring/references/frontmatter.md
+++ b/.agents/skills/blog-authoring/references/frontmatter.md
@@ -1,0 +1,68 @@
+# Blog frontmatter
+
+Use the current post schema below. Inspect a recently published post before adding a field not listed here.
+
+```yaml
+---
+title: '[Post title in sentence case]'
+description: >-
+  [Concise search and page description.]
+excerpt: >-
+  [Listing preview that gives readers a reason to open the post.]
+date: '2026-07-23T12:00:00'
+updatedOn: '2026-07-23T12:00:00'
+category: [primary-category-slug]
+categories:
+  - [primary-category-slug]
+authors:
+  - [author-slug]
+cover:
+  image: >-
+    https://cdn.neonapi.io/public/images/pages/blog/<slug>/<filename>
+  alt: '[Descriptive image alt text]'
+isFeatured: false
+draft: true
+seo:
+  title: '[Search title]'
+  description: >-
+    [Search description.]
+  keywords: []
+  noindex: false
+  ogTitle: '[Social title]'
+  ogDescription: >-
+    [Social description.]
+  image: >-
+    https://cdn.neonapi.io/public/images/pages/blog/<slug>/<filename>
+---
+```
+
+## Fields
+
+- `title`: Required display title. Don't add an `h1` to the body.
+- `description`: Concise page and search description. State what the post covers.
+- `excerpt`: Listing copy. It may be longer or more narrative than `description`, but it must accurately represent the post.
+- `date`: Publication date and time.
+- `updatedOn`: Last substantive update date and time. For a new post, use the publication time. Update it when revising published content.
+- `category`: Primary category slug.
+- `categories`: All applicable category slugs, with the primary category first.
+- `authors`: One or more slugs from `content/blog/authors/data.json`.
+- `cover.image`: Absolute public CDN URL. This field drives blog cards, listing thumbnails, and Open Graph / Twitter metadata. The post-page Hero component does not render it.
+- `cover.alt`: Describes the useful content of the cover. Don't start with "Image of."
+- `isFeatured`: Set only when the publishing plan calls for featured placement.
+- `draft`: Keep `true` while the post isn't ready for listing or publication. Set `false` for publication.
+- `seo.title`: Search title. Keep it accurate and avoid keyword stuffing.
+- `seo.description`: Search description. It may match `description`.
+- `seo.keywords`: Use only researched terms. An empty array is valid.
+- `seo.noindex`: Use `true` only when the page should be excluded from search.
+- `seo.ogTitle` and `seo.ogDescription`: Social sharing copy. They may match the SEO values.
+- `seo.image`: Optional. Many posts include it for parity with `cover.image`, but the site's OG/Twitter pipeline reads `cover.image`, not `seo.image`. Keep both in sync when both are present.
+
+## Consistency checks
+
+- The Markdown filename must match the intended URL slug.
+- `category` must appear in `categories`.
+- Every author and category slug must already exist in its data file.
+- The cover and SEO URLs must return successfully without authentication.
+- Put a relevant lead image as the first body element after frontmatter. It may differ from the cover and SEO image.
+- Keep title, description, excerpt, and social copy consistent with the published article.
+- Don't set future publication claims or dates without an explicit publishing plan.

--- a/.agents/skills/blog-authoring/references/images.md
+++ b/.agents/skills/blog-authoring/references/images.md
@@ -1,0 +1,182 @@
+# Blog images
+
+Blog images are served from a Cloudflare R2 bucket through the public CDN at `https://cdn.neonapi.io`, the same host used by published blog post image URLs.
+
+The bucket name, account endpoint, and access keys are environment-specific and aren't stored in this repository. There is no in-repo upload script. Get credentials from the user's locally saved configuration or ask the user, and reference the bucket through `BLOG_R2_BUCKET` rather than hardcoding it.
+
+Images are not committed to either the website or blog content repositories. Upload out of band before referencing a CDN URL in the post.
+
+## Object keys and public URLs
+
+Use this object-key pattern:
+
+```text
+public/images/pages/blog/<post-slug>/<filename>
+```
+
+The matching public URL is:
+
+```text
+https://cdn.neonapi.io/public/images/pages/blog/<post-slug>/<filename>
+```
+
+This mapping depends on the CDN root configuration. Always verify the public URL after uploading.
+
+Use lowercase kebab-case slugs and filenames. Group every image for a post under the post slug. Use a descriptive filename such as `branching-architecture.png`, not `image-1.png`.
+
+Don't overwrite an existing CDN object in place when replacing an image. Cached content may continue to appear. Use a new descriptive filename and update every reference.
+
+## Prepare the image
+
+- Use the final post slug before uploading.
+- Crop and compress the image before upload.
+- Use JPEG or WebP for photographic artwork and PNG when transparency or lossless UI detail matters.
+- Use GIF only when animation is necessary. Prefer a hosted video for large or high-resolution animation.
+- Remove private data, credentials, internal URLs, and unrelated UI from screenshots.
+- Write alt text that explains the useful information, not the visual decoration.
+
+## Use locally saved credentials
+
+Never print, copy into chat, commit, or add credentials to the repository.
+
+The upload uses the AWS CLI against R2's S3-compatible endpoint. Use either:
+
+1. An AWS CLI profile that already contains the R2 access key and secret, or
+2. A user-owned local environment file outside the repository.
+
+### AWS CLI profile
+
+List profile names without displaying credentials:
+
+```bash
+aws configure list-profiles
+```
+
+Set the profile, endpoint, and bucket in the current shell:
+
+```bash
+export BLOG_R2_AWS_PROFILE="<local-profile-name>"
+export BLOG_R2_ENDPOINT_URL="https://<cloudflare-account-id>.r2.cloudflarestorage.com"
+export BLOG_R2_BUCKET="<r2-bucket-name>"
+```
+
+Don't assume `default` is the R2 profile. If the profile uses AWS SSO and reports an expired session, select the R2 profile or run the profile's required login command. Don't replace or rewrite the user's credentials.
+
+### Local environment file
+
+Ask the user for the path if it isn't already provided in `BLOG_R2_CREDENTIALS_FILE`. Don't search arbitrary home-directory files.
+
+The local file may define standard AWS names:
+
+```bash
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+BLOG_R2_ENDPOINT_URL=...
+BLOG_R2_BUCKET=...
+```
+
+It may instead use plain S3-style names, optionally with a Cloudflare account ID:
+
+```bash
+ACCESS_KEY_ID=...
+SECRET_ACCESS_KEY=...
+ACCOUNT_ID=...
+ENDPOINT_URL=...
+BUCKET_NAME=...
+```
+
+Load it without printing the values:
+
+```bash
+set -a
+source "$BLOG_R2_CREDENTIALS_FILE"
+set +a
+
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$SECRET_ACCESS_KEY}"
+export BLOG_R2_ENDPOINT_URL="${BLOG_R2_ENDPOINT_URL:-${ENDPOINT_URL:-https://${ACCOUNT_ID}.r2.cloudflarestorage.com}}"
+export BLOG_R2_BUCKET="${BLOG_R2_BUCKET:-$BUCKET_NAME}"
+```
+
+Validate the configuration before making a request:
+
+```bash
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  echo "R2 access key or secret is missing" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+if [[ -z "${BLOG_R2_ENDPOINT_URL:-}" || "$BLOG_R2_ENDPOINT_URL" == *'https://.r2.'* ]]; then
+  echo "BLOG_R2_ENDPOINT_URL or ACCOUNT_ID is missing" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+if [[ -z "${BLOG_R2_BUCKET:-}" ]]; then
+  echo "BLOG_R2_BUCKET is missing" >&2
+  return 1 2>/dev/null || exit 1
+fi
+```
+
+When using an AWS CLI profile, only `BLOG_R2_AWS_PROFILE`, `BLOG_R2_ENDPOINT_URL`, and `BLOG_R2_BUCKET` are required in the shell. If required configuration is absent, stop and name the missing variable. Don't ask the user to paste a secret into chat.
+
+## Verify access
+
+Before an upload, make a read-only access check:
+
+```bash
+profile_args=()
+if [[ -n "${BLOG_R2_AWS_PROFILE:-}" ]]; then
+  profile_args=(--profile "$BLOG_R2_AWS_PROFILE")
+fi
+
+aws s3api head-bucket \
+  --bucket "$BLOG_R2_BUCKET" \
+  --endpoint-url "$BLOG_R2_ENDPOINT_URL" \
+  "${profile_args[@]}"
+```
+
+An authentication error is a blocker. Don't try unrelated profiles or expose credential configuration while debugging.
+
+## Upload
+
+From the directory containing the image:
+
+```bash
+slug="<post-slug>"
+image_path="<local-image-path>"
+filename="$(basename "$image_path")"
+content_type="$(file --brief --mime-type "$image_path")"
+object_key="public/images/pages/blog/${slug}/${filename}"
+profile_args=()
+if [[ -n "${BLOG_R2_AWS_PROFILE:-}" ]]; then
+  profile_args=(--profile "$BLOG_R2_AWS_PROFILE")
+fi
+
+aws s3 cp "$image_path" "s3://$BLOG_R2_BUCKET/$object_key" \
+  --endpoint-url "$BLOG_R2_ENDPOINT_URL" \
+  --content-type "$content_type" \
+  --cache-control "public, max-age=31536000, immutable" \
+  "${profile_args[@]}"
+```
+
+This is an external write. Confirm the slug, filename, object key, and local file before running it.
+
+## Verify the public asset
+
+Construct the CDN URL and verify it:
+
+```bash
+image_url="https://cdn.neonapi.io/$object_key"
+curl --fail --head "$image_url"
+```
+
+Then add image URLs to the post:
+
+1. Set `cover.image` and `seo.image` to the approved cover or social asset.
+2. Add the lead image as the first body element after frontmatter. It may use the cover URL or a distinct image URL.
+
+```md
+![Descriptive alt text](https://cdn.neonapi.io/public/images/pages/blog/<post-slug>/<filename>)
+```
+
+Review the local post and branch preview. Confirm the full image loads, the crop works at desktop and mobile widths, and the alt text matches the image.

--- a/.agents/skills/faq-authoring/SKILL.md
+++ b/.agents/skills/faq-authoring/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: faq-authoring
+description: Creates and edits Neon FAQ pages in content/faqs. Use for direct product questions, troubleshooting answers, comparison questions, and programmatic FAQ content.
+---
+
+# FAQ authoring
+
+Read `../neon-writing/SKILL.md` before drafting or editing an FAQ.
+
+FAQ pages live in `content/faqs/` and render through the docs MDX system at `/faqs/<slug>`. Don't put standalone FAQ pages in `content/docs/`.
+
+The FAQ index page injects a programmatic CTA banner above the content automatically. Don't duplicate that banner in the body.
+
+Production visibility is controlled by `isDraft` only. Legacy `status: draft` frontmatter does **not** hide a page from the index or search.
+
+## Decide whether the content is an FAQ
+
+Use an FAQ when the reader has one specific question and can get a useful answer without following a full tutorial.
+
+Use another content type when:
+
+- The task requires a sequence of setup or implementation steps: write or update a guide.
+- The subject needs a complete conceptual treatment: update product documentation.
+- The content is news, opinion, or a technical narrative: write a blog post.
+- An existing FAQ asks the same question with different wording: update it or add a redirect instead of creating a duplicate.
+
+## Research
+
+1. Search `content/faqs/` for the question, likely synonyms, and the intended search phrase.
+2. Find the canonical docs pages that support the answer.
+3. Verify current product behavior, plan limits, feature status, UI labels, commands, and API examples.
+4. Identify claims likely to change and link them to the source of truth.
+5. Inspect neighboring FAQ files for current frontmatter and previous/next navigation.
+
+## Answer structure
+
+1. Use the reader's natural-language question as `title`.
+2. Answer it directly in the first paragraph. A reader should understand the result without scrolling.
+3. Add only the explanation, procedure, constraints, or troubleshooting needed to make the answer useful.
+4. Use descriptive `h2` sections for longer answers.
+5. End with the relevant next action or canonical docs link. Don't add a recap.
+
+Don't add an `h1`; the title is rendered from frontmatter.
+
+For a short factual question, one or two paragraphs may be enough. Don't inflate every answer into a guide.
+
+## Frontmatter
+
+Use this shape for new FAQ pages:
+
+```yaml
+---
+title: '[Question in sentence case?]'
+subtitle: '[Direct one-sentence answer suitable for metadata and listings.]'
+enableTableOfContents: true
+createdAt: '[ISO 8601 timestamp]'
+isDraft: false
+redirectFrom: []
+previousLink:
+  title: '[Previous FAQ title]'
+  slug: previous-faq-slug
+nextLink:
+  title: '[Next FAQ title]'
+  slug: next-faq-slug
+---
+```
+
+Guidance:
+
+- Use a question mark when the title is a direct question.
+- Keep `subtitle` specific and self-contained. Don't use "Learn how" or repeat the title without answering it.
+- Set `enableTableOfContents: false` or omit it for an answer with no useful `h2` outline.
+- Use `isDraft: true` until an incomplete answer is ready. This is the only field that hides a page in production.
+- Add previous and next links that match the intended sequence, and update adjacent files when inserting a page into an existing sequence. The FAQ index sorts by `createdAt` descending; prev/next links are manual frontmatter, not derived from sort order.
+- Use `redirectFrom` for replaced FAQ paths, with each path beginning and ending with `/`.
+- Don't add or edit `updatedOn` manually. The pre-commit hook manages it.
+- Preserve legacy frontmatter fields on existing pages unless the task includes normalizing them. Don't copy legacy `status`, `category`, `date`, or `slug` fields into a new FAQ. In particular, `status: draft` on legacy pages does not control visibility; use `isDraft` instead.
+
+## Write the answer
+
+- Lead with "Yes," "No," a command, a location, a limit, or the product behavior when one of those directly answers the question.
+- Use the same terms the reader used, then introduce Neon's exact terminology.
+- Explain conditions and exceptions immediately after the answer.
+- Link each volatile detail, such as pricing or plan limits, to its canonical page.
+- Use a short procedure when needed. Link to a full guide for substantial setup.
+- Include commands or code only when they answer the question faster than prose.
+- Explain placeholders and keep examples safe to copy.
+- Don't claim Neon is the best, cheapest, most popular, or uniquely capable without current, cited evidence.
+- For comparison questions, define criteria first and support each comparison. Don't invent competitor behavior.
+- For troubleshooting, connect symptom, likely cause, diagnostic step, and fix.
+
+## Components
+
+Read [references/components.md](references/components.md) before adding custom MDX. It lists every component available to FAQ pages and when it is appropriate.
+
+Default to prose, lists, tables, and code blocks. In most FAQs:
+
+- Use `Admonition` for a risk or easy-to-miss requirement.
+- Use `Callout` for optional context.
+- Use `Tabs` for Console, CLI, or API alternatives.
+- Use `CodeTabs` for equivalent code options.
+- Use `CTA` for one relevant next action at the end of the answer.
+
+Don't add `<NeedHelp/>` to FAQ pages. Don't add a component only to make a short answer look more substantial.
+
+## Validate
+
+Before finishing:
+
+- Confirm the first paragraph directly answers the title.
+- Check for a duplicate or overlapping FAQ.
+- Verify claims, commands, code, links, plan limits, UI labels, and feature status.
+- Confirm `subtitle` works as a standalone answer and metadata description.
+- Check previous and next links in this file and adjacent files.
+- Confirm MDX tags and props are valid.
+- Run the narrowest relevant check. Use `npm run check:md` if formatting needs checking and `npm run build` when routing or MDX behavior changed.
+- Don't run `npm run lint:md` or broad formatting commands as part of the normal workflow.

--- a/.agents/skills/faq-authoring/references/components.md
+++ b/.agents/skills/faq-authoring/references/components.md
@@ -1,0 +1,174 @@
+# FAQ components
+
+FAQ pages render with the docs MDX registry in `src/components/shared/content/content.jsx`. The full syntax authority is `content/docs/README.md` and `content/docs/community/component-guide.md`.
+
+Use ordinary Markdown by default. A component must make the answer easier to understand or act on.
+
+## Components commonly useful in FAQs
+
+### Admonition
+
+Use when missing the information could lead to failure, data loss, a security problem, or a significant misunderstanding.
+
+```mdx
+<Admonition type="warning" title="Before you reset the password">
+Existing connection strings stop working after the reset.
+</Admonition>
+```
+
+Types:
+
+- `note`: Information worth noticing while skimming.
+- `important`: A requirement for success.
+- `tip`: Optional advice.
+- `info`: Explanatory context.
+- `warning`: Risk or destructive behavior.
+- `comingSoon`: A capability that isn't available yet.
+
+Don't use an admonition for the direct answer itself or for a marketing claim.
+
+### Callout
+
+Use for neutral supplementary context or a best practice. Use an admonition when overlooking the content could cause an error.
+
+```mdx
+<Callout title="Good to know">
+The pooled and direct connection strings use the same database credentials.
+</Callout>
+```
+
+### Tabs and TabItem
+
+Use when the same answer has parallel Console, CLI, or API paths.
+
+```mdx
+<Tabs labels={["Console", "CLI"]}>
+<TabItem>
+Open **Settings** in the Neon Console.
+</TabItem>
+<TabItem>
+Run the corresponding Neon CLI command.
+</TabItem>
+</Tabs>
+```
+
+Don't hide prerequisites or different outcomes in tabs. If the paths aren't equivalent, use separate sections.
+
+### CodeTabs
+
+Use for equivalent commands or code in different languages, clients, or package managers.
+
+````mdx
+<CodeTabs labels={["JavaScript", "Python"]}>
+
+```javascript
+const result = await client.query('SELECT 1');
+```
+
+```python
+cursor.execute("SELECT 1")
+```
+
+</CodeTabs>
+````
+
+### Steps
+
+Use only when the answer contains a short sequential procedure. A longer setup belongs in a guide.
+
+```mdx
+<Steps>
+
+## Open the project
+
+Select the project in the Neon Console.
+
+## Copy the connection string
+
+Click **Connect** and copy the connection string.
+
+</Steps>
+```
+
+### CTA
+
+Use one focused next action, usually a canonical docs page, console flow, or broadly available resource.
+
+```mdx
+<CTA title="Manage your project" description="Review project settings and limits." buttonText="Read the docs" buttonUrl="/docs/manage/projects" />
+```
+
+Don't send all readers to plan-gated support.
+
+### StickyTable
+
+Use for a long comparison or limits table whose header needs to remain visible. Use a normal Markdown table for short data.
+
+### DefinitionList
+
+Use when the answer defines several related terms. Don't use it for steps or arbitrary properties.
+
+### YoutubeIframe and Video
+
+Use only when a demo materially helps answer the question. Keep a complete text answer on the page.
+
+### ExternalCode
+
+Use for a code sample maintained in an external repository. Use a raw GitHub URL and confirm the external source is stable.
+
+### CopyPrompt
+
+Use when the answer intentionally provides a maintained LLM prompt. Store the prompt in `public/prompts/`.
+
+### CheckList and CheckItem
+
+Use only for a multi-part diagnostic or setup checklist that readers benefit from tracking. State persists in browser storage, so use a stable, unique title.
+
+## Navigation and visual components
+
+These are available but rarely improve a single FAQ:
+
+- `InfoBlock`: Compact grouped introductory content. Use only for a long FAQ with distinct learning and related-resource groups.
+- `DocsList`: A short themed list of tasks, docs, or repositories. Prefer inline links for one or two destinations.
+- `TechCards`: Technology or framework choices with approved logos.
+- `DetailIconCards`: Product features or docs destinations with approved monochrome icons.
+- `CompactCards`: Dense card navigation.
+- `FeatureList`: A visual feature overview split by headings.
+- `TwoColumnLayout` and its `Step`, `Item`, `Block`, and `Footer` subcomponents: Wide tutorial or reference layouts. A question that needs this usually belongs in docs or a guide. Set `layout: wide` if an established FAQ pattern requires it.
+- `NeedHelp`: Shared help footer. Use only where the established FAQ flow calls for it.
+
+Don't introduce cards, feature layouts, or two-column layouts to decorate a short answer.
+
+## Specialized registered components
+
+FAQ pages technically support the following components because they share the docs renderer. Use one only when the FAQ is specifically about that feature and a current docs page demonstrates the required data shape.
+
+| Component                                                                         | Intended use                                                  |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `ApiMethodBadge`, `ApiParam`, `ApiResourceGrid`, `ApiResponse`                    | Structured API reference                                      |
+| `CliCommandIndex`, `CliUsage`, `CliOptions`, `CliSubcommands`, `CliGlobalOptions` | Structured Neon CLI reference                                 |
+| `TwinPaths`, `QuickPath`, `GuidedPath`, `TourCallout`                             | Quick-path versus guided-path flows                           |
+| `QuickLinks`, `MegaLink`, `LinkPreview`                                           | Established navigation and link previews                      |
+| `Tag`                                                                             | Existing status or category label patterns                    |
+| `CommunityBanner`, `QuoteBlock`, `QuoteBlocksWrapper`                             | Community and customer-story layouts                          |
+| `UseCaseList`, `UseCaseContext`, `LogosSection`                                   | Use-case pages with established data contracts                |
+| `RequestForm`, `ProgramForm`, `SubprocessorsForm`, `SubscriptionForm`             | Approved forms with backend configuration                     |
+| `ChatOptions`                                                                     | Existing chat or AI configuration flows                       |
+| `AutoscalingChart`, `AutoscalingViz`                                              | Maintained autoscaling visuals                                |
+| `ComputeCalculator`, `LatencyCalculator`                                          | Maintained calculators                                        |
+| `McpSetupConfigurator`                                                            | Interactive MCP setup                                         |
+| `SqlToRestConverter`                                                              | SQL-to-REST conversion tool                                   |
+| `AiGatewayModelIndex`                                                             | Generated AI Gateway model index                              |
+| `Button`                                                                          | An established inline action that a link or CTA can't express |
+
+## Shared content components
+
+Use a shared content component when the same maintained notice or reference already exists under `content/docs/shared-content/`. Don't copy its content into the FAQ.
+
+- Help and navigation: `NeedHelp`, `NextSteps`, `LinkAPIKey`
+- Feature status: `PrivatePreview`, `PublicPreview`, `PrivatePreviewEnquire`, `EarlyAccessProps`, `FeatureBeta`, `FeatureBetaProps`
+- Product notices: `NewPricing`, `LRNotice`, `LRBeta`, `MigrationAssistant`, `NeonRLSDeprecation`, `AzureRegionsDeprecation`, `ConsumptionAccountApiDeprecation`, `NextjsProxyNote`
+- AI and setup: `MCPTools`, `AgentSkillsTip`, `AuthAISetup`, `AuthAISetupTip`
+- Neon Auth SDK: `SdkOverview`, `SdkStackApp`, `GetStarted`, `SdkUser`, `SdkTeam`, `SdkTeamUser`, `SdkTeamProfile`, `SdkProject`, `SdkTeamPermission`, `SdkApiKey`, `SdkContactChannel`, `SdkUseStackApp`, `SdkUseUser`
+
+Read the shared source and confirm that its wording and conditions fit the FAQ before using it.

--- a/.agents/skills/guide-authoring/SKILL.md
+++ b/.agents/skills/guide-authoring/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: guide-authoring
+description: Creates and edits Neon developer guides in content/guides and guide-style pages in content/docs. Use for tutorials, integrations, quickstarts, walkthroughs, and other task-based technical content.
+---
+
+# Guide authoring
+
+Read `../neon-writing/SKILL.md` before drafting or editing a guide.
+
+## Choose the correct content area
+
+Determine the destination before writing:
+
+- `content/docs/guides/` and `content/docs/auth/guides/`: Official Neon product documentation. New pages require an entry in `content/docs/navigation.yaml` and go through full docs review.
+- `content/guides/`: Community and third-party integration guides. These pages don't use `content/docs/navigation.yaml` and surface through the `/guides` index.
+
+If the request doesn't identify the destination, inspect related pages. Use `content/docs/` for maintained product procedures and reference material. Use `content/guides/` for end-to-end integrations, examples, and contributed tutorials.
+
+For official docs guides, use `content/docs/guides/GUIDE_TEMPLATE.md` as a starting point when creating a new page.
+
+## Research before drafting
+
+1. Read the nearest current guides for structure, terminology, and reusable links.
+2. Read the product's source documentation and current UI or API reference.
+3. Confirm package names, supported versions, commands, API behavior, plan limits, and feature status.
+4. Search for an existing page that already covers the task. Update or link it instead of duplicating it.
+5. Run or otherwise verify the critical path when the environment permits. Don't present untested code as verified.
+
+## Structure
+
+Use the smallest structure that lets the reader complete and verify the task:
+
+1. **Frontmatter**
+2. **Introduction:** Name the outcome, intended reader, and approach in one or two short paragraphs.
+3. **Prerequisites:** Include only requirements that can block the procedure.
+4. **Steps:** Put actions in execution order. Use one clear result per step.
+5. **Verification:** Tell the reader what success looks like and how to test it.
+6. **Troubleshooting:** Include likely failures only when they're specific and actionable.
+7. **Next steps:** Link the most relevant follow-on task. Don't add a generic recap.
+
+Don't add a manual `h1`. The page title comes from frontmatter.
+
+Use `<Steps>` when the page is a sequential procedure. Each `h2` inside it becomes a numbered step. Use ordinary `h2` sections when readers can complete sections independently.
+
+## Frontmatter
+
+For `content/docs/guides/` and `content/docs/auth/guides/`, use:
+
+```yaml
+---
+title: [Required page title in sentence case]
+subtitle: [Short outcome or audience]
+summary: [Search-focused description; include on every new docs guide]
+enableTableOfContents: true
+---
+```
+
+Add only fields the page needs:
+
+- `tag`: `new`, `beta`, `coming soon`, `deprecated`, or approved custom text. Repeat the tag in `content/docs/navigation.yaml`.
+- `redirectFrom`: Old paths, each beginning and ending with `/`.
+- `isDraft: true`: Hide the page in production while keeping it available in development.
+- `ogImage`: Social preview image path.
+- `layout: wide`: Required when using `TwoColumnLayout`.
+
+For Managed Better Auth guides under `content/docs/auth/guides/`, include `<FeatureBetaProps feature_name="Managed Better Auth" />` immediately after frontmatter.
+
+For `content/guides/`, use:
+
+```yaml
+---
+title: [Required guide title in sentence case]
+subtitle: [Short description of what the reader will build or learn]
+author: [Existing author slug]
+enableTableOfContents: true
+createdAt: '[ISO 8601 timestamp for a new guide]'
+---
+```
+
+Don't add or edit `updatedOn` manually. The pre-commit hook updates it on staged content files.
+
+For community guides, register the author in `content/guides/authors/data.json` and add a photo under `public/guides/authors/`. Prev/next navigation is computed from `createdAt` sort order, not frontmatter.
+
+## Write the procedure
+
+- Start each step with the action or goal.
+- Put context immediately before the action it explains.
+- Use numbered lists for actions within a step and bullets for unordered choices or results.
+- Tell the reader where to run each command and where to create each file.
+- Use filename labels on code blocks when the file location matters.
+- Use environment variables for credentials. Never put real secrets in examples.
+- Use fake data that follows repository conventions, including `@example.com` email addresses.
+- Keep sample code internally consistent across the guide.
+- Explain each placeholder the reader must replace.
+- Show only the output needed to confirm success or diagnose a likely failure.
+- Use direct links to canonical docs for setup that isn't central to the guide.
+
+## Components and media
+
+Read [references/components.md](references/components.md) before choosing custom MDX components. It documents the available components and when to use each one.
+
+For docs images:
+
+- Put files under `public/docs/`, mirroring the content path where practical.
+- Reference them with a root-relative path such as `/docs/guides/example.png`.
+- Write alt text that describes the useful information in the image.
+- Add the title `'no-border'` only for images that shouldn't use the default border.
+- Don't use screenshots when text or code communicates the same information more clearly.
+
+For community guide images, put files under `public/guides/` mirroring the guide path.
+
+Official docs guides commonly end with `<NeedHelp/>`. Community guides often do the same. Don't add `<NeedHelp/>` to FAQ pages.
+
+## Navigation
+
+For a new page under `content/docs/`:
+
+1. Add it to the appropriate location in `content/docs/navigation.yaml`.
+2. Set `slug` to the file path relative to `content/docs/`, without `.md`.
+3. Keep the navigation title short. It may differ from the page title.
+4. Add the same `tag` used in frontmatter, if any.
+
+Don't add `content/guides/` pages to docs navigation.
+
+## Validate
+
+Before finishing:
+
+- Confirm the reader can identify the outcome and prerequisites from the opening.
+- Verify code, commands, links, package versions, UI labels, and technical claims.
+- Check that each step has an observable result.
+- Check frontmatter and, for docs pages, the navigation entry.
+- Confirm local image and prompt paths exist.
+- Confirm MDX tags are balanced and component props are valid.
+- Run the narrowest relevant validation. For a focused content change, use `npm run check:md` if formatting needs checking and `npm run build` when routing or MDX behavior changed.
+- Don't run `npm run lint:md` or broad formatting commands as part of the normal workflow.

--- a/.agents/skills/guide-authoring/references/components.md
+++ b/.agents/skills/guide-authoring/references/components.md
@@ -1,0 +1,234 @@
+# Guide components
+
+Docs and guides use the MDX component registry in `src/components/shared/content/content.jsx`. `content/docs/README.md` and `content/docs/community/component-guide.md` are the syntax authorities. Inspect an existing page and the component implementation before using a specialized component.
+
+Prefer ordinary Markdown when it communicates the information clearly. Components should clarify sequence, choices, risk, navigation, or interaction.
+
+## Core components
+
+### Admonition
+
+Use an admonition when missing the information could cause an error, risk, or important misunderstanding.
+
+```mdx
+<Admonition type="warning" title="Before you continue">
+This operation deletes the branch and can't be undone.
+</Admonition>
+```
+
+Types:
+
+- `note`: Information readers should notice while skimming.
+- `important`: Information required for success.
+- `tip`: Optional advice that improves the result.
+- `info`: Context that explains behavior.
+- `warning`: Risk, destructive behavior, or a likely serious error.
+- `comingSoon`: A capability that isn't available yet.
+
+Don't use admonitions for routine steps or promotional claims.
+
+### Callout
+
+Use a callout for neutral supplementary context, a best practice, or "good to know" information. Use an admonition when overlooking the text could cause failure.
+
+```mdx
+<Callout title="Before you start">
+Use Node.js 20 or later for this example.
+</Callout>
+```
+
+### Steps
+
+Use for one sequential procedure. Each `h2` inside the wrapper becomes a numbered step.
+
+```mdx
+<Steps>
+
+## Install the dependency
+
+Run the install command.
+
+## Configure the application
+
+Add the environment variable.
+
+</Steps>
+```
+
+Don't combine unrelated procedures in one `Steps` block.
+
+### CodeTabs
+
+Use for equivalent code in different languages, clients, package managers, or runtimes. Keep the examples equivalent and keep labels in the same order throughout the page.
+
+````mdx
+<CodeTabs labels={["JavaScript", "Python"]}>
+
+```javascript
+const result = await client.query('SELECT 1');
+```
+
+```python
+cursor.execute("SELECT 1")
+```
+
+</CodeTabs>
+````
+
+Use ordinary code blocks when the reader needs only one option.
+
+### Tabs and TabItem
+
+Use for parallel non-code workflows such as Console, CLI, and API instructions.
+
+```mdx
+<Tabs labels={["Console", "CLI"]}>
+<TabItem>
+Console instructions.
+</TabItem>
+<TabItem>
+CLI instructions.
+</TabItem>
+</Tabs>
+```
+
+Use `CodeTabs`, not `Tabs`, when every tab contains only code.
+
+### CTA
+
+Use one focused next action at the end of a guide or major flow. Don't use a CTA to repeat an inline link or direct every reader to plan-gated support.
+
+```mdx
+<CTA title="Create a Neon project" description="Start with a free Neon account." buttonText="Sign up" buttonUrl="https://console.neon.tech/signup" />
+```
+
+### StickyTable
+
+Use around one long Markdown table when its header needs to remain visible. Don't wrap short tables.
+
+```mdx
+<StickyTable>
+
+| Option | Behavior |
+| --- | --- |
+| A | First behavior |
+
+</StickyTable>
+```
+
+### TwoColumnLayout
+
+Use for a tutorial or reference page that benefits from paired explanation and code. Set `layout: wide` in frontmatter.
+
+Available subcomponents:
+
+- `TwoColumnLayout.Step`: Numbered tutorial step with `title`.
+- `TwoColumnLayout.Item`: Reference item with `title`, `method`, and `id`.
+- `TwoColumnLayout.Block`: Content block with optional `label`.
+- `TwoColumnLayout.Footer`: Full-width content after the blocks.
+
+Don't use it for a conventional linear guide.
+
+### CheckList and CheckItem
+
+Use for a reader-managed setup checklist, often alongside `Steps`. Checklist state persists in browser storage, so give each checklist a stable, distinct title.
+
+```mdx
+<CheckList title="Setup checklist">
+<CheckItem title="Create a project" href="#create-a-project">Create the Neon project.</CheckItem>
+</CheckList>
+```
+
+### InfoBlock and DocsList
+
+Use `InfoBlock` near the opening when the page needs compact groups such as learning outcomes and related resources. Use `DocsList` inside it or alone for a short list of tasks, docs, or repositories.
+
+`DocsList` themes:
+
+- Default: tasks or learning outcomes.
+- `docs`: documentation links.
+- `repo`: repository links.
+
+Don't use either component for ordinary prose or a long table of contents.
+
+### DefinitionList
+
+Use for terms and definitions, not for steps or arbitrary key-value data.
+
+```mdx
+<DefinitionList>
+
+Compute
+: The virtualized service that runs Postgres.
+
+</DefinitionList>
+```
+
+### TechCards, DetailIconCards, and CompactCards
+
+- `TechCards`: Technology or framework choices with approved color logos.
+- `DetailIconCards`: Neon features, services, or docs destinations with approved monochrome icons.
+- `CompactCards`: Dense navigation where the larger card treatments add too much visual weight.
+
+Check that each icon exists before using it. Don't use cards for a list that reads better as bullets.
+
+### FeatureList
+
+Use for a visual feature overview, split by `h2` or `h3` headings. Don't use it for procedural steps or a generic benefits list.
+
+### CopyPrompt
+
+Use to display a maintained, copyable LLM prompt. Put prompt files in `public/prompts/` and pass the root-relative path.
+
+```mdx
+<CopyPrompt src="/prompts/example.md" description="Use this prompt to configure the integration." />
+```
+
+### ExternalCode
+
+Use to embed code maintained in an external repository. Always use a raw GitHub URL. Prefer local code when the guide owns the example.
+
+### YoutubeIframe and Video
+
+- `YoutubeIframe`: An existing YouTube tutorial or demo.
+- `Video`: A directly hosted video asset.
+
+Video should supplement written instructions, not replace them. Provide enough text for a reader to complete the task without watching.
+
+### NeedHelp
+
+Use the shared `<NeedHelp/>` footer only where established docs patterns call for it. It points readers to maintained help paths. Don't write a replacement that directs all readers to support.
+
+## Other registered components
+
+These components are available but tied to specific page types, product areas, or data contracts. Don't introduce one based only on its name. Read its implementation and copy a current use pattern first.
+
+| Component                                                                         | Use only for                                                                 |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `ApiMethodBadge`, `ApiParam`, `ApiResourceGrid`, `ApiResponse`                    | Structured API reference                                                     |
+| `CliCommandIndex`, `CliUsage`, `CliOptions`, `CliSubcommands`, `CliGlobalOptions` | Generated or structured Neon CLI reference                                   |
+| `TwinPaths`, `QuickPath`, `GuidedPath`, `TourCallout`                             | A deliberate quick-path versus guided-path experience                        |
+| `QuickLinks`, `MegaLink`, `LinkPreview`                                           | Established navigation and link-preview layouts                              |
+| `Tag`                                                                             | A small status or category label in an existing pattern                      |
+| `CommunityBanner`, `QuoteBlock`, `QuoteBlocksWrapper`                             | Community or use-case storytelling pages                                     |
+| `UseCaseList`, `UseCaseContext`, `LogosSection`                                   | Use-case pages with their existing data shape                                |
+| `RequestForm`, `ProgramForm`, `SubprocessorsForm`, `SubscriptionForm`             | An approved form flow with required backend configuration                    |
+| `ChatOptions`                                                                     | An established chat or AI configuration flow                                 |
+| `AutoscalingChart`, `AutoscalingViz`                                              | The maintained autoscaling visualizations                                    |
+| `ComputeCalculator`, `LatencyCalculator`                                          | The maintained interactive calculators                                       |
+| `McpSetupConfigurator`                                                            | Interactive MCP setup                                                        |
+| `SqlToRestConverter`                                                              | The SQL-to-REST interactive tool                                             |
+| `AiGatewayModelIndex`                                                             | The generated AI Gateway model index                                         |
+| `Button`                                                                          | An established inline action that can't be expressed as a normal link or CTA |
+
+## Shared content components
+
+Shared content components include maintained copy from `content/docs/shared-content/`. Use them instead of duplicating the same notice or reference. Current names include:
+
+- Help and navigation: `NeedHelp`, `NextSteps`, `LinkAPIKey`
+- Feature status: `PrivatePreview`, `PublicPreview`, `PrivatePreviewEnquire`, `EarlyAccessProps`, `FeatureBeta`, `FeatureBetaProps`
+- Product notices: `NewPricing`, `LRNotice`, `LRBeta`, `MigrationAssistant`, `NeonRLSDeprecation`, `AzureRegionsDeprecation`, `ConsumptionAccountApiDeprecation`, `NextjsProxyNote`
+- AI and setup: `MCPTools`, `AgentSkillsTip`, `AuthAISetup`, `AuthAISetupTip`
+- Neon Auth SDK reference: `SdkOverview`, `SdkStackApp`, `GetStarted`, `SdkUser`, `SdkTeam`, `SdkTeamUser`, `SdkTeamProfile`, `SdkProject`, `SdkTeamPermission`, `SdkApiKey`, `SdkContactChannel`, `SdkUseStackApp`, `SdkUseUser`
+
+Read the corresponding file and confirm it applies before inserting the component. Don't edit shared content solely to change one guide.

--- a/.agents/skills/neon-writing/SKILL.md
+++ b/.agents/skills/neon-writing/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: neon-writing
+description: Defines Neon's writing style for developer-facing website content. Use when drafting, editing, or reviewing Neon documentation, guides, FAQs, blog posts, landing-page copy, UI text, or other Neon-branded content. Apply alongside the relevant content-type authoring skill.
+---
+
+# Neon writing
+
+Neon's audience is developers. Write like a knowledgeable peer: clear, direct, precise, and useful. Avoid the tone of a marketing brochure.
+
+## Core principles
+
+**Be direct.** Say what the product, feature, or procedure does. Skip the buildup.
+
+**Be concise.** Every sentence should earn its place. Cut words or sentences that don't change the meaning.
+
+**Be precise.** Prefer specific, verifiable claims over vague ones. If you can't verify a claim, don't make it.
+
+**Use plain language.** Prefer short, familiar words. Use technical terms when they're familiar to the intended developer and are the clearest way to explain the idea.
+
+**Respect the reader.** Don't explain concepts the intended reader already knows. State prerequisites and assumptions, then spend the detail on the difficult or Neon-specific parts.
+
+## Write for developers
+
+- Lead with the task, problem, behavior, or technical consequence.
+- Explain mechanisms before benefits. Show what happens, then why it matters.
+- Give runnable commands and complete code when the reader needs to act.
+- State versions, environments, permissions, limits, and destructive effects when they affect the result.
+- Use realistic examples, but never use real credentials or personal information.
+- Distinguish facts from recommendations. Explain the tradeoff behind a recommendation.
+- Name the source for measurements, benchmarks, quotes, and comparisons.
+- Link to the source of truth instead of repeating details likely to drift.
+- Verify code, commands, UI labels, links, and product behavior before publishing.
+- Don't hide prerequisites or failure modes in a closing note.
+
+## Editing existing copy
+
+Read the full draft before editing. Identify its core point, audience, and the voice traits worth preserving.
+
+**Preserve the writer's voice.** Keep vocabulary, cadence, humor, uncertainty, and level of polish when they fit Neon's voice. Don't make every paragraph equally tidy.
+
+**Make the minimum effective edit.** Fix unclear passages, repetition, unsupported claims, and the patterns below. Leave strong sentences alone. Keep the original structure unless it gets in the reader's way.
+
+**Keep the meaning.** Don't invent claims, examples, numbers, quotes, or opinions. Ask when the intended meaning is unclear.
+
+**Protect specific facts.** Keep useful names, numbers, dates, mechanisms, and examples when the source supports them.
+
+**Use direct verbs.** Prefer "decided" to "made a decision" and "can" to "has the ability to." Prefer plain "is" and "has" to inflated constructions such as "serves as."
+
+## Tone
+
+- Developer-centric and matter-of-fact
+- Confident but not boastful
+- Helpful, not cheerful
+- Neutral, not breathless
+- Conversational, not corporate
+
+Avoid bubbly, flowery, or hype-driven language. Avoid false urgency. Appeal to function instead of emotion.
+
+When you aren't the domain expert, hedge instead of presenting a recommendation as authoritative fact. Don't hedge verified product behavior.
+
+## Words not to use
+
+Never use any form of these words in published copy:
+
+| Don't use                    | Use instead                                                            |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| utilize                      | use                                                                    |
+| effortless / effortlessly    | Cut it, or explain what makes the task easy                            |
+| delve                        | explore, look at, examine                                              |
+| solutions                    | Name the specific product, feature, or approach                        |
+| forever                      | State the duration or persistence behavior                             |
+| enhance                      | improve, add, extend, or name the change                               |
+| holistic                     | Name the included parts                                                |
+| incentivize                  | encourage, reward, motivate                                            |
+| intelligent, as an adjective | Describe the capability                                                |
+| unified                      | Say "a single interface," "one configuration," or the specific meaning |
+| challenges                   | problems, limits, or the specific issue                                |
+| best-in-class                | Cut it, or cite a source                                               |
+| purpose-built                | built for, designed for                                                |
+| state-of-the-art             | Cut it, or describe what's new                                         |
+| world-class                  | Cut it, or cite a source                                               |
+| web-scale                    | State the measured scale                                               |
+| demystify                    | explain, walk through, clarify                                         |
+| security posture             | security, security practices, security setup                           |
+
+Also avoid these AI-tell words:
+
+`seams`, `testament`, `underscore`, `propel`, `unwavering`, `heartfelt`, `embrace`, `foster`, `ignite`, `empower`, `amplify`, `catalyst`, `leverage`, `epitome`, `cornerstone`, `harness` as a verb, `noteworthy`, `unprecedented`, `profound`, `pivotal`, `journey`, `tapestry`, `game-changer`, `nuanced`, `elevate`, `intricate`, `cutting-edge`, `groundbreaking`, `innovative`, `illuminate`.
+
+Avoid filler transitions such as `moreover`, `furthermore`, `nevertheless`, and `additionally`. Start with the point or connect the sentence to the preceding one.
+
+Cut canned phrases such as:
+
+- "It's not X, it's Y"
+- "not just X but Y"
+- "it's important to note"
+- "shed light on"
+- "key takeaway"
+- "at its core"
+- "to be honest" and other uses of `honest` or `honestly`
+
+## Patterns to cut
+
+Don't guess whether AI wrote a draft. Review for observable problems:
+
+- **Throat-clearing:** Cut "Here's the thing," "Let me be clear," and similar setup.
+- **Binary contrasts and negative lists:** State the positive point directly.
+- **Dramatic reveals:** Don't use a noun phrase and colon to manufacture suspense.
+- **Superficial analysis:** Cut trailing clauses built around "highlighting," "underscoring," "reflecting," or "showcasing" when they only assert importance.
+- **Importance puffery:** Cut claims such as "marks a pivotal moment" or "plays a vital role."
+- **Weasel attribution:** Name and cite the source instead of writing "experts agree" or "studies show."
+- **Synonym cycling:** Repeat the clearest technical term instead of rotating through near-synonyms.
+- **Robotic rhythm:** Avoid stacked fragments and repetitive sentence shapes.
+- **Rhetorical setups:** Cut "What if I told you," "Think about it," self-answered questions, and similar devices.
+- **Fake-profound endings:** End on the last concrete point, result, or next action.
+- **Formatting clutter:** Don't decorate copy with emoji headings, scattered bold emphasis, unnecessary bullets, or headings over tiny sections.
+
+When asked to audit without rewriting, name the pattern, quote the line, and suggest a short fix. Don't score the draft or speculate about its author.
+
+## Neon terminology
+
+- Describe Neon as the backend platform for apps and agents when the broader platform is relevant. Name the relevant capabilities instead of reducing Neon to "just Postgres." Postgres-specific framing is correct when the subject is only the database.
+- Prefer **Postgres** in Neon-branded prose. Preserve **PostgreSQL** in official names, quotations, and source-specific terminology.
+- Write **database**, not DB, wherever possible.
+- Write **Neon Auth**, never NeonAuth.
+- Write **free plan**, not free tier.
+- Write **organization**, not workspace, for Neon account structure. Use **Organization ID** when asking which account a request applies to.
+- Don't refer to "the Neon docs" as a separate authority from content published in the docs. State the fact directly and link the source page when useful.
+- Never direct readers to GitHub Discussions. It isn't actively monitored. Use the [Neon Discord community](https://neon.com/discord), the relevant documentation, the [feedback form](https://console.neon.tech/app/projects?modal=feedback), or the [public roadmap](https://neon.com/docs/introduction/roadmap), depending on the need.
+- Don't use a generic "contact support" CTA. Support is plan-dependent. Link a resource available to the intended reader.
+- Match product names and UI labels exactly.
+
+## Mechanics
+
+- Prefer active voice.
+- Front-load important information.
+- Keep one main idea per sentence.
+- Use contractions when they sound natural.
+- Use US English.
+- Use sentence case for titles and headings.
+- Don't use em dashes. Use a comma, period, colon, or rewrite the sentence.
+- Don't use emoji or exclamation points in documentation. Avoid exclamation points elsewhere unless the context warrants one.
+- Cut adjectives that don't add verifiable information.
+- Use the same term for the same concept throughout.
+- Put commands, parameters, environment variables, filenames, and UI values in backticks.
+
+## Explain complex ideas
+
+**Concrete before abstract.** Introduce a concept through observable behavior or an example before naming the abstraction.
+
+**Connect sentences.** Show how one fact leads to the next. Don't stack unrelated statements.
+
+**Slow down for hard parts.** Use an extra sentence or concrete example when the mechanism is difficult. Don't pad simple steps.
+
+**Observations before implications.** Describe what happens, then explain the consequence.
+
+**Earn conclusions.** Support conclusions with the relevant mechanism or evidence. Don't open with an unsupported benefit claim and justify it afterward.
+
+## Final review
+
+Before finalizing:
+
+- Preserve the writer's useful details and voice.
+- Remove banned words, canned phrases, and AI-tell patterns.
+- Verify facts, links, code, commands, names, numbers, and UI labels.
+- Remove invented or unsupported claims, examples, quotes, and opinions.
+- Use Neon terminology consistently.
+- Remove em dashes, unnecessary exclamation points, and decorative formatting.
+- Confirm each section helps the intended developer understand or complete the task.
+- End on a concrete result or next action, not a recap paragraph.


### PR DESCRIPTION
## Summary

Add repository-owned skills for writing Neon content in a consistent, developer-focused voice. The new skills cover general writing guidance, guides, FAQs, and blog posts, with tactical references for frontmatter, supported MDX components, validation, and blog image uploads.

The blog image workflow uses environment variables and locally saved credentials. It contains no account IDs, bucket names, tokens, private URLs, or other unpublished infrastructure details.

## Skills changed

- `.agents/skills/neon-writing/`
- `.agents/skills/guide-authoring/`
- `.agents/skills/faq-authoring/`
- `.agents/skills/blog-authoring/`

## Validation

- Prettier check for all skill Markdown files
- Skill metadata, size, and reference-path validation
- Whitespace and sensitive-data scans
- Public-release content review
- Unit tests: 608 passed

## Notes for reviewers

Please review the content-type boundaries and tactical component guidance. The object-storage instructions intentionally parameterize account, endpoint, bucket, and credential values so the skill remains safe to publish.