### PR TITLE
Update AUP intro to Neon is part of the Databricks Platform

### DIFF
--- a/content/docs/security/acceptable-use-policy.md
+++ b/content/docs/security/acceptable-use-policy.md
@@ -6,9 +6,9 @@ summary: >-
   on resource abuse, unauthorized modifications, and security compliance, see
   the Neon Security overview.
 enableTableOfContents: false
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-07-30T22:54:59.059Z'
 ---
 
-Neon is a Databricks Company. Please refer to the [Databricks Acceptable Use Policy](https://www.databricks.com/legal/acceptable-use-policy).
+Neon is part of the Databricks Platform. Please refer to the [Databricks Acceptable Use Policy](https://www.databricks.com/legal/acceptable-use-policy).
 
 For Neon-specific expectations on abuse of resources, unauthorized modifications, and other security and compliance topics, see [Security overview](/docs/security/security-overview).


### PR DESCRIPTION
## Summary
- Change the Acceptable Use Policy intro from \"Neon is a Databricks Company\" to \"Neon is part of the Databricks Platform\"
- Page still links out to the Databricks AUP; no policy substance changes

## Test plan
- [ ] Check [/docs/security/acceptable-use-policy](https://neon.com/docs/security/acceptable-use-policy) intro copy
- [ ] Confirm the Databricks AUP link still works