### PR TITLE
docs: reconcile remaining pages to the new permissions model

### DIFF
--- a/content/docs/guides/project-collaboration-guide.md
+++ b/content/docs/guides/project-collaboration-guide.md
@@ -17,13 +17,11 @@ updatedOn: '2026-08-04T15:25:12.468Z'
 You can invite other users to collaborate with you on a Neon project. Project collaboration lets other users access and contribute to your project from all supported Neon interfaces, including the Neon Console, Neon API, and Neon CLI. Follow this guide to learn how.
 
 <Admonition type="important">
-Project sharing is being replaced by the **Collaborator** organization role combined with per-project permissions. For new access, use that instead: add the person to your organization as a Collaborator, then grant them a permission on each project they need. See [Assign project access](/docs/manage/user-permissions#assign-project-access).
+Project sharing is being deprecated and will be removed in a future release, so switch to organization-based collaboration now: add the person to your organization as a **Collaborator**, then grant them a permission on each project they need. See [Assign project access](/docs/manage/user-permissions#assign-project-access).
 
-Project sharing still works, and it remains the option for organizations on the [legacy permissions](/docs/manage/user-permissions#legacy-permissions) model, including [Vercel-managed organizations](/docs/guides/vercel-managed-integration).
-</Admonition>
+Project sharing still works today, and it remains the option for organizations on the [legacy permissions](/docs/manage/user-permissions#legacy-permissions) model, including [Vercel-managed organizations](/docs/guides/vercel-managed-integration).
 
-<Admonition type="note">
-The new **Collaborator** organization role is not the same as a project-sharing collaborator, even though the names match. A Collaborator is a member of your organization who you grant per-project permissions to. A project-sharing collaborator is an external Neon account invited to a single project, as described on this page.
+Note that the **Collaborator** organization role is not the same as a project-sharing collaborator, even though the names match. A Collaborator is a member of your organization who you grant per-project permissions to. A project-sharing collaborator is an external Neon account invited to a single project, as described on this page.
 </Admonition>
 
 <Admonition type="note">

--- a/content/docs/guides/project-collaboration-guide.md
+++ b/content/docs/guides/project-collaboration-guide.md
@@ -11,17 +11,23 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/guides/project-sharing-guide
-updatedOn: '2026-07-28T15:40:22.495Z'
+updatedOn: '2026-08-04T15:25:12.468Z'
 ---
 
 You can invite other users to collaborate with you on a Neon project. Project collaboration lets other users access and contribute to your project from all supported Neon interfaces, including the Neon Console, Neon API, and Neon CLI. Follow this guide to learn how.
 
 <Admonition type="important">
-This page describes project collaboration on the legacy permissions model. New organizations manage project access with [per-project permissions](/docs/manage/user-permissions) instead. The new model also has a **Collaborator** organization role, but that's separate: it's an organization member you grant a project role to, not an external person you invite to a single project as described here.
+Project sharing is being replaced by the **Collaborator** organization role combined with per-project permissions. For new access, use that instead: add the person to your organization as a Collaborator, then grant them a permission on each project they need. See [Assign project access](/docs/manage/user-permissions#assign-project-access).
+
+Project sharing still works, and it remains the option for organizations on the [legacy permissions](/docs/manage/user-permissions#legacy-permissions) model, including [Vercel-managed organizations](/docs/guides/vercel-managed-integration).
 </Admonition>
 
 <Admonition type="note">
-Use project collaboration to work with people outside your organization. If you're working with team members, create an [Organization](/docs/manage/organizations) instead. Organization members get automatic access to all projects within that organization. Organizations can still use project collaboration when needed (for example, to allow an external contractor to contribute to a specific project without making them a full organization member).
+The new **Collaborator** organization role is not the same as a project-sharing collaborator, even though the names match. A Collaborator is a member of your organization who you grant per-project permissions to. A project-sharing collaborator is an external Neon account invited to a single project, as described on this page.
+</Admonition>
+
+<Admonition type="note">
+Use project collaboration to work with people outside your organization. If you're working with team members, create an [Organization](/docs/manage/organizations) instead. Organization members get access to projects based on their organization role and any per-project permissions you grant them.
 </Admonition>
 
 ## Set up Neon accounts

--- a/content/docs/manage/organizations.md
+++ b/content/docs/manage/organizations.md
@@ -5,12 +5,12 @@ summary: >-
   Neon Organizations are the top-level containers for all projects, providing
   centralized billing, member management, and access controls for teams on free
   and paid plans. Teams use organizations to collaborate across projects, assign
-  Admin or Member roles, and auto-provision users by verified email domain.
-  Current limitations include all users being able to manage protected branches
-  regardless of role, and a permissions model that does not yet support
-  fine-grained access controls.
+  organization roles, grant per-project permissions, and auto-provision users by
+  verified email domain. Current limitations include all users being able to
+  manage protected branches regardless of role, and per-project permissions that
+  can raise a member's access but not restrict it.
 enableTableOfContents: true
-updatedOn: '2026-06-18T16:36:42.941Z'
+updatedOn: '2026-08-04T15:25:12.468Z'
 ---
 
 In Neon, all projects live within organizations. When you sign up, you automatically get a free organization for your first project. Organizations provide a central place to manage your projects and collaborate with team members. You can start inviting teammates as soon as your organization is created. Paid plans also include billing management for your organization.
@@ -23,12 +23,16 @@ In the Neon Console, the Organizations page gives you a centralized view of all 
 
 ## User roles and permissions
 
-Organizations have two main member roles:
+Access works in two layers. An organization role sets a member's baseline access across every project, and per-project permissions grant extra access on individual projects. The two are additive, so a per-project permission can only raise someone's access, never lower it.
 
-- **Admin**: Full control over the organization and all its projects.
-- **Member**: Access to all organization projects, but cannot modify org settings or delete projects.
+There are four organization roles:
 
-For a full breakdown of what each role can do, see the [User Permissions](/docs/manage/user-permissions) page. That page also explains [which roles receive certain organization emails](/docs/manage/user-permissions#email-notifications) (for example, alerts when a project is close to its storage limit).
+- **Admin**: Full control over the organization and all its projects, including billing, members, and settings.
+- **Editor**: Access to all organization projects, but cannot modify org settings, delete projects, or transfer them out of the organization.
+- **Viewer**: Read-only access to organization and project metadata. Cannot see connection strings or run SQL.
+- **Collaborator**: No access by default. Sees only the projects they're explicitly granted.
+
+For a full breakdown of what each role and per-project permission allows, see the [User permissions](/docs/manage/user-permissions) page. That page also explains [which roles receive certain organization emails](/docs/manage/user-permissions#email-notifications) (for example, alerts when a project is close to its storage limit).
 
 You can also [auto-provision members by email domain](/docs/manage/orgs-add-members-by-domain) so that users whose email matches a verified domain are added to the organization automatically when they sign up or log in.
 
@@ -41,7 +45,7 @@ You can create additional organizations at any time. [See how to create an organ
 As we continue to refine our organization features, here are some temporary limitations you should be aware of:
 
 - **Branch management**: All users are currently able to manage [protected branches](/docs/guides/protected-branches), regardless of their role or permission level. Granular permissions for this feature are not yet implemented.
-- **Permissions and roles**: The current permissions system may not meet all needs for granular control. Users are encouraged to share their feedback and requirements for more detailed permissions settings.
+- **Access can only be added, not restricted**: Per-project permissions raise a member's access above their organization-role baseline; they can't reduce it. There's no way to block an Editor from a single project. To limit someone to specific projects, give them the **Collaborator** role and grant permissions on just those projects. See [Notes and limitations](/docs/manage/user-permissions#notes-and-limitations).
 
 ## Feedback
 

--- a/content/docs/manage/orgs-add-members-by-domain.md
+++ b/content/docs/manage/orgs-add-members-by-domain.md
@@ -3,7 +3,7 @@ title: Add organization members by domain
 summary: >-
   Auto-join by domain lets admins verify email domains via DNS TXT record.
   Users who sign up or log in with a matching address are automatically added
-  as Members, with no manual invite required. Use this page to auto-provision
+  as Editors, with no manual invite required. Use this page to auto-provision
   org membership for your company domain instead of sending individual invites.
   An org can have multiple verified domains, and the same domain can be shared
   across multiple Neon organizations.
@@ -20,7 +20,7 @@ Only organization admins can add, verify, or remove domains. The **Auto-join by 
 
 - You add a domain (for example, `example.com`) on the organization **People** page under **Auto-join by domain**. The domain is added in a "Pending verification" state and Neon generates a verification code.
 - You add a TXT record at your domain with that exact code. After DNS propagates, you click **Verify** in the Console to confirm you own the domain.
-- When a user signs up or logs in to Neon with an email whose domain matches one of your verified domains (for example, `alex@example.com`), they are automatically added to your organization as a Member. They do not receive an invite email; they simply see the organization in their org switcher.
+- When a user signs up or logs in to Neon with an email whose domain matches one of your verified domains (for example, `alex@example.com`), they are automatically added to your organization as an Editor. They do not receive an invite email; they simply see the organization in their org switcher.
 
 An organization can have multiple verified domains. The same domain can also be added to multiple organizations. If a user's email domain matches verified domains in more than one org, they are added to all of those organizations.
 
@@ -64,13 +64,13 @@ Only organization admins can remove a domain. In the **Auto-join by domain** sec
 
 ## Behavior details
 
-- **Role:** Users who are automatically added receive the **Member** role. Admins can change their role later from the **People** page if needed.
+- **Role:** Users who are automatically added receive the **Editor** role, which gives them access to every project in the organization. Admins can change their role later from the **People** page if needed. See [Organization roles](/docs/manage/user-permissions#organization-roles).
 - **Existing members:** If the user is already a member of the organization, no duplicate is created; they are simply signed in as usual.
 - **Sign up and log in:** Users are automatically added both when they create a new Neon account and when an existing user logs in. So if you add and verify a domain after some colleagues already have Neon accounts, those colleagues will be added to the org the next time they log in (as long as their email domain matches).
 
 ## Related
 
 - [Manage organizations](/docs/manage/orgs-manage) for inviting members manually and managing roles.
-- [User permissions](/docs/manage/user-permissions) for a breakdown of Admin and Member capabilities.
+- [User permissions](/docs/manage/user-permissions) for a breakdown of what each organization role and per-project permission allows.
 
 <NeedHelp />

--- a/content/docs/manage/orgs-api.md
+++ b/content/docs/manage/orgs-api.md
@@ -8,7 +8,7 @@ summary: >-
   projects, require a personal admin key and reject organization API keys. A
   permission matrix maps each endpoint to its supported key type.
 enableTableOfContents: true
-updatedOn: '2026-07-28T20:12:21.572Z'
+updatedOn: '2026-08-04T15:25:12.468Z'
 ---
 
 Learn how to manage Neon Organizations using the Neon API, including managing organization API keys, working with organization members, and handling member invitations.
@@ -68,8 +68,10 @@ To find your organization's `org_id`, navigate to your Organization's **Settings
 
 There are two types of organization API keys:
 
-- **Organization API keys**: Provide admin-level access to all organization resources, including projects, members, and settings. Only organization admins can create these keys.
-- **Project-scoped organization API keys**: Provide limited, member-level access to specific projects within the organization. Any organization member can create a key for any organization-owned project.
+- **Organization API keys**: Provide admin-level access to all organization resources, including projects, members, and settings. Only organization Admins can create these keys.
+- **Project-scoped organization API keys**: Provide [**Editor** access](/docs/manage/user-permissions#per-project-permissions) to a single project within the organization, so they can read and modify project resources but can't delete the project or manage who can access it. Only organization Admins can create these keys.
+
+If you're an Editor, Viewer, or Collaborator, create a personal API key instead; it's scoped to your own access.
 
 The key token is only displayed once at creation time. Copy it immediately and store it securely. If lost, you’ll need to revoke the key and create a new one. For detailed instructions, see [Manage API Keys](/docs/manage/api-keys#create-an-organization-api-key).
 
@@ -249,13 +251,15 @@ Example response:
 
 Changes a member's current role in the organization. If using your personal API key, you need to be an admin in the organization to perform this action. Note: you cannot downgrade the role of the organization's only admin.
 
+Valid roles are `admin`, `editor`, `viewer`, and `collaborator`. The value `member` is still accepted as a legacy alias for `editor`. A member's organization role sets their baseline access on every project; to change their access on a single project, see [Manage project access](#manage-project-access).
+
 ```bash shouldWrap
 curl --request PATCH \
      --url 'https://console.neon.tech/api/v2/organizations/members/{member_id}' \
      --header 'accept: application/json' \
      --header 'authorization: Bearer $ORG_API_KEY' \
      --header 'content-type: application/json' \
-     --data '{"role": "admin"}' | jq
+     --data '{"role": "editor"}' | jq
 ```
 
 Example response:
@@ -265,7 +269,7 @@ Example response:
   "id": "abc123de-4567-8fab-9012-3cdef4567890",
   "user_id": "def456gh-7890-1abc-2def-3ghi4567890j",
   "org_id": "org-example-12345678",
-  "role": "admin",
+  "role": "editor",
   "joined_at": "2024-01-01T12:00:00Z"
 }
 ```
@@ -307,7 +311,7 @@ Example response:
       "org_id": "org-example-12345678",
       "invited_by": "def456gh-7890-1abc-2def-3ghi4567890j",
       "invited_at": "2024-01-01T12:00:00Z",
-      "role": "member"
+      "role": "editor"
     }
   ]
 }
@@ -317,10 +321,10 @@ Example response:
 
 ## Create invitations
 
-Creates invitations for new organization members. Each invited user:
+Creates invitations for new organization members. Specify the organization role each invited user should get (`admin`, `editor`, `viewer`, or `collaborator`). Each invited user:
 
 - Receives an email notification about the invitation
-- If they have an existing Neon account, they automatically join as a member
+- If they have an existing Neon account, they automatically join with the role you specified
 - If they don't have an account yet, the email invites them to create one
 
 You must use your personal API key and have admin-level permissions in the organization to use this endpoint. Organization API keys are not supported.
@@ -335,7 +339,7 @@ curl --request POST \
        "invitations": [
          {
            "email": "user@example.com",
-           "role": "member"
+           "role": "editor"
          }
        ]
      }' | jq
@@ -350,7 +354,7 @@ The API supports transferring projects between organizations. For detailed instr
 Key requirements:
 
 - Must use a personal API key
-- Requires admin permissions in the source organization and at least member permissions in the target
+- Requires Admin in the source organization, and a role that can create projects in the target (Admin, Editor, or Viewer)
 
 [Try in API Reference](/docs/reference/api/organizations/transfer-projects-from-org-to-org)
 

--- a/content/docs/manage/orgs-manage.md
+++ b/content/docs/manage/orgs-manage.md
@@ -2,19 +2,19 @@
 title: Manage Neon Organizations
 summary: >-
   Neon organization management covers Console workflows for creating
-  organizations, inviting members and collaborators, promoting users to Admin,
-  requiring 2FA, and managing per-organization billing. Use this page to add or
-  remove members, adjust role permissions, or delete an organization from the
-  UI. Admins control deletions, billing changes, 2FA enforcement, and project
-  deletion; all members can create projects and view billing.
+  organizations, inviting members, assigning organization roles, granting
+  per-project permissions, requiring 2FA, and managing per-organization
+  billing. Use this page to add or remove members, change someone's role, or
+  delete an organization from the UI. Admins control deletions, billing
+  changes, and 2FA enforcement.
 enableTableOfContents: true
-updatedOn: '2026-07-28T15:16:30.383Z'
+updatedOn: '2026-08-04T15:25:12.468Z'
 ---
 
-Learn how to manage your organization's projects, invite Members, revise permissions, and oversee billing details. This section explains which specific actions each Member can take based on their assigned roles and permissions.
+Learn how to manage your organization's projects, invite members, set their access, and oversee billing details. For a breakdown of what each organization role and per-project permission allows, see [User permissions](/docs/manage/user-permissions).
 
 <Admonition type="note">
-This page describes the legacy roles (Admin, Member, Collaborator). New organizations use an updated model with organization roles (Admin, Editor, Viewer, Collaborator) and per-project permissions. See [User permissions](/docs/manage/user-permissions) for the current model and how the two relate.
+Organizations managed through the [Vercel-managed integration](/docs/guides/vercel-managed-integration) still use the legacy roles (Admin, Member, Collaborator). See [Legacy permissions](/docs/manage/user-permissions#legacy-permissions).
 </Admonition>
 
 <Steps>
@@ -31,16 +31,17 @@ Select a plan for your new organization. Organizations can be free or paid; if y
 
 After confirming, you'll be directed to your new organization's **Projects** page, where you can get started creating projects and inviting [members](/docs/manage/orgs-manage#invite-members).
 
-## Invite Members
+## Invite members
 
-Only Admins have the authority to invite new Members to the organization. Invitations are issued via email. If a recipient does not have a Neon account, they will receive instructions to create one. Alternatively, you can [auto-provision members by domain](/docs/manage/orgs-add-members-by-domain) so that users with a matching email domain are added automatically when they sign up or log in.
+Only Admins can invite new members to the organization. Invitations are issued via email. If a recipient does not have a Neon account, they will receive instructions to create one. Alternatively, you can [auto-provision members by domain](/docs/manage/orgs-add-members-by-domain) so that users with a matching email domain are added automatically when they sign up or log in.
 
 ![organizations people tab](/docs/manage/orgs_people.png)
 
-To invite Members:
+To invite members:
 
 - Navigate to the **People** page in your Organization.
 - Click **Invite member** and enter the email addresses in a comma-separated list.
+- Choose the organization role each person should get. The role sets their baseline access across every project in the organization. See [Organization roles](/docs/manage/user-permissions#organization-roles).
 - Monitor the status of sent invites on the **Pending Invites** section; from here, you can resend or cancel invitations as needed.
 
 <Admonition type="note" title="Invites not received?">
@@ -53,13 +54,17 @@ The **People** page also shows deactivated organization members with a **Deactiv
 
 ## Set permissions
 
-Permissions within the organization are exclusively managed by Admins. As an Admin:
+Access works in two layers: an organization role sets a member's baseline across every project, and per-project permissions add to it on individual projects. Only Admins can change either one. For the full breakdown of what each level allows, see [User permissions](/docs/manage/user-permissions).
 
-- You can promote any Member to an Admin, granting them full administrative privileges.
-- You can demote any admin to a regular Member.
-- You cannot leave the organization if you are the only Admin. Promote a Member to Admin before you try to leave the org.
+There are four organization roles: **Admin**, **Editor**, **Viewer**, and **Collaborator**. To change someone's role, open the more options menu (⋮) next to their name on the **People** page and choose **Edit member**.
 
 ![organization members](/docs/manage/orgs_members_kebab.png 'no-border')
+
+A few things to keep in mind:
+
+- Changing a role changes a person's baseline on every project at once. To give someone more access on just one project, leave their role alone and [grant a per-project permission](/docs/manage/user-permissions#assign-project-access) instead.
+- Per-project permissions are additive, so they can only raise someone's access above their organization role, never lower it.
+- You cannot leave the organization if you are the only Admin. Promote another member to Admin before you try to leave the org.
 
 ## Require 2FA for organization members
 
@@ -70,51 +75,52 @@ Admins can require two-factor authentication (2FA) for everyone in the organizat
 
 See [Manage your Neon account](/docs/manage/accounts#two-factor-authentication) for personal 2FA setup steps, or [Passkeys](/docs/manage/accounts#passkeys) for passkey setup steps.
 
-## Invite Collaborators
+## Give someone access to specific projects only
 
-Any member can invite external users to [collaborate](/docs/guides/project-collaboration-guide) on specific projects. For example, if you want to give limited access to a contractor.
+To give a person access to a few projects instead of the whole organization, add them to the organization with the **Collaborator** role, then grant them a permission on each project they need. A Collaborator starts with no access at all: projects don't appear in their list until you grant one. This is the recommended way to work with contractors and anyone else who should see only part of the organization.
 
-Members can invite collaborators from a project's **Settings** page. If any project in your organization has collaborators, you'll also see the option to invite and manage collaborators from the organization's **People** page.
-
-Collaborators _do not_ have access to the organization. They access their shared projects by selecting the **Projects shared with me** option in the org switcher.
+For the steps, see [Assign project access](/docs/manage/user-permissions#assign-project-access).
 
 <Admonition type="note">
-Organization members don't need Collaborator invites as they already have full project access. When projects are transferred to an organization, existing collaborator permissions for organization members are automatically removed.
+The **Collaborator** organization role is not the same as a legacy project-sharing collaborator, even though the names match. A Collaborator is a member of your organization who you grant per-project permissions to. A project-sharing collaborator is an external Neon account invited to a single project. See [Legacy permissions](/docs/manage/user-permissions#legacy-permissions).
 </Admonition>
 
-![organization collaborators](/docs/manage/org_collaborators.png)
+### Project sharing
 
-To invite new Collaborators, click **Invite collaborators** and select the project you want to share, then add a comma-separated list of emails for anyone you want to give access to. These users will receive an email inviting them to the project.
+Project sharing invites an external Neon account by email to a single project, without adding them to your organization. It's still available from a project's **Settings** → **Collaborators** page, and if any project in your organization has collaborators, you'll also see them on the organization's **People** page.
+
+Project-sharing collaborators _do not_ have access to the organization itself. They reach their shared projects by selecting **Projects shared with me** in the org switcher. When a project is transferred into an organization, sharing-based access is automatically removed for anyone who is already a member of that organization.
+
+![organization collaborators](/docs/manage/org_collaborators.png)
 
 <Admonition type="note" title="Invites not received?">
 If invite emails aren't received, they may be in spam or quarantined. Recipients should check these folders and mark Neon emails as safe.
 </Admonition>
 
-### Manage Collaborators
+To manage an existing project-sharing collaborator, open the more options menu (⋮) next to their row in the **Collaborators** table:
 
-Click the More Options menu next to the row in the **Collaborators** table to manage Collaborator access. You have two options:
+- **Convert to member**: Admins can turn an external collaborator into a full organization member. Their sharing-based access is removed, and their organization role then determines what they can reach. Set that role on the **People** page.
+- **Remove from project**: Revoke the collaborator's access to the shared project.
 
-- **Convert to member**: Admins can promote an external Collaborator to a full Member. When promoted, their collaborator permissions will be automatically removed since they'll have access to all projects as a Member.
-- **Remove from project**: All members can revoke the Collaborator's access to the shared project.
+![collaborators more options menu](/docs/manage/orgs_collaborators_kebab.png 'no-border')
 
-  ![collaborators more options menu](/docs/manage/orgs_collaborators_kebab.png 'no-border')
+Project sharing is being replaced by the **Collaborator** role plus per-project permissions. For new access, prefer that approach. For details on sharing itself, see the [Project collaboration guide](/docs/guides/project-collaboration-guide).
 
 ## Create and delete projects
 
-All Members can create new projects from the Organization's **Projects** page; however, the organization itself retains ownership of these projects, not the individual user.
+Any member except a Collaborator can create projects from the organization's **Projects** page, including Viewers. The organization retains ownership of these projects, not the individual user. Whoever creates a project becomes **Admin** on it.
 
-- Any Member can create a project under the organization's ownership.
-- Only Admins can delete projects owned by the organization.
+Deleting a project takes **Admin** access on that project, which any organization Admin also has. It isn't limited to organization Admins: a member granted Admin on a single project can delete that project.
 
 ## Manage billing
 
 When you create a new organization, you'll choose a plan for that organization. Each organization manages its own billing and plan.
 
-As the Admin for the organization account:
+Billing is Admin-only, and no per-project permission grants it. As the Admin for the organization account:
 
 - You have full access to edit all billing information.
-- Promote a Member to Admin if you want to delegate billing management; however, all Admins will have the capability to edit billing details.
-- While all Members can view the **Billing** page, only admins can make changes.
+- Promote another member to Admin if you want to delegate billing management; however, all Admins will have the capability to edit billing details.
+- Other members can view the **Billing** page, but only Admins can make changes.
 
 For detailed information on pricing and plans, refer to [Neon plans](/docs/introduction/plans).
 

--- a/content/docs/manage/orgs-manage.md
+++ b/content/docs/manage/orgs-manage.md
@@ -104,7 +104,7 @@ To manage an existing project-sharing collaborator, open the more options menu (
 
 ![collaborators more options menu](/docs/manage/orgs_collaborators_kebab.png 'no-border')
 
-Project sharing is being replaced by the **Collaborator** role plus per-project permissions. For new access, prefer that approach. For details on sharing itself, see the [Project collaboration guide](/docs/guides/project-collaboration-guide).
+Project sharing is being deprecated and will be removed in a future release. For new access, use the **Collaborator** role plus per-project permissions instead. For details on sharing itself, see the [Project collaboration guide](/docs/guides/project-collaboration-guide).
 
 ## Create and delete projects
 

--- a/content/docs/manage/orgs-project-transfer.md
+++ b/content/docs/manage/orgs-project-transfer.md
@@ -5,7 +5,7 @@ summary: >-
   connection strings, via the Console or API. The destination organization's
   plan must be the same tier or higher than the source.
 enableTableOfContents: true
-updatedOn: '2026-07-21T16:33:46.856Z'
+updatedOn: '2026-08-04T15:25:12.468Z'
 ---
 
 Move projects between organizations you belong to in the Neon Console or via the Neon API. You can also hand a project to a different Neon account with a claim link.
@@ -90,7 +90,7 @@ As an alternative, to hand a project to a different Neon account, create a claim
 - Transfer up to **200** projects at a time in the Console, or **400** via the API.
 - Destination organization must have capacity for the projects under its [plan](/docs/introduction/plans) (for example, project count limits).
 - Destination organization plan must be the **same tier or higher** than the source organization plan (for example, Launch to Scale works; Scale to Launch does not). This is a plan-level check, independent of the project's settings.
-- Requires **Admin** in the source organization and at least **Member** in the destination organization. See [User Permissions](/docs/manage/user-permissions).
+- Requires **Admin** in the source organization, since transferring a project out of an organization is Admin-only. In the destination organization you need any role that can create projects: **Admin**, **Editor**, or **Viewer**. Collaborators can't receive transfers. See [User permissions](/docs/manage/user-permissions).
 - Disconnect project integrations before you transfer. Open the project's **Integrations** page and remove any added integrations (for example, GitHub or Vercel). See [Manage integrations](/docs/manage/integrations).
 - [Vercel-managed organizations](/docs/guides/vercel-managed-integration) are not supported as source or destination.
 - HIPAA projects can only move to a HIPAA-enabled organization.

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -161,7 +161,7 @@ How you grant access depends on whether the person is already in your organizati
 Neon's project collaboration feature allows you to invite external Neon accounts to collaborate on a Neon project.
 
 <Admonition type="note">
-Project sharing is being replaced by the **Collaborator** organization role combined with per-project permissions. To give a contractor or other limited-access user access to specific projects, prefer adding them to the organization as a Collaborator and granting per-project permissions. See [User permissions](/docs/manage/user-permissions).
+Project sharing is being deprecated and will be removed in a future release. To give a contractor or other limited-access user access to specific projects, add them to the organization as a **Collaborator** and grant per-project permissions instead. See [User permissions](/docs/manage/user-permissions).
 </Admonition>
 
 Organization members can't be added as collaborators on organization-owned projects. Grant them a per-project permission instead.

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -9,11 +9,11 @@ summary: >-
   configure, and delete, via the Console or API. Use it when you need to set
   project-level defaults such as compute autoscaling, history window for
   instant restore and Time Travel, IP Allow rules, logical replication, or
-  collaborator access. Deleted projects can be recovered within a 7-day
+  project access. Deleted projects can be recovered within a 7-day
   window using the CLI or API.
 redirectFrom:
   - /docs/get-started/projects
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-04T15:25:12.468Z'
 ---
 
 In Neon, the project is your main workspace. Within a project, you create branches for different workflows, like environments, features, or previews. Each branch contains its own databases, roles, computes, and replicas. Your [Neon Plan](/docs/introduction/plans) determines how many projects you can create and the resource limits within those projects.
@@ -81,11 +81,12 @@ The **Settings** page includes these sub-pages:
 - **Compute**: Set the scale to zero and sizing defaults for any new computes you create when branching.
 - **Instant restore**: Under **Settings → Instant restore**, set the **history window** to control how far back **instant restore**, Time Travel queries, and branching from past states can reach.
 - **Updates**: Schedule a time for Postgres and Neon updates.
+- **Project permissions**: Grant organization members access to this project, and review who can already reach it. See [User permissions](/docs/manage/user-permissions).
 - **Collaborators**: Invite external collaborators to join your Neon project.
 - **Network security**: Configure Neon's IP and Private Networking features for secure access.
 - **RLS**: Configure Neon Row-Level Security (RLS) to apply row-level security policies to your Neon project.
 - **Logical replication**: Enable logical replication to replicate data from your Neon project to external data services and platforms.
-- **Transfer**: Transfer your project from the current organization to another organization you are a member of.
+- **Transfer**: Transfer your project from the current organization to another organization you belong to. Transferring a project out of an organization requires the **Admin** organization role.
 - **Delete**: Use with care! This action deletes your entire project and all its objects, and is irreversible.
 
 ### General project settings
@@ -148,13 +149,22 @@ To set your project's update schedule or view currently scheduled updates:
 
 For more information, see [Updates](/docs/manage/updates).
 
-### Invite collaborators to a project
+### Give someone access to a project
+
+How you grant access depends on whether the person is already in your organization:
+
+- **Organization members**: Grant them a per-project permission (**Viewer**, **Editor**, or **Admin**) from the project's **Settings** → **Project permissions** page. This is also how you give a member more access on one project than their organization role provides. See [Assign project access](/docs/manage/user-permissions#assign-project-access).
+- **People outside your organization**: Invite them as a collaborator, as described below.
+
+#### Invite collaborators to a project
 
 Neon's project collaboration feature allows you to invite external Neon accounts to collaborate on a Neon project.
 
 <Admonition type="note">
-Organization members cannot be added as collaborators to organization-owned projects since they already have access to all projects through their organization membership.
+Project sharing is being replaced by the **Collaborator** organization role combined with per-project permissions. To give a contractor or other limited-access user access to specific projects, prefer adding them to the organization as a Collaborator and granting per-project permissions. See [User permissions](/docs/manage/user-permissions).
 </Admonition>
+
+Organization members can't be added as collaborators on organization-owned projects. Grant them a per-project permission instead.
 
 To invite collaborators to a Neon project:
 
@@ -420,6 +430,8 @@ After enabling logical replication, the next steps involve creating publications
 ### Delete a project
 
 Deleting a project is a permanent action, which also deletes any computes, branches, databases, and roles that belong to the project.
+
+Deleting a project requires **Admin** access on that project, which every organization Admin has. A member granted Admin on a single project can delete that project. See [Per-project permissions](/docs/manage/user-permissions#per-project-permissions).
 
 To delete a project:
 

--- a/content/docs/manage/user-permissions.md
+++ b/content/docs/manage/user-permissions.md
@@ -43,7 +43,7 @@ These examples show how an organization role and per-project grants combine:
 
 A couple of behaviors are worth calling out:
 
-- **Viewers can still create their own projects.** The read-only limit applies to projects a Viewer didn't create. Any organization member except a Collaborator can create a project, and whoever creates a project becomes **Admin** on it.
+- **Viewers can still create their own projects.** The read-only limit applies to projects a Viewer didn't create. Any organization member except a Collaborator can create a project, and whoever creates a project becomes **Admin** on it. They keep that access if their organization role changes later, so to reduce it, grant them a lower permission on the project explicitly.
 - **Deleting a project takes Admin access on that project**, not the Admin organization role. Anyone granted **Admin** on a project, along with any organization Admin, can delete it after typing the project name to confirm.
 
 ## Assign project access
@@ -223,7 +223,7 @@ The new **Collaborator** organization role is not the same as the legacy project
 | ---------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | **Collaborator** | An external user invited to individual projects through project sharing | An organization role that starts with no access, then receives per-project permissions |
 
-Project sharing is being deprecated, and the new **Collaborator** role plus per-project permissions replaces it. For new access, use the Collaborator role plus per-project permissions instead of project sharing.
+Project sharing is being deprecated and will be removed in a future release. For new access, use the **Collaborator** role plus per-project permissions instead.
 
 ## Notes and limitations (#notes-and-limitations)
 


### PR DESCRIPTION
The migration has run, so these pages were still describing the old three-role model (Admin/Member/Collaborator) to readers who no longer have it. Updates them to the new model and links to `/docs/manage/user-permissions` (#5207) instead of re-documenting roles.

- **orgs-manage** — legacy Admonition → Vercel-managed note; "Set permissions" rebuilt around the four roles; "Invite Collaborators" reframed as granting per-project access, sharing kept as a subsection
- **organizations** — four roles + additive rule; real expand-only limitation
- **projects** — added the Project permissions settings entry; delete gate corrected to Admin-on-that-project
- **orgs-project-transfer / orgs-api** — transfer split (out = Admin only, in = Admin/Editor/Viewer); role enum with the `member`→`editor` alias
- **orgs-add-members-by-domain** — auto-join grants Editor
- **project-collaboration-guide** — kept (sharing still ships, legacy/Vercel orgs need it), now leads with the replacement notice

Worth a look: Collaborator **changed meaning** and Viewer is new, so sharing sections were reframed, not renamed. Also fixes an `orgs-api` claim that any member could create project-scoped API keys (Admins only, per `api-keys.md`) — outside the strict scope, flagging it.

Facts checked against the live prod spec and neon-cloud `origin/main`.

DOC-26801

This pull request and its description were written by Isaac.