### PR TITLE
fix(components): center sidebar method dots on their text

### DIFF
--- a/src/components/pages/doc/menu/item/item.jsx
+++ b/src/components/pages/doc/menu/item/item.jsx
@@ -26,12 +26,14 @@ function hasActiveDescendant(items, slug) {
 }
 
 const MethodDot = ({ method }) => (
-  <span
-    className={cn(
-      'mt-[5px] inline-block size-[5px] shrink-0 rounded-full opacity-70',
-      METHOD_DOT_COLOR[method?.toUpperCase()] ?? 'bg-gray-new-50'
-    )}
-  />
+  <span className="flex h-[1.25em] shrink-0 items-center">
+    <span
+      className={cn(
+        'size-[5px] rounded-full opacity-70',
+        METHOD_DOT_COLOR[method?.toUpperCase()] ?? 'bg-gray-new-50'
+      )}
+    />
+  </span>
 );
 
 const Item = ({


### PR DESCRIPTION
Fixes #5438.

The method dots in the docs sidebar were positioned with a hardcoded `mt-[5px]`. Rows are `text-sm` + `leading-tight`, so the line box is 17.5px and a centered 5px dot needs 6.25px of offset. The dot rendered about a pixel high on every row.

This wraps the dot in a span whose height matches that line box (`h-[1.25em]`, which resolves against the inherited 14px font size) and centers it there. It now tracks the first line rather than a fixed number, so it holds when a title wraps and when the active state bumps the font weight.

`1lh` would be the more direct unit, but it isn't used anywhere else in the repo and there's no browserslist, so I used the `em` equivalent. Note that `h-5` would not work here, since `leading-tight` overrides the 20px line height `text-sm` ships with.

**Before**

![before](https://raw.githubusercontent.com/jal-co/website/pr-assets/before.png)

**After**

![after](https://raw.githubusercontent.com/jal-co/website/pr-assets/after.png)

The red line marks the vertical center of the text. Verified locally on `/docs/reference/api/projects/create-project`.
