### PR TITLE
Update Databricks branding to part of the Databricks Platform

### DIFF
--- a/src/components/pages/about/vision/vision.jsx
+++ b/src/components/pages/about/vision/vision.jsx
@@ -57,8 +57,8 @@ const Vision = () => (
         <SectionLabel icon="arrow">Where we&apos;re headed</SectionLabel>
 
         <h3 className="mt-5 max-w-[736px] text-5xl leading-dense font-normal tracking-tighter text-gray-new-40 xl:max-w-[600px] xl:text-[36px] lg:max-w-full lg:text-2xl md:mt-4 md:text-xl">
-          <span className="text-black-pure">Neon is a Databricks company.</span> In May 2025, Neon
-          joined Databricks to shape the future of AI-native application backends.
+          <span className="text-black-pure">Neon is part of the Databricks Platform.</span> In May
+          2025, Neon joined Databricks to shape the future of AI-native application backends.
         </h3>
 
         <div className="mt-[194px] flex gap-x-24 xl:mt-[136px] xl:gap-x-16 lg:gap-x-8 md:mt-9 md:flex-col md:gap-y-7 md:pr-24">
@@ -78,7 +78,7 @@ const Vision = () => (
               {' '}
               for developers and AI agents
             </mark>{' '}
-            — now backed by the scale and expertise of Databricks.
+            — now as part of the Databricks Platform.
           </p>
 
           <p className="text-xl leading-normal tracking-tighter text-black-pure xl:text-lg lg:text-base md:mr-8 md:text-[15px]">

--- a/src/components/pages/about/vision/vision.jsx
+++ b/src/components/pages/about/vision/vision.jsx
@@ -13,7 +13,7 @@ import Blob from './images/blob.inline.svg';
 const STATS_DATA = [
   {
     icon: databaseIcon,
-    value: '12,000,000',
+    value: '15,000,000',
     description: 'Postgres databases turned on every day.',
   },
   {

--- a/src/components/pages/home/backed-by/backed-by.jsx
+++ b/src/components/pages/home/backed-by/backed-by.jsx
@@ -19,8 +19,8 @@ const ITEMS = [
   {
     icon: databricksIcon,
     title: 'Databricks',
-    description: 'Neon has been a Databricks Company since May 2025.',
-    className: 'w-64 xl:w-[220px]',
+    description: 'Neon has been part of the Databricks Platform since May 2025.',
+    className: 'w-72 xl:w-64',
   },
 ];
 
@@ -41,7 +41,8 @@ const BackedBy = () => (
             )}
           >
             <strong>Trusted Postgres, Backed by Giants.</strong> Neon was founded by Postgres
-            committers, bringing decades of expertise. In 2025, Neon became a Databricks company.
+            committers, bringing decades of expertise. In 2025, Neon became part of the Databricks
+            Platform.
           </h2>
           <ul className="mt-[216px] flex gap-[92px] xl:mt-[136px] xl:gap-16 lg:gap-8 md:gap-5 sm:mt-9 xs:flex-col xs:gap-7">
             {ITEMS.map(({ icon, title, description, className }) => (

--- a/src/components/pages/home/backed-by/backed-by.jsx
+++ b/src/components/pages/home/backed-by/backed-by.jsx
@@ -12,7 +12,7 @@ import Quotes from './quotes';
 const ITEMS = [
   {
     icon: databaseIcon,
-    title: '12,000,000',
+    title: '15,000,000',
     description: 'Postgres databases started daily.',
     className: 'w-[216px] xl:w-48',
   },

--- a/src/components/pages/home/hero-mts/hero-mts.jsx
+++ b/src/components/pages/home/hero-mts/hero-mts.jsx
@@ -30,7 +30,7 @@ const HeroMts = () => (
     <Container className="relative z-30 pt-96 pb-2 xl:pt-54 lg:pt-52 md:px-5! md:pt-53" size="1600">
       <Link href="#backed-by-giants">
         <SectionLabel theme="white" icon="databricks">
-          A DATABRICKS COMPANY
+          NEON IS PART OF THE DATABRICKS PLATFORM
         </SectionLabel>
       </Link>
 

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -72,7 +72,7 @@ const Hero = () => (
     <Container className="relative z-30 pt-96 pb-2 xl:pt-54 lg:pt-52 md:px-5! md:pt-53" size="1600">
       <Link href="#backed-by-giants">
         <SectionLabel theme="white" icon="databricks">
-          A DATABRICKS COMPANY
+          NEON IS PART OF THE DATABRICKS PLATFORM
         </SectionLabel>
       </Link>
 

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -19,12 +19,12 @@ const Footer = ({ hasThemesSupport = false }) => (
           <Logo className="sm:h-6 sm:w-auto" width={102} height={28} />
           <span
             className={cn(
-              'mt-3.5 block text-[13px] leading-none tracking-extra-tight whitespace-nowrap',
+              'mt-3.5 block text-[13px] leading-none tracking-extra-tight',
               'text-gray-new-40 dark:text-gray-new-60',
               'xl:mt-3'
             )}
           >
-            A Databricks Company
+            Neon is part of the Databricks Platform
           </span>
         </div>
 


### PR DESCRIPTION
## Summary
- Update homepage hero eyebrow from "A Databricks Company" to "NEON IS PART OF THE DATABRICKS PLATFORM" (both hero variants)
- Update footer tagline to "Neon is part of the Databricks Platform"
- Reword Backed by Giants copy to say Neon became / has been part of the Databricks Platform since May 2025
- Update About vision section: "Neon is part of the Databricks Platform" and supporting vision copy
- Update daily Postgres databases metric from 12,000,000 to 15,000,000 (homepage and About page)

## Test plan
- [ ] Check homepage hero eyebrow text and wrapping on desktop and mobile
- [ ] Check footer tagline under the Neon logo
- [ ] Review Backed by Giants section headline, Databricks description, and 15M databases stat
- [ ] Review About page "Where we're headed" and "Our Vision" copy
- [ ] Confirm About page vision section shows 15,000,000
- [ ] Confirm MTS homepage variant shows the same eyebrow text