### PR TITLE
Feature neon-inspect-db in place of neon-sdk

### DIFF
--- a/content/blog/posts/neon-inspect-db.md
+++ b/content/blog/posts/neon-inspect-db.md
@@ -17,7 +17,7 @@ authors:
 cover:
   image: 'https://cdn.neonapi.io/public/images/pages/blog/neon-inspect-db/cover.jpg'
   alt: 'Debug your Postgres from the terminal: a tour of neon inspect db'
-isFeatured: false
+isFeatured: true
 draft: false
 seo:
   title: 'Debug your Postgres from the terminal: a tour of `neon inspect db` - Neon'

--- a/content/blog/posts/neon-sdk.md
+++ b/content/blog/posts/neon-sdk.md
@@ -21,7 +21,7 @@ cover:
   image: >-
     https://cdn.neonapi.io/public/images/pages/blog/neon-sdk/cover.jpg
   alt: 'Blog cover graphic on a blue dotted background with the Neon logo, the headline "Introducing @neon/sdk: TypeScript client for the Neon API", and a wireframe toolbox illustration labeled "SDK module" and "all-in-one".'
-isFeatured: true
+isFeatured: false
 seo:
   title: "Introducing @neon/sdk, our new TypeScript client for the Neon API - Neon"
   description: >-


### PR DESCRIPTION

- Feature `neon-inspect-db` and unfeature `neon-sdk` for the second featured blog slot (keeping `neon-backend-is-beta` featured)