### PR TITLE
docs(cli): document the [anon] branch status label

### DIFF
--- a/content/docs/cli/branches.md
+++ b/content/docs/cli/branches.md
@@ -48,7 +48,7 @@ neon branches list --project-id solitary-leaf-288182
 └────────────────────────┴──────────────────────────┴──────────────────────┴──────────────────────┘
 ```
 
-Branch names include text labels that indicate status: `[default]` marks the project's default branch, `[protected]` marks a protected branch, and `[current]` marks the branch pinned in your local `.neon` context file.
+Branch names include text labels that indicate status: `[default]` marks the project's default branch, `[protected]` marks a protected branch, `[anon]` marks an anonymized branch, and `[current]` marks the branch pinned in your local `.neon` context file.
 
 List branches with `--output json`, which returns more information than the `table` format:
 


### PR DESCRIPTION
## What

The `neon branches list` output includes text labels that indicate branch status. The documentation listed `[default]`, `[protected]`, and `[current]`, but omitted the `[anon]` label that the CLI displays for anonymized branches.

This adds `[anon]` to the status-label description in the branches CLI docs, matching the existing wording and format.

## How verified

Confirmed against current CLI behavior: the `branches list` command appends an `[anon]` label when a branch is anonymized. The docs now cover all four status labels.

Ticket: LKB-15149