### PR TITLE
feat: link startups apply CTA to new Google Sites form

### DIFF
--- a/cypress/e2e/startups-contact-form.cy.js
+++ b/cypress/e2e/startups-contact-form.cy.js
@@ -1,65 +1,14 @@
-describe('Startups Contact Form', () => {
+describe('Startups Apply Link', () => {
   beforeEach(() => {
     cy.visit('/startups');
   });
 
-  it('allows users to submit the startups form successfully', () => {
-    cy.formSuccessSubmit();
-
-    cy.get("input[name='firstname']").type('John');
-    cy.get("input[name='lastname']").type('Doe');
-    cy.get("input[name='email']").type('test+skipform@hubspot.com');
-    cy.get("input[name='companyWebsite']").type('startup.example.com');
-    cy.get("input[name='investor']").type('Y Combinator');
-    cy.get('form').submit();
-
-    cy.get('button').should('contain', 'Applied!');
-
-    cy.get('@zarazTrackSpy').should('have.been.calledWith', 'identify', {
-      email: 'test+skipform@hubspot.com',
-    });
-    cy.get('@zarazTrackSpy').should('have.been.calledWith', 'Startup Form Submitted', {
-      email: 'test+skipform@hubspot.com',
-      first_name: 'John',
-      last_name: 'Doe',
-      company_website: 'startup.example.com',
-      investor: 'Y Combinator',
-    });
-  });
-
-  it('displays validation errors when required fields are missing', () => {
-    cy.get("input[name='firstname']").type('John');
-    cy.get('form').submit();
-
-    cy.getByData('error-field-message').should('have.length', 4);
-    cy.getByData('error-field-message').should('contain', 'Required field');
-  });
-
-  it('displays validation error for invalid email format', () => {
-    cy.get("input[name='firstname']").type('John');
-    cy.get("input[name='lastname']").type('Doe');
-    cy.get("input[name='email']").type('invalid-email');
-    cy.get("input[name='companyWebsite']").type('startup.example.com');
-    cy.get("input[name='investor']").type('Y Combinator');
-    cy.get('form').submit();
-
-    cy.getByData('error-field-message').should('contain', 'Please enter a valid email');
-  });
-
-  it('displays an error message when there is server error', () => {
-    cy.formErrorSubmit();
-
-    cy.get("input[name='firstname']").type('John');
-    cy.get("input[name='lastname']").type('Doe');
-    cy.get("input[name='email']").type('test+skipform@hubspot.com');
-    cy.get("input[name='companyWebsite']").type('startup.example.com');
-    cy.get("input[name='investor']").type('Y Combinator');
-    cy.get('form').submit();
-
-    cy.getByData('error-message').should('exist');
-
-    cy.get('@zarazTrackSpy').should('have.been.calledWith', 'identify', {
-      email: 'test+skipform@hubspot.com',
-    });
+  it('renders the apply CTA linking to the external application form', () => {
+    cy.get('#startups-form')
+      .find('a')
+      .contains('Apply Now')
+      .should('have.attr', 'href', 'https://sites.google.com/databricks.com/startup-program-apply')
+      .and('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer');
   });
 });

--- a/src/app/startups/page.jsx
+++ b/src/app/startups/page.jsx
@@ -69,7 +69,7 @@ const faqItems = [
   {
     question: 'How does the application process work?',
     answer: `
-      <p>Apply using the form on this page. Our team reviews each application and typically responds within a few business days. If you qualify, we'll confirm and apply your credits to your account.</p>
+      <p>Apply using the link on this page. Our team reviews each application and typically responds within a few business days. If you qualify, we'll confirm and apply your credits to your account.</p>
     `,
   },
   {

--- a/src/components/pages/startups/hero/apply-link/apply-link.jsx
+++ b/src/components/pages/startups/hero/apply-link/apply-link.jsx
@@ -1,0 +1,60 @@
+import Image from 'next/image';
+
+import Button from 'components/shared/button';
+import Link from 'components/shared/link';
+import { cn } from 'utils/cn';
+
+import LINKS from '../../../../../constants/links';
+import formPattern from '../../../../../images/pages/contact-sales/form-pattern.png';
+
+const APPLY_URL = 'https://sites.google.com/databricks.com/startup-program-apply';
+
+const ApplyLink = () => (
+  <div
+    className={cn(
+      'relative z-10 grid scroll-mt-10 gap-y-6 overflow-hidden border border-gray-new-20 bg-black-pure/80 px-8 py-7',
+      'xl:gap-5 xl:px-7 xl:py-6 lg:max-w-full md:px-5 md:py-5'
+    )}
+    id="startups-form"
+  >
+    <h2 className="text-xl leading-snug font-medium tracking-tighter text-white">
+      Apply to the Databricks Startup Program
+    </h2>
+    <p className="leading-snug tracking-tight text-gray-new-70">
+      Tell us about your startup and we&apos;ll get back to you within a few business days.
+    </p>
+    <div className="relative z-0 col-span-full mt-1 flex items-end justify-between gap-6 sm:flex-col sm:items-start sm:gap-4">
+      <p className="max-w-[300px] text-sm leading-[1.5] tracking-tight text-gray-new-60 sm:max-w-full">
+        By applying you agree to the{' '}
+        <Link className="decoration-dashed" to={LINKS.websiteTerms} theme="grey-85-underlined">
+          Terms of Use
+        </Link>{' '}
+        and acknowledge the{' '}
+        <Link className="decoration-dashed" to={LINKS.privacyPolicy} theme="grey-85-underlined">
+          Privacy Notice
+        </Link>
+        .
+      </p>
+      <Button
+        className="min-w-[152px] px-10 sm:w-full sm:min-w-0"
+        to={APPLY_URL}
+        theme="white-filled"
+        size="new"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Apply Now
+      </Button>
+    </div>
+    <Image
+      className="absolute -right-px -bottom-px -z-10 max-w-none"
+      src={formPattern}
+      alt=""
+      width={576}
+      height={228}
+      priority
+    />
+  </div>
+);
+
+export default ApplyLink;

--- a/src/components/pages/startups/hero/apply-link/apply-link.jsx
+++ b/src/components/pages/startups/hero/apply-link/apply-link.jsx
@@ -1,59 +1,33 @@
-import Image from 'next/image';
-
 import Button from 'components/shared/button';
 import Link from 'components/shared/link';
-import { cn } from 'utils/cn';
 
 import LINKS from '../../../../../constants/links';
-import formPattern from '../../../../../images/pages/contact-sales/form-pattern.png';
 
 const APPLY_URL = 'https://sites.google.com/databricks.com/startup-program-apply';
 
 const ApplyLink = () => (
-  <div
-    className={cn(
-      'relative z-10 grid scroll-mt-10 gap-y-6 overflow-hidden border border-gray-new-20 bg-black-pure/80 px-8 py-7',
-      'xl:gap-5 xl:px-7 xl:py-6 lg:max-w-full md:px-5 md:py-5'
-    )}
-    id="startups-form"
-  >
-    <h2 className="text-xl leading-snug font-medium tracking-tighter text-white">
-      Apply to the Databricks Startup Program
-    </h2>
-    <p className="leading-snug tracking-tight text-gray-new-70">
-      Tell us about your startup and we&apos;ll get back to you within a few business days.
+  <div className="flex scroll-mt-10 flex-col items-start gap-5 sm:w-full" id="startups-form">
+    <Button
+      className="min-w-[200px] px-10 sm:w-full sm:min-w-0"
+      to={APPLY_URL}
+      theme="white-filled"
+      size="new"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Apply Now
+    </Button>
+    <p className="max-w-[420px] text-sm leading-[1.5] tracking-tight text-gray-new-60">
+      By applying you agree to the{' '}
+      <Link className="decoration-dashed" to={LINKS.websiteTerms} theme="grey-85-underlined">
+        Terms of Use
+      </Link>{' '}
+      and acknowledge the{' '}
+      <Link className="decoration-dashed" to={LINKS.privacyPolicy} theme="grey-85-underlined">
+        Privacy Notice
+      </Link>
+      .
     </p>
-    <div className="relative z-0 col-span-full mt-1 flex items-end justify-between gap-6 sm:flex-col sm:items-start sm:gap-4">
-      <p className="max-w-[300px] text-sm leading-[1.5] tracking-tight text-gray-new-60 sm:max-w-full">
-        By applying you agree to the{' '}
-        <Link className="decoration-dashed" to={LINKS.websiteTerms} theme="grey-85-underlined">
-          Terms of Use
-        </Link>{' '}
-        and acknowledge the{' '}
-        <Link className="decoration-dashed" to={LINKS.privacyPolicy} theme="grey-85-underlined">
-          Privacy Notice
-        </Link>
-        .
-      </p>
-      <Button
-        className="min-w-[152px] px-10 sm:w-full sm:min-w-0"
-        to={APPLY_URL}
-        theme="white-filled"
-        size="new"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Apply Now
-      </Button>
-    </div>
-    <Image
-      className="absolute -right-px -bottom-px -z-10 max-w-none"
-      src={formPattern}
-      alt=""
-      width={576}
-      height={228}
-      priority
-    />
   </div>
 );
 

--- a/src/components/pages/startups/hero/apply-link/index.js
+++ b/src/components/pages/startups/hero/apply-link/index.js
@@ -1,0 +1,3 @@
+import ApplyLink from './apply-link';
+
+export default ApplyLink;

--- a/src/components/pages/startups/hero/hero.jsx
+++ b/src/components/pages/startups/hero/hero.jsx
@@ -5,14 +5,20 @@ import Heading from 'components/shared/heading';
 import Logos, { allLogos } from 'components/shared/logos';
 import SectionLabel from 'components/shared/section-label';
 
+import ApplyLink from './apply-link';
 import ContactForm from './contact-form';
 import Quotes from './quotes';
+
+// Toggle between the external Google Sites application form (ApplyLink) and the
+// legacy inline HubSpot form (ContactForm). Flip this to `false` to instantly
+// restore the old form.
+const USE_EXTERNAL_APPLY_FORM = true;
 
 const Hero = ({ logos, quotes }) => (
   <section className="hero pt-40 lg:pt-16 md:pt-12">
     <Container size="1280">
-      <div className="relative flex justify-between gap-16 xl:gap-12 lg:mx-auto lg:max-w-lg lg:flex-col lg:gap-10">
-        <div className="flex max-w-xl flex-1 flex-col gap-10 xl:max-w-[48%] lg:max-w-full md:gap-8">
+      <div className="flex justify-between gap-16 xl:gap-12 lg:mx-auto lg:max-w-lg lg:flex-col lg:gap-10">
+        <div className="flex max-w-xl flex-1 flex-col justify-between gap-16 xl:max-w-[48%] lg:max-w-full lg:gap-10 md:gap-8">
           <div className="flex flex-col lg:max-w-[448px]">
             <SectionLabel className="mb-5 lg:mb-[18px] md:mb-4" theme="white">
               Databricks Startup Program
@@ -30,12 +36,12 @@ const Hero = ({ logos, quotes }) => (
               sure if you qualify? Apply or ask your investor.
             </p>
           </div>
+          <div className="max-w-[530px] lg:mt-2 lg:max-w-full">
+            <Quotes items={quotes} />
+          </div>
         </div>
         <div className="w-full max-w-xl shrink-0 xl:max-w-[48%] lg:max-w-full">
-          <ContactForm />
-        </div>
-        <div className="absolute bottom-0 left-0 max-w-[530px] xl:max-w-[48%] lg:relative lg:mt-2 lg:max-w-full">
-          <Quotes items={quotes} />
+          {USE_EXTERNAL_APPLY_FORM ? <ApplyLink /> : <ContactForm />}
         </div>
       </div>
 

--- a/src/components/pages/startups/hero/hero.jsx
+++ b/src/components/pages/startups/hero/hero.jsx
@@ -35,13 +35,20 @@ const Hero = ({ logos, quotes }) => (
               Qualifying startups can receive up to $200K in credits for Neon and Databricks. Not
               sure if you qualify? Apply or ask your investor.
             </p>
+            {USE_EXTERNAL_APPLY_FORM && (
+              <div className="mt-10 lg:mt-8 md:mt-7">
+                <ApplyLink />
+              </div>
+            )}
           </div>
-          <div className="max-w-[530px] lg:mt-2 lg:max-w-full">
-            <Quotes items={quotes} />
-          </div>
+          {!USE_EXTERNAL_APPLY_FORM && (
+            <div className="max-w-[530px] lg:mt-2 lg:max-w-full">
+              <Quotes items={quotes} />
+            </div>
+          )}
         </div>
         <div className="w-full max-w-xl shrink-0 xl:max-w-[48%] lg:max-w-full">
-          {USE_EXTERNAL_APPLY_FORM ? <ApplyLink /> : <ContactForm />}
+          {USE_EXTERNAL_APPLY_FORM ? <Quotes items={quotes} /> : <ContactForm />}
         </div>
       </div>
 


### PR DESCRIPTION
## What

Replaces the inline HubSpot startup application form on `/startups` with an **Apply Now** CTA that links out to the new application form at [sites.google.com/databricks.com/startup-program-apply](https://sites.google.com/databricks.com/startup-program-apply). The link opens in a new tab.

## Layout

- Left column: heading, description, **Apply Now** button, and terms/privacy line.
- Right column: quotes carousel.

Verified on desktop (1440px) and mobile (600px).

## Keeping the old form

The legacy `ContactForm` is left in place and gated behind a single toggle in `hero.jsx`:

```js
const USE_EXTERNAL_APPLY_FORM = true;
```

Flip it to `false` to instantly restore the original inline form (form on the right, quotes bottom-left) — no other changes needed.

## Also included

- Reworded the `/startups` FAQ "how to apply" answer to reference the link instead of an on-page form.
- Replaced the inline-form e2e tests in `cypress/e2e/startups-contact-form.cy.js` with a check that the Apply Now CTA points at the external application form.

This pull request and its description were written by Isaac.