### PR TITLE
Update Neon tagline to Neon, now part of Databricks

### DIFF
--- a/src/components/pages/home/hero-mts/hero-mts.jsx
+++ b/src/components/pages/home/hero-mts/hero-mts.jsx
@@ -30,7 +30,7 @@ const HeroMts = () => (
     <Container className="relative z-30 pt-96 pb-2 xl:pt-54 lg:pt-52 md:px-5! md:pt-53" size="1600">
       <Link href="#backed-by-giants">
         <SectionLabel theme="white" icon="databricks">
-          NEON IS PART OF THE DATABRICKS PLATFORM
+          Neon, now part of Databricks
         </SectionLabel>
       </Link>
 

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -72,7 +72,7 @@ const Hero = () => (
     <Container className="relative z-30 pt-96 pb-2 xl:pt-54 lg:pt-52 md:px-5! md:pt-53" size="1600">
       <Link href="#backed-by-giants">
         <SectionLabel theme="white" icon="databricks">
-          NEON IS PART OF THE DATABRICKS PLATFORM
+          Neon, now part of Databricks
         </SectionLabel>
       </Link>
 

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -24,7 +24,7 @@ const Footer = ({ hasThemesSupport = false }) => (
               'xl:mt-3'
             )}
           >
-            Neon is part of the Databricks Platform
+            Neon, now part of Databricks
           </span>
         </div>
 


### PR DESCRIPTION
## Summary
- Update homepage hero eyebrow to "Neon, now part of Databricks" (both hero variants; rendered uppercase via SectionLabel)
- Update global footer tagline to the same phrasing

Follow-up to #5391 based on branding feedback preferring this wording over "Databricks company" / "Databricks Platform" for the short site tagline.

## Test plan
- [ ] Check homepage hero eyebrow on desktop and mobile
- [ ] Check global footer under the Neon logo
- [ ] Confirm MTS homepage variant shows the same eyebrow