### PR TITLE
fix: regenerate api-ref artifacts after recoverProjectBranch removal

### DIFF
--- a/content/docs/api-navigation.yaml
+++ b/content/docs/api-navigation.yaml
@@ -119,9 +119,6 @@
     - title: "Set branch as default"
       slug: reference/api/branches/set-default-project-branch
       method: POST
-    - title: "Recover a deleted branch"
-      slug: reference/api/branches/recover-project-branch
-      method: POST
     - title: "Finalize branch restore from snapshot"
       slug: reference/api/branches/finalize-restore-branch
       method: POST

--- a/content/docs/api-operation-ids.json
+++ b/content/docs/api-operation-ids.json
@@ -1,6 +1,6 @@
 {
   "_generatedBy": "scripts/generate-api-ref.mjs — do not edit by hand",
-  "count": 169,
+  "count": 168,
   "operationIds": [
     "acceptProjectTransferRequest",
     "addBranchNeonAuthOauthProvider",
@@ -128,7 +128,6 @@
     "presignProjectBranchBucketObject",
     "queryProjectBranchLogs",
     "recoverProject",
-    "recoverProjectBranch",
     "removeOrganizationMember",
     "removeProjectMemberRole",
     "resetProjectBranchRolePassword",


### PR DESCRIPTION
## Summary

Production builds on `main` are failing in `prebuild`, before `next build` starts. This unblocks them.

Neon's live API spec (`https://neon.com/api_spec/release/v2.json`) no longer exposes the `recoverProjectBranch` operation ("Recover a deleted branch", POST). The committed api-ref artifacts still listed it, so `check:api-ref-generated` — which regenerates from the live spec and then runs `git diff HEAD` against the two committed files — exited 1 and failed the build with `Command "npm run build" exited with 1`.

This regenerates the artifacts via `npm run generate:api-ref`. The only changes are dropping the branch-recovery nav entry and the operation count going from 169 to 168.

Worth noting this failure is time-based rather than commit-based: because the guard compares committed files against a freshly fetched external spec, **every** build was failing regardless of its contents, so PR builds were affected too and reverting recent merges would not have helped.

## Notes

- No other code or content references the removed endpoint, so there is no orphaned doc page or link to clean up.
- The per-operation generated files under `src/data/api-ref/` and `public/md/` are gitignored and rebuilt at deploy time, so only these two committed artifacts needed updating.
- Unrelated and left for a follow-up: the generator also warns that the spec added a new `Logs` tag missing from `scripts/data/tag-config.json`, so those endpoints currently get auto-generated ordering and descriptions.

## Test plan

- [x] Reproduced the original failure locally on `06dd83084`; output matches the Vercel deployment log line for line
- [x] Confirmed `recoverProjectBranch` is absent from the live spec
- [x] `npm run check:api-ref-generated` passes (exit 0) with these files committed
- [x] Full `npm run build` succeeds end to end, through `next build` and postbuild sitemap generation
- [x] Unit tests pass (631 tests) via the pre-push hook
- [x] Vercel preview deployment succeeds