### PR TITLE
fix(utils): prevent EMFILE errors on blog listing/category pages

### DIFF
--- a/src/utils/api-blog.js
+++ b/src/utils/api-blog.js
@@ -74,12 +74,35 @@ const getBranchSnapshot = async (branch, { postSlug = null } = {}) => {
   );
 };
 
+// Local blog content is baked into the deployment and never changes at runtime,
+// so read it from disk once and reuse the resulting snapshot for the lifetime of
+// the process. This avoids re-reading every post file on each request/category,
+// which was exhausting the open-file limit (EMFILE) on Vercel.
+let localSnapshotPromise = null;
+
+const getLocalSnapshot = () => {
+  // In development, read fresh so edits to blog posts show up without a server
+  // restart. In build/production the content is immutable, so memoize it.
+  if (process.env.NODE_ENV !== 'production') {
+    return readLocalBlogSnapshot();
+  }
+
+  if (!localSnapshotPromise) {
+    localSnapshotPromise = readLocalBlogSnapshot().catch((error) => {
+      localSnapshotPromise = null;
+      throw error;
+    });
+  }
+
+  return localSnapshotPromise;
+};
+
 const getResolvedBlogSnapshot = async ({ previewBranch = null } = {}) => {
   if (previewBranch) {
     return getBranchSnapshot(previewBranch);
   }
 
-  return readLocalBlogSnapshot();
+  return getLocalSnapshot();
 };
 
 const mapAuthor = (slug, authorsData) => {

--- a/src/utils/blog-content-source.mjs
+++ b/src/utils/blog-content-source.mjs
@@ -12,6 +12,7 @@ const BLOG_CATEGORIES_DATA_PATH = `${BLOG_CONTENT_DIRNAME}/categories/data.json`
 const BLOG_POSTS_DIRNAME = `${BLOG_CONTENT_DIRNAME}/posts`;
 const GITHUB_BLOB_FETCH_BATCH_SIZE = 120;
 const GITHUB_BLOB_FETCH_BATCH_CONCURRENCY = 4;
+const LOCAL_POST_READ_CONCURRENCY = 32;
 
 class BlogContentBranchNotFoundError extends Error {
   constructor(branch) {
@@ -73,20 +74,18 @@ const readPostsFromDirectory = async (postsDir) => {
       .filter((fileName) => fileName.endsWith('.md'))
       .sort();
 
-    return Promise.all(
-      files.map(async (fileName) => {
-        const raw = await fs.readFile(path.join(postsDir, fileName), 'utf8');
-        const { data, content } = matter(raw);
+    return mapWithConcurrency(files, LOCAL_POST_READ_CONCURRENCY, async (fileName) => {
+      const raw = await fs.readFile(path.join(postsDir, fileName), 'utf8');
+      const { data, content } = matter(raw);
 
-        return {
-          slug: fileName.replace(/\.md$/u, ''),
-          fileName,
-          raw,
-          data,
-          content,
-        };
-      })
-    );
+      return {
+        slug: fileName.replace(/\.md$/u, ''),
+        fileName,
+        raw,
+        data,
+        content,
+      };
+    });
   } catch (error) {
     void error;
 


### PR DESCRIPTION
## Problem

Production logs on Vercel were flooded with `EMFILE: too many open files`
errors from `/blog` and `/blog/category/*`. Each render read the entire local
blog corpus (~466 markdown files), and enough of these ran concurrently to
exhaust the process file-descriptor limit.

## Fix

- **Cache the local snapshot** (`api-blog.js`): local content is baked into the
  deploy, so read it once in production instead of re-reading every file on each
  category, metadata call, and listing. Dev still reads fresh so edits show up
  without a restart.
- **Bound read concurrency** (`blog-content-source.mjs`): `readPostsFromDirectory`
  opened every file at once via an unbounded `Promise.all`; it now uses the
  existing `mapWithConcurrency` helper (limit 32).

The preview-branch path (GitHub-backed, already TTL-cached) is unchanged.

## Testing

- `npm run test:unit:run` — 618 tests pass
- `npm run fix:js` — clean

## Deferred

A build-time frontmatter index would remove the bulk read entirely; left out to
keep this fix minimal.

This pull request and its description were written by Isaac.