### PR TITLE
Revise why-neon.md to emphasize Lakebase Postgres

### DIFF
--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -29,8 +29,6 @@ This concept evolved into what's Lakebase Postgres today. Lakebase Postgres, our
 
 ## What makes Neon different
 
-<YoutubeIframe embedId="wLAeC-r4kfE" />
-
 ### Lakebase Postgres, built from first principles
 
 Lakebase Postgres isn’t “Postgres-like”: it is Postgres, with full compatibility across ORMs, extensions, and frameworks. But its defining characteristic is the lakebase architecture, which translates into serverless behavior that isn’t layered on but foundational to the system.

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -24,7 +24,7 @@ Neon started with a mission: to deliver Postgres as a cloud service that gets ou
 This concept evolved into what's Lakebase Postgres today. Lakebase Postgres, our database, is built on the lakebase architecture: a distributed, cloud-native design that separates storage and compute, giving Postgres the scale, reliability, and efficiency modern applications require. This foundation unlocks the features that agents (and the developers behind them) expect today: autoscaling, scale-to-zero, instant branching, instant restores, and usage-based pricing - without changing the Postgres you already know.
 
 <Admonition type="tip" title="Neon, now a part of Databricks">
-  In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Lakebase Postgres is also available via Databricks, giving you access to all the complete Databricks platform ([Lakebase](https://www.databricks.com/product/lakebase)). Learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
+  In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Lakebase Postgres is also available via the Databricks platform ([Lakebase](https://www.databricks.com/product/lakebase)) - learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
 </Admonition>
 
 ## What makes Neon different

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -2,13 +2,11 @@
 title: Why Neon?
 subtitle: 'The backend for apps and agents, by Databricks'
 summary: >-
-  Neon is a serverless Postgres platform built on a storage-compute separation
-  architecture, making instant branching, autoscaling, scale-to-zero, and
-  point-in-time restore intrinsic rather than add-ons. Choose Neon when you need
-  a fully managed, usage-based Postgres backend that scales from zero to
-  production without capacity planning. Neon, now a part of Databricks since May
-  2025, also offers Managed Better Auth and an HTTP Data API alongside full standard
-  Postgres compatibility.
+  Neon is a complete set of cloud backend primitives built around Lakebase
+  Postgres, for developers, startups, and agent platforms, from Databricks.
+  Lakebase Postgres runs on the lakebase architecture, making instant branching,
+  autoscaling, scale-to-zero, and point-in-time restore intrinsic rather than
+  add-ons. The Neon platform also comes with Managed Better Auth, Object Storage, Functions, and AI Gateway. 
 enableTableOfContents: true
 redirectFrom:
   - /docs/cloud/about
@@ -19,25 +17,25 @@ updatedOn: '2026-07-30T22:13:02.203Z'
 
 ## Our mission
 
-**Neon is the backend for apps and agents. Neon Postgres, Managed Better Auth, and Data API are available today, with Storage, Compute, and AI Gateway coming soon. Every service is agent-ready: instant, branchable, and serverless. Designed to help developers build scalable, dependable applications faster than ever.**
+**Neon is a complete set of cloud backend primitives built around Lakebase Postgres, for developers, startups, and agent platforms, from Databricks. The platform includes Lakebase Postgres, Managed Better Auth, Object Storage, Functions, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless - designed to help developers build scalable applications faster than ever.**
 
-We aim to deliver Postgres as a cloud service that feels effortless, from your first side project to millions of users in production. We believe Postgres should be as universal and accessible as object storage, something every developer can rely on without thinking about infrastructure.
+Neon started with a mission: to deliver Postgres as a cloud service that gets out of developers' way, from their first side project to millions of users in production. We believed Postgres should be as universal and accessible as object storage, something every developer can rely on without thinking about infrastructure.
 
-Neon is built on a distributed, cloud-native architecture that separates storage and compute, giving Postgres the scale, reliability, and efficiency modern applications require. This foundation unlocks the features developers expect today (autoscaling, scale-to-zero, instant branching, instant restores, usage-based pricing, and much more) without changing the Postgres you already know.
+This concept evolved into what's Lakebase Postgres today. Lakebase Postgres, our database, is built on the lakebase architecture: a distributed, cloud-native design that separates storage and compute, giving Postgres the scale, reliability, and efficiency modern applications require. This foundation unlocks the features that agents (and the developers behind them) expect today: autoscaling, scale-to-zero, instant branching, instant restores, and usage-based pricing - without changing the Postgres you already know.
 
 <Admonition type="tip" title="Neon, now a part of Databricks">
-  In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Our mission stayed the same, but we’re now backed by the performance, security, and global scale of the Databricks Data Intelligence Platform. Neon’s architectural foundation also powers [Lakebase](https://www.databricks.com/product/lakebase); learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
+  In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Lakebase Postgres is also available via Databricks, giving you access to all the complete Databricks platform ([Lakebase](https://www.databricks.com/product/lakebase)). Learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
 </Admonition>
 
 ## What makes Neon different
 
 <YoutubeIframe embedId="wLAeC-r4kfE" />
 
-### Serverless Postgres, built from first principles
+### Lakebase Postgres, built from first principles
 
-Neon isn’t “Postgres-like”: it is Postgres, with full compatibility across ORMs, extensions, and frameworks. But Neon’s defining characteristic lies in its architecture, which translates into serverless behavior that isn’t layered on but foundational to the system.
+Lakebase Postgres isn’t “Postgres-like”: it is Postgres, with full compatibility across ORMs, extensions, and frameworks. But its defining characteristic is the lakebase architecture, which translates into serverless behavior that isn’t layered on but foundational to the system.
 
-Traditional Postgres providers scale by moving VMs up and down, placing instances behind proxies, or by manual tuning. Neon does none of that. Instead, Neon is serverless, which to us means:
+Traditional Postgres providers scale by moving VMs up and down, placing instances behind proxies, or by manual tuning. Lakebase Postgres does none of that. Instead, the lakebase architecture is serverless, which to us means:
 
 - Storage and compute are fully separated
 - Compute is stateless and ephemeral
@@ -46,79 +44,70 @@ Traditional Postgres providers scale by moving VMs up and down, placing instance
 
 ### Developer-first features that fit modern workflows
 
-Neon’s architecture lets us design a database platform that behaves the way developers expect modern tools to behave: instant, intuitive, cost-efficient, and safe to experiment with. This modernizes workflows that, in many managed Postgres services, still feel decades old.
+The lakebase architecture lets Lakebase Postgres behave the way developers expect modern infra to behave: instant, intuitive, cost-efficient, and safe to experiment with. This modernizes workflows that, in other managed Postgres services, still feel decades old.
 
 - **Scale-to-zero.** Inactive databases shut down automatically to save costs. Ideal for side projects, development environments, and agent-generated apps.
-- **Autoscaling.** For your production database, Neon resizes your compute up and down automatically based on traffic. Your performance stays steady without capacity planning.
-- **Branching.** In Neon, you can clone your entire database (data and schema) instantly to create dev environments, run migrations safely, automate previews, enable safe staging workflows, and build versioning and checkpoints for agents.
+- **Autoscaling.** For your production database, Lakebase Postgres resizes your compute up and down automatically based on traffic. Your performance stays steady without capacity planning.
+- **Branching.** You can clone your entire database (data and schema) instantly to create dev environments, run migrations safely, automate previews, enable safe staging workflows, and build versioning and checkpoints for agents.
 - **Instant restores.** You can also go back to any point in time in seconds, no matter how large your database, or instantly revert to a previously-saved snapshot.
-- **Usage-based pricing.** In Neon, you pay only for what you use, without provisioning storage or compute in advance and without being forced into expensive add-ons.
-- **A Free Plan developers can actually use.** Our unique architecture makes it incredibly efficient to run a large Free Plan with many projects per account and enough resources to build real apps.
+- **Usage-based pricing.** On Neon, you pay only for what you use, without provisioning storage or compute in advance and without being forced into expensive add-ons.
+- **A Free Plan developers can actually use.** The lakebase architecture makes it incredibly efficient to run a large Free Plan with many projects per account and enough resources to build real apps.
 
 ## Who uses Neon and why
 
-### Developers: From side projects to live apps
+### Developers via agents: From side projects to live apps
 
-Independent developers want to build without friction. They don’t want to create accounts, configure VMs, or invest large sums just to test an idea. They want something that feels modern, straightforward, and aligned with today’s frameworks.
+Independent developers want to build without friction. They don’t want to create accounts, configure VMs, or invest large sums just to test an idea - they want their agent to directly handle their infra. 
 
 **Why they build on Neon**
 
-- They get a Postgres connection string immediately: no setup
-- The Free Plan is generous enough to build real apps
-- They can work on multiple projects at once
+- Our platform is agent-first: agents are a first-class interface
+- The Free Plan is generous enough to build real apps, not just to test things out
+- A Postgres connection string is available immediately, no provisioning waiting times
+- Branching, previews, and instant restores let agents experiment quickly 
 - Neon integrates easily with Next.js, Remix, Vercel, Prisma, Drizzle, and the broader ecosystem
-- Branching, previews, and instant restores let them experiment quickly
-- The experience feels lightweight, fast, and developer-first, not enterprise-heavy
-
-  <Admonition type="tip" title="Useful links to get started">
-    Check out our [framework guides](/docs/get-started/frameworks), [code examples](https://github.com/neondatabase/examples), and join our [community Discord](https://discord.gg/92vNTzKDGp).
-  </Admonition>
+- The experience feels lightweight and fast, not enterprise-heavy
 
 ### Startups: From dev to scale
 
-Startups want to ship product fast and avoid cloud infrastructure complexity. They need their Postgres to be reliable, scalable, and invisible, something they never have to think about unless something goes wrong.
+Startups want to ship product fast and avoid cloud infrastructure complexity. They need their Postgres to be reliable, scalable, and invisible, something they never have to think about unless something goes wrong, and they need their coding agent to handle everything reliably. 
 
 **Why they build on Neon**
 
-- Its serverless architecture removes most management
-- Autoscaling handles unpredictable traffic without overprovisioning or planning compute sizes
-- Branching speeds up building - teams can ship safely and quickly
-- Neon's straightforward and feature-complete [API](/docs/reference/api)
-- Usage-based pricing means no upfront commitments
-- Neon delivers on reliability, performance, and compliance
+- The lakebase architecture removes cumbersome DBA tasks
+- Those tasks that still exists can be handled by agents
+- Autoscaling takes care of unpredictable traffic without overprovisioning or planning compute sizes
+- Branching speeds up building - entire dev backend environments get deployed instantly with minimal costs
+- Usage-based pricing means no waste, no upfront commitments
+- Neon delivers on reliability, performance, and compliance - backed by Databricks
 
-<Admonition type="tip" title="Keep reading">
-  Check out our [success stories](https://neon.com/case-studies), [use cases](https://neon.com/use-cases/serverless-apps), and the [Startup Program](https://neon.com/startups). 
-</Admonition>
+### App generation platforms
 
-### Agents & codegen: From prompt to app
-
-Full-stack codegen platforms need to spin up thousands of independent applications instantly, each with its own backend. They need a database that can support a fleet of thousands of mostly inactive databases every day without breaking performance or blowing up costs.
+This is a specialty use case for Neon: full-stack codegen platforms that need to spin up thousands of independent applications instantly, each with its own backend. They need a backend platform that can support a fleet of thousands of mostly inactive apps every day without breaking performance or blowing up costs.
 
 **Why they build on Neon**
 
 - Neon is already tested at scale, powering platforms like Replit
-- They can deploy a Postgres backend instantly and transparently, without signup from the end-user
-- Thousands of short-lived, low-usage databases can be deployed programmatically
-- Scale-to-zero makes per-app databases economically viable, even at scale
-- Branching allows for agent-friendly workflows: versioning, snapshots, rollbacks, checkpoints
-- Managed Better Auth + Data API form a backend layer that works directly with the database
+- They can deploy a Postgres backend instantly and transparently on behalf of the end-user, including database, auth, AI models, functions, and blob storage
+- Thousands of short-lived, low-usage databases are deployed / deleted by APIs / agents  
+- Scale-to-zero makes this setup economically viable at scale
+- Branching makes it simple to build versioning, rollbacks, checkpoints
 
-<Admonition type="tip" title="Join the Agent Program">
-  Building a full-stack agent that needs databases? Apply to our [Agent Program](https://neon.com/programs/agents#agent-plan-pricing) and get access to special pricing, resource limits, and features.
+<Admonition type="tip" title="Neon Agent Plan">
+  Building a full-stack agent that deploys backends? Apply to our [Agent Plan](https://neon.com/programs/agents#agent-plan-pricing) and get access to special pricing, resource limits, features, and support from the team.
 </Admonition>
 
-## The architecture that makes it possible: how Neon works
+## The architecture that makes it possible: lakebase architecture
 
-The benefits developers experience with Neon (instant branching, autoscaling, scale-to-zero, and fast recovery) are not product features layered on top of Postgres. They fall out naturally from Neon’s architecture.
+The benefits developers experience with the Neon platform (instant branching, autoscaling, scale-to-zero, and fast recovery) are not product features layered on top of Postgres. They fall out naturally from the lakebase architecture.
 
-At the highest level, Neon is built on a simple but powerful idea: Postgres on the object store.
+At the highest level, the lakebase architecture is built on a simple but powerful idea: Postgres on the object store.
 
-Traditional Postgres systems are designed around local or attached disks. That design couples durability, storage capacity, and compute into a single machine. Neon breaks that coupling by moving durability and history into cloud object storage. Once storage lives in the object store, the rest of the system can be rethought.
+Traditional Postgres systems are designed around local or attached disks. That design couples durability, storage capacity, and compute into a single machine. The lakebase architecture breaks that coupling by moving durability and history into cloud object storage. Once storage lives in the object store, the rest of the system can be rethought.
 
 ### Object store first
 
-Neon treats the object store as the system of record. WAL, page versions, and database history are persisted directly to durable object storage rather than tied to a specific server or disk. The consequences:
+Lakebase Postgres treats the object store as the system of record. WAL, page versions, and database history are persisted directly to durable object storage rather than tied to a specific server or disk. The consequences:
 
 - Durability no longer depends on a single machine
 - Storage scales independently and effectively without limits
@@ -127,7 +116,7 @@ Neon treats the object store as the system of record. WAL, page versions, and da
 
 ### Separation of storage and compute
 
-With durability and history centralized in storage, compute can be fully decoupled. Data lives in a distributed, durable storage layer. Computes are lightweight and ephemeral processes that attach to that data when needed. This separation is the foundation of everything Neon can do:
+With durability and history centralized in storage, compute can be fully decoupled. Data lives in a distributed, durable storage layer. Computes are lightweight and ephemeral processes that attach to that data when needed. This separation is the foundation of everything Lakebase Postgres can do:
 
 - Start and stop compute in seconds
 - Scale compute independently of storage
@@ -137,7 +126,7 @@ With durability and history centralized in storage, compute can be fully decoupl
 
 ### A versioned storage engine (copy-on-write)
 
-Separation alone is not enough. Neon’s most distinctive capabilities come from its versioned storage engine, which preserves the full history of the database. Every WAL record and every page version is retained in a single, unified system. As a result:
+Separation alone is not enough. Lakebase Postgres’s most distinctive capabilities come from its versioned storage engine, which preserves the full history of the database. Every WAL record and every page version is retained in a single, unified system. As a result:
 
 - Entire databases can be branched instantly
 - Any past state can be restored without copying data
@@ -146,7 +135,7 @@ Separation alone is not enough. Neon’s most distinctive capabilities come from
 
 ### Stateless, ephemeral compute
 
-The final piece follows naturally from the others. Computes in Neon do not store data. They attach to the storage layer at a specific point in history, execute queries, and disappear when no longer needed. They can be created, resized, or destroyed at any time without risking data loss. This is what allows Neon to:
+The final piece follows naturally from the others. Computes in Lakebase Postgres do not store data. They attach to the storage layer at a specific point in history, execute queries, and disappear when no longer needed. They can be created, resized, or destroyed at any time without risking data loss. This is what allows Lakebase Postgres to:
 
 - Autoscale without downtime
 - Scale to zero when idle
@@ -154,7 +143,7 @@ The final piece follows naturally from the others. Computes in Neon do not store
 - Support agent-driven and highly dynamic workloads
 
 <Admonition type="tip" title="Neon and Lakebase">
-  Lakebase Postgres, the database Neon runs on, is also available on Databricks. For what's the same in both places and when to choose each, see [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
+  Lakebase Postgres is available via Neon and via Databricks. For what's the same in both places and when to choose each, see [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
 </Admonition>
 
-<CTA title="Contact us" description="Neon and Lakebase represent two paths built on the same architectural foundation. Explore your options and get help deciding which service is the best fit." buttonText="Reach out" buttonUrl="https://www.databricks.com/company/contact" />
+<CTA title="Contact us" description="Lakebase Postgres via Neon and via Databricks are two access paths to the same database product. Explore your options and get help deciding which fits your workload." buttonText="Reach out" buttonUrl="https://www.databricks.com/company/contact" />

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -13,7 +13,7 @@ redirectFrom:
   - /docs/cloud/about
   - /docs/introduction/about
   - /docs/get-started-with-neon/why-neon
-updatedOn: '2026-08-03T18:19:06.540Z'
+updatedOn: '2026-08-03T18:51:52.937Z'
 ---
 
 ## Our mission
@@ -28,9 +28,9 @@ That idea became what is now Lakebase Postgres, built on the lakebase architectu
   In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Our mission stayed the same. Lakebase Postgres is also available on Databricks, as [Lakebase](https://www.databricks.com/product/lakebase). Learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
 </Admonition>
 
-## What makes Lakebase Postgres different
+## What makes Neon different
 
-### Built from first principles
+### Lakebase Postgres, built from first principles
 
 Lakebase Postgres isn’t “Postgres-like”: it is Postgres, with full compatibility across ORMs, extensions, and frameworks. But its defining characteristic is the lakebase architecture, which translates into serverless behavior that isn’t layered on but foundational to the system.
 

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -6,34 +6,35 @@ summary: >-
   Postgres, for developers, startups, and agent platforms, from Databricks.
   Lakebase Postgres runs on the lakebase architecture, making instant branching,
   autoscaling, scale-to-zero, and point-in-time restore intrinsic rather than
-  add-ons. The Neon platform also comes with Managed Better Auth, Object Storage, Functions, and AI Gateway. 
+  add-ons. Neon also includes Managed Better Auth, Object Storage, Functions,
+  and AI Gateway.
 enableTableOfContents: true
 redirectFrom:
   - /docs/cloud/about
   - /docs/introduction/about
   - /docs/get-started-with-neon/why-neon
-updatedOn: '2026-07-30T22:13:02.203Z'
+updatedOn: '2026-08-03T18:19:06.540Z'
 ---
 
 ## Our mission
 
-**Neon is a complete set of cloud backend primitives built around Lakebase Postgres, for developers, startups, and agent platforms, from Databricks. The platform includes Lakebase Postgres, Managed Better Auth, Object Storage, Functions, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless - designed to help developers build scalable applications faster than ever.**
+**Neon is a complete set of cloud backend primitives built around Lakebase Postgres, for developers, startups, and agent platforms, from Databricks. Neon includes Lakebase Postgres, Managed Better Auth, Object Storage, Functions, and AI Gateway. Every service is agent-ready: instant, branchable, and serverless, designed to help developers build scalable applications faster than ever.**
 
-Neon started with a mission: to deliver Postgres as a cloud service that gets out of developers' way, from their first side project to millions of users in production. We believed Postgres should be as universal and accessible as object storage, something every developer can rely on without thinking about infrastructure.
+Neon started with a mission: to deliver Postgres as a cloud service that gets out of developers' way, from their first side project to millions of users in production. Postgres should be as universal and accessible as object storage, something every developer can rely on without thinking about infrastructure.
 
-This concept evolved into what's Lakebase Postgres today. Lakebase Postgres, our database, is built on the lakebase architecture: a distributed, cloud-native design that separates storage and compute, giving Postgres the scale, reliability, and efficiency modern applications require. This foundation unlocks the features that agents (and the developers behind them) expect today: autoscaling, scale-to-zero, instant branching, instant restores, and usage-based pricing - without changing the Postgres you already know.
+That idea became what is now Lakebase Postgres, built on the lakebase architecture: a distributed, cloud-native design that separates storage and compute, giving Postgres the scale, reliability, and efficiency modern applications require. This foundation unlocks the features that agents, and the developers behind them, expect today: autoscaling, scale-to-zero, instant branching, instant restores, and usage-based pricing, without changing the Postgres you already know.
 
 <Admonition type="tip" title="Neon, now a part of Databricks">
-  In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Lakebase Postgres is also available via the Databricks platform ([Lakebase](https://www.databricks.com/product/lakebase)) - learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
+  In May 2025, Neon joined Databricks to shape the future of Postgres and AI-native development. Our mission stayed the same. Lakebase Postgres is also available on Databricks, as [Lakebase](https://www.databricks.com/product/lakebase). Learn more in [Neon and Lakebase](/docs/introduction/neon-and-lakebase).
 </Admonition>
 
-## What makes Neon different
+## What makes Lakebase Postgres different
 
-### Lakebase Postgres, built from first principles
+### Built from first principles
 
 Lakebase Postgres isn’t “Postgres-like”: it is Postgres, with full compatibility across ORMs, extensions, and frameworks. But its defining characteristic is the lakebase architecture, which translates into serverless behavior that isn’t layered on but foundational to the system.
 
-Traditional Postgres providers scale by moving VMs up and down, placing instances behind proxies, or by manual tuning. Lakebase Postgres does none of that. Instead, the lakebase architecture is serverless, which to us means:
+Traditional Postgres providers scale by moving VMs up and down, placing instances behind proxies, or by manual tuning. Lakebase Postgres does none of that. Instead, it is serverless, which to us means:
 
 - Storage and compute are fully separated
 - Compute is stateless and ephemeral
@@ -42,62 +43,62 @@ Traditional Postgres providers scale by moving VMs up and down, placing instance
 
 ### Developer-first features that fit modern workflows
 
-The lakebase architecture lets Lakebase Postgres behave the way developers expect modern infra to behave: instant, intuitive, cost-efficient, and safe to experiment with. This modernizes workflows that, in other managed Postgres services, still feel decades old.
+The lakebase architecture lets Lakebase Postgres behave the way developers expect modern infrastructure to behave: instant, intuitive, cost-efficient, and safe to experiment with. This modernizes workflows that, in other managed Postgres services, still feel decades old.
 
 - **Scale-to-zero.** Inactive databases shut down automatically to save costs. Ideal for side projects, development environments, and agent-generated apps.
 - **Autoscaling.** For your production database, Lakebase Postgres resizes your compute up and down automatically based on traffic. Your performance stays steady without capacity planning.
 - **Branching.** You can clone your entire database (data and schema) instantly to create dev environments, run migrations safely, automate previews, enable safe staging workflows, and build versioning and checkpoints for agents.
 - **Instant restores.** You can also go back to any point in time in seconds, no matter how large your database, or instantly revert to a previously-saved snapshot.
 - **Usage-based pricing.** On Neon, you pay only for what you use, without provisioning storage or compute in advance and without being forced into expensive add-ons.
-- **A Free Plan developers can actually use.** The lakebase architecture makes it incredibly efficient to run a large Free Plan with many projects per account and enough resources to build real apps.
+- **A Free Plan developers can actually use.** The lakebase architecture makes it efficient for Neon to run a large Free Plan with many projects per account and enough resources to build real apps.
 
 ## Who uses Neon and why
 
-### Developers via agents: From side projects to live apps
+### Developers and their agents: From side projects to live apps
 
-Independent developers want to build without friction. They don’t want to create accounts, configure VMs, or invest large sums just to test an idea - they want their agent to directly handle their infra. 
+Independent developers want to build without friction. They don’t want to create accounts, configure VMs, or invest large sums just to test an idea. Increasingly, they want their agent to handle the infrastructure directly.
 
 **Why they build on Neon**
 
-- Our platform is agent-first: agents are a first-class interface
+- Neon is agent-first: agents are a first-class interface
 - The Free Plan is generous enough to build real apps, not just to test things out
-- A Postgres connection string is available immediately, no provisioning waiting times
-- Branching, previews, and instant restores let agents experiment quickly 
+- A Postgres connection string is available immediately, with no wait for provisioning
+- Branching, previews, and instant restores let agents experiment quickly
 - Neon integrates easily with Next.js, Remix, Vercel, Prisma, Drizzle, and the broader ecosystem
 - The experience feels lightweight and fast, not enterprise-heavy
 
 ### Startups: From dev to scale
 
-Startups want to ship product fast and avoid cloud infrastructure complexity. They need their Postgres to be reliable, scalable, and invisible, something they never have to think about unless something goes wrong, and they need their coding agent to handle everything reliably. 
+Startups want to ship product fast and avoid cloud infrastructure complexity. They need their Postgres to be reliable, scalable, and invisible, something they never have to think about unless something goes wrong. They also need their coding agent to handle it reliably.
 
 **Why they build on Neon**
 
-- The lakebase architecture removes cumbersome DBA tasks
-- Those tasks that still exists can be handled by agents
+- The lakebase architecture removes most database administration, and agents can handle the tasks that remain
 - Autoscaling takes care of unpredictable traffic without overprovisioning or planning compute sizes
-- Branching speeds up building - entire dev backend environments get deployed instantly with minimal costs
+- Branching speeds up building: entire dev backend environments get deployed instantly with minimal costs
+- Neon's straightforward and feature-complete [API](/docs/reference/api)
 - Usage-based pricing means no waste, no upfront commitments
-- Neon delivers on reliability, performance, and compliance - backed by Databricks
+- Neon delivers on reliability, performance, and compliance, backed by Databricks
 
-### App generation platforms
+### App generation platforms: From prompt to app
 
-This is a specialty use case for Neon: full-stack codegen platforms that need to spin up thousands of independent applications instantly, each with its own backend. They need a backend platform that can support a fleet of thousands of mostly inactive apps every day without breaking performance or blowing up costs.
+Full-stack codegen platforms spin up thousands of independent applications instantly, each with its own backend. They need a backend that can support a fleet of thousands of mostly inactive apps every day without breaking performance or blowing up costs.
 
 **Why they build on Neon**
 
 - Neon is already tested at scale, powering platforms like Replit
-- They can deploy a Postgres backend instantly and transparently on behalf of the end-user, including database, auth, AI models, functions, and blob storage
-- Thousands of short-lived, low-usage databases are deployed / deleted by APIs / agents  
+- They can deploy a backend instantly and transparently on behalf of the end-user, including Lakebase Postgres, Managed Better Auth, Object Storage, Functions, and AI Gateway
+- Agents and APIs create and delete thousands of short-lived, low-usage databases
 - Scale-to-zero makes this setup economically viable at scale
-- Branching makes it simple to build versioning, rollbacks, checkpoints
+- Branching makes it simple to build versioning, rollbacks, and checkpoints
 
-<Admonition type="tip" title="Neon Agent Plan">
-  Building a full-stack agent that deploys backends? Apply to our [Agent Plan](https://neon.com/programs/agents#agent-plan-pricing) and get access to special pricing, resource limits, features, and support from the team.
+<Admonition type="tip" title="Join the Agent Program">
+  Building a full-stack agent that deploys backends? Apply to our [Agent Program](https://neon.com/programs/agents#agent-plan-pricing) and get access to special pricing, resource limits, features, and support from the team.
 </Admonition>
 
 ## The architecture that makes it possible: lakebase architecture
 
-The benefits developers experience with the Neon platform (instant branching, autoscaling, scale-to-zero, and fast recovery) are not product features layered on top of Postgres. They fall out naturally from the lakebase architecture.
+The benefits developers experience with Neon (instant branching, autoscaling, scale-to-zero, and fast recovery) are not product features layered on top of Postgres. They fall out naturally from the lakebase architecture.
 
 At the highest level, the lakebase architecture is built on a simple but powerful idea: Postgres on the object store.
 
@@ -124,7 +125,7 @@ With durability and history centralized in storage, compute can be fully decoupl
 
 ### A versioned storage engine (copy-on-write)
 
-Separation alone is not enough. Lakebase Postgres’s most distinctive capabilities come from its versioned storage engine, which preserves the full history of the database. Every WAL record and every page version is retained in a single, unified system. As a result:
+Separation alone is not enough. The most distinctive capabilities of Lakebase Postgres come from its versioned storage engine, which preserves the full history of the database. Every WAL record and every page version is retained in a single system. As a result:
 
 - Entire databases can be branched instantly
 - Any past state can be restored without copying data


### PR DESCRIPTION
Updated the content to reflect Neon Postgres <> Lakebase Postgres and to add backend platform language