### PR TITLE
feat: add Mastra examples for image generation and web search on /models

### DIFF
--- a/src/app/models/examples.js
+++ b/src/app/models/examples.js
@@ -270,6 +270,29 @@ console.log(sources.filter((source) => source.sourceType === "url").map((source)
 `,
   }),
   tsExample({
+    id: 'mastra',
+    title: 'Mastra',
+    dependencies: ['@mastra/core', ...AI_SDK_DEPS],
+    endpoint: '/openai/v1 (via provider)',
+    // Mastra has no search API of its own. It passes the provider-executed tool through, and its
+    // own webSearchTool cannot be used here: that one infers the provider from the model id prefix
+    // and rejects neon/… with WEB_SEARCH_UNSUPPORTED_PROVIDER.
+    content: `import { Agent } from "@mastra/core/agent";
+import { neon } from "@neondatabase/ai-sdk-provider";
+
+const agent = new Agent({
+  id: "neon-demo",
+  name: "neon-demo",
+  instructions: "Use web search when you need current information.",
+  model: "neon/${model}",
+  tools: { web_search: neon.tools.webSearch({}) },
+});
+
+const { text } = await agent.generate("${SEARCH_PROMPT}");
+console.log(text);
+`,
+  }),
+  tsExample({
     id: 'typescript',
     title: 'TypeScript',
     dependencies: ['openai'],
@@ -327,8 +350,9 @@ print(response.output_text)
 
 /* ------------------------------------------------------ image generation */
 
-// Every variant streams. A generated image is ~3 MB of base64 and the gateway rejects buffered
-// responses over 655,360 bytes, which is also why there is no cURL variant.
+// A generated image is ~3 MB of base64 and the gateway rejects buffered responses over 655,360
+// bytes, which is why the SDK variants stream and why there is no cURL variant. Mastra is the
+// exception: its agent call returns once, with the base64 whole.
 const imageExamples = (model) => [
   tsExample({
     id: 'ai-sdk',
@@ -350,6 +374,29 @@ for await (const _ of result.textStream) {}
 
 const images = (await result.toolResults).filter((r) => r.toolName === "image_generation");
 console.log(images.length);
+`,
+  }),
+  tsExample({
+    id: 'mastra',
+    title: 'Mastra',
+    dependencies: ['@mastra/core', ...AI_SDK_DEPS],
+    endpoint: '/openai/v1 (via provider)',
+    // Mastra returns once with the base64 whole, so it is the one variant that does not iterate a
+    // stream. Its tool results carry an envelope the AI SDK does not have, hence payload.*.
+    content: `import { Agent } from "@mastra/core/agent";
+import { neon } from "@neondatabase/ai-sdk-provider";
+
+const agent = new Agent({
+  id: "neon-demo",
+  name: "neon-demo",
+  instructions: "Generate the image the user asks for.",
+  model: "neon/${model}",
+  tools: { image_generation: neon.tools.imageGeneration({ outputFormat: "jpeg" }) },
+});
+
+const { toolResults } = await agent.generate("${IMAGE_PROMPT}");
+const images = toolResults.filter((r) => r.payload.toolName === "image_generation");
+console.log(images.map((r) => r.payload.result.result.length));
 `,
   }),
   tsExample({

--- a/src/app/models/route.test.js
+++ b/src/app/models/route.test.js
@@ -119,7 +119,20 @@ describe('GET /models', () => {
       const { model } = await body(res);
 
       expect(model.unsupported).toBeUndefined();
-      expect(model.examples.map((e) => e.id)).toEqual(['ai-sdk', 'typescript', 'python']);
+      expect(model.examples.map((e) => e.id)).toEqual(['ai-sdk', 'mastra', 'typescript', 'python']);
+    });
+
+    it('carries the provider-executed tool in the Mastra tool examples', async () => {
+      for (const useCase of ['image-generation', 'web-search']) {
+        const res = await GET(request(`?model=gpt-5-nano&use_case=${useCase}`));
+        const { model } = await body(res);
+        const mastra = model.examples.find((e) => e.id === 'mastra');
+
+        // The tool factory lives in the provider package even though the model is a router string.
+        expect(mastra.dependencies).toContain('@neondatabase/ai-sdk-provider');
+        expect(mastra.files[0].content).toContain('model: "neon/gpt-5-nano"');
+        expect(mastra.files[0].content).toContain('neon.tools.');
+      }
     });
   });
 


### PR DESCRIPTION
`/models` shipped Mastra for chat only. The image-generation and web-search use cases listed AI SDK, TypeScript, Python, and cURL, because Mastra was believed not to reach the Responses API. It does: `models.dev` marks the twelve `gpt-5*` ids `shape: "responses"`, Mastra's model router honours that, and provider-executed tools pass straight through — so `neon.tools.imageGeneration()` and `neon.tools.webSearch()` work on an agent whose model is the `neon/<model>` string.

Both were run against a live gateway branch before being added, and the same snippets now ship in [`neon-console-code-examples`](https://github.com/neondatabase/neon-console-code-examples/commit/ea373db).

```
GET /models?model=gpt-5-nano&use_case=image-generation
```

```json
{ "id": "mastra", "title": "Mastra", "endpoint": "/openai/v1 (via provider)",
  "dependencies": ["@mastra/core", "ai", "@neondatabase/ai-sdk-provider"] }
```

```typescript
import { Agent } from "@mastra/core/agent";
import { neon } from "@neondatabase/ai-sdk-provider";

const agent = new Agent({
  id: "neon-demo",
  name: "neon-demo",
  instructions: "Generate the image the user asks for.",
  model: "neon/gpt-5-nano",
  tools: { image_generation: neon.tools.imageGeneration({ outputFormat: "jpeg" }) },
});

const { toolResults } = await agent.generate("A red apple on a wooden table.");
const images = toolResults.filter((r) => r.payload.toolName === "image_generation");
console.log(images.map((r) => r.payload.result.result.length));
```

Two things a reader of these snippets has to know, and both are in the code rather than a caveat. Mastra wraps tool results as `{ type, runId, from, payload }`, so the name is at `payload.toolName` and the base64 at `payload.result.result` — the AI SDK's flat `r.toolName` returns nothing here. And Mastra is the only image variant that does not iterate a stream: `agent.generate()` returns once with the base64 whole, which is why the comment above `imageExamples` no longer claims every variant streams.

Mastra's own `webSearchTool` is deliberately not used. It infers the provider from the model id prefix and accepts only `openai`, `anthropic`, `google`, and `xai`, so a `neon/…` id fails with `WEB_SEARCH_UNSUPPORTED_PROVIDER`.

Verification: `npx vitest run src/app/models/route.test.js` — 14 pass, including a new case asserting the Mastra variant carries the provider-executed tool for both use cases; `node src/scripts/check-models-endpoint-sync.js` — 21 models in sync on 14 shared fields; eslint and prettier clean. The image example ids are now `['ai-sdk', 'mastra', 'typescript', 'python']`, which is the one existing assertion that changed.