### PR TITLE
Fix table name in the PostgreSQL PERCENT_RANK Function docs

### DIFF
--- a/content/postgresql/window-function/percent_rank-function.md
+++ b/content/postgresql/window-function/percent_rank-function.md
@@ -69,7 +69,7 @@ SELECT
 	name,
 	amount
 FROM
-	actual_sales
+	sales_stats
 ORDER BY
 	year, name;
 ```


### PR DESCRIPTION
### Detail
- Fix a table name in a query.