### PR TITLE
docs: remove GROUP BY ALL from PostgreSQL 19 feature docs

### DIFF
--- a/content/postgresql/navigation.yaml
+++ b/content/postgresql/navigation.yaml
@@ -394,7 +394,7 @@
         - slug: postgresql-19/json-copy-to
           title: 'JSON Format for COPY TO'
         - slug: postgresql-19/query-improvements
-          title: 'Query Improvements: GROUP BY ALL, IGNORE NULLS'
+          title: 'Query Improvements: IGNORE NULLS, Memoize Estimates'
     - section: Schema & Operations
       items:
         - slug: postgresql-19/schema-management

--- a/content/postgresql/postgresql-19-new-features.md
+++ b/content/postgresql/postgresql-19-new-features.md
@@ -65,7 +65,7 @@ The initial implementation covers fixed-depth pattern matching. Variable-length 
 
 ## DML and Query Improvements
 
-PostgreSQL 19 adds several long-requested DML primitives. `ON CONFLICT DO SELECT` finally provides atomic get-or-create semantics, `FOR PORTION OF` completes SQL:2011 temporal modifications, and convenience features like `GROUP BY ALL` and `IGNORE NULLS` reduce verbosity in common query patterns.
+PostgreSQL 19 adds several long-requested DML primitives. `ON CONFLICT DO SELECT` finally provides atomic get-or-create semantics, `FOR PORTION OF` completes SQL:2011 temporal modifications, and convenience features like `IGNORE NULLS` reduce verbosity in common query patterns.
 
 ### [ON CONFLICT DO SELECT](/postgresql/postgresql-19/on-conflict-do-select)
 
@@ -99,24 +99,6 @@ WHERE product_id = 1;
 ```
 
 This completes PostgreSQL's SQL:2011 temporal feature set, making it suitable for booking systems, employee records, insurance policies, and any data with validity periods.
-
-### [GROUP BY ALL](/postgresql/postgresql-19/query-improvements)
-
-A convenience feature that automatically groups by every non-aggregate expression in the SELECT list:
-
-```sql
--- Before: manually repeat column names
-SELECT department, role, count(*)
-FROM employees
-GROUP BY department, role;
-
--- PostgreSQL 19: GROUP BY ALL
-SELECT department, role, count(*)
-FROM employees
-GROUP BY ALL;
-```
-
-This eliminates a common source of errors when adding or removing columns from SELECT lists.
 
 ### [IGNORE NULLS / RESPECT NULLS for Window Functions](/postgresql/postgresql-19/query-improvements)
 

--- a/content/postgresql/postgresql-19/query-improvements.md
+++ b/content/postgresql/postgresql-19/query-improvements.md
@@ -1,7 +1,7 @@
 ---
 title: 'PostgreSQL 19 Query Writing Improvements'
-page_title: 'PostgreSQL 19 Query Improvements - GROUP BY ALL, IGNORE NULLS, and Memoize Estimates'
-page_description: 'Learn about PostgreSQL 19 query writing improvements including GROUP BY ALL for automatic grouping, IGNORE NULLS for window functions, and Memoize plan estimates in EXPLAIN.'
+page_title: 'PostgreSQL 19 Query Improvements - IGNORE NULLS and Memoize Estimates'
+page_description: 'Learn about PostgreSQL 19 query writing improvements including IGNORE NULLS for window functions and Memoize plan estimates in EXPLAIN.'
 ogImage: ''
 updatedOn: '2026-06-04T14:03:00.799Z'
 enableTableOfContents: true
@@ -14,83 +14,10 @@ nextLink:
 ---
 
 <Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
-[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the new query features for yourself ahead of the final release expected later in 2026. Beta 1 adds `GROUP BY ALL`, `IGNORE NULLS`/`RESPECT NULLS` for window functions, and Memoize cache estimates in `EXPLAIN` output.
+[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try the new query features for yourself ahead of the final release expected later in 2026. Beta 1 includes `IGNORE NULLS`/`RESPECT NULLS` for window functions and Memoize cache estimates in `EXPLAIN` output.
 </Admonition>
 
-**Summary**: PostgreSQL 19 adds `GROUP BY ALL` for automatic grouping, `IGNORE NULLS` and `RESPECT NULLS` options for window functions, and Memoize cost estimates in EXPLAIN output. These features reduce boilerplate, improve time-series queries, and make query plan analysis easier.
-
-## GROUP BY ALL
-
-Every SQL developer has written a `GROUP BY` clause and forgotten to update it after adding a column to the SELECT list. PostgreSQL 19 adds `GROUP BY ALL`, which automatically groups by every non-aggregate, non-window-function expression in the SELECT list.
-
-### Basic Usage
-
-The mechanical example shows the saving: the explicit `GROUP BY` lists every non-aggregate column from the SELECT list, while `GROUP BY ALL` infers them.
-
-```sql
--- Before: manually list every grouped column
-SELECT department, region, fiscal_year, count(*), sum(revenue)
-FROM sales
-GROUP BY department, region, fiscal_year;
-
--- PostgreSQL 19: GROUP BY ALL
-SELECT department, region, fiscal_year, count(*), sum(revenue)
-FROM sales
-GROUP BY ALL;
-```
-
-Both queries produce the same result. `GROUP BY ALL` identifies which SELECT expressions contain aggregate functions (`count`, `sum`) and groups by everything else.
-
-### How It Decides What to Group By
-
-`GROUP BY ALL` includes a SELECT expression in the group list if it does not contain:
-
-- An aggregate function (`count`, `sum`, `avg`, `min`, `max`, etc.)
-- A window function (anything with an `OVER` clause)
-
-Everything else goes into the implicit GROUP BY. This includes plain columns, expressions, CASE statements, and subqueries that do not contain aggregates.
-
-```sql
--- Expressions and CASE work as expected
-SELECT
-    EXTRACT(YEAR FROM created_at) AS year,
-    CASE WHEN amount > 1000 THEN 'large' ELSE 'small' END AS size,
-    count(*) AS total,
-    avg(amount) AS avg_amount
-FROM orders
-GROUP BY ALL;
--- Groups by: EXTRACT(YEAR FROM created_at), CASE expression
-```
-
-### Using with HAVING
-
-`GROUP BY ALL` works normally with HAVING:
-
-```sql
-SELECT department, count(*) AS headcount
-FROM employees
-GROUP BY ALL
-HAVING count(*) > 10;
-```
-
-### Using with ORDER BY
-
-`GROUP BY ALL` composes with `ORDER BY` exactly like an explicit grouping clause.
-
-```sql
-SELECT category, count(*) AS total
-FROM products
-GROUP BY ALL
-ORDER BY total DESC;
-```
-
-<Admonition type="note">
-`GROUP BY ALL` cannot be combined with ROLLUP, CUBE, or GROUPING SETS in the same clause. Use explicit GROUP BY when you need advanced grouping operations.
-</Admonition>
-
-### When to Use It
-
-`GROUP BY ALL` is best for ad-hoc queries, analytics, and reporting where you are frequently adding or removing columns from the SELECT list. For production application code where the query structure is stable, explicit `GROUP BY` is still clearer about intent.
+**Summary**: PostgreSQL 19 adds `IGNORE NULLS` and `RESPECT NULLS` options for window functions, and Memoize cost estimates in EXPLAIN output. These features improve time-series queries and make query plan analysis easier.
 
 ## IGNORE NULLS and RESPECT NULLS for Window Functions
 
@@ -268,10 +195,9 @@ The ANALYZE output shows actual hits, misses, evictions, and memory usage, which
 
 ## Summary
 
-These query improvements in PostgreSQL 19 address everyday friction points. `GROUP BY ALL` removes a common source of errors in analytical queries. `IGNORE NULLS` makes time-series gap-filling a one-liner instead of a subquery workaround. And the Memoize EXPLAIN estimates give you visibility into the planner's caching decisions without running the query first.
+These query improvements in PostgreSQL 19 address everyday friction points. `IGNORE NULLS` makes time-series gap-filling a one-liner instead of a subquery workaround. And the Memoize EXPLAIN estimates give you visibility into the planner's caching decisions without running the query first.
 
 ## References
 
-- [Commit `ef38a4d9`: Add GROUP BY ALL](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=ef38a4d9)
 - [Commit `25a30bbd`: Add IGNORE NULLS/RESPECT NULLS option to Window functions](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=25a30bbd)
 - [PostgreSQL devel docs: Window Functions](https://www.postgresql.org/docs/devel/functions-window.html)


### PR DESCRIPTION
## Summary
- Remove `GROUP BY ALL` from PostgreSQL 19 docs after it was reverted upstream and will not ship in the final PG19 release
- Update the overview page, query improvements guide, and navigation title so we no longer present `GROUP BY ALL` as a PG19 feature
- Keep `IGNORE NULLS` / `RESPECT NULLS` and Memoize EXPLAIN estimates as the remaining query improvement coverage

## Test plan
- [ ] Confirm `/postgresql/postgresql-19-new-features` no longer mentions `GROUP BY ALL`
- [ ] Confirm `/postgresql/postgresql-19/query-improvements` covers only IGNORE NULLS and Memoize estimates
- [ ] Confirm nav label reads `Query Improvements: IGNORE NULLS, Memoize Estimates`
- [ ] Spot-check that remaining PG19 feature pages are unaffected