### PR TITLE
revert: brace-expansion bump (#5426) — versions not yet on Databricks proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13906,9 +13906,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17867,9 +17867,9 @@
       "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -20776,15 +20776,15 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/markdownlint-cli/node_modules/commander": {


### PR DESCRIPTION
Reverts #5426.

## Why

CI installs exclusively through the Databricks JFrog npm mirror, which quarantines every package version for its first ~7 days. brace-expansion `1.1.18`, `2.1.4`, and `5.0.9` are all still in that cooldown and 404 on the proxy, so `npm ci` now fails with an opaque 403 on every branch:

```
npm error 403 Forbidden - GET .../db-npm/brace-expansion/-/brace-expansion-5.0.9.tgz
```

Confirmed against the proxy: `1.1.18`, `2.1.4`, `5.0.9` → E404. The reverted versions `1.1.13`, `2.0.3`, `5.0.6` all resolve.

The `Dependencies ↔ Databricks proxy` gate flagged all three versions on #5426 before it merged:

```
✗ brace-expansion@1.1.18 — no publish date on the registry; cannot confirm it is available
✗ brace-expansion@2.1.4  — …
✗ brace-expansion@5.0.9  — …
```

## Security tradeoff

This reopens three advisories:

| Advisory | Severity | Fixed in |
|---|---|---|
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (CVE-2026-13149) | high | 1.1.16 / 2.1.2 / 5.0.7 |
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | high | 1.1.17 / 2.1.3 / 5.0.8 |
| [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | high | 1.1.18 / 2.1.4 / 5.0.9 |

All three are DoS-class issues in brace expansion. Every copy in this repo is dev-tooling only:

- `eslint-plugin-import` → `minimatch@3` → `brace-expansion@1.x`
- `glob` → `minimatch@9` → `brace-expansion@2.x`
- `markdownlint-cli` → `minimatch@10` → `brace-expansion@5.x`

None ships in the built site or runs at request time, so exposure is limited to lint/build tooling operating on repo-controlled glob patterns.

## Follow-up

- Re-apply the bump once the versions clear the 7-day cooldown (`@dependabot rebase` on a fresh PR), or add them to `scripts/deps-proxy-allowlist.json` if the proxy team allowlists them explicitly.
- #5430 (fast-uri) and #5431 (postcss) are blocked by this same broken main. #5431 additionally fails the gate on its own: it pulls `nanoid@3.3.17`, also still in cooldown.
- Worth considering making `Dependencies available on Databricks proxy` a required check, so a red gate cannot be merged past.

This pull request and its description were written by Isaac.