### PR TITLE
fix: small adjustments docs and blog

### DIFF
--- a/src/app/(blog)/blog-preview/category/[slug]/page.jsx
+++ b/src/app/(blog)/blog-preview/category/[slug]/page.jsx
@@ -57,14 +57,12 @@ const BlogPreviewCategoryPage = async ({ params, searchParams }) => {
           posts={validPosts}
           routeConfig={routeConfig}
         >
-          <div className="grid grid-cols-2 gap-x-16 xl:gap-x-5 md:grid-cols-1 md:pt-[96px]">
+          <div className="grid grid-cols-1 md:pt-24">
             {validPosts.slice(0, 10).map((post, index) => (
               <BlogGridItem
                 key={post.slug}
-                className={index < 2 ? 'lg:border-t-0! lg:pt-0! md:border-t-0! md:pt-0!' : ''}
                 post={post}
                 category={category}
-                isFeatured={post.isFeatured}
                 isPriority={index < 5}
                 routeConfig={routeConfig}
               />

--- a/src/app/(blog)/blog/(index)/category/[slug]/page.jsx
+++ b/src/app/(blog)/blog/(index)/category/[slug]/page.jsx
@@ -42,14 +42,12 @@ const BlogCategoryPage = async ({ params }) => {
           posts={validPosts}
           routeConfig={DEFAULT_BLOG_ROUTE_CONFIG}
         >
-          <div className="grid grid-cols-2 gap-x-16 xl:gap-x-5 md:grid-cols-1 md:pt-[96px]">
+          <div className="grid grid-cols-1 md:pt-24">
             {validPosts.slice(0, 10).map((post, index) => (
               <BlogGridItem
                 key={post.slug}
-                className={index < 2 ? 'lg:border-t-0! lg:pt-0! md:border-t-0! md:pt-0!' : ''}
                 post={post}
                 category={category}
-                isFeatured={post.isFeatured}
                 isPriority={index < 5}
                 routeConfig={DEFAULT_BLOG_ROUTE_CONFIG}
               />

--- a/src/components/pages/blog/blog-post-card/blog-post-card.jsx
+++ b/src/components/pages/blog/blog-post-card/blog-post-card.jsx
@@ -75,7 +75,7 @@ const BlogPostCard = ({
         <Link
           className={cn(
             'group overflow-hidden bg-[#181818]',
-            isSmart ? 'shrink-0' : 'aspect-[40/21] w-full',
+            isSmart ? 'shrink-0' : 'aspect-40/21 w-full',
             fullSize && 'min-w-0 flex-1 basis-[42%] self-start'
           )}
           to={link}
@@ -84,7 +84,7 @@ const BlogPostCard = ({
             className={cn(
               'transition-transform duration-200',
               !isSmart && 'size-full',
-              fullSize ? 'object-contain' : !isSmart && 'object-cover',
+              !isSmart && 'object-cover',
               withImageHover && !fullSize && 'group-hover:scale-110'
             )}
             src={largeCover?.mediaItemUrl}

--- a/src/components/pages/doc/docs-link/docs-link.jsx
+++ b/src/components/pages/doc/docs-link/docs-link.jsx
@@ -5,9 +5,10 @@ import { Children, isValidElement } from 'react';
 
 import LinkPreview from 'components/pages/doc/link-preview';
 import Link from 'components/shared/link';
+import { cn } from 'utils/cn';
 import getGlossaryItem from 'utils/get-glossary-item';
 
-const DocsLink = ({ href, children, ...otherProps }) => {
+const DocsLink = ({ href, children, className = null, ...otherProps }) => {
   const baseUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
   const isExternal = href?.startsWith('http') && !href?.startsWith(baseUrl);
   const isGlossary =
@@ -34,7 +35,13 @@ const DocsLink = ({ href, children, ...otherProps }) => {
     if (glossaryItem) {
       const { title, preview } = glossaryItem;
       return (
-        <LinkPreview href={href} title={title} preview={preview} {...otherProps}>
+        <LinkPreview
+          href={href}
+          title={title}
+          preview={preview}
+          className={className}
+          {...otherProps}
+        >
           {children}
         </LinkPreview>
       );
@@ -48,6 +55,7 @@ const DocsLink = ({ href, children, ...otherProps }) => {
       rel={isExternal ? 'noopener noreferrer' : undefined}
       icon={icon}
       tagName="DocsInlineLink"
+      className={cn(isExternal && 'text-pretty', className)}
       {...otherProps}
     >
       {children}
@@ -58,6 +66,7 @@ const DocsLink = ({ href, children, ...otherProps }) => {
 DocsLink.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };
 
 export default DocsLink;

--- a/src/components/pages/doc/docs-list/docs-list.jsx
+++ b/src/components/pages/doc/docs-list/docs-list.jsx
@@ -11,7 +11,7 @@ import PageIcon from './images/page.inline.svg';
 const Icon = ({ theme = 'default', className = null }) => {
   if (theme === 'docs') return <PageIcon className={cn('top-1', className)} aria-hidden />;
   if (theme === 'repo') return <GitHubIcon className={cn('top-1', className)} aria-hidden />;
-  return <CheckIcon className={cn('top-[12px]', className)} aria-hidden />;
+  return <CheckIcon className={cn('top-1.25', className)} aria-hidden />;
 };
 
 Icon.propTypes = {
@@ -34,7 +34,7 @@ const DocsList = ({ title, theme = 'default', children }) => (
         {title}
       </h3>
     )}
-    <ul className="m-0! flex flex-col gap-y-2 p-0!">
+    <ul className="docs-list m-0! flex flex-col gap-y-3.5 p-0!">
       {parsedChildren(children).map((child, index) => (
         <li
           key={index}

--- a/src/components/pages/doc/docs-list/images/check.inline.svg
+++ b/src/components/pages/doc/docs-list/images/check.inline.svg
@@ -1,3 +1,3 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2 7.33333L4.4 10L10 2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.5 6.5L4 9.5L10.5 2.5" stroke="currentColor" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square"/>
 </svg>

--- a/src/styles/doc-content.css
+++ b/src/styles/doc-content.css
@@ -121,6 +121,11 @@
       @apply my-2!;
     }
 
+    /* DocsList owns its item spacing; do not apply loose Markdown list margins. */
+    & .docs-list li > p {
+      @apply my-0!;
+    }
+
     > h2:first-child,
     > h3:first-child,
     > h4:first-child {


### PR DESCRIPTION
This PR applies a set of small rendering refinements across the docs and blog. It aligns docs list presentation with the design specifications and makes blog category cards and cover images render consistently across older and newer content.

### Docs
- Set docs list item spacing to 14px and prevent Markdown paragraph margins from affecting the layout.
- Update the check icon alignment and color behavior, and improve external-link wrapping so the icon does not hang on its own line.
- [preview](https://neon-next-git-small-adjustments-docs-and-blog-pixelpoint.vercel.app/docs/reference/python-sdk)

### Blog
- Render featured posts as standard full-width rows on blog category pages
- Use cover cropping so legacy 16:9 and current 40:21 images fill their card frames consistently.
- [preview](https://neon-next-git-small-adjustments-docs-and-blog-pixelpoint.vercel.app/blog/category/product)