### PR TITLE
Rename database product to Lakebase Postgres on marketing pages

### DIFF
--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -213,7 +213,7 @@
   title: Products
   icon: features
   subnav:
-    - title: Postgres
+    - title: Lakebase Postgres
       slug: postgres/overview
       icon: book
       items:

--- a/content/docs/postgres/overview.md
+++ b/content/docs/postgres/overview.md
@@ -1,8 +1,8 @@
 ---
-title: Neon Postgres
-subtitle: The serverless database in the Neon backend
+title: Lakebase Postgres
+subtitle: The database product in the Neon backend
 summary: >-
-  Neon Postgres is a fully managed, serverless PostgreSQL database compatible
+  Lakebase Postgres is a fully managed Postgres-compatible database that works
   with any Postgres driver, ORM, or framework. Key features include
   autoscaling, scale to zero, database branching, instant point-in-time
   restore, and read replicas. Use this page as a starting point to create a
@@ -10,7 +10,7 @@ summary: >-
 enableTableOfContents: true
 ---
 
-Neon Postgres is fully managed and compatible with any Postgres driver, ORM, or framework. Key capabilities include:
+Lakebase Postgres is fully managed and compatible with any Postgres driver, ORM, or framework. Key capabilities include:
 
 - **Autoscaling** — compute scales up and down automatically with your workload
 - **Scale to zero** — idle databases suspend so you only pay for what you use

--- a/content/pages/programs/agents.md
+++ b/content/pages/programs/agents.md
@@ -8,7 +8,7 @@ image: '/images/social-previews/use-cases/ai-agents.jpg'
 
 <ProgramForm type="agent" />
 
-If you're building agents that generate apps from prompts, your users want to build apps, not manage databases. Industry-leading platforms like Replit and V0 create databases on Neon because it aligns with how agents work: Instant, branchable, serverless Postgres data layer, invisible to users.
+If you're building agents that generate apps from prompts, your users want to build apps, not manage databases. Industry-leading platforms like Replit and V0 create databases on Neon because it aligns with how agents work: Instant, branchable, Lakebase Postgres data layer, invisible to users.
 
 **Neon Features for Agents:**
 

--- a/content/pages/programs/open-source.md
+++ b/content/pages/programs/open-source.md
@@ -8,7 +8,7 @@ image: '/images/social-previews/programs/open-source.jpg'
 
 <ProgramForm type="openSource" />
 
-<QuoteBlock quote="With Neon's serverless Postgres and the support from the Open Source Program, integrating a scalable database into Medusa was straightforward and fast. The developer experience has been outstanding, and it's helped us deliver a frictionless experience to our users." author="oli-juhl" role="CTO MedusaJS" />
+<QuoteBlock quote="With Neon's Lakebase Postgres and the support from the Open Source Program, integrating a scalable database into Medusa was straightforward and fast. The developer experience has been outstanding, and it's helped us deliver a frictionless experience to our users." author="oli-juhl" role="CTO MedusaJS" />
 
 If you're building open source tools that use Postgres, we want to help you scale. Selected projects receive up to $5,000 yearly in platform credits and marketing support to expand your project's visibility.
 

--- a/content/pages/use-cases/ai-agents.md
+++ b/content/pages/use-cases/ai-agents.md
@@ -1,13 +1,13 @@
 ---
 title: 'Neon for AI Agent Platforms'
-subtitle: Build full-stack agents on a serverless Postgres backend
-summary: Covers the setup of a serverless Postgres backend specifically designed for AI agent platforms, enabling instant provisioning, automatic scaling, and integrated services for building full-stack applications.
+subtitle: Build full-stack agents on a Lakebase Postgres backend
+summary: Covers the setup of a Lakebase Postgres backend specifically designed for AI agent platforms, enabling instant provisioning, automatic scaling, and integrated services for building full-stack applications.
 enableTableOfContents: true
 updatedOn: '2025-07-26T09:00:00.000Z'
 image: '/images/social-previews/use-cases/ai-agents.jpg'
 ---
 
-<MegaLink tag="80% of Neon databases are deployed by agents." title="Platforms like Replit Agent run their backend on Neon because it fits how agents operate: a serverless Postgres data layer that’s instant, branchable, and invisible to end users." url="https://neon.com/use-cases/ai-agents#serverless-postgres-api-first" />
+<MegaLink tag="80% of Lakebase Postgres databases are deployed by agents." title="Platforms like Replit Agent run their backend on Neon because it fits how agents operate: a Lakebase Postgres data layer that’s instant, branchable, and invisible to end users." url="https://neon.com/use-cases/ai-agents#serverless-postgres-api-first" />
 
 <LogosSection containerClassName='py-3' logos={[
 'anything',
@@ -27,8 +27,8 @@ image: '/images/social-previews/use-cases/ai-agents.jpg'
 
 The Neon architecture aligns with how agents work:
 
-**Serverless Postgres at the core.**
-Neon’s backend is powered by a serverless Postgres engine built on separated compute and storage. It provisions instantly, scales automatically, and idles to zero when not in use - perfect for the bursty, on-demand workloads that agents create.
+**Lakebase Postgres at the core.**
+Neon’s backend is powered by a Lakebase Postgres engine built on separated compute and storage. It provisions instantly, scales automatically, and idles to zero when not in use - perfect for the bursty, on-demand workloads that agents create.
 
 **With integrated services for full-stack backends.**
 Around that core, Neon includes Auth and a PostgREST-compatible Data API, so agents and developers can assemble complete, production-ready backends without stitching multiple services together.
@@ -39,9 +39,9 @@ Every capability - provisioning, quotas, branching, and fleet management - is ex
 **And version-aware by design.**
 Neon’s copy-on-write storage makes time travel effortless. Branching, snapshots, and point-in-time recovery enable undo, checkpoints, and safe experimentation across millions of databases.
 
-## Serverless Postgres, API-first
+## Lakebase Postgres, API-first
 
-At the core of Neon is a serverless Postgres architecture that [separates compute from storage](https://neon.com/blog/architecture-decisions-in-neon). Each database runs on ephemeral computes while the data itself lives on durable, high-performance storage.
+At the core of Neon is a Lakebase Postgres architecture that [separates compute from storage](https://neon.com/blog/architecture-decisions-in-neon). Each database runs on ephemeral computes while the data itself lives on durable, high-performance storage.
 
 **This architecture makes it possible for agents to provision databases instantly on demand, operate them at massive scale, and still keep costs under control.** Tens of thousands of projects can spin up and idle as users create apps, all programmatically, without intervention from you.
 
@@ -104,4 +104,4 @@ For instructions on using the Neon API to provision and manage backends on behal
 
 To learn more about the Agent Plan, [see the details on this page](https://neon.com/programs/agents#agent-plan-pricing) or [fill out the application form directly, at the top of this page](#agent-form).
 
-<CTA title="Prefer a claimable flow?" description="You can also allow your end-users to deploy a Neon database in seconds, use it immediately via connection string, claim it later." theme="column" buttonText="Explore this route" buttonUrl="https://neon.new/" linkText="See a case study" linkUrl="https://neon.com/blog/netlify-db-powered-by-neon" />
+<CTA title="Prefer a claimable flow?" description="You can also allow your end-users to deploy a Lakebase Postgres database in seconds, use it immediately via connection string, claim it later." theme="column" buttonText="Explore this route" buttonUrl="https://neon.new/" linkText="See a case study" linkUrl="https://neon.com/blog/netlify-db-powered-by-neon" />

--- a/content/pages/use-cases/database-per-user.md
+++ b/content/pages/use-cases/database-per-user.md
@@ -19,7 +19,7 @@ Traditionally, provisioning thousands of Postgres databases meant:
 - Building internal control planes
 - Hiring infrastructure engineers just to keep up
 
-Neon changes the economics and the operational burden. **Because Neon is built on a [unique serverless Postgres architecture](https://neon.com/docs/introduction/architecture-overview), those constraints disappear.** You can embed real Postgres directly into your platform and deploy thousands of Postgres databases for your users, without hiring extra engineers to manage your fleet.
+Neon changes the economics and the operational burden. **Because Neon is built on a [unique Lakebase Postgres architecture](https://neon.com/docs/introduction/architecture-overview), those constraints disappear.** You can embed real Postgres directly into your platform and deploy thousands of Postgres databases for your users, without hiring extra engineers to manage your fleet.
 
 ## Importantly: your users need their own isolated database
 
@@ -93,7 +93,7 @@ _Sample API operations platforms use to implement database-per-user workflows wi
 
 ### Serverless economics: the key enabler
 
-Neon databases,
+Lakebase Postgres databases,
 
 - Provision in approximately 1 second
 - Scale to zero when inactive

--- a/content/pages/use-cases/fast-dev-workflows.md
+++ b/content/pages/use-cases/fast-dev-workflows.md
@@ -130,7 +130,7 @@ Neon's model maps cleanly to that way of working. That is why Neon is the Postgr
 
 What makes Neon so fitting for agents:
 
-- **Postgres that agents can deploy and manage.** With Neon, agents can provision Postgres databases programmatically via API, without manual sizing, capacity planning, or configuration work.
+- **Lakebase Postgres that agents can deploy and manage.** With Neon, agents can provision Postgres databases programmatically via API, without manual sizing, capacity planning, or configuration work.
 - **Large fleets != large costs.** Those same databases scale down to zero when inactive, so deploying thousands of rarely used databases does not become a cost concern.
 - **Branches for checkpoints and versions.** Agents can use branches and snapshots to maintain versioned states of an app or workflow, or to offer restore and rollback features directly to end users.
 - **A full backend via SDKs.** For full-stack agents, Neon also provides [Auth](https://neon.com/docs/auth/overview) and PostgREST-compatible APIs, packaged together in a single SDK.

--- a/content/pages/use-cases/postgres-for-saas.md
+++ b/content/pages/use-cases/postgres-for-saas.md
@@ -11,7 +11,7 @@ image: '/images/social-previews/use-cases/postgres-for-saas.jpg'
 
 ## Summary
 
-Three features make Postgres on Neon a solid foundation for teams building SaaS applications:
+Three features make Lakebase Postgres on Neon a solid foundation for teams building SaaS applications:
 
 <DefinitionList bulletType="check">
 Database branching

--- a/content/pages/use-cases/variable-load.md
+++ b/content/pages/use-cases/variable-load.md
@@ -121,7 +121,7 @@ Your database setup isn’t just production \- it includes development, testing,
 Our [platform data](https://neon.com/autoscaling-report) shows that non-production workloads that scale to zero use 13.7x less compute than their provisioned equivalent and cost 7.5x less.
 </Admonition>
 
-## Extra serverless Postgres perks
+## Extra Lakebase Postgres perks
 
 When compute scales dynamically and can drop to zero, features built on top of it inherit those efficiencies. For example: read replicas and connection pooling become lighter, cheaper, and more responsive than their equivalents in provisioned infrastructure.
 

--- a/src/app/pricing/page.jsx
+++ b/src/app/pricing/page.jsx
@@ -35,7 +35,7 @@ const faqItems = [
     id: 'does-neon-offer-a-backend',
     initialState: 'open',
     answer: `
-      <p>Yes. Alongside our serverless Postgres database, Neon now offers Managed Better Auth, Object Storage, Functions, and AI Gateway - a full backend suite that runs alongside your database and branches with it.</p>
+      <p>Yes. Alongside our Lakebase Postgres database, Neon now offers Managed Better Auth, Object Storage, Functions, and AI Gateway - a full backend suite that runs alongside your database and branches with it.</p>
     `,
   },
   {
@@ -55,14 +55,14 @@ const faqItems = [
   {
     question: 'What is a CU?',
     answer: `
-      <p>A CU (short for Compute Unit) is Neon's way of representing <strong>Postgres database compute size</strong>. Neon databases <a href="${LINKS.autoscaling}">autoscale</a>, and CUs define how much CPU and memory your database is using at any moment - with each CU allocating approximately 1 vCPU and 4 GB of RAM.</p>
+      <p>A CU (short for Compute Unit) is Neon's way of representing <strong>Postgres database compute size</strong>. Lakebase Postgres databases <a href="${LINKS.autoscaling}">autoscale</a>, and CUs define how much CPU and memory your database is using at any moment - with each CU allocating approximately 1 vCPU and 4 GB of RAM.</p>
     `,
   },
   {
     question: 'What is a CU-hour?',
     id: 'compute-usage',
     answer: `
-      <p>A CU-hour is Neon's unit for measuring <strong>Postgres database compute usage</strong>. Because Neon databases scale to zero and autoscale, you're billed only for the database compute resources you actually use. In other words, your monthly database compute usage depends on:</p>
+      <p>A CU-hour is Neon's unit for measuring <strong>Postgres database compute usage</strong>. Because Lakebase Postgres databases scale to zero and autoscale, you're billed only for the database compute resources you actually use. In other words, your monthly database compute usage depends on:</p>
       <ul>
         <li>How many compute endpoints are you running</li>
         <li>How large your compute endpoints are (in CUs)</li>
@@ -168,7 +168,7 @@ const faqItems = [
     question: 'What does "no monthly minimum" mean on paid plans?',
     answer: `
       <p>Neon's paid plans don't require a minimum monthly spend or base fee. You're billed purely based on usage. If one month you barely use Neon, your bill might be just a few dollars.</p>
-      <p>For example, if your databases are mostly idle that month, or you only run them briefly for development or testing, you'll only pay for the compute and storage actually consumed during that time. Remember that Neon databases scale to zero by default.</p>
+      <p>For example, if your databases are mostly idle that month, or you only run them briefly for development or testing, you'll only pay for the compute and storage actually consumed during that time. Remember that Lakebase Postgres databases scale to zero by default.</p>
     `,
   },
   {
@@ -194,7 +194,7 @@ const faqItems = [
       <p><strong>History</strong> storage is billed based on the amount of Write-Ahead Log (WAL) retained within that history window, at $0.20 per GB-month on paid plans. This is billed separately from your regular database storage.</p>
       <p>If you don't need deep recovery or long Time Travel, shorten the history window to reduce costs.</p>
       <p><strong>Database storage (root and child branches)</strong></p>
-      <p>This is the storage used by your database data itself. Since Neon databases can branch, this is how branches contribute to database storage:</p>
+      <p>This is the storage used by your database data itself. Since Lakebase Postgres databases can branch, this is how branches contribute to database storage:</p>
       <ul>
         <li>Root branches are billed based on their actual data size (for example, 5 GB)</li>
         <li>Child branches <em>might</em> be billed based on the minimum of: the accumulated data changes since the branch was created, or the underlying storage footprint, which is zero if the branch is still within the history window used for instant restore (in this case, the child branch effectively shares storage with its parent).</li>
@@ -230,14 +230,14 @@ const faqItems = [
   {
     question: 'How is Managed Better Auth billed?',
     answer: `
-      <p>Neon Managed Better Auth is included at no additional cost for all Neon databases until you reach 1 million monthly active users (MAU). If you surpass that threshold, a member of our team will reach out to discuss pricing.</p>
+      <p>Neon Managed Better Auth is included at no additional cost for all Lakebase Postgres databases until you reach 1 million monthly active users (MAU). If you surpass that threshold, a member of our team will reach out to discuss pricing.</p>
       <p>On the Free plan, Managed Better Auth is included for up to 60,000 MAU.</p>
     `,
   },
   {
     question: 'How can I control my Postgres database costs (compute and storage consumption)?',
     answer: `
-      <p>Database compute is often the most variable part of a monthly bill. For Neon databases, the most effective way to control compute costs is to configure maximum autoscaling limits and scale-to-zero.</p>
+      <p>Database compute is often the most variable part of a monthly bill. For Lakebase Postgres databases, the most effective way to control compute costs is to configure maximum autoscaling limits and scale-to-zero.</p>
       <p>Autoscaling limits act as a built-in cost ceiling: your database will never scale beyond the limit you set, even during traffic spikes. If you want to prioritize performance over costs in a particular compute endpoint (e.g. production), choose a higher limit. If you want to optimize for cost predictability, set a lower one. <a href="${LINKS.docs}/guides/autoscaling-guide#configure-autoscaling-defaults-for-your-project">Learn how to configure autoscaling limits.</a></p>
       <p>Another effective way to control database compute costs is to ensure scale to zero is enabled for all non-production branches. When a branch is idle, compute scales down automatically, so you're not charged for unused databases. <a href="${LINKS.docs}/introduction/scale-to-zero">Learn about scale to zero.</a></p>
       <p>To manage database storage costs, regularly clean up unused branches, snapshots, and projects, and avoid retaining a large history window for instant restore if your use case does not require it. <a href="${LINKS.docs}/introduction/cost-optimization#storage-root-and-child-branches">Learn more about optimizing storage usage.</a></p>

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -26,8 +26,8 @@ const logos = [
 
 export const heroServiceItems = [
   {
-    title: 'Postgres Database',
-    description: 'Serverless Postgres that scales and branches with your app.',
+    title: 'Lakebase Postgres',
+    description: 'Serverless database that scales and branches with your app.',
     videoBase: 'postgres-database',
     aspectRatio: 'aspect-square',
     width: 512,

--- a/src/components/pages/pricing/features/features.jsx
+++ b/src/components/pages/pricing/features/features.jsx
@@ -36,7 +36,7 @@ const FEATURES = [
   {
     icon: connectionsIcon,
     title: 'Connection pooling.',
-    description: `All Neon databases can use pooled connections built on pgBouncer (up to <a href="${LINKS.connectionPooling}">10,000 connections</a>).`,
+    description: `All Lakebase Postgres databases can use pooled connections built on pgBouncer (up to <a href="${LINKS.connectionPooling}">10,000 connections</a>).`,
   },
   {
     icon: extensionsIcon,
@@ -65,8 +65,8 @@ const Features = () => (
           '[&>strong]:font-normal [&>strong]:text-white'
         )}
       >
-        <strong>Included with every Neon database, on every plan, by default.</strong> These are
-        core platform capabilities that come out of the box with Neon.
+        <strong>Included with every Lakebase Postgres database, on every plan, by default.</strong>{' '}
+        These are core platform capabilities that come out of the box with Neon.
       </h2>
       <ul
         className={cn(

--- a/src/components/pages/pricing/hero/plans/data/plans.js
+++ b/src/components/pages/pricing/hero/plans/data/plans.js
@@ -9,7 +9,7 @@ export default [
     price: 0,
     features: {
       database: {
-        title: 'Postgres database',
+        title: 'Lakebase Postgres',
         features: [
           {
             title: '100 projects',
@@ -65,7 +65,7 @@ export default [
     storageRate: 0.35,
     features: {
       database: {
-        title: 'Postgres database',
+        title: 'Lakebase Postgres',
         features: [
           {
             title: '100 projects',
@@ -122,7 +122,7 @@ export default [
     storageRate: 0.35,
     features: {
       database: {
-        title: 'Postgres database',
+        title: 'Lakebase Postgres',
         features: [
           {
             title: '1,000+ projects',

--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -54,7 +54,7 @@ export default {
     },
     {
       rows: '1',
-      feature: 'Postgres database',
+      feature: 'Lakebase Postgres',
     },
     {
       rows: '2',

--- a/src/components/shared/header/menu-banner/menu-banner.jsx
+++ b/src/components/shared/header/menu-banner/menu-banner.jsx
@@ -40,7 +40,7 @@ const MenuBanner = ({ linkProps: { className, ...linkProps } = {} }) => (
         <ArrowTopRightIcon className="-translate-x-2 scale-75 text-white opacity-0 transition-[translate,opacity] duration-200 group-hover:translate-x-0 group-hover:scale-100 group-hover:opacity-100" />
       </p>
       <p className="text-[15px] leading-tight tracking-extra-tight text-gray-new-60 lg:text-[13px]">
-        Serverless Postgres, by Databricks
+        Lakebase Postgres, by Databricks
       </p>
     </div>
   </Link>

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -9,9 +9,9 @@ export default {
           title: 'Core Primitives',
           items: [
             {
-              title: 'Database',
+              title: 'Lakebase Postgres',
               to: LINKS.postgresOverview,
-              description: 'Serverless Postgres',
+              description: 'Advanced Postgres Database',
             },
             {
               title: 'Auth',


### PR DESCRIPTION
## Summary
- Rename the database product to **Lakebase Postgres** on the most visible marketing surfaces
- Homepage hero service card and header menu banner
- Header Product nav + docs Products nav
- Pricing plans labels, features blurb, and FAQ copy
- Docs page: [/docs/postgres/overview](https://neon.com/docs/postgres/overview)
- Use-cases and programs pages

Intentionally scoped. Broader docs, prompts, FAQs catalog, and integration guides are left for separate review.

## Test plan
- [ ] Homepage: hero card shows Lakebase Postgres
- [ ] Header Product menu: Lakebase Postgres / Advanced Postgres Database
- [ ] Menu banner: Lakebase Postgres, by Databricks
- [ ] Pricing plans and FAQ language
- [ ] Docs Products nav + /docs/postgres/overview title
- [ ] Spot-check use-cases (AI agents, database-per-user) and programs pages