### PR TITLE
Replace Databricks company phrasing with Neon, now a part of Databricks

### DIFF
--- a/content/blog/posts/new-neon-logo.md
+++ b/content/blog/posts/new-neon-logo.md
@@ -38,7 +38,7 @@ seo:
 
 ![Image](https://cdn.neonapi.io/public/images/pages/blog/new-neon-logo/image-9-1024x574-3ebd7b70.png)
 
-The logo is refreshed, but it’s still recognizably true to the elephant and N that we founded the company with. _Did you know there has always been an elephant hiding in it?_ This update helps bring our visual identity into the Databricks universe. Since joining Databricks, we’ve grown our amazingly talented team, leveled up the product, and most importantly: we’ve helped more than a million developers ship faster with Postgres. We’re proud to be a Databricks company and excited to continue growing together.
+The logo is refreshed, but it’s still recognizably true to the elephant and N that we founded the company with. _Did you know there has always been an elephant hiding in it?_ This update helps bring our visual identity into the Databricks universe. Since joining Databricks, we’ve grown our amazingly talented team, leveled up the product, and most importantly: we’ve helped more than a million developers ship faster with Postgres. We’re proud of Neon, now a part of Databricks, and excited to continue growing together.
 
 ## Use the new logo
 

--- a/content/blog/posts/why-so-many-projects-in-the-neon-free-plan.md
+++ b/content/blog/posts/why-so-many-projects-in-the-neon-free-plan.md
@@ -42,7 +42,7 @@ Over the past few weeks, you might’ve noticed something in our [changelog](htt
 We’ve reached two significant milestones that have allowed us to do this:
 
 - First, our infrastructure efficiency continues to scale. This is because our [architecture separates storage and compute](https://neon.com/blog/architecture-decisions-in-neon), and the platform optimizations we’re able to achieve as a result.
-- Second, [we’re now a Databricks company.](https://neon.com/blog/neon-and-databricks) As part of the integration, we’ve started running Neon on Databricks’ global infrastructure, which directly translates into lower operating costs.
+- Second, [Neon, now a part of Databricks.](https://neon.com/blog/neon-and-databricks) As part of the integration, we’ve started running Neon on Databricks’ global infrastructure, which directly translates into lower operating costs.
 
 We could have chosen to turn these efficiency gains into larger margins and profit, but that’s not in our DNA. Instead, we’re on a mission to deliver even more value to customers and developers, with two strategic goals in mind:
 

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -6,15 +6,15 @@ summary: >-
   architecture, making instant branching, autoscaling, scale-to-zero, and
   point-in-time restore intrinsic rather than add-ons. Choose Neon when you need
   a fully managed, usage-based Postgres backend that scales from zero to
-  production without capacity planning. A Databricks company since May 2025,
-  Neon also offers Managed Better Auth and an HTTP Data API alongside full standard
+  production without capacity planning. Neon, now a part of Databricks since May
+  2025, also offers Managed Better Auth and an HTTP Data API alongside full standard
   Postgres compatibility.
 enableTableOfContents: true
 redirectFrom:
   - /docs/cloud/about
   - /docs/introduction/about
   - /docs/get-started-with-neon/why-neon
-updatedOn: '2026-07-16T01:03:00.406Z'
+updatedOn: '2026-07-30T22:13:02.203Z'
 ---
 
 ## Our mission
@@ -25,7 +25,7 @@ We aim to deliver Postgres as a cloud service that feels effortless, from your f
 
 Neon is built on a distributed, cloud-native architecture that separates storage and compute, giving Postgres the scale, reliability, and efficiency modern applications require. This foundation unlocks the features developers expect today (autoscaling, scale-to-zero, instant branching, instant restores, usage-based pricing, and much more) without changing the Postgres you already know.
 
-<Admonition type="tip" title="A Databricks company">
+<Admonition type="tip" title="Neon, now a part of Databricks">
   In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Our mission stayed the same, but we’re now backed by the performance, security, and global scale of the Databricks Data Intelligence Platform. Neon’s architectural foundation also powers [Lakebase](https://www.databricks.com/product/lakebase); learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
 </Admonition>
 


### PR DESCRIPTION
## Summary
- Update Why Neon docs summary and tip title to \"Neon, now a part of Databricks\"
- Update two blog posts that still said \"Databricks company\"
- Leave acceptable use policy unchanged

## Test plan
- [ ] Check [/docs/get-started/why-neon](https://neon.com/docs/get-started/why-neon) tip title and page summary
- [ ] Spot-check the updated logo and free-plan blog posts
- [ ] Confirm acceptable use policy still says \"Neon is a Databricks Company\"