### PR TITLE
docs: lead CLI install page with npm, collapse the other options

### DIFF
--- a/content/docs/cli/install.md
+++ b/content/docs/cli/install.md
@@ -2,21 +2,33 @@
 title: 'Neon CLI: Install and connect'
 subtitle: Install the Neon CLI and connect with web auth or API key
 summary: >-
-  Install the Neon CLI (neon) on macOS, Windows, or Linux via Homebrew, npm,
-  bun, or standalone binary, with no-install options via npx or bunx. After
-  installing, connect by running `neon auth` for browser-based authentication,
+  Install the Neon CLI (neon) with npm i -g neon@latest, or on macOS, Windows,
+  or Linux via Homebrew, bun, or a standalone binary, with no-install options
+  via npx or bunx. After installing, connect by running `neon auth` for
+  browser-based authentication,
   or set the NEON_API_KEY environment variable or pass --api-key per command.
   Vercel-Managed Integration users must use an API key because web auth requires
   a Neon-registered account.
 enableTableOfContents: true
-updatedOn: '2026-07-03T14:03:07.441Z'
+updatedOn: '2026-07-27T17:01:44.761Z'
 redirectFrom:
   - /docs/reference/cli-install
 ---
 
 ## Install
 
-The CLI is invoked as `neon`, and `neonctl` is an alias for `neon`. The Homebrew formula is named `neonctl`, so install commands use that name even though you run the CLI as `neon`.
+Install the Neon CLI globally with [npm](https://www.npmjs.com/package/neon):
+
+```shell
+npm i -g neon@latest
+```
+
+Requires [Node.js 20.19.0](https://nodejs.org/en/download/) or higher. The CLI is invoked as `neon`, and `neonctl` is an alias for `neon`.
+
+<details>
+<summary>Other install options</summary>
+
+Homebrew, bun, and standalone binaries are also available. The Homebrew formula is named `neonctl`, so install commands use that name even though you run the CLI as `neon`.
 
 <Tabs labels={["macOS", "Windows", "Linux"]}>
 
@@ -27,14 +39,6 @@ The CLI is invoked as `neon`, and `neonctl` is an alias for `neon`. The Homebrew
 ```bash
 brew install neonctl
 ```
-
-**Install via [npm](https://www.npmjs.com/package/neon)**
-
-```shell
-npm i -g neon
-```
-
-Requires [Node.js 20.19.0](https://nodejs.org/en/download/) or higher.
 
 **Install with bun**
 
@@ -60,14 +64,6 @@ neon <command> [options]
 
 <TabItem>
 
-**Install via [npm](https://www.npmjs.com/package/neon)**
-
-```shell
-npm i -g neon
-```
-
-Requires [Node.js 20.19.0](https://nodejs.org/en/download/) or higher.
-
 **Install with bun**
 
 ```bash
@@ -91,14 +87,6 @@ neon-win-x64.exe <command> [options]
 </TabItem>
 
 <TabItem>
-
-**Install via [npm](https://www.npmjs.com/package/neon)**
-
-```shell
-npm i -g neon
-```
-
-Requires [Node.js 20.19.0](https://nodejs.org/en/download/) or higher.
 
 **Install with bun**
 
@@ -132,8 +120,7 @@ neon <command> [options]
 
 </Tabs>
 
-<Admonition title="Use the Neon CLI without installing" type="note">
-You can run the Neon CLI without installing it using **npx** or the `bun` equivalent, **bunx**:
+You can also run the Neon CLI without installing it using **npx** or the `bun` equivalent, **bunx**:
 
 ```shell
 # npx
@@ -143,7 +130,7 @@ npx neon <command>
 bunx neon <command>
 ```
 
-</Admonition>
+</details>
 
 ### Upgrade
 

--- a/content/docs/cli/install.md
+++ b/content/docs/cli/install.md
@@ -10,7 +10,7 @@ summary: >-
   Vercel-Managed Integration users must use an API key because web auth requires
   a Neon-registered account.
 enableTableOfContents: true
-updatedOn: '2026-07-27T17:01:44.761Z'
+updatedOn: '2026-07-27T17:11:36.776Z'
 redirectFrom:
   - /docs/reference/cli-install
 ---
@@ -172,7 +172,7 @@ To upgrade a [binary](https://github.com/neondatabase/neon-pkgs/releases) versio
 
 In CI/CD tools like GitHub Actions, you can safely pin the Neon CLI to `latest`, as we prioritize stability for CI/CD processes.
 
-<Tabs labels={["npm", "Homebrew", "Binary"]}>
+<Tabs labels={["npm (recommended)", "Binary"]}>
 
 <TabItem>
 
@@ -181,17 +181,6 @@ In your GitHub Actions workflow, use the `latest` tag with `npm`:
 ```yaml
 - name: Install Neon CLI
   run: npm install -g neon@latest
-```
-
-</TabItem>
-
-<TabItem>
-
-Homebrew automatically fetches the latest version when running the `install` or `upgrade` command. You can include the following in your workflow:
-
-```yaml
-- name: Install Neon CLI
-  run: brew install neonctl || brew upgrade neonctl
 ```
 
 </TabItem>


### PR DESCRIPTION
## Problem

[/docs/cli/install](https://neon.com/docs/cli/install) opened with a three-OS tab set (macOS / Windows / Linux). `npm i -g neon` was repeated inside every tab alongside Homebrew, bun, and binary downloads, so the one install command that works everywhere was buried behind a tab choice and four competing options.

The CI/CD section further down had the same problem in miniature: it offered Homebrew as a peer of npm for GitHub Actions, which isn't a realistic path on a runner.

## Solution

Lead with npm in both places, and demote the rest.

### Install section

Everything except npm moves into a collapsed `<details>` block that still holds the original per-OS tabs. The page now opens with:

> ## Install
>
> Install the Neon CLI globally with [npm](https://www.npmjs.com/package/neon):
>
> ```shell
> npm i -g neon@latest
> ```
>
> Requires [Node.js 20.19.0](https://nodejs.org/en/download/) or higher. The CLI is invoked as `neon`, and `neonctl` is an alias for `neon`.
>
> ▸ Other install options

Expanding **Other install options** reveals the unchanged macOS / Windows / Linux tabs — now carrying only Homebrew (macOS), bun, and the standalone binaries — plus the npx/bunx no-install snippet, which moved from a standalone `Admonition` into the same collapsed block.

### CI/CD section

The tab set under "In CI/CD tools like GitHub Actions, you can safely pin the Neon CLI to `latest`" goes from `["npm", "Homebrew", "Binary"]` to `["npm (recommended)", "Binary"]`. The Homebrew tab and its `brew install neonctl || brew upgrade neonctl` snippet are removed; the npm and binary snippets are unchanged.

## What's untouched

All commands, URLs, and the `Upgrade`, `Connect`, and `Configure autocompletion` sections. The `Upgrade` tab set still offers npm / Homebrew / Binary, since Homebrew is a real upgrade path on a developer machine even though it isn't one in CI.

No new components: `<details>`/`<summary>` is already styled in `src/styles/doc-content.css` and used across the docs, and `src/scripts/process-md-for-llms.js` already preserves it for the `.md` and `llms.txt` outputs.

## Verification

Ran the site locally and exercised the page in a browser:

- Install section: collapsed state renders as a single disclosure row under the npm command; expanding reveals the per-OS tabs; switching macOS → Windows works inside the disclosure; npx/bunx snippet renders at the bottom.
- CI/CD section: two tabs, npm active by default, binary snippet intact.
- Dark mode renders correctly.

Also confirmed the generated `/docs/cli/install.md` on the Vercel preview flattens the tabs to `**macOS**` / `**Windows**` / `**Linux**` headings inside the `<details>` with no content lost.

Checks: `prettier --check` and `markdownlint` on the file, `npm run check:docs` (47 tests), and the pre-push `vitest run` suite (618 tests). Console on the page is clean apart from a pre-existing "script tag while rendering React component" warning that also fires on `/docs/cli/quickstart`.

## Notes

- The primary install command uses `neon@latest` rather than bare `neon`, matching what the CI/CD section already recommends.
- `Other install options` is a `<summary>`, not a heading, so it does not add an "On this page" entry. The right-hand outline stays Install / Upgrade / Connect / Configure autocompletion.
- `Tabs` syncs the active tab across the page by label. Renaming the CI/CD tab to `npm (recommended)` makes that sync one-directional between the two remaining tab sets: clicking **Binary** in either still switches both, but clicking **npm (recommended)** in CI/CD no longer moves the `Upgrade` set off whatever tab it's on. Naming both `npm` would restore symmetry at the cost of the explicit recommendation.
- The frontmatter `summary` was reworded to lead with npm so the AI summary matches the page.