### PR TITLE
Update homepage hero text

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -77,9 +77,9 @@ const Hero = () => (
       </Link>
 
       <h1 className="mt-5 max-w-280 text-[72px] leading-dense tracking-tighter xl:max-w-215 xl:text-[64px] lg:max-w-180 lg:text-[52px] md:mt-4 md:text-[42px] sm:text-[32px]">
-        Neon is the Postgres backend
+        The backend for apps and agents,
         <br />
-        designed for apps and agents.
+        built to scale on Lakebase Postgres.
       </h1>
 
       <div className="mt-8 flex gap-x-5 lg:mt-7 lg:gap-x-4">

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -76,7 +76,7 @@ const Hero = () => (
         </SectionLabel>
       </Link>
 
-      <h1 className="mt-5 max-w-280 text-[72px] leading-dense tracking-tighter xl:max-w-215 xl:text-[64px] lg:max-w-180 lg:text-[52px] md:mt-4 md:text-[42px] sm:text-[32px]">
+      <h1 className="mt-5 max-w-280 text-[68px] leading-dense tracking-tighter xl:max-w-215 xl:text-[60px] lg:max-w-180 lg:text-[48px] md:mt-4 md:text-[42px] sm:text-[32px]">
         The backend for apps and agents,
         <br />
         built to scale on Lakebase Postgres.

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -37,6 +37,8 @@ Tools are grouped into categories. Use the \`?category=\` URL parameter to restr
 
 Search and navigation tools (search across projects, fetch resource details by ID) are available by default but disabled in [project-scoped mode](https://neon.com/docs/ai/neon-mcp-server#project-scoped-mode).
 
+Schema tools accept schema-qualified table names, such as \`crm.contacts\`. An unqualified name resolves against the database \`search_path\`, which defaults to the \`public\` schema.
+
 **Note:** The \`observability\` tools query [Neon Functions logs](https://neon.com/docs/compute/functions/logs) and [object storage logs](https://neon.com/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS \`us-east-2\` only. Log querying returns results only for projects in a supported region.
 
 ### LinkAPIKey


### PR DESCRIPTION
## Summary
- Updates the homepage hero headline from "Neon is the Postgres backend designed for apps and agents." to "The backend for apps and agents, built to scale on Lakebase Postgres."
- Refreshes an unrelated `process-md-for-llms` snapshot that was blocking pre-push due to MCP docs content drift on `main`.

## Test plan
- [ ] Confirm homepage hero renders the new headline on desktop and mobile breakpoints
- [ ] Spot-check line wrap at xl/lg/md/sm sizes