### PR TITLE
Fix docs feedback layout on mobile

### DIFF
--- a/src/components/shared/doc-footer/feedback/feedback.jsx
+++ b/src/components/shared/doc-footer/feedback/feedback.jsx
@@ -28,7 +28,7 @@ const Feedback = ({ slug }) => {
     <div className="relative">
       <div
         className={cn(
-          'flex items-center space-x-5 transition-opacity duration-200 xs:flex-col xs:space-y-4 xs:space-x-0',
+          'flex items-center space-x-5 transition-opacity duration-200 sm:flex-col sm:space-y-4 sm:space-x-0',
           isFeedbackSent ? 'invisible opacity-0' : 'visible opacity-100'
         )}
       >


### PR DESCRIPTION
The feedback prompt previously moved to its own row only at 413px and below. This updates the mobile breakpoint so “Was this page helpful?” moves above the controls while Yes, No, and Edit on GitHub remain on one line.

Validated at 500px, 414px, and 413px; unit tests pass.
