### PR TITLE
docs(cli): point binary downloads and the docs refresh at the neon release

### DIFF
--- a/content/docs/cli/install.md
+++ b/content/docs/cli/install.md
@@ -47,7 +47,7 @@ bun install -g neon
 Download the binary. No installation required.
 
 ```bash shouldWrap
-curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-macos-x64 -o neon
+curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neon-macos-x64 -o neon
 ```
 
 Run the CLI from the download directory:
@@ -79,13 +79,13 @@ bun install -g neon
 Download the binary. No installation required.
 
 ```bash shouldWrap
-curl -sL -O https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-win-x64.exe
+curl -sL -O https://github.com/neondatabase/neon-pkgs/releases/latest/download/neon-win-x64.exe
 ```
 
 Run the CLI from the download directory:
 
 ```bash
-neonctl-win-x64.exe <command> [options]
+neon-win-x64.exe <command> [options]
 ```
 
 </TabItem>
@@ -113,13 +113,13 @@ Download the x64 or ARM64 binary, depending on your processor type. No installat
 x64:
 
 ```bash shouldWrap
-curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-linux-x64 -o neon
+curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neon-linux-x64 -o neon
 ```
 
 ARM64:
 
 ```bash shouldWrap
-curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-linux-arm64 -o neon
+curl -sL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neon-linux-arm64 -o neon
 ```
 
 Run the CLI from the download directory:
@@ -216,7 +216,7 @@ If you're downloading a binary, reference the latest release from the [Releases 
 ```yaml
 - name: Install Neon CLI
   run: |
-    curl -L https://github.com/neondatabase/neon-pkgs/releases/latest/download/neonctl-linux-x64 -o /usr/local/bin/neon
+    curl -L https://github.com/neondatabase/neon-pkgs/releases/latest/download/neon-linux-x64 -o /usr/local/bin/neon
     chmod +x /usr/local/bin/neon
 ```
 

--- a/scripts/docs-checks/neonctl/refresh.js
+++ b/scripts/docs-checks/neonctl/refresh.js
@@ -4,12 +4,12 @@
 //   npm run cli-docs -- refresh
 //
 // The CLI source lives in the neon-pkgs monorepo (packages/cli); its
-// releases are tagged `neonctl@<version>`. The published npm package and
-// its `neonctlVersion` schema field are still named `neonctl`, though the
-// CLI is now documented and invoked as `neon` (the package ships both bins).
+// releases are tagged `neon@<version>`. The CLI is published as the `neon`
+// package and invoked as `neon`; `neonctl` is now a compatibility package
+// that depends on it. The `neonctlVersion` schema field keeps its name.
 //
 // What it does:
-//   1. Looks up the latest `neonctl@*` release tag on GitHub (no clone needed).
+//   1. Looks up the latest `neon@*` release tag on GitHub (no clone needed).
 //   2. Downloads and extracts the release tarball to a temp directory.
 //   3. Regenerates schema.json from packages/cli (generate-schema.js + overrides.json).
 //   4. Prints a summary of command/option additions and removals vs the
@@ -27,7 +27,10 @@ const path = require('path');
 
 const REPO = 'neondatabase/neon-pkgs';
 // Monorepo release tags are `<package>@<version>`; the CLI uses this prefix.
-const TAG_PREFIX = 'neonctl@';
+// Releases up to 2.37.1 were tagged `neonctl@<version>`, before the CLI package
+// was renamed to `neon`. Sibling packages like `neon-new@*` don't collide,
+// because the `@` has to follow `neon` immediately.
+const TAG_PREFIX = 'neon@';
 // The CLI package lives under this subdirectory of the repo tarball.
 const CLI_SUBDIR = path.join('packages', 'cli');
 const SCHEMA_PATH = path.join(__dirname, 'schema.json');
@@ -41,7 +44,7 @@ const PREFER_ALIAS = {};
 
 // The monorepo publishes releases for many packages, so `/releases/latest`
 // is not necessarily the CLI. List releases and pick the highest-versioned
-// `neonctl@*` tag.
+// `neon@*` tag.
 function compareSemver(a, b) {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
@@ -70,7 +73,7 @@ async function latestTag() {
 }
 
 async function downloadTarball(tag, destDir) {
-  // Tags contain `@` (e.g. neonctl@2.29.2); encode it for the codeload path.
+  // Tags contain `@` (e.g. neon@2.38.0); encode it for the codeload path.
   const url = `https://codeload.github.com/${REPO}/tar.gz/refs/tags/${encodeURIComponent(tag)}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Tarball download failed: ${res.status} for ${url}`);
@@ -78,7 +81,7 @@ async function downloadTarball(tag, destDir) {
   fs.writeFileSync(tarPath, Buffer.from(await res.arrayBuffer()));
   execSync(`tar -xzf ${JSON.stringify(tarPath)} -C ${JSON.stringify(destDir)}`);
   // GitHub names the extracted dir after the repo and tag, replacing `/` and
-  // `@` with `-` (e.g. neon-pkgs-neonctl-2.29.2). Match the repo prefix.
+  // `@` with `-` (e.g. neon-pkgs-neon-2.38.0). Match the repo prefix.
   const repoName = REPO.split('/')[1];
   const extracted = fs
     .readdirSync(destDir)


### PR DESCRIPTION
## Problem

The Neon CLI is being renamed from `neonctl` to `neon` ([neon-pkgs#331](https://github.com/neondatabase/neon-pkgs/pull/331), [releases#187](https://github.com/databricks/secure-public-registry-releases-eng/pull/187)). Two things in this repo are coupled to the old name and neither fails loudly.

**1. The documented binary downloads.** `content/docs/cli/install.md` tells people to `curl` five URLs of the form `releases/latest/download/neonctl-<platform>`. After the rename the release ships `neon-<platform>` assets under a `neon@<version>` tag.

**2. The CLI reference pipeline.** `scripts/docs-checks/neonctl/refresh.js` picks the highest-versioned `neonctl@*` release to regenerate `schema.json`. Once releases move to `neon@*`, it doesn't error — it keeps resolving `neonctl@2.37.1` forever, so the entire CLI reference silently freezes at that version.

## Solution

Point both at the new names.

- The five `curl` commands and the Windows run example now use `neon-<platform>`.
- `TAG_PREFIX` is `neon@`. `neon-new@*` and friends don't collide, because the `@` has to follow `neon` immediately — the existing `startsWith` check is enough.

## The old URLs keep working

The release workflow uploads every binary under **both** names, so `releases/latest/download/neonctl-linux-x64` does not 404 — that rolling URL is baked into user CI (21 downloads on the 2.37.1 release alone), and the rename must not break it. This PR changes which name we *document*, not which ones exist.

That also means this PR is a no-op for correctness and purely a naming cleanup. Its only hard requirement is ordering.

## Merge order

**Merge after `neon@2.38.0` is published** — the `neon-*` assets and the `neon@*` tag don't exist until then. Draft until the release lands.

## Verification

- Grepped the repo for every reference to the release assets and tag prefix; these two files are the only ones. `npx neonctl@latest` references in blog posts and changelogs are npm installs, which are unaffected — `neonctl` stays published as a compatibility package.
- Asset names confirmed against the workflow's `pkg` output: `neon-linux-arm64`, `neon-linux-x64`, `neon-macos-x64`, `neon-win-x64.exe`.
- Couldn't run `prettier` locally (repo deps not installed, missing `prettier-plugin-tailwindcss`); changes are in-line string substitutions and comments, so CI formatting checks should be authoritative here.

## Follow-up

The `neonctlVersion` schema field and the `scripts/docs-checks/neonctl/` directory name still say `neonctl`. Left alone deliberately — renaming them touches the schema contract and is unrelated to this break.