### PR TITLE
feat: add colors section to the brand page

### DIFF
--- a/src/app/brand/page.jsx
+++ b/src/app/brand/page.jsx
@@ -1,3 +1,4 @@
+import Colors from 'components/pages/brand/colors';
 import Hero from 'components/pages/brand/hero';
 import Logo from 'components/pages/brand/logo';
 import Logomark from 'components/pages/brand/logomark';
@@ -11,6 +12,7 @@ const BrandPage = () => (
     <Logo />
     <Logomark />
     <Spacing />
+    <Colors />
   </Layout>
 );
 

--- a/src/components/pages/brand/colors/colors.jsx
+++ b/src/components/pages/brand/colors/colors.jsx
@@ -1,0 +1,84 @@
+'use client';
+
+import PropTypes from 'prop-types';
+
+import CheckIcon from 'components/shared/code-block-wrapper/images/check.inline.svg';
+import CopyIcon from 'components/shared/code-block-wrapper/images/copy.inline.svg';
+import useCopyToClipboard from 'hooks/use-copy-to-clipboard';
+import { cn } from 'utils/cn';
+
+import Section from '../section';
+
+const colors = [
+  {
+    name: 'Neon Green',
+    hex: '#34D59A',
+    className: 'bg-green-52 text-black-pure',
+  },
+  {
+    name: 'Black',
+    hex: '#000000',
+    className: 'border border-gray-new-30 bg-black-pure text-white',
+  },
+  {
+    name: 'Off-White',
+    hex: '#E4F1EB',
+    className: 'bg-[#E4F1EB] text-black-pure',
+  },
+];
+
+const Color = ({ name, hex, className }) => {
+  const { isCopied, handleCopy } = useCopyToClipboard(3000);
+
+  return (
+    <li className={cn('group relative flex h-[180px] flex-col justify-end p-4', className)}>
+      <span className="flex flex-col gap-px text-sm leading-snug tracking-extra-tight">
+        <span>{name}</span>
+        <span>{hex}</span>
+      </span>
+      <div
+        className={cn(
+          'absolute top-2.5 right-2.5',
+          'opacity-0 transition-opacity duration-300',
+          'group-hover:opacity-100 focus-within:opacity-100 lg:opacity-100'
+        )}
+      >
+        <button
+          className={cn(
+            'flex size-7 items-center justify-center border',
+            'border-gray-new-30 bg-gray-new-8 text-gray-new-94',
+            'transition-colors duration-200 hover:bg-gray-new-15'
+          )}
+          type="button"
+          aria-label={isCopied ? 'Copied' : `Copy ${name} hex code`}
+          disabled={isCopied}
+          onClick={() => handleCopy(hex)}
+        >
+          {isCopied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
+        </button>
+      </div>
+    </li>
+  );
+};
+
+Color.propTypes = {
+  name: PropTypes.string.isRequired,
+  hex: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+const Colors = () => (
+  <Section
+    title="Colors"
+    description="The Neon colors keep Neon Green as a primary color and pair it with a neutral black-and-white duo for a clean, high-contrast style."
+    className="mb-40 xl:mb-32 lg:mb-28 md:mb-[88px]"
+  >
+    <ul className="grid grid-cols-3 gap-4 sm:grid-cols-1">
+      {colors.map((color) => (
+        <Color {...color} key={color.hex} />
+      ))}
+    </ul>
+  </Section>
+);
+
+export default Colors;

--- a/src/components/pages/brand/colors/index.js
+++ b/src/components/pages/brand/colors/index.js
@@ -1,0 +1,3 @@
+import Colors from './colors';
+
+export default Colors;

--- a/src/components/pages/brand/spacing/spacing.jsx
+++ b/src/components/pages/brand/spacing/spacing.jsx
@@ -9,7 +9,6 @@ const Spacing = () => (
   <Section
     title="Spacing considerations"
     description="The safety area surrounding the Logo is defined by the height of our symbol."
-    className="mb-40 xl:mb-32 lg:mb-28 md:mb-[88px]"
   >
     <div className="flex items-center justify-between md:justify-start md:gap-20 sm:flex-col sm:items-start sm:gap-7">
       <Image


### PR DESCRIPTION
This PR adds a new **Colors** section to the [brand pag](https://neon-next-git-feat-add-colors-to-brand-pixelpoint.vercel.app/brand)e, placed at the bottom of the page after "Spacing considerations".

The section documents the three core brand colors (Neon Green, Black, Off-White) as a row of swatches, each labeled with its name and hex value. Every swatch has a copy button that puts the hex value on the clipboard and confirms with a check icon for three seconds.