### PR TITLE
feat: /models REST endpoint pairing each model with the code examples that work for it

### DIFF
--- a/.github/workflows/agent-discovery-verify.yml
+++ b/.github/workflows/agent-discovery-verify.yml
@@ -20,8 +20,10 @@ on:
       - 'scripts/verify-agent-endpoints.mjs'
       - 'src/app/.well-known/**'
       - 'src/app/models.json/**'
+      - 'src/app/models/**'
       - 'src/scripts/generate-skills-index.js'
       - 'src/scripts/check-models-sync.js'
+      - 'src/scripts/check-models-endpoint-sync.js'
       - 'next.config.js'
   schedule:
     # Every day at 8:00 AM UTC (matches the old AI Gateway Models Sync cadence)

--- a/config/agent-endpoints.yaml
+++ b/config/agent-endpoints.yaml
@@ -114,6 +114,25 @@ endpoints:
     generator: src/scripts/generate-models-json.js
     liveSync: src/scripts/check-models-sync.js
 
+  - id: models-rest
+    name: AI Gateway models REST API
+    description: >-
+      Neon AI Gateway models as a REST resource at /models. Sibling of /models.json:
+      same models and same core data, but paired with the code examples that actually
+      work for each one. Query params scope it to a single model and use case. Must
+      never disagree with /models.json on the fields they share.
+    servedPath: /models
+    contentType: application/json
+    spec:
+      name: Neon AI Gateway models (REST)
+      url: https://neon.com/models
+      standard: false
+    validator: models-rest
+    check: file
+    file: src/app/models/capabilities.json
+    generator: live gateway probe (see $howToRegenerate in src/app/models/capabilities.json)
+    liveSync: src/scripts/check-models-endpoint-sync.js
+
   - id: llms-txt
     name: llms.txt
     description: >-

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check:broken-links": "linkinator --config linkinator.config.json",
     "check:pricing-sync": "node src/scripts/check-pricing-sync.js",
     "check:models-sync": "node src/scripts/check-models-sync.js",
+    "check:models-endpoint-sync": "node --no-warnings=MODULE_TYPELESS_PACKAGE_JSON src/scripts/check-models-endpoint-sync.js",
     "generate:models": "node src/scripts/generate-models-json.js",
     "verify:agent-endpoints": "node scripts/verify-agent-endpoints.mjs",
     "verify:agent-endpoints:live": "node scripts/verify-agent-endpoints.mjs --live",

--- a/scripts/verify-agent-endpoints.mjs
+++ b/scripts/verify-agent-endpoints.mjs
@@ -141,7 +141,11 @@ const SCHEMAS = {
             },
             'service-doc': {
               type: 'array',
-              items: { type: 'object', required: ['href'], properties: { href: { type: 'string' } } },
+              items: {
+                type: 'object',
+                required: ['href'],
+                properties: { href: { type: 'string' } },
+              },
             },
           },
         },
@@ -175,7 +179,11 @@ const SCHEMAS = {
     required: ['specVersion', 'host', 'entries'],
     properties: {
       specVersion: { type: 'string' },
-      host: { type: 'object', required: ['identifier'], properties: { identifier: { type: 'string' } } },
+      host: {
+        type: 'object',
+        required: ['identifier'],
+        properties: { identifier: { type: 'string' } },
+      },
       entries: {
         type: 'array',
         minItems: 1,
@@ -225,7 +233,11 @@ const VALIDATORS = {
         sot.MCP_SERVER.authorizationServer
       )
     );
-    checks.push(payload.url && isUrl(payload.url) ? ok('url is a valid URL') : fail('url is a valid URL', payload.url));
+    checks.push(
+      payload.url && isUrl(payload.url)
+        ? ok('url is a valid URL')
+        : fail('url is a valid URL', payload.url)
+    );
     return checks;
   },
 
@@ -241,7 +253,11 @@ const VALIDATORS = {
       )
     );
     checks.push(
-      equalsCheck('service-doc href matches SoT docsUrl', link['service-doc']?.[0]?.href, sot.NEON_API.docsUrl)
+      equalsCheck(
+        'service-doc href matches SoT docsUrl',
+        link['service-doc']?.[0]?.href,
+        sot.NEON_API.docsUrl
+      )
     );
     return checks;
   },
@@ -253,10 +269,16 @@ const VALIDATORS = {
     for (const skill of payload.skills || []) {
       const skillPath = path.join(SKILLS_DIR, skill.name, 'SKILL.md');
       if (!fs.existsSync(skillPath)) {
-        checks.push(fail(`digest up to date: ${skill.name}`, `missing SKILL.md at ${path.relative(ROOT, skillPath)}`));
+        checks.push(
+          fail(
+            `digest up to date: ${skill.name}`,
+            `missing SKILL.md at ${path.relative(ROOT, skillPath)}`
+          )
+        );
         continue;
       }
-      const digest = 'sha256:' + crypto.createHash('sha256').update(fs.readFileSync(skillPath)).digest('hex');
+      const digest =
+        'sha256:' + crypto.createHash('sha256').update(fs.readFileSync(skillPath)).digest('hex');
       checks.push(
         digest === skill.digest
           ? ok(`digest up to date: ${skill.name}`)
@@ -271,7 +293,9 @@ const VALIDATORS = {
 
   'ai-catalog'(payload, entry, sot) {
     const checks = [schemaCheck(entry.spec.name, SCHEMAS.aiCatalog, payload)];
-    const mcpEntry = (payload.entries || []).find((e) => e.type === 'application/mcp-server-card+json');
+    const mcpEntry = (payload.entries || []).find(
+      (e) => e.type === 'application/mcp-server-card+json'
+    );
     checks.push(
       mcpEntry
         ? equalsCheck('MCP entry url matches SoT cardUrl', mcpEntry.url, sot.MCP_SERVER.cardUrl)
@@ -312,7 +336,55 @@ const VALIDATORS = {
       } else if (res.status === 1) {
         checks.push(fail('in sync with models.dev', `catalog drift — ${output}`));
       } else {
-        checks.push(fail('in sync with models.dev', `sync check errored (exit ${res.status}) — ${output}`));
+        checks.push(
+          fail('in sync with models.dev', `sync check errored (exit ${res.status}) — ${output}`)
+        );
+      }
+    }
+    return checks;
+  },
+
+  // /models pairs each model with the code examples that work for it. Offline we can only
+  // check the committed capability data is well formed; the cross-endpoint comparison needs
+  // both endpoints live, so it runs via liveSync.
+  'models-rest'(payload, entry, sot, { live }) {
+    const checks = [];
+    const models = Array.isArray(payload?.models) ? payload.models : null;
+    checks.push(
+      models && models.length > 0
+        ? ok('capability data present', `${models.length} models probed ${payload.probedAt || '?'}`)
+        : fail('capability data present', 'capabilities.json has no models array')
+    );
+
+    if (models) {
+      const REQUIRED = ['id', 'chat', 'nativeDialect', 'webSearch', 'imageGeneration'];
+      const incomplete = models
+        .filter((m) => REQUIRED.some((k) => m[k] === undefined))
+        .map((m) => m.id || '(unnamed)');
+      checks.push(
+        incomplete.length === 0
+          ? ok('every model has complete capability data')
+          : fail('every model has complete capability data', `incomplete: ${incomplete.join(', ')}`)
+      );
+    }
+
+    if (live && entry.liveSync) {
+      const res = spawnSync('node', [path.join(ROOT, entry.liveSync), '--live', '--ci'], {
+        cwd: ROOT,
+        encoding: 'utf-8',
+      });
+      const output = `${res.stdout || ''}${res.stderr || ''}`.trim();
+      if (res.status === 0) {
+        checks.push(ok('core data matches /models.json', output.split('\n').pop()));
+      } else if (res.status === 1) {
+        checks.push(fail('core data matches /models.json', `endpoint drift — ${output}`));
+      } else {
+        checks.push(
+          fail(
+            'core data matches /models.json',
+            `sync check errored (exit ${res.status}) — ${output}`
+          )
+        );
       }
     }
     return checks;
@@ -321,8 +393,12 @@ const VALIDATORS = {
   'llms-txt'(payload, entry, sot, { live, liveBody }) {
     if (!live) return [ok('generator present (checked live)', entry.generator)];
     const checks = [];
-    checks.push(liveBody && liveBody.length > 0 ? ok('non-empty') : fail('non-empty', 'empty body'));
-    checks.push(/neon/i.test(liveBody || '') ? ok('mentions Neon') : fail('mentions Neon', 'no "Neon" found'));
+    checks.push(
+      liveBody && liveBody.length > 0 ? ok('non-empty') : fail('non-empty', 'empty body')
+    );
+    checks.push(
+      /neon/i.test(liveBody || '') ? ok('mentions Neon') : fail('mentions Neon', 'no "Neon" found')
+    );
     return checks;
   },
 
@@ -353,7 +429,10 @@ async function runEntry(entry, sot) {
     checks.push(
       src.includes(entry.builder)
         ? ok('route delegates to SoT builder', entry.builder)
-        : fail('route delegates to SoT builder', `${entry.routeFile} does not reference ${entry.builder}`)
+        : fail(
+            'route delegates to SoT builder',
+            `${entry.routeFile} does not reference ${entry.builder}`
+          )
     );
   }
 
@@ -377,7 +456,10 @@ async function runEntry(entry, sot) {
         checks.push(
           served.contentType.includes(entry.contentType.split(';')[0])
             ? ok('content-type', served.contentType)
-            : fail('content-type', `expected ${entry.contentType}, got ${served.contentType || '(none)'}`)
+            : fail(
+                'content-type',
+                `expected ${entry.contentType}, got ${served.contentType || '(none)'}`
+              )
         );
       }
     } catch (err) {
@@ -414,7 +496,9 @@ async function main() {
   }
 
   if (JSON_MODE) {
-    console.log(JSON.stringify({ mode: LIVE ? 'live' : 'offline', base: BASE_URL, results }, null, 2));
+    console.log(
+      JSON.stringify({ mode: LIVE ? 'live' : 'offline', base: BASE_URL, results }, null, 2)
+    );
     process.exit(results.every((r) => r.ok) ? 0 : 1);
   }
 
@@ -431,7 +515,9 @@ async function main() {
       totalChecks += 1;
       if (!c.ok) failedChecks += 1;
       const mark = c.ok ? '  ✓' : '  ✗';
-      console.log(`${mark} ${c.name}${c.detail && (!c.ok || c.detail !== true) ? `  ${c.detail}` : ''}`);
+      console.log(
+        `${mark} ${c.name}${c.detail && (!c.ok || c.detail !== true) ? `  ${c.detail}` : ''}`
+      );
     }
     if (!entryOk) {
       console.log(`      spec: ${entry.spec.name} → ${entry.spec.url}`);

--- a/src/app/models/capabilities.json
+++ b/src/app/models/capabilities.json
@@ -1,0 +1,258 @@
+{
+  "$comment": "Measured behaviour of every model the Neon AI Gateway serves. Produced by calling each model on /v1/chat/completions, its provider-native dialect, and /openai/v1/responses with the web_search and image_generation tools. This is what the gateway DID; models.json is what each model CLAIMS. /models needs both to know which code examples are correct.",
+  "$howToRegenerate": "Re-probe against a branch with all models enabled and replace `models`. Fields per model: id, owner, entitled, chat (conforms | array-content | not-served | not-entitled), deviations[], nativeDialect (openai-responses | gemini | none), responses, webSearch, imageGeneration. CI checks completeness, not freshness \u2014 see the models-rest validator in scripts/verify-agent-endpoints.mjs.",
+  "probedAt": "2026-07-28T22:50:55.124Z",
+  "models": [
+    {
+      "id": "qwen3-next-80b-a3b-instruct",
+      "owner": "alibaba",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "qwen35-122b-a10b",
+      "owner": "alibaba",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": ["content is array[2] of {summary/text/type}, spec requires string"],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gpt-oss-120b",
+      "owner": "databricks",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": ["content is array[2] of {summary/text/type}, spec requires string"],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gpt-oss-20b",
+      "owner": "databricks",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": ["content is array[2] of {summary/text/type}, spec requires string"],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gemini-3-1-flash-lite",
+      "owner": "google",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "id is null, spec requires string",
+        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
+        "usage.total_tokens is 170, but prompt + completion = 11",
+        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+      ],
+      "nativeDialect": "gemini",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gemini-3-1-pro",
+      "owner": "google",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "id is null, spec requires string",
+        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
+        "usage.total_tokens is 252, but prompt + completion = 11",
+        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+      ],
+      "nativeDialect": "gemini",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gemini-3-5-flash",
+      "owner": "google",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "id is null, spec requires string",
+        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
+        "usage.total_tokens is 309, but prompt + completion = 11",
+        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+      ],
+      "nativeDialect": "gemini",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gemini-3-flash",
+      "owner": "google",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "id is null, spec requires string",
+        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
+        "usage.total_tokens is 119, but prompt + completion = 11",
+        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+      ],
+      "nativeDialect": "gemini",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gemma-3-12b",
+      "owner": "google",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "llama-4-maverick",
+      "owner": "meta",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "meta-llama-3-1-8b-instruct",
+      "owner": "meta",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "meta-llama-3-3-70b-instruct",
+      "owner": "meta",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gpt-5",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-1",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-2",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-3-codex",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "not-served",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-4",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-4-mini",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-4-nano",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-mini",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-nano",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    }
+  ]
+}

--- a/src/app/models/examples.js
+++ b/src/app/models/examples.js
@@ -1,0 +1,451 @@
+// Runnable code examples per model and use case.
+//
+// Support on the AI Gateway is not uniform per model, and the differences are not derivable
+// from the model id. Three independent facts decide which examples are correct:
+//
+//   1. whether /v1/chat/completions returns a spec-conforming body,
+//   2. whether the model has a provider-native dialect,
+//   3. whether /openai/v1/responses is served for it (image generation and web search).
+//
+// Every branch below keys off a measured value in ./capabilities.json, never off a family name.
+
+const ENV = ['NEON_AI_GATEWAY_BASE_URL', 'NEON_AI_GATEWAY_TOKEN'];
+const AI_SDK_DEPS = ['ai', '@neondatabase/ai-sdk-provider'];
+
+const CHAT_PROMPT = 'Explain Serverless Postgres.';
+const SEARCH_PROMPT = 'What is the latest stable Postgres release?';
+const IMAGE_PROMPT = 'A red apple on a wooden table.';
+
+export const USE_CASES = ['chat', 'image-generation', 'web-search'];
+
+const example = ({
+  id,
+  title,
+  language,
+  dependencies,
+  endpoint,
+  path,
+  content,
+  variantReason,
+}) => ({
+  id,
+  title,
+  language,
+  dependencies,
+  envVars: ENV,
+  endpoint,
+  ...(variantReason ? { variantReason } : {}),
+  files: [{ path, content }],
+});
+
+const tsExample = (props) => example({ ...props, language: 'typescript', path: 'index.ts' });
+const pyExample = (props) =>
+  example({ ...props, language: 'python', dependencies: ['openai'], path: 'main.py' });
+const shExample = (props) =>
+  example({ ...props, language: 'bash', dependencies: [], path: 'run.sh' });
+
+/* ------------------------------------------------------------------ chat */
+
+const aiSdkChat = (model, responsesOnly) =>
+  tsExample({
+    id: 'ai-sdk',
+    title: 'AI SDK',
+    dependencies: AI_SDK_DEPS,
+    endpoint: responsesOnly ? '/openai/v1 (via provider)' : '/v1/chat/completions (via provider)',
+    content: `import { generateText } from "ai";
+import { neon } from "@neondatabase/ai-sdk-provider";
+
+const { text } = await generateText({
+  model: neon("${model}"),
+  prompt: "${CHAT_PROMPT}",
+});
+
+console.log(text);
+`,
+  });
+
+const mastraChat = (model, needsProvider, responsesOnly) =>
+  tsExample({
+    id: 'mastra',
+    title: 'Mastra',
+    dependencies: needsProvider ? ['@mastra/core', ...AI_SDK_DEPS] : ['@mastra/core'],
+    endpoint: responsesOnly ? '/openai/v1 (via provider)' : '/v1/chat/completions',
+    variantReason: needsProvider
+      ? "The neon/<model> string resolves through Mastra's own registry, which cannot parse this model's response."
+      : undefined,
+    content: needsProvider
+      ? `import { Agent } from "@mastra/core/agent";
+import { neon } from "@neondatabase/ai-sdk-provider";
+
+const agent = new Agent({
+  id: "neon-demo",
+  name: "neon-demo",
+  instructions: "You are a helpful assistant.",
+  model: neon("${model}"),
+});
+
+const { text } = await agent.generate("${CHAT_PROMPT}");
+console.log(text);
+`
+      : `import { Agent } from "@mastra/core/agent";
+
+const agent = new Agent({
+  id: "neon-demo",
+  name: "neon-demo",
+  instructions: "You are a helpful assistant.",
+  model: "neon/${model}",
+});
+
+const { text } = await agent.generate("${CHAT_PROMPT}");
+console.log(text);
+`,
+  });
+
+const openaiTsChat = (model, responsesOnly) =>
+  tsExample({
+    id: 'typescript',
+    title: 'TypeScript',
+    dependencies: ['openai'],
+    endpoint: responsesOnly ? '/openai/v1/responses' : '/v1/chat/completions',
+    variantReason: responsesOnly ? 'This model is not served on /v1/chat/completions.' : undefined,
+    content: responsesOnly
+      ? `import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: \`\${process.env.NEON_AI_GATEWAY_BASE_URL}/openai/v1\`,
+});
+
+const response = await client.responses.create({
+  model: "${model}",
+  input: "${CHAT_PROMPT}",
+});
+console.log(response.output_text);
+`
+      : `import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: \`\${process.env.NEON_AI_GATEWAY_BASE_URL}/v1\`,
+});
+
+const resp = await client.chat.completions.create({
+  model: "${model}",
+  messages: [{ role: "user", content: "${CHAT_PROMPT}" }],
+});
+console.log(resp.choices[0].message.content);
+`,
+  });
+
+const openaiPyChat = (model, responsesOnly) =>
+  pyExample({
+    id: 'python',
+    title: 'Python',
+    endpoint: responsesOnly ? '/openai/v1/responses' : '/v1/chat/completions',
+    variantReason: responsesOnly ? 'This model is not served on /v1/chat/completions.' : undefined,
+    content: responsesOnly
+      ? `import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/openai/v1",
+)
+
+response = client.responses.create(
+    model="${model}",
+    input="${CHAT_PROMPT}",
+)
+print(response.output_text)
+`
+      : `import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/v1",
+)
+
+resp = client.chat.completions.create(
+    model="${model}",
+    messages=[{"role": "user", "content": "${CHAT_PROMPT}"}],
+)
+print(resp.choices[0].message.content)
+`,
+  });
+
+const curlChat = (model, nativeDialect, responsesOnly) => {
+  if (nativeDialect === 'gemini') {
+    return shExample({
+      id: 'curl',
+      title: 'cURL',
+      endpoint: `/ai-gateway/gemini/v1beta/models/${model}:generateContent`,
+      variantReason:
+        'The native Gemini dialect returns a conforming body; /v1/chat/completions does not.',
+      content: `curl "\${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini/v1beta/models/${model}:generateContent" \\
+  -H "Authorization: Bearer \${NEON_AI_GATEWAY_TOKEN}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "contents": [
+      {"role": "user", "parts": [{"text": "${CHAT_PROMPT}"}]}
+    ]
+  }'
+`,
+    });
+  }
+
+  if (responsesOnly) {
+    return shExample({
+      id: 'curl',
+      title: 'cURL',
+      endpoint: '/openai/v1/responses',
+      variantReason: 'This model is not served on /v1/chat/completions.',
+      content: `curl "\${NEON_AI_GATEWAY_BASE_URL}/openai/v1/responses" \\
+  -H "Authorization: Bearer \${NEON_AI_GATEWAY_TOKEN}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${model}",
+    "input": "${CHAT_PROMPT}"
+  }'
+`,
+    });
+  }
+
+  return shExample({
+    id: 'curl',
+    title: 'cURL',
+    endpoint: '/v1/chat/completions',
+    content: `curl "\${NEON_AI_GATEWAY_BASE_URL}/v1/chat/completions" \\
+  -H "Authorization: Bearer \${NEON_AI_GATEWAY_TOKEN}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${model}",
+    "messages": [{"role": "user", "content": "${CHAT_PROMPT}"}]
+  }'
+`,
+  });
+};
+
+const chatExamples = (model, caps) => {
+  const arrayContent = caps.chat === 'array-content';
+  const responsesOnly = caps.chat === 'not-served' && caps.nativeDialect === 'openai-responses';
+
+  const examples = [
+    // The AI SDK provider absorbs every difference — array content, Responses-only routing —
+    // so this is the one surface that never needs a variant.
+    aiSdkChat(model, responsesOnly),
+    mastraChat(model, arrayContent || responsesOnly, responsesOnly),
+  ];
+
+  // The OpenAI SDKs declare `content` as a string. When the gateway returns an array they hand
+  // back a value that type-checks and then misbehaves — string methods throw and `.length`
+  // silently returns the part count — so these are omitted rather than shown with a caveat.
+  if (!arrayContent) {
+    examples.push(openaiTsChat(model, responsesOnly), openaiPyChat(model, responsesOnly));
+  }
+
+  examples.push(curlChat(model, caps.nativeDialect, responsesOnly));
+  return examples;
+};
+
+/* ------------------------------------------------------------ web search */
+
+const webSearchExamples = (model) => [
+  tsExample({
+    id: 'ai-sdk',
+    title: 'AI SDK',
+    dependencies: AI_SDK_DEPS,
+    endpoint: '/openai/v1 (via provider)',
+    content: `import { generateText } from "ai";
+import { neon } from "@neondatabase/ai-sdk-provider";
+
+const { text, sources } = await generateText({
+  model: neon("${model}"),
+  prompt: "${SEARCH_PROMPT}",
+  tools: { web_search: neon.tools.webSearch({}) },
+});
+
+console.log(text);
+console.log(sources.filter((source) => source.sourceType === "url").map((source) => source.url));
+`,
+  }),
+  tsExample({
+    id: 'typescript',
+    title: 'TypeScript',
+    dependencies: ['openai'],
+    endpoint: '/openai/v1/responses',
+    content: `import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: \`\${process.env.NEON_AI_GATEWAY_BASE_URL}/openai/v1\`,
+});
+
+const response = await client.responses.create({
+  model: "${model}",
+  input: "${SEARCH_PROMPT}",
+  tools: [{ type: "web_search" }],
+});
+console.log(response.output_text);
+`,
+  }),
+  pyExample({
+    id: 'python',
+    title: 'Python',
+    endpoint: '/openai/v1/responses',
+    content: `import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/openai/v1",
+)
+
+response = client.responses.create(
+    model="${model}",
+    input="${SEARCH_PROMPT}",
+    tools=[{"type": "web_search"}],
+)
+print(response.output_text)
+`,
+  }),
+  shExample({
+    id: 'curl',
+    title: 'cURL',
+    endpoint: '/openai/v1/responses',
+    content: `curl "\${NEON_AI_GATEWAY_BASE_URL}/openai/v1/responses" \\
+  -H "Authorization: Bearer \${NEON_AI_GATEWAY_TOKEN}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${model}",
+    "input": "${SEARCH_PROMPT}",
+    "tools": [{"type": "web_search"}]
+  }'
+`,
+  }),
+];
+
+/* ------------------------------------------------------ image generation */
+
+// Every variant streams. A generated image is ~3 MB of base64 and the gateway rejects buffered
+// responses over 655,360 bytes, which is also why there is no cURL variant.
+const imageExamples = (model) => [
+  tsExample({
+    id: 'ai-sdk',
+    title: 'AI SDK',
+    dependencies: AI_SDK_DEPS,
+    endpoint: '/openai/v1 (via provider)',
+    content: `import { streamText } from "ai";
+import { neon } from "@neondatabase/ai-sdk-provider";
+
+const result = streamText({
+  model: neon("${model}"),
+  prompt: "${IMAGE_PROMPT}",
+  tools: {
+    image_generation: neon.tools.imageGeneration({ outputFormat: "jpeg" }),
+  },
+});
+
+for await (const _ of result.textStream) {}
+
+const images = (await result.toolResults).filter((r) => r.toolName === "image_generation");
+console.log(images.length);
+`,
+  }),
+  tsExample({
+    id: 'typescript',
+    title: 'TypeScript',
+    dependencies: ['openai'],
+    endpoint: '/openai/v1/responses',
+    content: `import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: \`\${process.env.NEON_AI_GATEWAY_BASE_URL}/openai/v1\`,
+});
+
+const stream = client.responses.stream({
+  model: "${model}",
+  input: "${IMAGE_PROMPT}",
+  tools: [{ type: "image_generation" }],
+});
+
+const response = await stream.finalResponse();
+const sizes = response.output.flatMap((item) => {
+  if (item.type !== "image_generation_call") return [];
+  if (!("result" in item) || typeof item.result !== "string") return [];
+  return [item.result.length];
+});
+console.log(sizes);
+`,
+  }),
+  pyExample({
+    id: 'python',
+    title: 'Python',
+    endpoint: '/openai/v1/responses',
+    content: `import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/openai/v1",
+)
+
+with client.responses.stream(
+    model="${model}",
+    input="${IMAGE_PROMPT}",
+    tools=[{"type": "image_generation"}],
+) as stream:
+    for _ in stream:
+        pass
+    response = stream.get_final_response()
+
+sizes = [
+    len(item.result)
+    for item in response.output
+    if item.type == "image_generation_call" and getattr(item, "result", None)
+]
+print(sizes)
+`,
+  }),
+];
+
+const RESPONSES_ONLY_NOTE =
+  'The gateway serves /openai/v1/responses for OpenAI gpt-5 models only, so this tool is unavailable.';
+
+/**
+ * @returns {{ examples: Array, unsupported?: string }} Examples for the use case, or an
+ *   `unsupported` reason and an empty list when the model cannot do it. Never both.
+ */
+export function buildExamples(modelId, useCase, caps) {
+  if (caps.chat === 'not-entitled') {
+    return {
+      examples: [],
+      unsupported: `${modelId} requires a verified account. It is listed in /v1/models with enabled: false, which is an entitlement gap rather than a defect.`,
+    };
+  }
+
+  if (useCase === 'web-search') {
+    return caps.webSearch
+      ? { examples: webSearchExamples(modelId) }
+      : {
+          examples: [],
+          unsupported: `${modelId} cannot use the web_search tool. ${RESPONSES_ONLY_NOTE}`,
+        };
+  }
+
+  if (useCase === 'image-generation') {
+    return caps.imageGeneration
+      ? { examples: imageExamples(modelId) }
+      : {
+          examples: [],
+          unsupported: `${modelId} cannot use the image_generation tool. ${RESPONSES_ONLY_NOTE}`,
+        };
+  }
+
+  if (caps.chat === 'not-served' && caps.nativeDialect === 'none') {
+    return { examples: [], unsupported: `${modelId} is not reachable on any route.` };
+  }
+
+  return { examples: chatExamples(modelId, caps) };
+}

--- a/src/app/models/resolve.js
+++ b/src/app/models/resolve.js
@@ -1,0 +1,75 @@
+// Joins the models.json catalog with measured gateway capabilities.
+//
+// models.json says what a model *advertises* (it mirrors models.dev); capabilities say what the
+// gateway *did* when the model was called. The two disagree often enough that code examples
+// cannot be derived from the catalog alone.
+//
+// Pure on purpose: callers pass the data in. The route imports the JSON, and the CI sync check
+// requires it, so neither has to know how the other loads it.
+
+import { buildExamples, USE_CASES } from './examples.js';
+
+export const DEFAULT_USE_CASE = 'chat';
+export { USE_CASES };
+
+const blendedCost = (cost) =>
+  typeof cost?.input === 'number' && typeof cost?.output === 'number'
+    ? Math.round(((3 * cost.input + cost.output) / 4) * 1000) / 1000
+    : undefined;
+
+/** models.json fields plus the measured ones. Snake_case is kept so the two line up. */
+function toModel(id, entry, caps) {
+  return {
+    id,
+    name: entry.name ?? id,
+    provider: entry.provider ?? caps.owner,
+    family: entry.family,
+    release_date: entry.release_date,
+    last_updated: entry.last_updated,
+    knowledge: entry.knowledge,
+    reasoning: Boolean(entry.reasoning),
+    tool_call: Boolean(entry.tool_call),
+    structured_output: entry.structured_output,
+    temperature: entry.temperature,
+    open_weights: entry.open_weights,
+    modalities: entry.modalities ?? { input: [], output: [] },
+    limit: entry.limit ?? {},
+    cost: entry.cost ?? {},
+    blended_cost: blendedCost(entry.cost),
+    capabilities: {
+      entitled: caps.entitled !== false,
+      chat: caps.chat,
+      deviations: caps.deviations ?? [],
+      native_dialect: caps.nativeDialect,
+      responses: caps.responses,
+      web_search: caps.webSearch,
+      image_generation: caps.imageGeneration,
+    },
+  };
+}
+
+/**
+ * @param {object} catalog models.json payload (the whole file, with its `neon` key)
+ * @param {object} capabilities capabilities.json payload
+ * @param {string} id
+ * @param {string} useCase
+ * @returns {object|null} The model with its examples, or null when the gateway does not serve it.
+ */
+export function resolveModel(catalog, capabilities, id, useCase = DEFAULT_USE_CASE) {
+  const caps = capabilities.models.find((entry) => entry.id === id);
+  if (!caps) return null;
+
+  const { examples, unsupported } = buildExamples(id, useCase, caps);
+  return {
+    ...toModel(id, catalog.neon.models[id] ?? {}, caps),
+    use_case: useCase,
+    ...(unsupported ? { unsupported } : {}),
+    examples,
+  };
+}
+
+export function resolveAll(catalog, capabilities, useCase = DEFAULT_USE_CASE) {
+  return capabilities.models.map((caps) => resolveModel(catalog, capabilities, caps.id, useCase));
+}
+
+export const servedModelIds = (capabilities) => capabilities.models.map((entry) => entry.id);

--- a/src/app/models/route.js
+++ b/src/app/models/route.js
@@ -1,0 +1,78 @@
+import catalog from '../models.json/data.json';
+
+import capabilities from './capabilities.json';
+import {
+  DEFAULT_USE_CASE,
+  USE_CASES,
+  resolveAll,
+  resolveModel,
+  servedModelIds,
+} from './resolve.js';
+
+// Must be dynamic: under 'force-static' Next prerenders the handler once and
+// `request.nextUrl.searchParams` is always empty, so ?model= and ?use_case= are silently
+// ignored. The Cache-Control header below still lets the CDN cache each query string.
+export const dynamic = 'force-dynamic';
+
+const SCHEMA = 'https://neon.com/schemas/ai-gateway-models.json';
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+
+// Neon AI Gateway models as a REST resource, served at /models.
+//
+// Sibling of /models.json, and deliberately a different thing. /models.json mirrors the
+// models.dev schema so anything that reads models.dev can read it unchanged. /models answers the
+// question a developer actually has — "what do I paste to use this model?" — by pairing each
+// model with the code examples that work for it.
+//
+// Support is not uniform: 7 of 21 models return a non-conforming chat completions body, only
+// Gemini has a native dialect, codex is Responses-only, and image generation and web search are
+// served for the gpt-5 family alone. Those facts are measured against the live gateway and
+// committed in ./capabilities.json, and they decide which examples each model gets. A model that
+// cannot do the requested use case returns `unsupported` with an empty `examples` array rather
+// than examples that would fail.
+//
+//   /models                                          every model, chat examples
+//   /models?use_case=web-search                      every model, web search examples
+//   /models?model=gpt-5-4-mini                       one model, chat examples
+//   /models?model=gpt-5-4-mini&use_case=image-generation
+//
+// Core model data comes from the same ./models.json/data.json this site already serves, so the
+// two endpoints cannot drift on the facts they share. CI enforces that — see
+// src/scripts/check-models-endpoint-sync.js.
+export function GET(request) {
+  const { searchParams } = request.nextUrl;
+
+  const useCase = searchParams.get('use_case') ?? DEFAULT_USE_CASE;
+  if (!USE_CASES.includes(useCase)) {
+    return json({ error: `Unknown use_case "${useCase}"`, supported: USE_CASES }, 400);
+  }
+
+  const modelId = searchParams.get('model');
+  if (modelId) {
+    const model = resolveModel(catalog, capabilities, modelId, useCase);
+    if (!model) {
+      return json(
+        { error: `Unknown model "${modelId}"`, supported: servedModelIds(capabilities) },
+        404
+      );
+    }
+    return json({ $schema: SCHEMA, probed_at: capabilities.probedAt, use_case: useCase, model });
+  }
+
+  const models = resolveAll(catalog, capabilities, useCase);
+  return json({
+    $schema: SCHEMA,
+    probed_at: capabilities.probedAt,
+    use_case: useCase,
+    total: models.length,
+    models,
+  });
+}

--- a/src/app/models/route.test.js
+++ b/src/app/models/route.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+
+import { GET } from './route.js';
+
+// The route reads `request.nextUrl`, which Next populates. A plain URL is enough here.
+const request = (query = '') => ({ nextUrl: new URL(`https://neon.com/models${query}`) });
+const body = async (res) => JSON.parse(await res.text());
+
+describe('GET /models', () => {
+  it('returns every served model with chat examples by default', async () => {
+    const res = await GET(request());
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+
+    const payload = await body(res);
+    expect(payload.use_case).toBe('chat');
+    expect(payload.total).toBe(payload.models.length);
+    expect(payload.models.length).toBeGreaterThan(0);
+    expect(payload.probed_at).toEqual(expect.any(String));
+  });
+
+  it('scopes to a single model', async () => {
+    const res = await GET(request('?model=gpt-5-4-mini'));
+    const payload = await body(res);
+
+    expect(res.status).toBe(200);
+    expect(payload.model.id).toBe('gpt-5-4-mini');
+    expect(payload.models).toBeUndefined();
+  });
+
+  it('404s an unknown model and lists the ones it serves', async () => {
+    const res = await GET(request('?model=not-a-model'));
+    const payload = await body(res);
+
+    expect(res.status).toBe(404);
+    expect(payload.error).toMatch(/not-a-model/);
+    expect(payload.supported).toContain('gpt-5-4-mini');
+  });
+
+  it('400s an unknown use case', async () => {
+    const res = await GET(request('?use_case=embeddings'));
+    const payload = await body(res);
+
+    expect(res.status).toBe(400);
+    expect(payload.supported).toEqual(['chat', 'image-generation', 'web-search']);
+  });
+
+  describe('example selection follows measured capability, not model family', () => {
+    it('omits the OpenAI SDK examples for a model that returns array content', async () => {
+      const res = await GET(request('?model=gemini-3-5-flash'));
+      const { model } = await body(res);
+      const ids = model.examples.map((e) => e.id);
+
+      expect(model.capabilities.chat).toBe('array-content');
+      expect(ids).toContain('ai-sdk');
+      // The OpenAI SDKs type `content` as a string, so an array silently misbehaves.
+      expect(ids).not.toContain('typescript');
+      expect(ids).not.toContain('python');
+    });
+
+    it('points cURL at the native dialect where one exists', async () => {
+      const res = await GET(request('?model=gemini-3-5-flash'));
+      const { model } = await body(res);
+      const curl = model.examples.find((e) => e.id === 'curl');
+
+      expect(curl.endpoint).toContain('/ai-gateway/gemini/v1beta');
+      expect(curl.variantReason).toBeTruthy();
+    });
+
+    it('keeps cURL on chat completions for an array-content model with no native dialect', async () => {
+      const res = await GET(request('?model=gpt-oss-20b'));
+      const { model } = await body(res);
+      const curl = model.examples.find((e) => e.id === 'curl');
+
+      expect(model.capabilities.native_dialect).toBe('none');
+      expect(curl.endpoint).toBe('/v1/chat/completions');
+    });
+
+    it('gives Mastra a provider instance when the neon/ string cannot work', async () => {
+      const res = await GET(request('?model=gemini-3-5-flash'));
+      const { model } = await body(res);
+      const mastra = model.examples.find((e) => e.id === 'mastra');
+
+      expect(mastra.dependencies).toContain('@neondatabase/ai-sdk-provider');
+      expect(mastra.files[0].content).toContain('model: neon(');
+    });
+
+    it('uses the neon/ string for a conforming model', async () => {
+      const res = await GET(request('?model=gpt-5-4-mini'));
+      const { model } = await body(res);
+      const mastra = model.examples.find((e) => e.id === 'mastra');
+
+      expect(mastra.dependencies).toEqual(['@mastra/core']);
+      expect(mastra.files[0].content).toContain('model: "neon/gpt-5-4-mini"');
+    });
+
+    it('routes codex through the Responses API', async () => {
+      const res = await GET(request('?model=gpt-5-3-codex'));
+      const { model } = await body(res);
+      const ts = model.examples.find((e) => e.id === 'typescript');
+
+      expect(model.capabilities.chat).toBe('not-served');
+      expect(ts.endpoint).toBe('/openai/v1/responses');
+      expect(ts.files[0].content).toContain('client.responses.create');
+    });
+  });
+
+  describe('unsupported use cases', () => {
+    it('explains why rather than returning examples that would fail', async () => {
+      const res = await GET(request('?model=gemini-3-5-flash&use_case=web-search'));
+      const { model } = await body(res);
+
+      expect(model.examples).toEqual([]);
+      expect(model.unsupported).toMatch(/web_search/);
+    });
+
+    it('returns image examples for a model that supports the tool', async () => {
+      const res = await GET(request('?model=gpt-5-nano&use_case=image-generation'));
+      const { model } = await body(res);
+
+      expect(model.unsupported).toBeUndefined();
+      expect(model.examples.map((e) => e.id)).toEqual(['ai-sdk', 'typescript', 'python']);
+    });
+  });
+
+  it('every example is self-describing enough to run', async () => {
+    const res = await GET(request());
+    const { models } = await body(res);
+
+    for (const model of models) {
+      for (const example of model.examples) {
+        expect(example.files.length).toBeGreaterThan(0);
+        expect(example.files[0].content.length).toBeGreaterThan(0);
+        expect(example.envVars).toContain('NEON_AI_GATEWAY_TOKEN');
+        expect(example.endpoint).toEqual(expect.any(String));
+        expect(Array.isArray(example.dependencies)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/scripts/check-models-endpoint-sync.js
+++ b/src/scripts/check-models-endpoint-sync.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Verify that /models and /models.json describe the same models with the same core data.
+ *
+ * The two endpoints intentionally differ in shape — /models.json mirrors models.dev, /models is a
+ * REST resource carrying code examples — but they must never disagree on the facts they share.
+ * A model present in one and missing from the other, or priced differently in each, means one of
+ * them is lying to whoever reads it.
+ *
+ * Structure is not compared. Only the model id set and the fields both endpoints carry.
+ *
+ * Usage:
+ *   node src/scripts/check-models-endpoint-sync.js            # local files
+ *   node src/scripts/check-models-endpoint-sync.js --live     # fetch from --base (default neon.com)
+ *   node src/scripts/check-models-endpoint-sync.js --ci       # terse output for CI logs
+ *
+ * Exit codes: 0 in sync, 1 drift, 2 could not load an endpoint.
+ */
+
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+const args = process.argv.slice(2);
+const LIVE = args.includes('--live');
+const CI = args.includes('--ci') || (process.env.CI && !args.includes('--verbose'));
+const JSON_OUT = args.includes('--json');
+const baseIndex = args.indexOf('--base');
+const BASE = baseIndex === -1 ? 'https://neon.com' : args[baseIndex + 1];
+
+/** Fields both endpoints carry and must agree on. Anything else is shape, not fact. */
+const SHARED_FIELDS = [
+  'name',
+  'provider',
+  'family',
+  'release_date',
+  'last_updated',
+  'knowledge',
+  'reasoning',
+  'tool_call',
+  'structured_output',
+  'temperature',
+  'open_weights',
+  'modalities',
+  'limit',
+  'cost',
+];
+
+const canonical = (value) => JSON.stringify(value ?? null);
+
+async function loadLive(pathname) {
+  const url = `${BASE}${pathname}`;
+  const res = await fetch(url, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`${url} returned ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Offline, the REST payload is rebuilt from the same modules the route uses rather than by
+ * booting Next. That still catches what matters, because the drift lives in the data.
+ */
+async function loadModelsEndpoint() {
+  if (LIVE) return loadLive('/models');
+  const catalog = require(path.join(ROOT, 'src/app/models.json/data.json'));
+  const capabilities = require(path.join(ROOT, 'src/app/models/capabilities.json'));
+  const { resolveAll } = await import(
+    require('url').pathToFileURL(path.join(ROOT, 'src/app/models/resolve.js')).href
+  );
+  const models = resolveAll(catalog, capabilities);
+  return { probed_at: capabilities.probedAt, total: models.length, models };
+}
+
+async function loadModelsJson() {
+  if (LIVE) return loadLive('/models.json');
+  return require(path.join(ROOT, 'src/app/models.json/data.json'));
+}
+
+async function main() {
+  let modelsEndpoint;
+  let modelsJson;
+  try {
+    [modelsEndpoint, modelsJson] = await Promise.all([loadModelsEndpoint(), loadModelsJson()]);
+  } catch (error) {
+    console.error(`Could not load an endpoint: ${error.message}`);
+    process.exit(2);
+  }
+
+  const catalogModels = modelsJson?.neon?.models ?? {};
+  const restModels = new Map((modelsEndpoint?.models ?? []).map((m) => [m.id, m]));
+
+  const catalogIds = new Set(Object.keys(catalogModels));
+  const restIds = new Set(restModels.keys());
+
+  // /models lists what the gateway serves; /models.json lists the published catalog. The published
+  // catalog is allowed to be a superset — a model can be catalogued before it is enabled — but a
+  // model the gateway serves and the catalog has never heard of is a real problem.
+  const servedButUncatalogued = [...restIds].filter((id) => !catalogIds.has(id));
+  const cataloguedButUnserved = [...catalogIds].filter((id) => !restIds.has(id));
+
+  const fieldDrift = [];
+  for (const id of [...restIds].filter((candidate) => catalogIds.has(candidate))) {
+    const rest = restModels.get(id);
+    const entry = catalogModels[id];
+    for (const field of SHARED_FIELDS) {
+      if (canonical(rest[field]) !== canonical(entry[field])) {
+        fieldDrift.push({
+          id,
+          field,
+          models: canonical(entry[field]),
+          rest: canonical(rest[field]),
+        });
+      }
+    }
+  }
+
+  const inSync = servedButUncatalogued.length === 0 && fieldDrift.length === 0;
+
+  if (JSON_OUT) {
+    console.log(
+      JSON.stringify({ inSync, servedButUncatalogued, cataloguedButUnserved, fieldDrift }, null, 2)
+    );
+    process.exit(inSync ? 0 : 1);
+  }
+
+  const source = LIVE ? `${BASE}/models vs ${BASE}/models.json` : 'local /models vs /models.json';
+
+  if (servedButUncatalogued.length) {
+    console.error(
+      `Served by /models but absent from /models.json: ${servedButUncatalogued.join(', ')}`
+    );
+  }
+
+  if (fieldDrift.length) {
+    console.error(`${fieldDrift.length} field(s) disagree between the endpoints:`);
+    for (const drift of fieldDrift) {
+      console.error(
+        CI
+          ? `  ${drift.id}.${drift.field}`
+          : `  ${drift.id}.${drift.field}\n    /models.json: ${drift.models}\n    /models:      ${drift.rest}`
+      );
+    }
+  }
+
+  if (cataloguedButUnserved.length) {
+    // Not a failure. The catalog legitimately runs ahead of what a branch is entitled to serve.
+    console.log(
+      `Note: catalogued but not served (${cataloguedButUnserved.length}): ${cataloguedButUnserved.join(', ')}`
+    );
+  }
+
+  if (!inSync) {
+    console.error(
+      '\nRegenerate with `npm run generate:models`, then re-probe capabilities if the model set changed.'
+    );
+    process.exit(1);
+  }
+
+  console.log(`${source}: ${restIds.size} models in sync on ${SHARED_FIELDS.length} shared fields`);
+}
+
+main();


### PR DESCRIPTION
## The problem

`/models.json` mirrors the models.dev schema, which is exactly right for its job — anything that reads models.dev can read it unchanged. It answers *"what models exist"*.

It cannot answer the question a developer actually has: **"what do I paste to use this model?"** Support on the AI Gateway is not uniform, and the differences are not derivable from a model id:

- **7 of 21** served models return `choices[0].message.content` as an **array** rather than a string. The OpenAI SDKs declare it `string | null`, so the value type-checks and then misbehaves — string methods throw, and `.length` silently returns the part count instead of the character count.
- Only **Gemini** has a provider-native dialect. `gpt-oss-*` and `qwen35-122b-a10b` return the same array shape but have nowhere better to go.
- **`gpt-5-3-codex` is Responses-only** — `/v1/chat/completions` returns `not available on the chat_completions endpoint`.
- **Image generation and web search** are served for the nine `gpt-5*` models and nothing else.

None of that is in the catalog, so today every consumer has to rediscover it.

## The endpoint

```
GET /models                                            every model, chat examples
GET /models?use_case=web-search                        every model, web search examples
GET /models?model=gpt-5-4-mini                         one model
GET /models?model=gpt-5-nano&use_case=image-generation one model, one use case
```

`use_case` is one of `chat` (default), `image-generation`, `web-search`. Unknown use case → `400` with the supported list; unknown model → `404` with the served list.

Each model carries its models.json fields plus a measured `capabilities` block, and the examples that actually work for it:

```json
{
  "id": "gemini-3-5-flash",
  "blended_cost": 3.375,
  "capabilities": {
    "chat": "array-content",
    "native_dialect": "gemini",
    "web_search": false,
    "image_generation": false,
    "deviations": [
      "id is null, spec requires string",
      "content is array[1] of {text/thoughtSignature/type}, spec requires string",
      "usage.total_tokens is 218, but prompt + completion = 11"
    ]
  },
  "use_case": "chat",
  "examples": [
    {
      "id": "mastra",
      "title": "Mastra",
      "language": "typescript",
      "dependencies": ["@mastra/core", "ai", "@neondatabase/ai-sdk-provider"],
      "envVars": ["NEON_AI_GATEWAY_BASE_URL", "NEON_AI_GATEWAY_TOKEN"],
      "endpoint": "/v1/chat/completions",
      "variantReason": "The neon/<model> string resolves through Mastra's own registry, which cannot parse this model's response.",
      "files": [{ "path": "index.ts", "content": "import { Agent } from \"@mastra/core/agent\";\n…" }]
    }
  ]
}
```

Shape follows a shadcn registry item — metadata plus `files` — so a consumer can write them straight to disk. What each model gets:

| Model group | Examples returned |
|---|---|
| 8 conforming `gpt-5*` | AI SDK, Mastra (`neon/` string), TypeScript, Python, cURL |
| 4 Gemini 3.x | AI SDK, Mastra (provider instance), cURL **on the native Gemini dialect** |
| `gpt-oss-*`, `qwen35` | AI SDK, Mastra (provider instance), cURL on `/v1` |
| `gpt-5-3-codex` | all five, with TypeScript/Python/cURL **on `/openai/v1/responses`** |
| Anything lacking the tool | `unsupported` with an empty `examples` array |

That last row matters: a model that cannot do the requested use case explains why rather than returning examples that would fail.

## Keeping the two endpoints honest

`src/scripts/check-models-endpoint-sync.js` compares `/models` and `/models.json` on the **id set and 14 shared fields** — name, provider, family, release/update dates, knowledge, reasoning, tool_call, structured_output, temperature, open_weights, modalities, limit, cost. Structure is deliberately not compared; the endpoints are meant to differ in shape.

It's registered as the `models-rest` entry in `config/agent-endpoints.yaml` with `liveSync`, so it runs from the existing Agent Discovery workflow: offline schema checks on PRs, live cross-endpoint comparison on the daily schedule, and the existing drift-issue behaviour on failure. Workflow `paths:` extended to cover the new files.

Core data is read from the same `models.json/data.json` this site already serves, so the endpoints share one source rather than two copies that agree by luck.

One deliberate non-failure: models **catalogued but not served** are reported as a note. The published catalog legitimately runs ahead of what a branch is entitled to serve — currently 6 of them.

## `capabilities.json`

The measured half. It records, per model, what the gateway *did* when called: chat conformance and the specific deviations, native dialect, and whether Responses/web search/image generation work. `$comment` and `$howToRegenerate` fields explain provenance and how to refresh it.

CI checks it is **complete**, not fresh — every model must have all capability fields — since freshness is a live-probe question, not a schema one.

## Verification

- **13 unit tests** in `src/app/models/route.test.js`, colocated per the `docs-feedback` and `docs/mcp` pattern. They assert behaviour rather than snapshots: OpenAI SDK examples are absent for array-content models, cURL points at the native dialect only where one exists, Mastra takes a provider instance only when the string can't work, codex routes through Responses.
- **All 9 query combinations exercised against a running dev server**, not just the handler.
- `node scripts/verify-agent-endpoints.mjs` → 8/8 endpoints, 29/29 checks.
- `check-models-endpoint-sync.js` → 21 models in sync on 14 shared fields.
- ESLint and Prettier clean.

## One thing worth reviewing closely

**The route is `force-dynamic`, and it has to be.** I first wrote it `force-static` to match `/models.json`. The unit tests all passed, and every query param was silently ignored in the browser — under `force-static` Next prerenders the handler once and `request.nextUrl.searchParams` is always empty. It only showed up when I hit the running server.

The reason is recorded in a comment next to the export so nobody "optimises" it back. The `Cache-Control` header is unchanged, so the CDN still caches per query string; we lose build-time prerendering, which a parameterised endpoint could never have used anyway.

## Notes

- Touches `src/` per explicit request, which `CLAUDE.md` otherwise reserves for the web team.
- `capabilities.json` is a point-in-time probe. If the gateway's behaviour changes, the examples go stale silently — CI catches *completeness* but not *accuracy*. Extending Orbit's daily `verify_models_dev` job to assert response shape would close that; it currently reads the body and discards it, treating any 2xx as a pass.