### PR TITLE
fix(components): add missing observability category to MCP config generator

### DIFF
--- a/.github/workflows/mcp-categories-sync.yml
+++ b/.github/workflows/mcp-categories-sync.yml
@@ -1,0 +1,75 @@
+name: MCP Categories Sync
+
+# The Neon MCP server owns the list of tool categories (`?category=` values).
+# Two places here restate it for readers and silently rot when the server gains
+# or drops one: SCOPE_CATEGORIES in the docs config generator, and the
+# "Available tools" table in content/docs/shared-content/mcp-tools.md. A missing
+# entry in the generator is the worst case — it emits a `?category=` URL that
+# quietly disables tools the user never chose to turn off.
+#
+#   - Pull requests touching either surface -> offline check (no network): the
+#     generator and the docs table must agree.
+#   - Daily schedule / manual dispatch -> --live: both are additionally compared
+#     against mcp.neon.tech's advertised x-neon-scope-categories, and drift
+#     opens/updates a tracking issue so a new category can't rot silently.
+
+on:
+  pull_request:
+    paths:
+      - 'src/components/pages/doc/mcp-setup-configurator/**'
+      - 'content/docs/shared-content/mcp-tools.md'
+      - 'scripts/check-mcp-categories-sync.mjs'
+      - '.github/workflows/mcp-categories-sync.yml'
+  schedule:
+    # Every day at 9:00 AM UTC (after the agent-discovery and skills checks)
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: 'Check MCP tool categories are in sync'
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+
+      # Zero-dependency check (Node builtins + global fetch) — no install needed,
+      # so nothing to fetch from the npm registry.
+      - name: Check categories (offline)
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-mcp-categories-sync.mjs | tee mcp-categories-report.txt
+
+      - name: Check categories (live)
+        if: github.event_name != 'pull_request'
+        run: node scripts/check-mcp-categories-sync.mjs --live | tee mcp-categories-report.txt
+
+      - name: Open or update drift issue
+        if: failure() && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title="MCP tool categories drifted from mcp.neon.tech"
+          body="$(cat mcp-categories-report.txt 2>/dev/null || echo 'The MCP category sync check failed. See the workflow run for details.')"
+          body="${body}"$'\n\n'"— Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          existing="$(gh issue list --state open --search "${title} in:title" --json number --jq '.[0].number' 2>/dev/null || echo '')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "check:api-ref-generated": "node scripts/check-api-ref-generated.mjs",
     "check:docs-api-consistency": "node scripts/check-docs-api-consistency.mjs",
     "check:skills-sync": "node scripts/check-skills-sync.mjs",
+    "check:mcp-categories": "node scripts/check-mcp-categories-sync.mjs",
+    "check:mcp-categories:live": "node scripts/check-mcp-categories-sync.mjs --live",
     "audit:api-ref": "node scripts/audit-api-spec.mjs",
     "audit:field-groups": "node scripts/validate-field-groups.mjs",
     "check:broken-links": "linkinator --config linkinator.config.json",

--- a/scripts/check-mcp-categories-sync.mjs
+++ b/scripts/check-mcp-categories-sync.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * MCP tool-category drift check.
+ *
+ * The Neon MCP server owns the list of tool categories (`?category=` values).
+ * Two places in this repo restate that list for readers, and both silently rot
+ * when the server gains or drops a category:
+ *
+ *   1. SCOPE_CATEGORIES in the config generator
+ *      (src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx)
+ *      — a missing entry means the generator emits a `?category=` URL that
+ *      quietly disables tools the user never chose to turn off.
+ *   2. The "Available tools" table in content/docs/shared-content/mcp-tools.md.
+ *
+ * The server advertises its own list at
+ * https://mcp.neon.tech/.well-known/oauth-authorization-server under
+ * `x-neon-scope-categories`, so drift is detectable rather than guessable.
+ *
+ *   - Offline (default, PR gate): the generator and the docs table must list the
+ *     same categories in the same order. Deterministic, no network. This alone
+ *     catches the common case where one of the two gets updated and the other
+ *     doesn't.
+ *   - --live (daily schedule / manual): additionally fetches the well-known
+ *     document and requires both local lists to match the server exactly. This
+ *     is what catches a category added to the MCP server that nobody mirrored
+ *     here at all.
+ *
+ * Order matters, not just membership: both lists are rendered to users, and the
+ * server's array is the intended presentation order.
+ *
+ * Zero-dependency (Node builtins + global fetch) so CI needs no install.
+ *
+ * Usage:
+ *   node scripts/check-mcp-categories-sync.mjs           # offline
+ *   node scripts/check-mcp-categories-sync.mjs --live    # + compare against mcp.neon.tech
+ *   node scripts/check-mcp-categories-sync.mjs --live --server https://staging.example.com
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const CONFIGURATOR_PATH = path.join(
+  ROOT,
+  'src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx'
+);
+const DOCS_TABLE_PATH = path.join(ROOT, 'content/docs/shared-content/mcp-tools.md');
+
+const DEFAULT_SERVER = 'https://mcp.neon.tech';
+const WELL_KNOWN_PATH = '/.well-known/oauth-authorization-server';
+const CATEGORIES_FIELD = 'x-neon-scope-categories';
+
+// ── parsers (pure) ───────────────────────────────────────────────────────────
+
+/**
+ * Category ids from the generator's `const SCOPE_CATEGORIES = [...]` literal, in
+ * source order. Reading the array rather than importing the module keeps this a
+ * plain Node script: the component is JSX with 'use client' and app-root imports.
+ */
+export function parseConfiguratorCategories(source) {
+  const match = source.match(/const SCOPE_CATEGORIES\s*=\s*\[([\s\S]*?)\];/);
+  if (!match) {
+    throw new Error('could not find a `const SCOPE_CATEGORIES = [...]` array literal');
+  }
+  return [...match[1].matchAll(/\bid:\s*'([^']+)'/g)].map((entry) => entry[1]);
+}
+
+/**
+ * Category slugs from the "Available tools" table, in row order. Each Category
+ * cell reads like `Managed Better Auth (\`neon_auth\`)`, so the slug is the
+ * backticked token in the first column.
+ */
+export function parseDocsTableCategories(markdown) {
+  const section = markdown.split(/^##\s+Available tools\s*$/m)[1];
+  if (section === undefined) {
+    throw new Error('could not find an "## Available tools" heading');
+  }
+  const rows = section.split('\n').filter((line) => line.trim().startsWith('|'));
+  const slugs = [];
+  for (const row of rows) {
+    const firstCell = row.split('|')[1];
+    if (firstCell === undefined) continue;
+    const slug = firstCell.match(/`([^`]+)`/);
+    if (slug) slugs.push(slug[1]);
+  }
+  if (slugs.length === 0) {
+    throw new Error('the "Available tools" table listed no `category` slugs');
+  }
+  return slugs;
+}
+
+/** Human-readable description of how `actual` diverges from `expected`, or null. */
+export function describeDrift({ actual, expected, actualLabel, expectedLabel }) {
+  if (actual.length === expected.length && actual.every((id, i) => id === expected[i])) {
+    return null;
+  }
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+  const missing = expected.filter((id) => !actualSet.has(id));
+  const extra = actual.filter((id) => !expectedSet.has(id));
+
+  const details = [];
+  if (missing.length > 0) {
+    details.push(`missing from ${actualLabel}: ${missing.join(', ')}`);
+  }
+  if (extra.length > 0) {
+    details.push(`present in ${actualLabel} but not ${expectedLabel}: ${extra.join(', ')}`);
+  }
+  if (details.length === 0) {
+    details.push(`same categories, different order`);
+  }
+  return (
+    `${details.join('; ')}\n` +
+    `           ${expectedLabel}: [${expected.join(', ')}]\n` +
+    `           ${actualLabel}: [${actual.join(', ')}]`
+  );
+}
+
+// ── I/O ──────────────────────────────────────────────────────────────────────
+
+async function fetchServerCategories(serverBase) {
+  const url = `${serverBase}${WELL_KNOWN_PATH}`;
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'neon-website-mcp-category-drift-check' },
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!response.ok) {
+    throw new Error(`${url} responded ${response.status} ${response.statusText}`);
+  }
+  const payload = await response.json();
+  const categories = payload[CATEGORIES_FIELD];
+  if (!Array.isArray(categories) || categories.length === 0) {
+    throw new Error(`${url} did not advertise a non-empty "${CATEGORIES_FIELD}" array`);
+  }
+  return categories;
+}
+
+const REMEDIATION = [
+  'To fix, make all listed sources agree with the MCP server, in the same order:',
+  '  - config generator: SCOPE_CATEGORIES in',
+  '    src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx',
+  '    (each entry also needs a user-facing label and description)',
+  '  - docs table: the "Available tools" table in content/docs/shared-content/mcp-tools.md',
+  'The server list is authoritative:',
+  `  curl -s ${DEFAULT_SERVER}${WELL_KNOWN_PATH} | jq '."${CATEGORIES_FIELD}"'`,
+].join('\n');
+
+async function main() {
+  const args = process.argv.slice(2);
+  const live = args.includes('--live');
+  const serverIndex = args.indexOf('--server');
+  const serverBase = (
+    serverIndex !== -1 && args[serverIndex + 1] ? args[serverIndex + 1] : DEFAULT_SERVER
+  ).replace(/\/$/, '');
+
+  console.log('MCP tool-category drift check');
+  console.log(`  mode: ${live ? `live (${serverBase})` : 'offline'}\n`);
+
+  const configurator = parseConfiguratorCategories(fs.readFileSync(CONFIGURATOR_PATH, 'utf8'));
+  const docsTable = parseDocsTableCategories(fs.readFileSync(DOCS_TABLE_PATH, 'utf8'));
+
+  // Offline, the generator is the reference the docs table is compared against;
+  // live, both are compared against the server, which actually owns the list.
+  let reference = { label: 'config generator', categories: configurator };
+  const sources = [{ label: 'docs table', categories: docsTable }];
+
+  if (live) {
+    reference = { label: 'MCP server', categories: await fetchServerCategories(serverBase) };
+    sources.unshift({ label: 'config generator', categories: configurator });
+  }
+
+  const problems = [];
+  for (const source of sources) {
+    const drift = describeDrift({
+      actual: source.categories,
+      expected: reference.categories,
+      actualLabel: source.label,
+      expectedLabel: reference.label,
+    });
+    if (drift) {
+      problems.push({ label: source.label, drift });
+      console.log(`  [FAIL] ${source.label} vs ${reference.label}`);
+      console.log(`           - ${drift}`);
+    } else {
+      console.log(`  [OK]   ${source.label} matches ${reference.label}`);
+    }
+  }
+
+  console.log(`\n  categories (${reference.label}): ${reference.categories.join(', ')}`);
+
+  if (problems.length > 0) {
+    console.error(
+      `\n[FAIL] ${problems.length} source(s) drifted from the ${reference.label} category list.\n\n` +
+        REMEDIATION
+    );
+    process.exit(1);
+  }
+
+  console.log(`\n[OK] All ${sources.length + 1} category lists agree.`);
+}
+
+// Only run when invoked directly, so the parsers stay importable from tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((err) => {
+    console.error('Error:', err.message);
+    process.exit(2);
+  });
+}

--- a/scripts/check-mcp-categories-sync.test.js
+++ b/scripts/check-mcp-categories-sync.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  parseConfiguratorCategories,
+  parseDocsTableCategories,
+  describeDrift,
+} from './check-mcp-categories-sync.mjs';
+
+describe('parseConfiguratorCategories', () => {
+  it('reads ids from the SCOPE_CATEGORIES literal in source order', () => {
+    const source = [
+      "const AUTH_MODES = [{ id: 'oauth', label: 'OAuth' }];",
+      'const SCOPE_CATEGORIES = [',
+      "  { id: 'projects', label: 'Projects', description: 'Create and manage projects' },",
+      "  { id: 'observability', label: 'Observability', description: 'Query logs' },",
+      "  { id: 'docs', label: 'Docs', description: 'Search and fetch docs' },",
+      '];',
+      'const SCOPE_IDS = SCOPE_CATEGORIES.map((scope) => scope.id);',
+    ].join('\n');
+
+    expect(parseConfiguratorCategories(source)).toEqual(['projects', 'observability', 'docs']);
+  });
+
+  it('throws when the array literal is gone (renamed or restructured)', () => {
+    expect(() => parseConfiguratorCategories('const OTHER = [];')).toThrow(/SCOPE_CATEGORIES/);
+  });
+});
+
+describe('parseDocsTableCategories', () => {
+  const markdown = [
+    '## Something else',
+    '',
+    '| Category | What |',
+    '| --- | --- |',
+    '| Not a real (`ignored`) | row before the heading |',
+    '',
+    '## Available tools',
+    '',
+    'Tools are grouped into categories.',
+    '',
+    '| Category | What it enables |',
+    '| --- | --- |',
+    '| Project management (`projects`) | List, create, describe projects |',
+    '| Managed Better Auth (`neon_auth`) | Set up app authentication |',
+    '| Observability (`observability`) | Query logs |',
+    '',
+    'Search and navigation tools are available by default.',
+  ].join('\n');
+
+  it('reads slugs from the Available tools table in row order', () => {
+    expect(parseDocsTableCategories(markdown)).toEqual(['projects', 'neon_auth', 'observability']);
+  });
+
+  it('ignores tables that appear before the Available tools heading', () => {
+    expect(parseDocsTableCategories(markdown)).not.toContain('ignored');
+  });
+
+  it('throws when the heading is missing', () => {
+    expect(() => parseDocsTableCategories('# Nothing here')).toThrow(/Available tools/);
+  });
+
+  it('throws when the table has no backticked slugs', () => {
+    const noSlugs = ['## Available tools', '', '| Category |', '| --- |', '| Projects |'].join(
+      '\n'
+    );
+    expect(() => parseDocsTableCategories(noSlugs)).toThrow(/no `category` slugs/);
+  });
+});
+
+describe('describeDrift', () => {
+  const labels = { actualLabel: 'config generator', expectedLabel: 'MCP server' };
+
+  it('returns null when both lists match exactly', () => {
+    expect(describeDrift({ actual: ['a', 'b'], expected: ['a', 'b'], ...labels })).toBeNull();
+  });
+
+  it('reports a category the server has that the local list lacks', () => {
+    const drift = describeDrift({
+      actual: ['projects', 'docs'],
+      expected: ['projects', 'observability', 'docs'],
+      ...labels,
+    });
+    expect(drift).toContain('missing from config generator: observability');
+  });
+
+  it('reports a category the local list has that the server dropped', () => {
+    const drift = describeDrift({
+      actual: ['projects', 'performance'],
+      expected: ['projects'],
+      ...labels,
+    });
+    expect(drift).toContain('present in config generator but not MCP server: performance');
+  });
+
+  it('treats a reordered but otherwise equal list as drift', () => {
+    const drift = describeDrift({ actual: ['b', 'a'], expected: ['a', 'b'], ...labels });
+    expect(drift).toContain('same categories, different order');
+  });
+});

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -33,6 +33,11 @@ const AUTH_MODES = [
   },
 ];
 
+// Must stay in sync with the MCP server's own category list, advertised at
+// https://mcp.neon.tech/.well-known/oauth-authorization-server as
+// `x-neon-scope-categories`, and with the table in
+// content/docs/shared-content/mcp-tools.md. Enforced by
+// `npm run check:mcp-categories` — see scripts/check-mcp-categories-sync.mjs.
 const SCOPE_CATEGORIES = [
   { id: 'projects', label: 'Projects', description: 'Create and manage projects' },
   { id: 'branches', label: 'Branches', description: 'Create, reset, delete branches' },
@@ -40,6 +45,7 @@ const SCOPE_CATEGORIES = [
   { id: 'querying', label: 'Querying', description: 'Run SQL and explain plans' },
   { id: 'neon_auth', label: 'Neon Auth', description: 'Users and sessions' },
   { id: 'data_api', label: 'Data API', description: 'RESTful data endpoints' },
+  { id: 'observability', label: 'Observability', description: 'Function and storage logs' },
   { id: 'docs', label: 'Docs', description: 'Search and fetch docs' },
 ];
 const SCOPE_IDS = SCOPE_CATEGORIES.map((scope) => scope.id);


### PR DESCRIPTION
## Problem

The MCP server added an `observability` tool category ([mcp-server-neon#292](https://github.com/neondatabase/mcp-server-neon/pull/292)). The **Available tools** table in `content/docs/shared-content/mcp-tools.md` was updated for it — the **config generator** on [/docs/ai/neon-mcp-server#config-generator](https://neon.com/docs/ai/neon-mcp-server#config-generator) was not.

This was worse than a cosmetic omission. `buildQueryParams` only emits `?category=` once the selection is a strict subset of the known list, so:

- With everything checked, no `category` param is emitted and the URL is correct — the gap is invisible.
- The moment a user unchecks **any** category, the generator emits a `category` list built from the 7 it knew about, **silently dropping `observability`** — disabling five tools the user never chose to turn off.

Before this PR, unchecking "Projects" produced:

```
https://mcp.neon.tech/mcp?category=branches,schema,querying,neon_auth,data_api,docs
```

After:

```
https://mcp.neon.tech/mcp?category=branches,schema,querying,neon_auth,data_api,observability,docs
```

## Solution

1. Add `observability` to `SCOPE_CATEGORIES` in the config generator, in the server's order (between `data_api` and `docs`).
2. Add a drift check so the next category can't rot the same way.

The MCP server advertises its own category list, so this is verifiable rather than a convention:

```bash
curl -s https://mcp.neon.tech/.well-known/oauth-authorization-server | jq '."x-neon-scope-categories"'
[ "projects", "branches", "schema", "querying", "neon_auth", "data_api", "observability", "docs" ]
```

`scripts/check-mcp-categories-sync.mjs` parses the two places this repo restates that list — `SCOPE_CATEGORIES` and the "Available tools" table — and compares them. Order is enforced too, since both are rendered to users. It follows the existing `agent-discovery-verify` / `skills-readonly` pattern:

- **Offline (PR gate):** generator and docs table must agree. No network, deterministic. This alone catches this exact bug, since the docs table was updated and the generator wasn't.
- **`--live` (daily 09:00 UTC + manual):** both are additionally compared against the server's advertised list, and drift opens/updates a tracking issue. This is what catches a new category that nobody mirrored here at all.

Zero-dependency (Node builtins + `fetch`), so the workflow needs no `npm ci`.

## User-facing API

New npm scripts:

```bash
npm run check:mcp-categories        # offline: generator vs docs table
npm run check:mcp-categories:live   # + compare both against mcp.neon.tech
```

`--server <base>` overrides the MCP base URL for staging.

Failure output names the drift and how to fix it:

```
  [FAIL] config generator vs MCP server
           - missing from config generator: observability
           MCP server: [projects, branches, schema, querying, neon_auth, data_api, observability, docs]
           config generator: [projects, branches, schema, querying, neon_auth, data_api, docs]

To fix, make all listed sources agree with the MCP server, in the same order:
  - config generator: SCOPE_CATEGORIES in
    src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
    (each entry also needs a user-facing label and description)
  - docs table: the "Available tools" table in content/docs/shared-content/mcp-tools.md
```

## Verification

**The check is red before the fix, green after.** Stashing the `SCOPE_CATEGORIES` change reproduces the failure above in both modes (exit 1); with the fix both exit 0.

- `npm run check:mcp-categories` and `:live` — pass.
- `npm run test:unit:run` — 618 passed (33 files), including 10 new tests covering both parsers and the diff formatter (missing / extra / reordered / exact match, plus the throw paths for a renamed `SCOPE_CATEGORIES` or a missing table).
- ESLint + Prettier clean.

**Browser (local dev, real `mcp.neon.tech`):**

- All 8 categories render, light and dark mode.
- Selecting **only** Observability produces `?category=observability`, and the live tools preview returns exactly the expected 5 tools — `Search`, `Fetch`, `Query Logs`, `List Log Fields`, `List Log Field Values` — matching `curl "https://mcp.neon.tech/api/list-tools?category=observability"`.
- Unchecking one category now keeps `observability` in the generated URL (the regression above).

## Screenshots

The **Tool categories** card now renders a uniform 4×2 grid, all eight entries on a single description line, verified in both light and dark mode:

```
Projects              Branches
Create and manage…    Create, reset, delete…

Schema                Querying
Tables, columns…      Run SQL and explain plans

Neon Auth             Data API
Users and sessions    RESTful data endpoints

Observability         Docs
Function and…         Search and fetch docs
```

I can attach the PNGs on request — flagging that I verified visually rather than pasting images, since I generated them locally.

## Notes and known gaps

- **Description wording** — `observability` is described as "Function and storage logs" to match the one-line noun-phrase style of the neighbouring cells; a longer string wraps and makes that grid row taller than the others. Happy to reword.
- **`?category=` is comma-joined, docs show it repeated.** `buildQueryParams` emits `?category=a,b`; the docs show `?category=a&category=b`. I verified the server accepts both and returns identical grants, so this is not a bug and I left it alone — flagging it only because the generated URL doesn't look like the documented form.
- **The daily live check depends on `mcp.neon.tech` being reachable** from the runner. If the well-known endpoint is flaky it will open a drift issue; the offline PR gate is unaffected.
- **This only covers category *names*, not labels or descriptions.** The server no longer ships human-readable labels (they were removed in mcp-server-neon#199), so the generator's label/description text stays hand-written and unverified. Adding a category still requires writing those by hand — the check just makes it impossible to forget the entry entirely.
