### PR TITLE
fix: don't fail builds on api-ref spec drift; report it in the weekly check

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=8.6.0"
   },
   "scripts": {
-    "prebuild": "node scripts/generate-api-ref.mjs && npm run check:api-ref-generated && node src/scripts/update-github-stars.js && node src/scripts/generate-docs-icons-config.js && npm run check:content-data && npm run check:pricing-sync && node scripts/docs-checks/neonctl/check-staleness.js",
+    "prebuild": "node scripts/generate-api-ref.mjs && node src/scripts/update-github-stars.js && node src/scripts/generate-docs-icons-config.js && npm run check:content-data && npm run check:pricing-sync && node scripts/docs-checks/neonctl/check-staleness.js",
     "predev": "node scripts/generate-api-ref.mjs && node src/scripts/update-github-stars.js && node src/scripts/generate-docs-icons-config.js && npm run check:content-data && npm run check:pricing-sync && node scripts/docs-checks/neonctl/check-staleness.js",
     "dev": "next dev",
     "build": "next build",

--- a/scripts/check-docs-api-consistency.mjs
+++ b/scripts/check-docs-api-consistency.mjs
@@ -32,8 +32,12 @@
  *       reference tables)
  *     - operation-set coverage skew: documented ops ↔ @neon/sdk raw methods, and
  *       (in --strict) the live OpenAPI spec ↔ documented ops / @neon/sdk raw.
- *       Either side being ahead usually means "run npm run generate:api-ref" or
- *       "bump @neon/sdk".
+ *       The pairwise diffs are collapsed into action groups (see actionGroups
+ *       below): the spec is the source of truth, so each group is titled by who
+ *       is behind it and states the single command that resolves it — either
+ *       "run npm run generate:api-ref" (docs/artifacts stale) or "bump
+ *       @neon/sdk". This includes the "committed artifacts describe a removed
+ *       endpoint" case that used to fail production builds via prebuild.
  *
  * The scheduled watchdog runs this against `@neon/sdk@latest` with --strict (and
  * fetches the live spec) so a newly published SDK or endpoint that drifts from
@@ -50,8 +54,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { computeCoverage, operationIdsFromSpec, sdkRawOperationNames } from './lib/api-coverage.mjs';
+import {
+  computeCoverage,
+  groupCoverageActions,
+  operationIdsFromSpec,
+  sdkRawOperationNames,
+} from './lib/api-coverage.mjs';
 import { defaultSpecCachePath, loadOpenApiSpec } from './lib/openapi-spec-source.mjs';
+import { findMissingSpecTags, readTagConfig } from './lib/tag-config.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -281,8 +291,8 @@ async function main() {
   // Offline (PR): committed manifest vs the installed @neon/sdk raw layer.
   // Strict (watchdog): also fetch the live spec and diff its operationIds.
   const documentedOps = loadDocumentedOps();
-  let specVersionNote = '';
   let specOps = null;
+  let missingTags = [];
   if (STRICT) {
     try {
       const { spec } = await loadOpenApiSpec({
@@ -291,45 +301,50 @@ async function main() {
         log: () => {},
       });
       specOps = [...operationIdsFromSpec(spec)];
-      specVersionNote = ` (live spec: ${specOps.length} operations)`;
+      // Spec tags with no entry in tag-config.json render with auto-generated
+      // display/order in the API reference (the [tag-config] build warning). The
+      // build only logs it; surface it here so the weekly issue flags it too.
+      missingTags = findMissingSpecTags(readTagConfig(), spec);
     } catch (err) {
       notices.push(`Could not fetch the live OpenAPI spec for coverage: ${err.message}`);
     }
   }
 
-  const { sdkNotDocumented, documentedNotInSdk, specNotDocumented, specNotInSdk } = computeCoverage({
+  const coverage = computeCoverage({
     documentedOps,
     rawOps: rawOperations,
     specOps,
   });
 
-  if (sdkNotDocumented.length) {
-    notices.push(
-      `@neon/sdk@${version} raw layer exposes ${sdkNotDocumented.length} operation(s) the docs do not document ` +
-        `(docs behind — run npm run generate:api-ref): ${sdkNotDocumented.join(', ')}`
-    );
-  }
-  if (documentedNotInSdk.length) {
-    notices.push(
-      `docs document ${documentedNotInSdk.length} operation(s) missing from @neon/sdk@${version} raw layer ` +
-        `(SDK behind spec — bump @neon/sdk): ${documentedNotInSdk.join(', ')}`
-    );
-  }
-  if (specNotDocumented?.length) {
-    notices.push(
-      `OpenAPI spec exposes ${specNotDocumented.length} endpoint(s) the docs do not document ` +
-        `(docs behind — run npm run generate:api-ref and commit): ${specNotDocumented.join(', ')}`
-    );
-  }
-  if (specNotInSdk?.length) {
-    notices.push(
-      `OpenAPI spec exposes ${specNotInSdk.length} endpoint(s) missing from @neon/sdk@${version} raw layer ` +
-        `(SDK behind spec — bump @neon/sdk): ${specNotInSdk.join(', ')}`
-    );
+  // Collapse the pairwise diffs into spec-anchored action groups. See
+  // groupCoverageActions in ./lib/api-coverage.mjs for the routing rationale
+  // (spec-relative classification avoids mislabeling stale artifacts as an SDK
+  // bump). Kept pure and in the lib so the routing is unit tested.
+  const actionGroups = groupCoverageActions(coverage, {
+    sdkVersion: version,
+    hasSpec: Boolean(specOps),
+  });
+
+  // New spec tags missing from tag-config.json — same class of drift (the API
+  // grew a section the docs config doesn't curate yet), so it belongs in the
+  // report alongside operation coverage.
+  if (missingTags.length) {
+    actionGroups.push({
+      title:
+        'New API spec tag(s) missing from tag-config.json (section renders with auto-generated display/order)',
+      action:
+        'add an entry to scripts/data/tag-config.json for curated display, description, and operation groups',
+      ops: missingTags,
+    });
   }
 
   // --- Report -------------------------------------------------------------
-  const strictFail = STRICT && notices.length > 0;
+  // Two non-blocking signal sources: `notices` (unresolved prose references and
+  // any spec-fetch error) and `actionGroups` (coverage drift). Strict mode fails
+  // on either. Kept as distinct lists so a future edit can't update one and
+  // silently drop the other from the fail decision.
+  const driftCount = notices.length + actionGroups.length;
+  const strictFail = STRICT && driftCount > 0;
   const ok = blocking.length === 0 && !strictFail;
 
   if (JSON_MODE) {
@@ -344,6 +359,7 @@ async function main() {
           ok,
           blocking,
           notices,
+          actionGroups,
         },
         null,
         2
@@ -353,9 +369,25 @@ async function main() {
   }
 
   console.log(`Neon docs ↔ API consistency check`);
-  console.log(`  @neon/sdk version: ${version} (${rawOperations.size} raw operations)`);
-  console.log(`  docs scanned:      ${docFiles.length} file(s) referencing @neon/sdk`);
-  console.log(`  documented ops:    ${documentedOps.length}${specVersionNote}\n`);
+  console.log(
+    `Counts: ${specOps ? `live spec ${specOps.length}` : 'live spec n/a (offline)'}` +
+      ` · docs ${documentedOps.length} · @neon/sdk@${version} raw ${rawOperations.size}`
+  );
+  console.log(`Docs scanned: ${docFiles.length} file(s) referencing @neon/sdk\n`);
+
+  // The legend only earns its space when there's drift to interpret. A clean run
+  // stays terse.
+  if (actionGroups.length) {
+    console.log(`The ${specOps ? 'three' : 'two'} views compared, in operationId space:`);
+    // Only claim the spec as a source when it was actually fetched (strict runs).
+    if (specOps) {
+      console.log(`  - live OpenAPI spec  — the source of truth (${SPEC_URL})`);
+    }
+    console.log(
+      '  - docs               — the committed api-ref artifacts (api-operation-ids.json)'
+    );
+    console.log('  - @neon/sdk raw      — operations exposed by the installed SDK\n');
+  }
 
   if (blocking.length) {
     console.log(`[FAIL] ${blocking.length} broken @neon/sdk reference(s) in docs:\n`);
@@ -363,17 +395,29 @@ async function main() {
     console.log('');
   }
 
+  if (actionGroups.length) {
+    const label = STRICT ? 'FAIL (strict)' : 'NOTICE';
+    console.log(
+      `[${label}] ${actionGroups.length} coverage drift item(s) — each names the single action that resolves it:\n`
+    );
+    for (const group of actionGroups) {
+      console.log(`  ▸ ${group.title} (${group.ops.length})`);
+      console.log(`    Action: ${group.action}`);
+      console.log(`    Operations: ${group.ops.join(', ')}\n`);
+    }
+  }
+
   if (notices.length) {
     const label = STRICT ? 'FAIL (strict)' : 'NOTICE';
-    console.log(`[${label}] ${notices.length} coverage/drift notice(s):\n`);
+    console.log(`[${label}] ${notices.length} unresolved reference/fetch notice(s):\n`);
     for (const msg of notices) console.log(`  • ${msg}`);
     console.log('');
   }
 
   if (ok) {
     console.log(
-      notices.length
-        ? `[OK] No broken references. ${notices.length} non-blocking notice(s) above.`
+      driftCount
+        ? `[OK] No broken references. ${driftCount} non-blocking notice(s) above.`
         : `[OK] Docs are in sync with @neon/sdk@${version}.`
     );
     process.exit(0);
@@ -384,7 +428,9 @@ async function main() {
       'Fix broken references above, or run `npm run generate:api-ref` if the API reference is stale.'
     );
     if (strictFail)
-      console.log('Strict mode: coverage/drift notices are treated as failures (scheduled watchdog).');
+      console.log(
+        'Strict mode: coverage/drift notices are treated as failures (scheduled watchdog).'
+      );
   }
   process.exit(1);
 }

--- a/scripts/generate-api-ref.md
+++ b/scripts/generate-api-ref.md
@@ -23,8 +23,11 @@ Build pipeline and UI for the [Neon Management API reference](https://neon.com/d
 | `llms.txt` index                   | `public/docs/reference/api/llms.txt`           | No (gitignored) |
 | `llms-full.txt` (all ops)          | `public/docs/reference/api/llms-full.txt`      | No (gitignored) |
 | Navigation YAML (sidebar)          | `content/docs/api-navigation.yaml`             | **Yes**         |
+| Operation-id manifest              | `content/docs/api-operation-ids.json`          | **Yes**         |
 
-Navigation YAML is committed because it drives the sidebar and must be in the repo before `next build` reads it. Everything else is regenerated on every build.
+`api-navigation.yaml` and `api-operation-ids.json` are the only committed outputs; everything else is gitignored and regenerated on every build.
+
+**What the committed copies are for, and when they update.** Both are overwritten by the generator during `prebuild` on every build, so `next build` (and the sidebar via `src/utils/api-docs.js`) always reads a freshly regenerated `api-navigation.yaml`, never the committed bytes. The committed copies matter in two situations only: (1) a fresh `git` clone needs a valid `api-navigation.yaml` for local `npm run dev` **before** anyone runs the generator (`api-docs.js` falls back to no API section if the file is absent), and (2) `api-operation-ids.json` is the docs-side source of truth the consistency check diffs against. Nothing updates either file in git automatically — a Vercel build overwrites them only inside its ephemeral container. They enter git **only** when a human runs `npm run generate:api-ref` and commits the result. So a committed copy can drift from the live spec between those manual commits; that drift never affects the deployed site (regenerated at build time) — its only cost is a stale sidebar in a fresh local checkout and a noisier consistency check. The build-log `[api-ref] WARNING` and the weekly workflow flag the drift, but neither commits the fix for you.
 
 ## Running locally
 
@@ -54,7 +57,7 @@ Vercel runs `npm run build`, which triggers `prebuild` first. The generator fetc
 
 After a successful generation run, the generator writes the validated spec to `.next/cache/api-reference/openapi-v2.json`. If the live fetch fails, it uses that cache only when it is fresh (default: 7 days). If the cache is missing or stale, the generator throws and the build fails fast. Override the cache path with `API_REF_SPEC_CACHE_PATH` and the TTL with `API_REF_SPEC_CACHE_TTL_MS` when needed.
 
-`prebuild` also runs `npm run check:api-ref-generated` after generation. If either regenerated committed file (`content/docs/api-navigation.yaml` or `content/docs/api-operation-ids.json`) differs from the committed copy, the build fails with a diff. Run `npm run generate:api-ref`, review the change, and commit it.
+The generator overwrites the committed artifacts (`content/docs/api-navigation.yaml` and `content/docs/api-operation-ids.json`) from the freshly fetched spec on every build, so a spec change never fails the build — it just ships on the next deploy. As a heads-up, the generator emits a non-fatal `[api-ref] WARNING` in the build log when the committed manifest differed from what it regenerated (listing the added/removed operationIds), so drift is visible in the log. Committing the regenerated files keeps git history honest, but is not required for the build to pass. The enforcing signal is the weekly [Docs ↔ API consistency](#docs--api-consistency-check) workflow, not the build.
 
 **Recovery:** check the Vercel build log for the HTTP error code, verify `https://neon.com/api_spec/release/v2.json` is reachable (open in a browser or `curl -I`), then trigger a redeploy. No code changes are needed for a transient outage.
 
@@ -110,7 +113,7 @@ Additional manual exception lists (small, inline) live near the top of `build-co
 
 ### When the OpenAPI spec changes
 
-The generator fetches the spec fresh on every build, so most spec changes ship on the next Vercel deploy with no action. The spec is the source of truth for operation structure, field order, types, defaults, enums, descriptions, the `deprecated` flag, and which fields are required. The committed config files (`tag-config.json`, `field-group-config.mjs`, `console-breadcrumbs.json`, `response-examples.json`, coverage data) only enrich and organize; they never gate rendering. The only committed generator output is `content/docs/api-navigation.yaml`, so changes that add or remove pages or sections require committing the regenerated nav file.
+The generator fetches the spec fresh on every build, so most spec changes ship on the next Vercel deploy with no action. The spec is the source of truth for operation structure, field order, types, defaults, enums, descriptions, the `deprecated` flag, and which fields are required. The committed config files (`tag-config.json`, `field-group-config.mjs`, `console-breadcrumbs.json`, `response-examples.json`, coverage data) only enrich and organize; they never gate rendering. The committed generator outputs are `content/docs/api-navigation.yaml` (sidebar) and `content/docs/api-operation-ids.json` (operation manifest); both are regenerated at build time, so a stale copy never breaks the build, but changes that add or remove pages, sections, or operations should be committed to keep git history and the consistency check accurate.
 
 What happens for the common kinds of spec drift:
 
@@ -120,6 +123,7 @@ What happens for the common kinds of spec drift:
 | Endpoint description changed                        | Yes. Flows into the page, per-op markdown, and llms files.                                                                                                                         | None.                                                                                                                                                                                                                                        |
 | Default value, type, enum, or required-ness changed | Yes. The rendered field rows, type badges, enum pills, and the "N required" summary update from the schema.                                                                        | Only if a curated example now conflicts: `seed` values in `field-group-config.mjs` and `response-examples.json` overrides do not auto-track the spec. `npm run audit:api-ref` flags schema-invalid examples.                                 |
 | New tag (set of endpoints)                          | Yes, warn-only. `loadTagConfig(schema)` auto-injects a minimal entry (slug/display derived from the raw spec tag name) and the operations appear in nav. The build does not fail.  | Add a proper entry to `scripts/data/tag-config.json` for display name, order, description, and groups (see [Adding a new tag](#adding-a-new-tag)), optionally a `content/api-docs/{tag}.md` intro, then commit `api-navigation.yaml`.        |
+| Removed endpoint                                    | Yes. The operation's page, markdown, llms entry, and nav entry disappear; the regenerated `api-navigation.yaml`/`api-operation-ids.json` drop it. The build does not fail (this class used to fail `prebuild` before the gate was removed). | Commit the regenerated `api-navigation.yaml` and `api-operation-ids.json`. A `[api-ref] WARNING` in the build log and the weekly consistency workflow both flag the still-committed-but-removed operation until then. |
 
 For request-body grouping drift specifically (new/renamed/removed fields on a configured operation), see the table in [`field-group-config.md`](field-group-config.md#spec-drift-what-happens-the-site-build-never-breaks).
 
@@ -163,9 +167,12 @@ npm run check:api-ref-generated
 
 Review the generated committed files — `content/docs/api-navigation.yaml` (sidebar)
 and `content/docs/api-operation-ids.json` (operation manifest) — separately from UI
-changes. They can drift when the upstream spec changes. `prebuild` runs
-`check:api-ref-generated`, which fails if either regenerated file differs from
-`HEAD`; commit them when the diff is expected.
+changes. They can drift when the upstream spec changes. `npm run check:api-ref-generated`
+diffs the regenerated files against `HEAD` and exits non-zero if either differs; commit
+them when the diff is expected. This check is a manual/CI aid, not a build gate — it is
+**not** wired into `prebuild`, so a stale artifact on `main` never fails a production
+build (the generator overwrites these files at build time regardless). Spec drift surfaces
+as a build-log `[api-ref] WARNING` and in the weekly consistency workflow.
 
 For UI changes, walk [`SMOKE-CHECKLIST.md`](../src/components/pages/doc/api-operation/SMOKE-CHECKLIST.md) against a local `npm run dev`.
 
@@ -202,8 +209,14 @@ operations are documented. Coverage logic lives in the pure
   a `neon.*` ergonomic method, or imports a symbol that the SDK does not provide — readers
   copy these.
 - **Operation coverage (notifies; fails under `--strict`)** — skew between the documented ops,
-  the `@neon/sdk` raw layer, and (in `--strict`) the live OpenAPI spec. Either side being ahead
-  usually means "run `npm run generate:api-ref`" or "bump `@neon/sdk`".
+  the `@neon/sdk` raw layer, and (in `--strict`) the live OpenAPI spec. The pairwise diffs are
+  collapsed into spec-anchored **action groups** by `groupCoverageActions()` — the spec is the
+  source of truth, so each group states the single fix: "run `npm run generate:api-ref`" (docs
+  or committed artifacts behind/ahead of the spec, including the removed-endpoint case that used
+  to fail the build) or "bump `@neon/sdk`" (SDK behind the spec).
+- **Tag coverage (fails under `--strict`)** — under `--strict` the check also reports live spec
+  tags with no entry in `tag-config.json` (via `findMissingSpecTags()`), the same drift the
+  generator's `[tag-config]` build warning flags. Fix: add a `tag-config.json` entry.
 
 CI wiring — one workflow, `.github/workflows/docs-api-consistency.yml`:
 

--- a/scripts/generate-api-ref.mjs
+++ b/scripts/generate-api-ref.mjs
@@ -1157,6 +1157,38 @@ function buildOperationData(
 // Main
 // ---------------------------------------------------------------------------
 
+// Compare the committed operation-id manifest against the freshly generated
+// operationIds and warn (non-fatal) on any set difference. Reads the committed
+// file directly rather than diffing rendered files so it works from a single
+// source of truth; a parse/read failure is treated as "nothing to compare".
+function warnIfManifestStale(freshOperationIds) {
+  let committed;
+  try {
+    committed = JSON.parse(readFileSync(PATHS.operationIdsPath, 'utf8'));
+  } catch {
+    return; // no committed manifest yet (or unreadable) — nothing to compare
+  }
+
+  const committedIds = new Set(committed?.operationIds ?? []);
+  const fresh = new Set(freshOperationIds);
+  const removed = [...committedIds].filter((id) => !fresh.has(id)).sort();
+  const added = [...fresh].filter((id) => !committedIds.has(id)).sort();
+
+  if (removed.length === 0 && added.length === 0) return;
+
+  process.stderr.write(
+    `[api-ref] WARNING: committed api-operation-ids.json is stale vs the spec used this run ` +
+      `(${committedIds.size} -> ${fresh.size} operations). ` +
+      `Commit the regenerated content/docs/api-navigation.yaml and api-operation-ids.json.\n`
+  );
+  if (removed.length) {
+    process.stderr.write(`[api-ref]   removed (spec dropped): ${removed.join(', ')}\n`);
+  }
+  if (added.length) {
+    process.stderr.write(`[api-ref]   added (spec introduced): ${added.join(', ')}\n`);
+  }
+}
+
 async function main() {
   const { cachePath, ttlMs } = getSpecCacheConfig();
   const { spec: specRaw, cacheCandidate } = await loadOpenApiSpec({
@@ -1287,10 +1319,18 @@ async function main() {
 
   // Operation-id manifest (committed — docs-side source of truth for API
   // reference coverage; see scripts/lib/api-coverage.mjs)
-  writeOperationIdsManifest(
-    PATHS,
-    allOps.map((op) => op.operationId)
-  );
+  const freshOperationIds = allOps.map((op) => op.operationId);
+
+  // Build-visible staleness warning. The build overwrites the committed manifest
+  // regardless (so this never blocks — that failure class was removed from
+  // prebuild), but comparing the committed operationIds against the freshly
+  // generated set surfaces spec drift in every build log, matching the
+  // [cli-flags]/field-group advisory pattern. The weekly docs↔API workflow is
+  // the enforcing signal; this is the early heads-up so drift is noticed before
+  // Monday. WARN-ONLY.
+  warnIfManifestStale(freshOperationIds);
+
+  writeOperationIdsManifest(PATHS, freshOperationIds);
 
   writeRunSummary(PATHS, {
     opCount,

--- a/scripts/lib/api-coverage.mjs
+++ b/scripts/lib/api-coverage.mjs
@@ -58,6 +58,8 @@ export function sdkRawOperationNames(rawModule) {
  *   - sdkNotDocumented   raw methods with no matching documented operation
  *   - documentedNotInSdk documented operations with no matching raw method
  *   - specNotDocumented  spec operations the docs manifest omits (live only)
+ *   - documentedNotInSpec documented operations the spec no longer exposes,
+ *                        i.e. committed api-ref artifacts are stale (live only)
  *   - specNotInSdk       spec operations with no matching raw method (live only)
  */
 export function computeCoverage({ documentedOps, rawOps, specOps = null }) {
@@ -68,17 +70,96 @@ export function computeCoverage({ documentedOps, rawOps, specOps = null }) {
   const documentedAsMethods = new Set([...documented].map((id) => toSdkMethodName(id)));
 
   const sdkNotDocumented = [...raw].filter((m) => !documentedAsMethods.has(m)).sort();
-  const documentedNotInSdk = [...documented]
-    .filter((id) => !raw.has(toSdkMethodName(id)))
-    .sort();
+  const documentedNotInSdk = [...documented].filter((id) => !raw.has(toSdkMethodName(id))).sort();
 
   let specNotDocumented = null;
+  let documentedNotInSpec = null;
   let specNotInSdk = null;
   if (specOps) {
     const spec = new Set(specOps);
     specNotDocumented = [...spec].filter((id) => !documented.has(id)).sort();
+    documentedNotInSpec = [...documented].filter((id) => !spec.has(id)).sort();
     specNotInSdk = [...spec].filter((id) => !raw.has(toSdkMethodName(id))).sort();
   }
 
-  return { sdkNotDocumented, documentedNotInSdk, specNotDocumented, specNotInSdk };
+  return {
+    sdkNotDocumented,
+    documentedNotInSdk,
+    specNotDocumented,
+    documentedNotInSpec,
+    specNotInSdk,
+  };
+}
+
+export const REGEN_ACTION = 'run `npm run generate:api-ref` and commit the regenerated artifacts';
+export const BUMP_ACTION = 'publish/bump @neon/sdk to a version that includes these operations';
+
+/**
+ * Collapse the pairwise coverage diffs into a small, ordered list of action
+ * groups — each { title, action, ops } — ready to render in a report or an
+ * issue body. Pure and side-effect-free so the routing logic can be unit tested.
+ *
+ * The spec is the source of truth. When it's available (strict runs) every op is
+ * classified relative to the spec, so a documented op missing from BOTH the spec
+ * and the SDK is correctly routed to "regenerate" (stale artifacts), never to
+ * "bump @neon/sdk". Offline (no spec) we fall back to the two SDK-relative diffs
+ * and can't distinguish those cases, so documentedNotInSdk gets an ambiguous
+ * action.
+ *
+ * @param coverage result of computeCoverage()
+ * @param opts.sdkVersion used only for group titles
+ * @param opts.hasSpec whether the live spec was compared (specOps provided)
+ */
+export function groupCoverageActions(coverage, { sdkVersion, hasSpec }) {
+  const {
+    sdkNotDocumented,
+    documentedNotInSdk,
+    specNotDocumented,
+    documentedNotInSpec,
+    specNotInSdk,
+  } = coverage;
+  const groups = [];
+
+  if (hasSpec) {
+    if (documentedNotInSpec?.length) {
+      groups.push({
+        title:
+          'Committed api-ref artifacts are stale (docs describe operations the spec no longer exposes)',
+        action: REGEN_ACTION,
+        ops: documentedNotInSpec,
+      });
+    }
+    if (specNotDocumented?.length) {
+      groups.push({
+        title: 'Docs are behind the spec (spec exposes undocumented endpoints)',
+        action: REGEN_ACTION,
+        ops: specNotDocumented,
+      });
+    }
+    if (specNotInSdk?.length) {
+      groups.push({
+        title: `@neon/sdk@${sdkVersion} raw layer is behind the spec (missing operations)`,
+        action: BUMP_ACTION,
+        ops: specNotInSdk,
+      });
+    }
+    return groups;
+  }
+
+  if (documentedNotInSdk.length) {
+    groups.push({
+      title: `docs document operations missing from @neon/sdk@${sdkVersion} raw layer`,
+      action:
+        'if the spec still exposes them, bump @neon/sdk; if not, regenerate the api-ref artifacts',
+      ops: documentedNotInSdk,
+    });
+  }
+  if (sdkNotDocumented.length) {
+    groups.push({
+      title: `@neon/sdk@${sdkVersion} raw layer exposes operations the docs do not cover`,
+      action: REGEN_ACTION,
+      ops: sdkNotDocumented,
+    });
+  }
+  return groups;
 }

--- a/scripts/lib/api-coverage.test.js
+++ b/scripts/lib/api-coverage.test.js
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  BUMP_ACTION,
   NON_OPERATION_RAW_EXPORTS,
+  REGEN_ACTION,
   computeCoverage,
+  groupCoverageActions,
   operationIdsFromSpec,
   sdkRawOperationNames,
 } from './api-coverage.mjs';
@@ -64,6 +67,7 @@ describe('computeCoverage', () => {
     expect(result.sdkNotDocumented).toEqual([]);
     expect(result.documentedNotInSdk).toEqual([]);
     expect(result.specNotDocumented).toBeNull();
+    expect(result.documentedNotInSpec).toBeNull();
     expect(result.specNotInSdk).toBeNull();
   });
 
@@ -93,5 +97,70 @@ describe('computeCoverage', () => {
     });
     expect(result.specNotDocumented).toEqual(['newEndpoint']);
     expect(result.specNotInSdk).toEqual(['newEndpoint']);
+    expect(result.documentedNotInSpec).toEqual([]);
+  });
+
+  it('flags documented operations the spec no longer exposes (stale artifacts)', () => {
+    // Synthetic op names — `removedOp` stands for the build-breaking class where
+    // the committed manifest still lists an operation the live spec has dropped.
+    const result = computeCoverage({
+      documentedOps: ['presentOp', 'removedOp'],
+      rawOps: ['presentOp'],
+      specOps: ['presentOp'],
+    });
+    expect(result.documentedNotInSpec).toEqual(['removedOp']);
+    expect(result.specNotDocumented).toEqual([]);
+  });
+});
+
+describe('groupCoverageActions', () => {
+  const group = (coverage, opts) =>
+    groupCoverageActions(coverage, { sdkVersion: '1.0.0', ...opts });
+
+  it('routes a stale documented op (missing from spec AND sdk) to regenerate, not bump', () => {
+    // Regression for the routing bug: `removedOp` is gone from the spec and
+    // absent from the SDK, so it lands in documentedNotInSdk too. Spec-first
+    // classification must call this "regenerate", never "bump @neon/sdk".
+    const coverage = computeCoverage({
+      documentedOps: ['presentOp', 'removedOp'],
+      rawOps: ['presentOp'],
+      specOps: ['presentOp'],
+    });
+    const groups = group(coverage, { hasSpec: true });
+    const forOp = groups.find((g) => g.ops.includes('removedOp'));
+    expect(forOp.action).toBe(REGEN_ACTION);
+    expect(groups.some((g) => g.action === BUMP_ACTION)).toBe(false);
+  });
+
+  it('routes a genuine SDK-behind op to bump', () => {
+    const coverage = computeCoverage({
+      documentedOps: ['presentOp', 'sdkMissingOp'],
+      rawOps: ['presentOp'],
+      specOps: ['presentOp', 'sdkMissingOp'],
+    });
+    const groups = group(coverage, { hasSpec: true });
+    const forOp = groups.find((g) => g.ops.includes('sdkMissingOp'));
+    expect(forOp.action).toBe(BUMP_ACTION);
+  });
+
+  it('emits no groups when everything is aligned', () => {
+    const coverage = computeCoverage({
+      documentedOps: ['presentOp'],
+      rawOps: ['presentOp'],
+      specOps: ['presentOp'],
+    });
+    expect(group(coverage, { hasSpec: true })).toEqual([]);
+  });
+
+  it('offline: reports documentedNotInSdk with an ambiguous action (no spec to classify)', () => {
+    const coverage = computeCoverage({
+      documentedOps: ['presentOp', 'removedOp'],
+      rawOps: ['presentOp'],
+    });
+    const groups = group(coverage, { hasSpec: false });
+    const forOp = groups.find((g) => g.ops.includes('removedOp'));
+    expect(forOp).toBeDefined();
+    expect(forOp.action).not.toBe(BUMP_ACTION);
+    expect(forOp.action).not.toBe(REGEN_ACTION);
   });
 });

--- a/scripts/lib/tag-config.mjs
+++ b/scripts/lib/tag-config.mjs
@@ -86,10 +86,12 @@ function validateStatic(cfg) {
   }
 }
 
-// Detect spec tags not in cfg, warn, and return synthesized minimal entries
-// for each. Resolution chain matches buildOperationData in generate-api-ref.mjs:
-//   raw spec tag → toTagSlug → specName map → final url slug
-function synthesizeMissingTags(cfg, specSchema) {
+// Pure detection: return the sorted list of raw spec tag names that have no
+// entry in cfg. Resolution chain matches buildOperationData in
+// generate-api-ref.mjs: raw spec tag → toTagSlug → specName map → final url
+// slug. Side-effect-free so the consistency check can reuse it without emitting
+// the build-log warning. `specSchema` may be a raw or dereferenced OpenAPI doc.
+export function findMissingSpecTags(cfg, specSchema) {
   const specToSlug = new Map();
   const slugSet = new Set();
   for (const t of cfg.tags) {
@@ -98,7 +100,7 @@ function synthesizeMissingTags(cfg, specSchema) {
   }
 
   const missing = new Set();
-  for (const [, pathItem] of Object.entries(specSchema.paths ?? {})) {
+  for (const [, pathItem] of Object.entries(specSchema?.paths ?? {})) {
     for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
       const op = pathItem[method];
       if (!op?.operationId) continue;
@@ -111,7 +113,22 @@ function synthesizeMissingTags(cfg, specSchema) {
     }
   }
 
-  if (missing.size === 0) return [];
+  return [...missing].sort();
+}
+
+// Read the raw tag config from disk (parsed JSON). Exposed so callers other than
+// the generator (e.g. the consistency check) can run findMissingSpecTags without
+// building the full view.
+export function readTagConfig() {
+  return readRaw();
+}
+
+// Detect spec tags not in cfg, warn, and return synthesized minimal entries
+// for each.
+function synthesizeMissingTags(cfg, specSchema) {
+  const missing = findMissingSpecTags(cfg, specSchema);
+
+  if (missing.length === 0) return [];
 
   process.stderr.write(
     `[tag-config] warn: new spec tag(s) not in config: ${[...missing].join(', ')}.\n` +

--- a/scripts/lib/tag-config.test.js
+++ b/scripts/lib/tag-config.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+import { findMissingSpecTags } from './tag-config.mjs';
+
+describe('findMissingSpecTags', () => {
+  const specWith = (tagsByOp) => ({
+    paths: Object.fromEntries(
+      Object.entries(tagsByOp).map(([opId, tag], i) => [
+        `/path-${i}`,
+        { get: { operationId: opId, tags: tag ? [tag] : [] } },
+      ])
+    ),
+  });
+
+  it('returns spec tags with no matching config entry', () => {
+    const cfg = { tags: [{ slug: 'alpha', specName: 'alpha' }] };
+    const spec = specWith({ opOne: 'alpha', opTwo: 'Bravo' });
+    expect(findMissingSpecTags(cfg, spec)).toEqual(['Bravo']);
+  });
+
+  it('returns nothing when every spec tag is configured', () => {
+    const cfg = {
+      tags: [
+        { slug: 'alpha', specName: 'alpha' },
+        { slug: 'bravo', specName: 'bravo' },
+      ],
+    };
+    // 'Bravo' → toTagSlug → 'bravo' → matches config slug.
+    const spec = specWith({ opOne: 'alpha', opTwo: 'Bravo' });
+    expect(findMissingSpecTags(cfg, spec)).toEqual([]);
+  });
+
+  it('respects operationOverrides (op reassigned to a configured tag)', () => {
+    const cfg = {
+      tags: [{ slug: 'alpha', specName: 'alpha' }],
+      operationOverrides: { opTwo: 'alpha' },
+    };
+    const spec = specWith({ opTwo: 'Bravo' });
+    expect(findMissingSpecTags(cfg, spec)).toEqual([]);
+  });
+
+  it('sorts and de-dupes multiple missing tags', () => {
+    const cfg = { tags: [] };
+    const spec = specWith({ opOne: 'Zed', opTwo: 'Alpha', opThree: 'Alpha' });
+    expect(findMissingSpecTags(cfg, spec)).toEqual(['Alpha', 'Zed']);
+  });
+
+  it('handles an empty or pathless spec', () => {
+    const cfg = { tags: [{ slug: 'alpha', specName: 'alpha' }] };
+    expect(findMissingSpecTags(cfg, {})).toEqual([]);
+    expect(findMissingSpecTags(cfg, null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem
A live-spec change (e.g. the recoverProjectBranch removal, #5422) failed *every*
production build: `prebuild` regenerated the api-ref artifacts from the live spec,
then `check:api-ref-generated` diffed them against HEAD and exited 1. The gate was
time-based, not commit-based.

## Change
- Remove `check:api-ref-generated` from `prebuild` — the build regenerates and reads
  the artifacts fresh, so a stale committed copy never affects the deployed site.
- Add a non-fatal `[api-ref] WARNING` in the generator as an early, build-log
  heads-up when the committed manifest drifts.
- Fold drift into the weekly docs↔API check: detect removed endpoints and new
  spec tags missing from `tag-config.json`, and collapse coverage diffs into
  deduped, spec-anchored action groups (fixes the confusing duplicate bullets in
  the drift issue).
- Extract unit-tested helpers (`groupCoverageActions`, `findMissingSpecTags`);
  update `scripts/generate-api-ref.md`.

## Note
Staleness is detected at operationId/tag level, not a full `navigation.yaml` diff.
Reordering/summary drift is intentionally not flagged — the build regenerates the
file every deploy, so the deployed site is always correct.

This pull request and its description were written by Isaac.