### PR TITLE
docs: curate API reference tags and add intros for new resources

### DIFF
--- a/content/api-docs/ai-gateway.md
+++ b/content/api-docs/ai-gateway.md
@@ -1,0 +1,7 @@
+This read-only endpoint returns the AI Gateway host for a branch as `base_url`. No dialect path is included, so append the route your client needs, for example `/v1` for chat completions. Each branch gets its own host, so requests from a preview branch stay scoped to that branch.
+
+A `404` includes a `reason` field explaining why the gateway is unavailable.
+
+Authenticating to the gateway uses a scoped [credential](/docs/reference/api/credentials) with the `ai_gateway:invoke` scope, not your Neon API key.
+
+AI Gateway is in beta, requires a paid plan, and is available only in AWS US East (Ohio) (`aws-us-east-2`). See [AI Gateway](/docs/ai-gateway/overview) for supported models and [Chat completions](/docs/ai-gateway/chat-completions) for the request format.

--- a/content/api-docs/buckets.md
+++ b/content/api-docs/buckets.md
@@ -1,0 +1,5 @@
+Buckets are S3-compatible object storage built into the Neon backend. They branch with your data using the same copy-on-write model as Postgres: a new branch inherits its parent's buckets and their objects at the moment of forking. From there, uploads, overwrites, and deletes on a child are visible only on that branch and its descendants, and the parent stays unchanged.
+
+These endpoints are served by your session, so they need no S3 credentials. For browser uploads or sharing a download with an unauthenticated client, use the presign endpoint; to remove a whole folder, use the delete-by-prefix endpoint. Call [Storage](/docs/reference/api/storage) first for the branch's S3 endpoint.
+
+Object Storage is in beta and available only in AWS US East (Ohio) (`aws-us-east-2`). See [Object Storage](/docs/storage/overview) for setup and [S3 compatibility](/docs/storage/s3-compatibility) for supported operations.

--- a/content/api-docs/credentials.md
+++ b/content/api-docs/credentials.md
@@ -1,0 +1,7 @@
+Scoped credentials are branch-anchored tokens for workloads that can't use a user session, such as CI jobs, servers, and S3 clients. One credential API serves multiple Neon services, and the scopes you request determine what a credential can do. Each service documents its own scopes.
+
+The create response returns `api_token` and `s3_secret_access_key` exactly once, and they can't be retrieved again; list responses return metadata only. To rotate, create a new credential, update your environment, then revoke the old one.
+
+A credential is valid on the branch it was created on and any branch descended from it, but not on branches outside that lineage.
+
+Scoped credentials are in beta. See [Object Storage authentication](/docs/storage/authentication) and [AI Gateway authentication](/docs/ai-gateway/authentication) for scope details and client setup.

--- a/content/api-docs/functions.md
+++ b/content/api-docs/functions.md
@@ -1,0 +1,7 @@
+Functions are serverless compute you deploy onto a branch, so your backend code runs next to your database. A function doesn't configure the services it uses: enable a service on the branch and its connection strings and credentials are injected into `process.env` at runtime. A function has 15 minutes to start responding and can keep streaming while data flows, which suits agents and WebSocket or SSE servers. Each branch runs its own functions at their own URLs.
+
+The slug is assigned at first deploy and can't be changed; `name` is a display label only.
+
+Renaming acts only on a function the branch owns. A slug that's only inherited from an ancestor returns `404`, so rename it on the owning branch.
+
+Functions are in beta and available only in AWS US East (Ohio) (`aws-us-east-2`). See [Neon Functions](/docs/compute/functions/overview) for the deployment workflow, [Environment variables](/docs/compute/functions/environment-variables) for what gets injected, and [Runtime limits](/docs/compute/functions/reference/runtime-limits) for timeouts and concurrency.

--- a/content/api-docs/logs.md
+++ b/content/api-docs/logs.md
@@ -1,0 +1,7 @@
+Logs from every service on a branch land in one queryable stream. Filter by `source` to scope to functions, storage, or Postgres endpoints. Records follow OpenTelemetry conventions, so you can match on `service_name`, `scope_name`, `severity_text`, or `trace_id`.
+
+Structured filters combine with `AND`, so a record must match every filter. For selections they can't express, supply a raw LogQL expression as `logql`; combining it with any structured filter is rejected rather than ignored.
+
+Give a time window as either `since` or `start_time`, not both; the default window differs per endpoint. The maximum range is seven days, but logs are retained for only 3 days, so a longer range can't return older data. When a response is truncated, pass `next_cursor` back as `cursor`, repeating the range and filters unchanged.
+
+Logs are in beta. See [Monitor logs](/docs/introduction/monitor-logs) for the Console view and retention details.

--- a/content/api-docs/storage.md
+++ b/content/api-docs/storage.md
@@ -1,0 +1,7 @@
+This read-only endpoint returns the S3 connection details for a branch: `s3_endpoint`, `region`, and `force_path_style`. Call it before issuing bucket calls, so you know the branch is ready and you have the endpoint your S3 client needs.
+
+A `404` means object storage isn't available for that branch, with a `reason` field explaining why.
+
+Neon Object Storage uses path-style addressing only, which is why `force_path_style` is returned. See [S3 compatibility](/docs/storage/s3-compatibility) for client configuration and [Buckets](/docs/reference/api/buckets) for the endpoints that read and write data.
+
+Object Storage is in beta and available only in AWS US East (Ohio) (`aws-us-east-2`).

--- a/content/docs/api-navigation.yaml
+++ b/content/docs/api-navigation.yaml
@@ -430,85 +430,6 @@
     - title: "Delete Neon Data API"
       slug: reference/api/dataapi/delete-project-branch-data-api
       method: DELETE
-- title: "Legacy Auth"
-  slug: reference/api/auth-legacy
-  items:
-    - title: "Create Auth Provider SDK keys"
-      slug: reference/api/auth-legacy/create-neon-auth-provider-sdk-keys
-      method: POST
-    - title: "Transfer Neon-managed auth project to your own account"
-      slug: reference/api/auth-legacy/transfer-neon-auth-provider-project
-      method: POST
-    - title: "Create Neon Auth integration"
-      slug: reference/api/auth-legacy/create-neon-auth-integration
-      method: POST
-      tag: deprecated
-      tagTheme: orange
-    - title: "List trusted redirect URI domains"
-      slug: reference/api/auth-legacy/list-neon-auth-redirect-uri-whitelist-domains
-      method: GET
-      tag: deprecated
-      tagTheme: orange
-    - title: "Add trusted redirect URI domain"
-      slug: reference/api/auth-legacy/add-neon-auth-domain-to-redirect-uri-whitelist
-      method: POST
-      tag: deprecated
-      tagTheme: orange
-    - title: "Delete trusted redirect URI domain"
-      slug: reference/api/auth-legacy/delete-neon-auth-domain-from-redirect-uri-whitelist
-      method: DELETE
-      tag: deprecated
-      tagTheme: orange
-    - title: "Create new auth user"
-      slug: reference/api/auth-legacy/create-neon-auth-new-user
-      method: POST
-      tag: deprecated
-      tagTheme: orange
-    - title: "Delete auth user"
-      slug: reference/api/auth-legacy/delete-neon-auth-user
-      method: DELETE
-      tag: deprecated
-      tagTheme: orange
-    - title: "List active integrations with auth providers"
-      slug: reference/api/auth-legacy/list-neon-auth-integrations
-      method: GET
-      tag: deprecated
-      tagTheme: orange
-    - title: "List OAuth providers"
-      slug: reference/api/auth-legacy/list-neon-auth-oauth-providers
-      method: GET
-      tag: deprecated
-      tagTheme: orange
-    - title: "Add an OAuth provider"
-      slug: reference/api/auth-legacy/add-neon-auth-oauth-provider
-      method: POST
-      tag: deprecated
-      tagTheme: orange
-    - title: "Update OAuth provider"
-      slug: reference/api/auth-legacy/update-neon-auth-oauth-provider
-      method: PATCH
-      tag: deprecated
-      tagTheme: orange
-    - title: "Delete OAuth provider"
-      slug: reference/api/auth-legacy/delete-neon-auth-oauth-provider
-      method: DELETE
-      tag: deprecated
-      tagTheme: orange
-    - title: "Retrieve email server configuration"
-      slug: reference/api/auth-legacy/get-neon-auth-email-server
-      method: GET
-      tag: deprecated
-      tagTheme: orange
-    - title: "Update email server configuration"
-      slug: reference/api/auth-legacy/update-neon-auth-email-server
-      method: PATCH
-      tag: deprecated
-      tagTheme: orange
-    - title: "Delete integration with auth provider"
-      slug: reference/api/auth-legacy/delete-neon-auth-integration
-      method: DELETE
-      tag: deprecated
-      tagTheme: orange
 - title: "Buckets"
   slug: reference/api/buckets
   items:
@@ -590,3 +511,82 @@
     - title: "List branch log field values"
       slug: reference/api/logs/list-project-branch-log-field-values
       method: GET
+- title: "Legacy Auth"
+  slug: reference/api/auth-legacy
+  items:
+    - title: "Create Auth Provider SDK keys"
+      slug: reference/api/auth-legacy/create-neon-auth-provider-sdk-keys
+      method: POST
+    - title: "Transfer Neon-managed auth project to your own account"
+      slug: reference/api/auth-legacy/transfer-neon-auth-provider-project
+      method: POST
+    - title: "Create Neon Auth integration"
+      slug: reference/api/auth-legacy/create-neon-auth-integration
+      method: POST
+      tag: deprecated
+      tagTheme: orange
+    - title: "List trusted redirect URI domains"
+      slug: reference/api/auth-legacy/list-neon-auth-redirect-uri-whitelist-domains
+      method: GET
+      tag: deprecated
+      tagTheme: orange
+    - title: "Add trusted redirect URI domain"
+      slug: reference/api/auth-legacy/add-neon-auth-domain-to-redirect-uri-whitelist
+      method: POST
+      tag: deprecated
+      tagTheme: orange
+    - title: "Delete trusted redirect URI domain"
+      slug: reference/api/auth-legacy/delete-neon-auth-domain-from-redirect-uri-whitelist
+      method: DELETE
+      tag: deprecated
+      tagTheme: orange
+    - title: "Create new auth user"
+      slug: reference/api/auth-legacy/create-neon-auth-new-user
+      method: POST
+      tag: deprecated
+      tagTheme: orange
+    - title: "Delete auth user"
+      slug: reference/api/auth-legacy/delete-neon-auth-user
+      method: DELETE
+      tag: deprecated
+      tagTheme: orange
+    - title: "List active integrations with auth providers"
+      slug: reference/api/auth-legacy/list-neon-auth-integrations
+      method: GET
+      tag: deprecated
+      tagTheme: orange
+    - title: "List OAuth providers"
+      slug: reference/api/auth-legacy/list-neon-auth-oauth-providers
+      method: GET
+      tag: deprecated
+      tagTheme: orange
+    - title: "Add an OAuth provider"
+      slug: reference/api/auth-legacy/add-neon-auth-oauth-provider
+      method: POST
+      tag: deprecated
+      tagTheme: orange
+    - title: "Update OAuth provider"
+      slug: reference/api/auth-legacy/update-neon-auth-oauth-provider
+      method: PATCH
+      tag: deprecated
+      tagTheme: orange
+    - title: "Delete OAuth provider"
+      slug: reference/api/auth-legacy/delete-neon-auth-oauth-provider
+      method: DELETE
+      tag: deprecated
+      tagTheme: orange
+    - title: "Retrieve email server configuration"
+      slug: reference/api/auth-legacy/get-neon-auth-email-server
+      method: GET
+      tag: deprecated
+      tagTheme: orange
+    - title: "Update email server configuration"
+      slug: reference/api/auth-legacy/update-neon-auth-email-server
+      method: PATCH
+      tag: deprecated
+      tagTheme: orange
+    - title: "Delete integration with auth provider"
+      slug: reference/api/auth-legacy/delete-neon-auth-integration
+      method: DELETE
+      tag: deprecated
+      tagTheme: orange

--- a/scripts/data/tag-config.json
+++ b/scripts/data/tag-config.json
@@ -416,10 +416,60 @@
       ]
     },
     {
+      "slug": "buckets",
+      "display": "Buckets",
+      "description": "Manage branch buckets and objects",
+      "groups": [
+        {
+          "label": "Buckets",
+          "slugs": [
+            "list-project-branch-buckets",
+            "create-project-branch-bucket",
+            "delete-project-branch-bucket"
+          ]
+        },
+        {
+          "label": "Objects",
+          "slugs": [
+            "list-project-branch-bucket-objects",
+            "get-project-branch-bucket-object",
+            "presign-project-branch-bucket-object",
+            "delete-project-branch-bucket-object",
+            "delete-project-branch-bucket-objects-by-prefix"
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "storage",
+      "display": "Storage",
+      "description": "Inspect branch storage state"
+    },
+    {
+      "slug": "ai-gateway",
+      "display": "AI Gateway",
+      "description": "Retrieve branch AI Gateway endpoints"
+    },
+    {
+      "slug": "credentials",
+      "display": "Credentials",
+      "description": "Issue and revoke scoped branch credentials"
+    },
+    {
+      "slug": "functions",
+      "display": "Functions",
+      "description": "Manage branch functions and deployments"
+    },
+    {
+      "slug": "logs",
+      "display": "Logs",
+      "description": "Query logs emitted by services running on branches"
+    },
+    {
       "slug": "auth-legacy",
       "specName": "auth-legacy",
       "display": "Legacy Auth",
-      "description": null,
+      "description": "Deprecated Neon Auth endpoints; use the Auth endpoints instead",
       "groups": [
         {
           "label": "Integrations",
@@ -468,31 +518,6 @@
           ]
         }
       ]
-    },
-    {
-      "slug": "buckets",
-      "display": "Buckets",
-      "description": "Manage branch buckets and objects"
-    },
-    {
-      "slug": "storage",
-      "display": "Storage",
-      "description": "Inspect branch storage state"
-    },
-    {
-      "slug": "ai-gateway",
-      "display": "AI Gateway",
-      "description": "Retrieve branch AI Gateway endpoints"
-    },
-    {
-      "slug": "credentials",
-      "display": "Credentials",
-      "description": "Issue and revoke scoped branch credentials"
-    },
-    {
-      "slug": "functions",
-      "display": "Functions",
-      "description": "Manage branch functions and deployments"
     }
   ],
   "operationOverrides": {


### PR DESCRIPTION
Six API tags shipped without curation: auto-generated display names, no
descriptions, no operation grouping, no intro pages. `Logs` had no config entry
at all, so every build logged `[tag-config] warn: new spec tag(s) not in
config: Logs`.

## Changes

- Add a `logs` tag entry, silencing the build warning.
- Group the 8 buckets operations into Buckets and Objects cards.
- Move the deprecated `auth-legacy` tag last so it no longer outranks six live
  resources. Its `description` was `null`, so the overview grid rendered
  "Generated API endpoints for Legacy Auth" to users; now it has a real one.
- Add intro pages for buckets, storage, ai-gateway, credentials, functions, and
  logs. These render on each tag page and are prepended to the per-tag agent
  markdown. All six tags are beta, so each intro says so.
- Regenerate `content/docs/api-navigation.yaml`.

Config and content only, no `src/` or generator changes. Intros written against
the OpenAPI spec and the product docs, not inference.

`npm run test:unit:run` — 641 passed.

## One source conflict I left unresolved

The spec says "Private Beta" for these endpoints; the product docs say plain
"beta" with public quickstarts. Intros follow the docs.

This pull request and its description were written by Isaac.