### PR TITLE
fix: map API reference CLI flags to request-body fields

### DIFF
--- a/scripts/data/cli-coverage.json
+++ b/scripts/data/cli-coverage.json
@@ -54,7 +54,6 @@
   "updateNeonAuthUserRole": "neon neon-auth user set-role <user-id>",
   "getCurrentUserOrganizations": "neon orgs list",
   "listProjects": "neon projects list",
-  "listSharedProjects": "neon projects list",
   "createProject": "neon projects create",
   "deleteProject": "neon projects delete",
   "updateProject": "neon projects update",

--- a/scripts/generate-api-ref.mjs
+++ b/scripts/generate-api-ref.mjs
@@ -686,22 +686,46 @@ function generateApiMd(tagOps) {
 // drift.
 const GLOBAL_CLI_FLAGS = new Set(CLI_GLOBAL_FLAGS_LIST);
 
-// Return operationIds with CLI coverage where the kebab→snake heuristic in
-// buildCliFlags failed to map any non-global flag to its API param twin.
+// cli-global-flags.json must cover every flag neonctl declares globally.
+// A global flag missing from the list leaks through as an API-specific flag,
+// which makes pure-positional commands look unmapped and skews the tripwire
+// below. Fail hard: a neonctl bump that adds a global flag needs the list
+// updated, and a silent warning here caused exactly that drift before.
+export function assertGlobalFlagsCovered(cliSchema, globalFlags = GLOBAL_CLI_FLAGS) {
+  const declared = Object.keys(cliSchema?.globalOptions ?? {});
+  const missing = declared.filter((name) => !globalFlags.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `scripts/data/cli-global-flags.json is missing neonctl global flag(s): ${missing.join(', ')}. ` +
+        'Add them so they are not counted as API-specific flags.'
+    );
+  }
+}
+
+// Return operationIds with CLI coverage where NOTHING in the rendered command
+// maps back to the API — no positional, no flag. Both carry `apiEquiv`, and
+// both count: `neon projects delete <project_id>` is fully mapped via its
+// positional even though it has no flags. A hit means the command genuinely
+// shares no inputs with the operation it documents (usually a mis-mapped
+// cli-coverage entry), not merely that a naming heuristic missed.
 // Exclusions (skip the warning):
-//   - operation has 0 non-global flags (nothing to map)
-//   - operation has 0 API params (heuristic compares against params)
-//   - operation is pure-positional (>=1 positional AND 0 non-global flags)
+//   - operation has no positionals AND no non-global flags (nothing to map)
 // Returns an empty array when everything is healthy.
-export function findOpsWithNoFlagMappings(allOps) {
+export function findOpsWithNoApiMappings(allOps) {
   const unmapped = [];
   for (const op of allOps) {
-    if (!op.cli?.command) continue; // multi-cmd ops have flags per-cmd; out of scope
-    if (!op.parameters?.length) continue;
-    const nonGlobal = (op.cli.flags ?? []).filter((f) => !GLOBAL_CLI_FLAGS.has(f.name));
-    if (nonGlobal.length === 0) continue; // nothing to map
-    const mapped = nonGlobal.filter((f) => f.apiEquiv);
-    if (mapped.length === 0) unmapped.push(op.operationId);
+    // Multi-command ops carry inputs per-command; check each independently.
+    const commands = op.cli?.commands ?? (op.cli?.command ? [op.cli] : []);
+    for (const cmd of commands) {
+      const positionals = cmd.positionals ?? [];
+      const nonGlobalFlags = (cmd.flags ?? []).filter((f) => !GLOBAL_CLI_FLAGS.has(f.name));
+      if (positionals.length === 0 && nonGlobalFlags.length === 0) continue;
+      const mapped = [...positionals, ...nonGlobalFlags].filter((x) => x.apiEquiv);
+      if (mapped.length === 0) {
+        unmapped.push(op.operationId);
+        break;
+      }
+    }
   }
   return unmapped;
 }
@@ -762,24 +786,45 @@ function collectCliPathOptions(commandStr, cliSchema) {
   return accumulated;
 }
 
+// Index a request-body schema by leaf field name -> dot path, so a CLI flag
+// can be matched against a nested body field (`--hipaa` ->
+// `project.settings.hipaa`). Shallower paths win: `--name` on
+// `neon projects create` resolves to `project.name`, not `project.branch.name`.
+// Recurses through objects and arrays-of-objects; depth-capped like the other
+// schema walkers here.
+export function indexBodyFieldPaths(properties, prefix = '', index = new Map(), depth = 0) {
+  if (!properties || depth > 6) return index;
+  for (const [name, schema] of Object.entries(properties)) {
+    const path = prefix ? `${prefix}.${name}` : name;
+    if (!index.has(name)) index.set(name, path);
+    const children = schema.type === 'object' ? schema.properties : schema.items?.properties;
+    indexBodyFieldPaths(children, path, index, depth + 1);
+  }
+  return index;
+}
+
 // Build the flags array for an operation by merging command-level options
 // with global options, excluding hidden flags. Heuristic mapping:
 //   - apiEquiv: kebab-case flag name maps to a snake_case OP PARAMETER name
-//     (path or query). Drives the API↔CLI hover hint today.
-export function buildCliFlags(commandStr, cliSchema, paramProps) {
+//     (path or query), else to a request-body field's dot path.
+//   - apiEquivIn: 'parameter' | 'body' — which of the two matched. Together
+//     they drive the API↔CLI hover hint and the interactive CLI snippet.
+export function buildCliFlags(commandStr, cliSchema, paramProps, bodyProperties = null) {
   if (!cliSchema) return [];
   const globalOpts = cliSchema.globalOptions ?? {};
   const cmdOpts = collectCliPathOptions(commandStr, cliSchema);
   const allOpts = { ...globalOpts, ...cmdOpts };
 
   const paramNames = new Set(paramProps.map((p) => p.name));
+  const bodyPaths = indexBodyFieldPaths(bodyProperties);
   const kebabToSnake = (s) => s.replace(/-/g, '_');
 
   return Object.entries(allOpts)
     .filter(([, v]) => !v.hidden)
     .map(([name, spec]) => {
       const snake = kebabToSnake(name);
-      const apiEquiv = paramNames.has(snake) ? snake : null;
+      const apiEquiv = paramNames.has(snake) ? snake : (bodyPaths.get(snake) ?? null);
+      const apiEquivIn = apiEquiv ? (paramNames.has(snake) ? 'parameter' : 'body') : null;
       const flag = {
         name,
         type: spec.type === 'unknown' ? 'string' : (spec.type ?? 'string'),
@@ -792,7 +837,10 @@ export function buildCliFlags(commandStr, cliSchema, paramProps) {
       }
       if (spec.choices) flag.enum = spec.choices;
       if (spec.default !== undefined) flag.default = spec.default;
-      if (apiEquiv) flag.apiEquiv = apiEquiv;
+      if (apiEquiv) {
+        flag.apiEquiv = apiEquiv;
+        flag.apiEquivIn = apiEquivIn;
+      }
       return flag;
     });
 }
@@ -1097,7 +1145,12 @@ function buildOperationData(
       cliSchema,
       paramProps
     );
-    const flags = buildCliFlags(enrichedCommand, cliSchema, paramProps);
+    const flags = buildCliFlags(
+      enrichedCommand,
+      cliSchema,
+      paramProps,
+      requestBodyData?.properties
+    );
     cliData = { command: enrichedCommand, flags, positionals };
   } else if (cliCoverageEntry?.commands) {
     const commands = cliCoverageEntry.commands.map(({ cmd, covers }) => {
@@ -1106,7 +1159,12 @@ function buildOperationData(
         cliSchema,
         paramProps
       );
-      const flags = buildCliFlags(enrichedCommand, cliSchema, paramProps);
+      const flags = buildCliFlags(
+        enrichedCommand,
+        cliSchema,
+        paramProps,
+        requestBodyData?.properties
+      );
       return { command: enrichedCommand, covers, flags, positionals };
     });
     cliData = { commands, uncovered: cliCoverageEntry.uncovered ?? [] };
@@ -1230,6 +1288,8 @@ async function main() {
   process.stderr.write(`CLI table output examples: ${Object.keys(cliTableOutput).length} ops\n`);
   process.stderr.write(`Response examples override: ${Object.keys(responseExamples).length} ops\n`);
 
+  if (cliSchema) assertGlobalFlagsCovered(cliSchema);
+
   const allOps = [];
   const tagOps = {};
 
@@ -1267,14 +1327,14 @@ async function main() {
 
   process.stderr.write(`Generated ${opCount} operations.\n`);
 
-  // Tripwire: surface ops where the kebab→snake CLI-flag heuristic mapped
-  // ZERO non-global flags to API params. Either a new flag naming convention
-  // in neonctl OR a positional-only command (excluded). Not fail-hard —
+  // Tripwire: surface ops whose CLI command shares no inputs at all with the
+  // API operation — no positional and no flag maps back. Usually a mis-mapped
+  // cli-coverage entry or a new neonctl naming convention. Not fail-hard —
   // heuristic warnings are advisory; review on bumps.
-  const unmappedFlagOps = findOpsWithNoFlagMappings(allOps);
-  if (unmappedFlagOps.length > 0) {
+  const unmappedOps = findOpsWithNoApiMappings(allOps);
+  if (unmappedOps.length > 0) {
     process.stderr.write(
-      `[cli-flags] WARNING: ${unmappedFlagOps.length} op(s) with CLI coverage have ZERO API↔flag mappings (review if these aren't pure-positional): ${unmappedFlagOps.join(', ')}\n`
+      `[cli-flags] WARNING: ${unmappedOps.length} op(s) with CLI coverage have ZERO API↔CLI mappings (no positional or flag maps to a parameter or body field): ${unmappedOps.join(', ')}\n`
     );
   }
 

--- a/scripts/generate-api-ref.test.js
+++ b/scripts/generate-api-ref.test.js
@@ -24,6 +24,9 @@ import {
   descriptionToHtml,
   appendCliPositionals,
   buildCliFlags,
+  indexBodyFieldPaths,
+  assertGlobalFlagsCovered,
+  findOpsWithNoApiMappings,
   resolveCliPositionals,
   main,
   buildOperationData,
@@ -1122,25 +1125,265 @@ describe('buildCliFlags', () => {
     },
   };
 
+  // Mirrors POST /projects: nested body with `name` at two depths.
+  const bodyProperties = {
+    project: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        settings: { type: 'object', properties: { hipaa: { type: 'boolean' } } },
+        branch: { type: 'object', properties: { name: { type: 'string' } } },
+      },
+    },
+  };
+
   it('sets apiEquiv when a CLI flag maps to an API parameter', () => {
     const paramProps = [{ name: 'org_id', in: 'query' }];
     const flags = buildCliFlags('neon projects list', cliSchema, paramProps);
     const orgFlag = flags.find((f) => f.name === 'org-id');
     expect(orgFlag.apiEquiv).toBe('org_id');
+    expect(orgFlag.apiEquivIn).toBe('parameter');
   });
 
-  it('does not set apiEquiv when a CLI flag is only a request-body field', () => {
-    const paramProps = [];
-    const flags = buildCliFlags('neon projects create', cliSchema, paramProps);
+  it('maps a CLI flag to a nested request-body field by dot path', () => {
+    const flags = buildCliFlags('neon projects create', cliSchema, [], bodyProperties);
+    const nameFlag = flags.find((f) => f.name === 'name');
+    expect(nameFlag.apiEquiv).toBe('project.name');
+    expect(nameFlag.apiEquivIn).toBe('body');
+  });
+
+  it('prefers an API parameter over a body field of the same name', () => {
+    const paramProps = [{ name: 'name', in: 'query' }];
+    const flags = buildCliFlags('neon projects create', cliSchema, paramProps, bodyProperties);
+    const nameFlag = flags.find((f) => f.name === 'name');
+    expect(nameFlag.apiEquiv).toBe('name');
+    expect(nameFlag.apiEquivIn).toBe('parameter');
+  });
+
+  it('sets no mapping when the flag matches neither a parameter nor a body field', () => {
+    const flags = buildCliFlags('neon projects create', cliSchema, [], bodyProperties);
     const orgFlag = flags.find((f) => f.name === 'org-id');
     expect(orgFlag.apiEquiv).toBeUndefined();
+    expect(orgFlag.apiEquivIn).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `--name` mapping regression table
+// ---------------------------------------------------------------------------
+//
+// `--name` means a different thing on every command, and the leaf-name
+// heuristic in buildCliFlags only agrees with neonctl's real semantics as long
+// as no shallower body field shadows the intended one. `neon projects create`
+// is the one live collision: its body holds both `project.name` and
+// `project.branch.name`, and shallowest-path-wins is what picks correctly
+// (verified against neonctl src/commands/projects.ts, where
+// `project.name = props.name` and `project.branch` is populated only from
+// --database/--role).
+//
+// Pinning the expected target per command means a neonctl bump that re-points
+// --name, or a spec change that adds a shadowing field, fails here instead of
+// silently shipping a wrong CLI↔API hint. Bodies mirror the live spec shapes.
+describe('--name flag maps to the right body field per command', () => {
+  const neonctlSchema = readJsonFixture('scripts/docs-checks/neonctl/schema.json');
+
+  const cases = [
+    {
+      command: 'neon projects create',
+      // Collision case: project.name must win over project.branch.name.
+      body: {
+        project: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            branch: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                role_name: { type: 'string' },
+                database_name: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      expected: 'project.name',
+    },
+    {
+      command: 'neon projects update',
+      body: { project: { type: 'object', properties: { name: { type: 'string' } } } },
+      expected: 'project.name',
+    },
+    {
+      command: 'neon branches create',
+      body: { branch: { type: 'object', properties: { name: { type: 'string' } } } },
+      expected: 'branch.name',
+    },
+    {
+      command: 'neon databases create',
+      body: {
+        database: {
+          type: 'object',
+          properties: { name: { type: 'string' }, owner_name: { type: 'string' } },
+        },
+      },
+      expected: 'database.name',
+    },
+    {
+      command: 'neon roles create',
+      body: { role: { type: 'object', properties: { name: { type: 'string' } } } },
+      expected: 'role.name',
+    },
+    {
+      command: 'neon branches add-compute',
+      body: { endpoint: { type: 'object', properties: { name: { type: 'string' } } } },
+      expected: 'endpoint.name',
+    },
+  ];
+
+  it.each(cases)('$command maps --name to $expected', ({ command, body, expected }) => {
+    const flags = buildCliFlags(command, neonctlSchema, [], body);
+    const nameFlag = flags.find((f) => f.name === 'name');
+    expect(nameFlag, `${command} should declare a --name flag`).toBeTruthy();
+    expect(nameFlag.apiEquiv).toBe(expected);
+    expect(nameFlag.apiEquivIn).toBe('body');
   });
 
-  it('sets no mapping when the flag has no API parameter twin', () => {
-    const paramProps = [];
-    const flags = buildCliFlags('neon projects create', cliSchema, paramProps);
-    const nameFlag = flags.find((f) => f.name === 'name');
-    expect(nameFlag.apiEquiv).toBeUndefined();
+  it('leaves --name unmapped rather than mis-mapped when no body field matches', () => {
+    // Safe failure direction: a flag with no body twin gets no hint at all.
+    const flags = buildCliFlags('neon projects create', neonctlSchema, [], {
+      project: { type: 'object', properties: { region_id: { type: 'string' } } },
+    });
+    expect(flags.find((f) => f.name === 'name').apiEquiv).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// indexBodyFieldPaths
+// ---------------------------------------------------------------------------
+
+describe('indexBodyFieldPaths', () => {
+  it('indexes nested fields by leaf name, shallowest path winning', () => {
+    const index = indexBodyFieldPaths({
+      project: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          branch: { type: 'object', properties: { name: { type: 'string' } } },
+        },
+      },
+    });
+    expect(index.get('name')).toBe('project.name');
+    expect(index.get('branch')).toBe('project.branch');
+  });
+
+  it('walks arrays of objects', () => {
+    const index = indexBodyFieldPaths({
+      rules: { type: 'array', items: { properties: { action: { type: 'string' } } } },
+    });
+    expect(index.get('action')).toBe('rules.action');
+  });
+
+  it('returns an empty index for no properties', () => {
+    expect(indexBodyFieldPaths(null).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertGlobalFlagsCovered
+// ---------------------------------------------------------------------------
+
+describe('assertGlobalFlagsCovered', () => {
+  it('throws when neonctl declares a global flag missing from the list', () => {
+    const schema = { globalOptions: { help: {}, 'context-file': {} } };
+    expect(() => assertGlobalFlagsCovered(schema, new Set(['help']))).toThrow(/context-file/);
+  });
+
+  it('passes when every declared global flag is listed', () => {
+    const schema = { globalOptions: { help: {}, output: {} } };
+    expect(() => assertGlobalFlagsCovered(schema, new Set(['help', 'output']))).not.toThrow();
+  });
+
+  it('the committed list covers the committed neonctl schema', () => {
+    const schema = readJsonFixture('scripts/docs-checks/neonctl/schema.json');
+    expect(() => assertGlobalFlagsCovered(schema)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findOpsWithNoApiMappings
+// ---------------------------------------------------------------------------
+
+describe('findOpsWithNoApiMappings', () => {
+  it('does not flag a pure-positional command whose positional maps', () => {
+    const ops = [
+      {
+        operationId: 'deleteProject',
+        cli: {
+          command: 'neon projects delete <project_id>',
+          flags: [],
+          positionals: [{ display: '<project_id>', apiEquiv: 'project_id' }],
+        },
+      },
+    ];
+    expect(findOpsWithNoApiMappings(ops)).toEqual([]);
+  });
+
+  it('does not flag an op mapped only through a body field', () => {
+    const ops = [
+      {
+        operationId: 'updateNeonAuthUserRole',
+        cli: {
+          command: 'neon neon-auth user update',
+          flags: [{ name: 'roles', apiEquiv: 'user.roles', apiEquivIn: 'body' }],
+          positionals: [],
+        },
+      },
+    ];
+    expect(findOpsWithNoApiMappings(ops)).toEqual([]);
+  });
+
+  it('flags an op where no positional or flag maps back to the API', () => {
+    const ops = [
+      {
+        operationId: 'someMismappedOp',
+        cli: {
+          command: 'neon projects list',
+          flags: [{ name: 'org-id' }, { name: 'recoverable-only' }],
+          positionals: [],
+        },
+      },
+    ];
+    expect(findOpsWithNoApiMappings(ops)).toEqual(['someMismappedOp']);
+  });
+
+  it('ignores global flags when deciding there is nothing to map', () => {
+    const ops = [
+      {
+        operationId: 'getSomething',
+        cli: { command: 'neon something', flags: [{ name: 'help' }], positionals: [] },
+      },
+    ];
+    expect(findOpsWithNoApiMappings(ops)).toEqual([]);
+  });
+
+  it('checks each command of a multi-command op and reports the op once', () => {
+    const ops = [
+      {
+        operationId: 'multiOp',
+        cli: {
+          commands: [
+            {
+              command: 'neon a <project_id>',
+              flags: [],
+              positionals: [{ display: '<project_id>', apiEquiv: 'project_id' }],
+            },
+            { command: 'neon b', flags: [{ name: 'unmapped' }], positionals: [] },
+          ],
+        },
+      },
+    ];
+    expect(findOpsWithNoApiMappings(ops)).toEqual(['multiOp']);
   });
 });
 

--- a/src/components/pages/doc/api-operation/__tests__/doc-quick-start.test.jsx
+++ b/src/components/pages/doc/api-operation/__tests__/doc-quick-start.test.jsx
@@ -31,9 +31,9 @@ const operation = {
   cli: {
     command: 'neon projects create',
     flags: [
-      { name: 'name', type: 'string' },
-      { name: 'region-id', type: 'string' },
-      { name: 'pg-version', type: 'integer' },
+      { name: 'name', type: 'string', apiEquiv: 'project.name', apiEquivIn: 'body' },
+      { name: 'region-id', type: 'string', apiEquiv: 'project.region_id', apiEquivIn: 'body' },
+      { name: 'pg-version', type: 'integer', apiEquiv: 'project.pg_version', apiEquivIn: 'body' },
     ],
   },
   mcp: {

--- a/src/components/pages/doc/api-operation/doc-quick-start.jsx
+++ b/src/components/pages/doc/api-operation/doc-quick-start.jsx
@@ -15,18 +15,23 @@ const LABELS = {
   console: 'Console',
 };
 
+// Pre-fill the CLI snippet from the request-body seed, keyed off the body-field
+// mappings the generator already resolved (flag.apiEquiv is the field's dot
+// path when apiEquivIn === 'body'). Matching those paths exactly — rather than
+// re-deriving a leaf name here — keeps this in step with buildCliFlags and
+// avoids mapping the wrong field when a leaf name repeats at two depths
+// (`project.name` vs `project.branch.name` on `neon projects create`).
 function seedToCliEdits(seed, flags) {
   const edits = {};
   const included = new Set();
   if (!seed || !flags?.length) return { edits, included };
 
-  const byName = new Map(flags.map((flag) => [flag.name, flag]));
-  for (const [path, value] of Object.entries(seed)) {
-    const leaf = path.slice(path.lastIndexOf('.') + 1);
-    const flagName = leaf.replaceAll('_', '-');
-    if (!byName.has(flagName)) continue;
-    edits[flagName] = String(value);
-    included.add(flagName);
+  for (const flag of flags) {
+    if (flag.apiEquivIn !== 'body') continue;
+    const value = seed[flag.apiEquiv];
+    if (value === undefined) continue;
+    edits[flag.name] = String(value);
+    included.add(flag.name);
   }
   return { edits, included };
 }


### PR DESCRIPTION
## What

The API reference shows a CLI tab alongside each endpoint. Flags in that tab link back to the API parameter they correspond to, which drives the hover hints and the interactive snippet.

That link only ever compared a flag against path and query parameters. Flags that map to request-body fields found no match, so `neon projects update --name` showed no connection to `project.name`. A tripwire meant to catch gaps then warned about five operations, most of which were fine.

## Changes

- Map flags to nested body fields by dot path (`project.settings.hipaa`), shallowest path winning, tagged with `apiEquivIn: 'parameter' | 'body'`. Mappings go from 82 to 137, adding 55 hover hints across 19 operations including `createProject`, `updateProject`, `createProjectBranch`, and the Neon Auth update family.
- `doc-quick-start` now reads those mappings instead of re-deriving them from leaf names, so the generator and the UI cannot disagree.
- Count positionals and body fields in the tripwire, not just flags. `neon projects delete <project_id>` was reported as unmapped even though its positional maps correctly.
- Fail the build when neonctl declares a global flag that `cli-global-flags.json` is missing. A missing entry made pure-positional commands look unmapped, which is what hid this.
- Drop the `listSharedProjects` CLI mapping.

Warnings go from 5 to 0. No existing mapping changed or was lost.

## listSharedProjects

`neon projects list` does call that endpoint and prints a "Shared with you" section, but it shares no inputs with `GET /projects/shared`: the CLI paginates internally and the endpoint's `cursor`, `limit`, and `search` never surface as flags. Rather than special-case it, the mapping is removed, so the page shows no CLI tab. 111 of 168 operations already have none.

## Testing

661 unit tests pass, including 19 new ones. A regression table pins `--name` to its expected body field on all six commands that declare it, because `neon projects create` has both `project.name` and `project.branch.name` and only shallowest-path-wins picks correctly. Verified against neonctl source (`project.name = props.name`; `project.branch` is populated only from `--database` and `--role`).

Generator output verified against the live spec: 168 operations, zero warnings.

This pull request and its description were written by Isaac.