### PR TITLE
Publish the August AI Gateway catalog and the Anthropic dialect

### DIFF
--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -6,20 +6,20 @@ summary: >-
   Gateway by changing only the base URL. Supports streaming, prompt caching,
   and extended thinking on Claude models.
 enableTableOfContents: true
-updatedOn: '2026-08-06T05:40:01.168Z'
+updatedOn: '2026-08-06T06:41:36.256Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
 
 The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it when you need extended thinking or prompt caching, which require the native Anthropic SDK. For standard completions, the [chat completions](/docs/ai-gateway/chat-completions) endpoint works with all Anthropic models and doesn't require the Anthropic SDK.
 
-**Base URL:** `https://<branch-host>/ai-gateway/anthropic`
+**Base URL:** `https://<branch-host>/anthropic`
 
 <Admonition type="note">
-The Anthropic SDK appends `/v1/messages` to the base URL automatically. Set the base URL to `/ai-gateway/anthropic` (without `/v1`).
+The Anthropic SDK appends `/v1/messages` to the base URL automatically. Set the base URL to `/anthropic` (without `/v1`).
 </Admonition>
 
-This endpoint is also reachable at the shorter `/anthropic/v1/messages` path (no `/ai-gateway` prefix). Both behave identically. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full list of aliases.
+This endpoint is also reachable at the longer `/ai-gateway/anthropic/v1/messages` path. Both behave identically and neither is deprecated. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full list of aliases.
 
 ## Setup
 
@@ -50,7 +50,7 @@ import Anthropic from '@anthropic-ai/sdk';
 
 const client = new Anthropic({
   authToken: process.env.NEON_AI_GATEWAY_TOKEN,
-  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/anthropic`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/anthropic`,
 });
 
 const message = await client.messages.create({
@@ -68,7 +68,7 @@ import os
 
 client = anthropic.Anthropic(
     auth_token=os.environ['NEON_AI_GATEWAY_TOKEN'],
-    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/anthropic",
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/anthropic",
 )
 
 message = client.messages.create(
@@ -81,7 +81,7 @@ print(message.content[0].text)
 ```
 
 ```bash shouldWrap
-curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/anthropic/v1/messages" \
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/anthropic/v1/messages" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -H "anthropic-version: 2023-06-01" \

--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -1,0 +1,230 @@
+---
+title: Anthropic Messages API
+subtitle: Use the Anthropic SDK with Neon AI Gateway
+summary: >-
+  The Anthropic Messages endpoint lets you use the Anthropic SDK with Neon AI
+  Gateway by changing only the base URL. Supports streaming, prompt caching,
+  and extended thinking on Claude models.
+enableTableOfContents: true
+updatedOn: '2026-08-06T05:40:01.168Z'
+---
+
+<FeatureBetaProps feature_name="Neon AI Gateway" />
+
+The Anthropic Messages endpoint exposes the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) through Neon AI Gateway. Use it when you need extended thinking or prompt caching, which require the native Anthropic SDK. For standard completions, the [chat completions](/docs/ai-gateway/chat-completions) endpoint works with all Anthropic models and doesn't require the Anthropic SDK.
+
+**Base URL:** `https://<branch-host>/ai-gateway/anthropic`
+
+<Admonition type="note">
+The Anthropic SDK appends `/v1/messages` to the base URL automatically. Set the base URL to `/ai-gateway/anthropic` (without `/v1`).
+</Admonition>
+
+This endpoint is also reachable at the shorter `/anthropic/v1/messages` path (no `/ai-gateway` prefix). Both behave identically. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full list of aliases.
+
+## Setup
+
+Set these environment variables. See [Get started](/docs/ai-gateway/get-started) for how to obtain them.
+
+```bash
+NEON_AI_GATEWAY_TOKEN=nt_live_...
+NEON_AI_GATEWAY_BASE_URL=https://br-winter-pond-aptw82ef-api.ai.c-2.us-east-2.aws.neon.tech
+```
+
+## Supported models
+
+This endpoint accepts Anthropic models only. See the [AI Gateway catalog](/docs/ai-gateway/models) for the full list. Supported models:
+
+- `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`
+- `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5`, `claude-opus-4-1`
+- `claude-sonnet-4-6`, `claude-sonnet-4-5`
+- `claude-haiku-4-5`
+
+Sending a non-Anthropic model ID returns `400 model "<model-id>" is not available on the anthropic_messages endpoint`, naming whichever model you sent. Use the [chat completions endpoint](/docs/ai-gateway/chat-completions) if you need to call multiple providers from the same code.
+
+## Basic request
+
+<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)", "cURL"]}>
+
+```typescript shouldWrap
+import Anthropic from '@anthropic-ai/sdk';
+
+const client = new Anthropic({
+  authToken: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/anthropic`,
+});
+
+const message = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'What is Neon?' }],
+});
+
+console.log(message.content[0].text);
+```
+
+```python shouldWrap
+import anthropic
+import os
+
+client = anthropic.Anthropic(
+    auth_token=os.environ['NEON_AI_GATEWAY_TOKEN'],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/anthropic",
+)
+
+message = client.messages.create(
+    model='claude-sonnet-4-6',
+    max_tokens=1024,
+    messages=[{'role': 'user', 'content': 'What is Neon?'}],
+)
+
+print(message.content[0].text)
+```
+
+```bash shouldWrap
+curl -X POST "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/anthropic/v1/messages" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-sonnet-4-6",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "What is Neon?"}]
+  }'
+```
+
+</CodeTabs>
+
+## Streaming
+
+Streaming works the same as with the Anthropic SDK directly. Use `client.messages.stream()` or pass `"stream": true` in a cURL request. The only change from standard usage is `base_url`.
+
+## Prompt caching
+
+The gateway forwards the `cache_control` field to Anthropic unchanged. Prompt caching works exactly as described in the [Anthropic prompt caching docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
+
+<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)"]}>
+
+```typescript shouldWrap
+const message = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  system: [
+    { type: 'text', text: 'You are a helpful assistant.' },
+    {
+      type: 'text',
+      text: longDocumentContent,
+      cache_control: { type: 'ephemeral' },
+    },
+  ],
+  messages: [{ role: 'user', content: 'Summarize the key points.' }],
+});
+
+console.log(message.usage);
+// { input_tokens: 50, output_tokens: 200,
+//   cache_creation_input_tokens: 10000, cache_read_input_tokens: 0 }
+```
+
+```python shouldWrap
+message = client.messages.create(
+    model='claude-sonnet-4-6',
+    max_tokens=1024,
+    system=[
+        {'type': 'text', 'text': 'You are a helpful assistant.'},
+        {
+            'type': 'text',
+            'text': long_document_content,
+            'cache_control': {'type': 'ephemeral'},
+        },
+    ],
+    messages=[{'role': 'user', 'content': 'Summarize the key points.'}],
+)
+
+print(message.usage)
+# input_tokens=50, output_tokens=200,
+# cache_creation_input_tokens=10000, cache_read_input_tokens=0
+```
+
+</CodeTabs>
+
+## Extended thinking
+
+The gateway forwards the `thinking` parameter to Anthropic unchanged. Set `budget_tokens` to control how many tokens Claude can use for thinking. `max_tokens` must be greater than `budget_tokens`.
+
+<Admonition type="important">
+The Claude 5 models — `claude-opus-5`, `claude-sonnet-5`, and `claude-fable-5` — do not accept `thinking.type: "enabled"`. They return `400` with:
+
+```
+"thinking.type.enabled" is not supported for this model.
+Use "thinking.type.adaptive" and "output_config.effort" to control thinking.
+```
+
+Use `thinking: { type: 'adaptive' }` with `output_config: { effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' }` instead. `claude-fable-5` also rejects `thinking.type: "disabled"` — it always thinks adaptively.
+
+The Claude 4.x models accept the `enabled` + `budget_tokens` form shown below.
+</Admonition>
+
+<CodeTabs labels={["TypeScript (Anthropic SDK)", "Python (Anthropic SDK)"]}>
+
+```typescript shouldWrap
+const message = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 16000,
+  thinking: {
+    type: 'enabled',
+    budget_tokens: 10000,
+  },
+  messages: [{ role: 'user', content: 'Design a database schema for a multi-tenant SaaS app.' }],
+});
+
+for (const block of message.content) {
+  if (block.type === 'thinking') {
+    console.log('Thinking:', block.thinking);
+  } else if (block.type === 'text') {
+    console.log(block.text);
+  }
+}
+```
+
+```python shouldWrap
+message = client.messages.create(
+    model='claude-sonnet-4-6',
+    max_tokens=16000,
+    thinking={
+        'type': 'enabled',
+        'budget_tokens': 10000,
+    },
+    messages=[{'role': 'user', 'content': 'Design a database schema for a multi-tenant SaaS app.'}],
+)
+
+for block in message.content:
+    if block.type == 'thinking':
+        print('Thinking:', block.thinking)
+    elif block.type == 'text':
+        print(block.text)
+```
+
+</CodeTabs>
+
+## Forwarded headers
+
+The gateway forwards these request headers to the upstream provider:
+`Accept`, `Anthropic-Beta`, `Anthropic-Version`, `Content-Type`, `User-Agent`.
+
+All other headers are stripped. The `Authorization` header is replaced with the workspace credential before forwarding. Your `NEON_AI_GATEWAY_TOKEN` is never sent to Anthropic directly.
+
+## Error handling
+
+| Status            | Message                                                                  | Cause                                     |
+| ----------------- | ------------------------------------------------------------------------ | ----------------------------------------- |
+| `400 Bad Request` | `unknown model "<model-id>"`                                             | Model ID not in the catalog               |
+| `400 Bad Request` | `model "<model-id>" is not available on the anthropic_messages endpoint` | Non-Anthropic model sent to this endpoint |
+
+For authentication, quota, and upstream errors, see [Troubleshooting](/docs/ai-gateway/troubleshooting).
+
+## Next steps
+
+- [Models](/docs/ai-gateway/models): full model catalog
+- [Chat completions](/docs/ai-gateway/chat-completions): use any model including Anthropic via the unified endpoint
+- [Authentication](/docs/ai-gateway/authentication): credential scopes and branch binding
+
+<NeedHelp/>

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-07-20T20:13:30.657Z'
+updatedOn: '2026-08-06T06:41:36.256Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -112,7 +112,7 @@ NEON_AI_GATEWAY_BASE_URL + /openai/v1     → OpenAI Responses API
 NEON_AI_GATEWAY_BASE_URL + /v1/gemini     → Gemini generateContent API
 ```
 
-Each inference dialect is also reachable at a longer `/ai-gateway/<dialect>/v1` path (e.g. `/ai-gateway/mlflow/v1` for chat completions, `/ai-gateway/openai/v1` for Responses, `/ai-gateway/gemini` for Gemini). Both forms behave identically and neither is deprecated. The model list is the exception: it has only `GET /v1/models`, with no `/ai-gateway/...` form. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full mapping.
+Each inference dialect is also reachable at a longer `/ai-gateway/<dialect>/v1` path (e.g. `/ai-gateway/mlflow/v1` for chat completions, `/ai-gateway/openai/v1` for Responses, `/ai-gateway/anthropic/v1` for Anthropic Messages, `/ai-gateway/gemini` for Gemini). Both forms behave identically and neither is deprecated, but the shorter paths are what the docs and SDKs use. The model list is the exception: it has only `GET /v1/models`, with no `/ai-gateway/...` form. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full mapping.
 
 To use an OpenAI SDK, set its `apiKey` and `baseURL` from these variables (see the examples below).
 

--- a/content/docs/ai-gateway/chat-completions.md
+++ b/content/docs/ai-gateway/chat-completions.md
@@ -6,9 +6,7 @@ summary: >-
   Gateway. It is OpenAI Chat Completions-compatible, works with any model in
   the catalog, and lets you switch providers without changing your SDK code.
 enableTableOfContents: true
-redirectFrom:
-  - /docs/ai-gateway/anthropic-messages/
-updatedOn: '2026-07-20T19:53:53.968Z'
+updatedOn: '2026-08-06T05:40:01.168Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -6,7 +6,7 @@ summary: >-
   streamGenerateContent APIs through Neon AI Gateway. Use the google-genai SDK
   with a custom base URL.
 enableTableOfContents: true
-updatedOn: '2026-08-05T16:08:55.589Z'
+updatedOn: '2026-08-06T06:41:36.256Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -15,13 +15,13 @@ The Gemini endpoint exposes the [Google Gemini API](https://ai.google.dev/api/ge
 
 **Supported actions:** `:generateContent` and `:streamGenerateContent`
 
-**Endpoint pattern:** `https://<branch-host>/ai-gateway/gemini/v1beta/models/<model>:<action>`
+**Endpoint pattern:** `https://<branch-host>/v1/gemini/v1beta/models/<model>:<action>`
 
 <Admonition type="note">
 Only `generateContent` and `streamGenerateContent` are supported. Requests to other actions (such as `countTokens`) return `404 unsupported gemini action`.
 </Admonition>
 
-This endpoint also has a shorter alias with no `/ai-gateway` prefix: `https://<branch-host>/v1/gemini/v1beta/models/<model>:<action>`. Both behave identically. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full list of aliases.
+This endpoint is also reachable at the longer `/ai-gateway/gemini/v1beta/models/<model>:<action>` path. Both behave identically and neither is deprecated. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full list of aliases.
 
 ## Setup
 
@@ -59,7 +59,7 @@ import { GoogleGenAI } from '@google/genai';
 const client = new GoogleGenAI({
   apiKey: 'placeholder',
   httpOptions: {
-    baseUrl: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini`,
+    baseUrl: `${process.env.NEON_AI_GATEWAY_BASE_URL}/v1/gemini`,
     headers: {
       Authorization: `Bearer ${process.env.NEON_AI_GATEWAY_TOKEN}`,
     },
@@ -82,7 +82,7 @@ import os
 client = genai.Client(
     api_key='placeholder',
     http_options=types.HttpOptions(
-        base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/ai-gateway/gemini",
+        base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/v1/gemini",
         headers={'Authorization': f"Bearer {os.environ['NEON_AI_GATEWAY_TOKEN']}"},
     ),
 )
@@ -97,7 +97,7 @@ print(response.text)
 
 ```bash shouldWrap
 curl -X POST \
-  "$NEON_AI_GATEWAY_BASE_URL/ai-gateway/gemini/v1beta/models/gemini-3-flash:generateContent" \
+  "$NEON_AI_GATEWAY_BASE_URL/v1/gemini/v1beta/models/gemini-3-flash:generateContent" \
   -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -137,12 +137,12 @@ for chunk in client.models.generate_content_stream(
 The gateway uses the model ID and action directly in the URL path. The `google-genai` SDK constructs this automatically from the base URL and model parameter:
 
 ```
-base_url: https://<branch-host>/ai-gateway/gemini
+base_url: https://<branch-host>/v1/gemini
 model:    gemini-3-flash
 action:   generateContent or streamGenerateContent
 
-→ https://<branch-host>/ai-gateway/gemini/v1beta/models/gemini-3-flash:generateContent
-→ https://<branch-host>/ai-gateway/gemini/v1beta/models/gemini-3-flash:streamGenerateContent
+→ https://<branch-host>/v1/gemini/v1beta/models/gemini-3-flash:generateContent
+→ https://<branch-host>/v1/gemini/v1beta/models/gemini-3-flash:streamGenerateContent
 ```
 
 When calling the REST API directly, the model ID and action must appear in the path as shown above.

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -6,7 +6,7 @@ summary: >-
   OpenAI, Google, Meta, Databricks, and Alibaba. Use short model IDs
   like gpt-5-mini or gemini-3-flash. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-08-06T06:23:44.441Z'
+updatedOn: '2026-08-06T06:43:16.300Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -61,13 +61,14 @@ Most models work with the [Chat completions](/docs/ai-gateway/chat-completions) 
 
 All paths below are appended to your branch's bare AI Gateway host (`NEON_AI_GATEWAY_BASE_URL`).
 
-| Provider                  | Recommended endpoint   | Notes                                                                                    |
-| ------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
-| OpenAI (most models)      | `/v1/chat/completions` | Use `/openai/v1/responses` for Responses API features                                    |
-| OpenAI (codex variants)   | `/openai/v1/responses` | These models require the Responses API and don't work with chat/completions              |
-| Google Gemini             | `/v1/chat/completions` | Use `/ai-gateway/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK |
-| Google Gemma 3 12B        | `/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                           |
-| Meta, Databricks, Alibaba | `/v1/chat/completions` | Chat completions only                                                                    |
+| Provider                                   | Recommended endpoint   | Notes                                                                                        |
+| ------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------- |
+| OpenAI (most models)                       | `/v1/chat/completions` | Use `/openai/v1/responses` for Responses API features                                        |
+| OpenAI (`gpt-5-3-codex`, `gpt-5-5-pro`)    | `/openai/v1/responses` | These models require the Responses API and don't work with chat/completions                  |
+| Anthropic Claude                           | `/v1/chat/completions` | Use `/anthropic/v1/messages` with the Anthropic SDK for extended thinking and prompt caching |
+| Google Gemini                              | `/v1/chat/completions` | Use `/v1/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK             |
+| Google Gemma 3 12B                         | `/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                               |
+| Meta, Alibaba, Zhipu AI, Thinking Machines | `/v1/chat/completions` | Chat completions only                                                                        |
 
 <Admonition type="warning" title="Content shape varies by model">
 For most models, `message.content` in a chat completions response is a plain string. For some models, confirmed on Gemini 3.x (`gemini-3-5-flash`, `gemini-3-1-pro`), `gpt-oss-120b`, and `qwen35-122b-a10b`, it's an array of typed content blocks instead (`{ type: 'reasoning', ... }`, `{ type: 'text', text: ... }`), matching how those models represent output natively. A low `max_tokens` value can also cut a response off before the `text` block appears, leaving only a `reasoning` block. Handle both shapes:

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -6,7 +6,7 @@ summary: >-
   OpenAI, Google, Meta, Databricks, and Alibaba. Use short model IDs
   like gpt-5-mini or gemini-3-flash. The databricks- prefix is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-07-20T19:53:53.968Z'
+updatedOn: '2026-08-06T06:23:44.441Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -91,6 +91,7 @@ Use the shorter paths when you want OpenAI/OpenRouter-style URLs. Use the `/ai-g
 | ------------------------------------------------------- | ---------------------------------------------------------- |
 | `POST /v1/chat/completions`                             | `/ai-gateway/mlflow/v1/chat/completions`                   |
 | `POST /openai/v1/responses`                             | `/ai-gateway/openai/v1/responses`                          |
+| `POST /anthropic/v1/messages`                           | `/ai-gateway/anthropic/v1/messages`                        |
 | `POST /v1/gemini/v1beta/models/{model}:generateContent` | `/ai-gateway/gemini/v1beta/models/{model}:generateContent` |
 
 ### List available models

--- a/content/docs/ai-gateway/openai-responses.md
+++ b/content/docs/ai-gateway/openai-responses.md
@@ -6,7 +6,7 @@ summary: >-
   AI Gateway. Required for codex model variants, which do not work with the
   chat completions endpoint.
 enableTableOfContents: true
-updatedOn: '2026-08-05T16:08:55.589Z'
+updatedOn: '2026-08-06T05:40:01.168Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -38,6 +38,11 @@ This endpoint accepts OpenAI models only:
 
 | Model ID        | Notes                  |
 | --------------- | ---------------------- |
+| `gpt-5-6-sol`   |                        |
+| `gpt-5-6-terra` |                        |
+| `gpt-5-6-luna`  |                        |
+| `gpt-5-5`       |                        |
+| `gpt-5-5-pro`   | Requires this endpoint |
 | `gpt-5-4`       |                        |
 | `gpt-5-4-mini`  |                        |
 | `gpt-5-4-nano`  |                        |

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -856,6 +856,8 @@
               slug: ai-gateway/chat-completions
             - title: OpenAI Responses API
               slug: ai-gateway/openai-responses
+            - title: Anthropic Messages API
+              slug: ai-gateway/anthropic-messages
             - title: Gemini API
               slug: ai-gateway/gemini
         - section: Reference

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -10,6 +10,512 @@
     ],
     "doc": "https://neon.com/docs/ai-gateway/models",
     "models": {
+      "claude-fable-5": {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "provider": "anthropic",
+        "family": "claude-fable",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "open_weights": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-09",
+        "last_updated": "2026-06-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
+      "claude-haiku-4-5": {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "provider": "anthropic",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 63999
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "open_weights": false,
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
+      "claude-opus-4-1": {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1 (latest)",
+        "provider": "anthropic",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 31999
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "open_weights": false,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        }
+      },
+      "claude-opus-4-5": {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "provider": "anthropic",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 63999
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "open_weights": false,
+        "knowledge": "2025-05",
+        "release_date": "2025-11-24",
+        "last_updated": "2025-11-24",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "provider": "anthropic",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 127999
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "open_weights": false,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "claude-opus-4-7": {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "provider": "anthropic",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "open_weights": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "claude-opus-4-8": {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "provider": "anthropic",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "open_weights": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "claude-opus-5": {
+        "id": "claude-opus-5",
+        "name": "Claude Opus 5",
+        "provider": "anthropic",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "open_weights": false,
+        "knowledge": "2026-05",
+        "release_date": "2026-07-24",
+        "last_updated": "2026-07-24",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "claude-sonnet-4-5": {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "provider": "anthropic",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 63999
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "open_weights": false,
+        "knowledge": "2025-07-31",
+        "release_date": "2025-09-29",
+        "last_updated": "2025-09-29",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "provider": "anthropic",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 63999
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "open_weights": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-17",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "claude-sonnet-5": {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "provider": "anthropic",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "open_weights": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-30",
+        "last_updated": "2026-06-30",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
       "gpt-oss-120b": {
         "id": "gpt-oss-120b",
         "name": "GPT OSS 120B",
@@ -527,6 +1033,306 @@
           "cache_read": 0.02
         }
       },
+      "gpt-5-5": {
+        "id": "gpt-5-5",
+        "name": "GPT-5.5",
+        "provider": "openai",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "structured_output": true,
+        "open_weights": false,
+        "knowledge": "2025-12-01",
+        "release_date": "2026-04-23",
+        "last_updated": "2026-04-23",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 45,
+            "cache_read": 1
+          }
+        }
+      },
+      "gpt-5-5-pro": {
+        "id": "gpt-5-5-pro",
+        "name": "GPT-5.5 Pro",
+        "provider": "openai",
+        "family": "gpt-pro",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "structured_output": true,
+        "open_weights": false,
+        "knowledge": "2025-12-01",
+        "release_date": "2026-04-23",
+        "last_updated": "2026-04-23",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
+      "gpt-5-6-luna": {
+        "id": "gpt-5-6-luna",
+        "name": "GPT-5.6 Luna",
+        "provider": "openai",
+        "family": "gpt-luna",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "structured_output": true,
+        "open_weights": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1,
+          "output": 6,
+          "cache_read": 0.1,
+          "tiers": [
+            {
+              "input": 2,
+              "output": 9,
+              "cache_read": 0.2,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 2,
+            "output": 9,
+            "cache_read": 0.2
+          }
+        }
+      },
+      "gpt-5-6-sol": {
+        "id": "gpt-5-6-sol",
+        "name": "GPT-5.6 Sol",
+        "provider": "openai",
+        "family": "gpt-sol",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "structured_output": true,
+        "open_weights": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 45,
+            "cache_read": 1
+          }
+        }
+      },
+      "gpt-5-6-terra": {
+        "id": "gpt-5-6-terra",
+        "name": "GPT-5.6 Terra",
+        "provider": "openai",
+        "family": "gpt-terra",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "structured_output": true,
+        "open_weights": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 2.5,
+          "output": 15,
+          "cache_read": 0.25,
+          "tiers": [
+            {
+              "input": 5,
+              "output": 22.5,
+              "cache_read": 0.5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 5,
+            "output": 22.5,
+            "cache_read": 0.5
+          }
+        }
+      },
       "gemini-3-flash": {
         "id": "gemini-3-flash",
         "name": "Gemini 3 Flash Preview",
@@ -924,6 +1730,96 @@
         "cost": {
           "input": 0.22,
           "output": 2.2
+        }
+      },
+      "glm-5-2": {
+        "id": "glm-5-2",
+        "name": "GLM-5.2",
+        "provider": "zhipuai",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "structured_output": true,
+        "open_weights": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cache_read": 0.26
+        }
+      },
+      "inkling": {
+        "id": "inkling",
+        "name": "Inkling",
+        "provider": "thinkingmachines",
+        "family": "ling",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "open_weights": true,
+        "release_date": "2026-07-15",
+        "last_updated": "2026-07-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 1048576
         }
       }
     }

--- a/src/app/models/capabilities.json
+++ b/src/app/models/capabilities.json
@@ -1,48 +1,131 @@
 {
   "$comment": "Measured behaviour of every model the Neon AI Gateway serves. Produced by calling each model on /v1/chat/completions, its provider-native dialect, and /openai/v1/responses with the web_search and image_generation tools. This is what the gateway DID; models.json is what each model CLAIMS. /models needs both to know which code examples are correct.",
-  "$howToRegenerate": "Re-probe against a branch with all models enabled and replace `models`. Fields per model: id, owner, entitled, chat (conforms | array-content | not-served | not-entitled), deviations[], nativeDialect (openai-responses | gemini | none), responses, webSearch, imageGeneration. CI checks completeness, not freshness \u2014 see the models-rest validator in scripts/verify-agent-endpoints.mjs.",
-  "probedAt": "2026-07-28T22:50:55.124Z",
+  "$howToRegenerate": "Generated from the conformance record in neondatabase/neon-console-code-examples: run `bun run probe:conformance` there, then copy its conformance.json into the shape below. One probe feeds both repos so the console and /models cannot disagree. Fields per model: id, owner, entitled, chat (conforms | array-content | not-served | not-entitled), deviations[], nativeDialect (anthropic | openai-responses | gemini | none), responses, webSearch, imageGeneration. Conformance MUST be measured with a prompt that makes the model reason as well as a trivial one, taking the worse shape: claude-opus-5, claude-sonnet-5 and claude-fable-5 return a compliant string for a trivial prompt and an array of {reasoning, text} parts once they think, and an easy-prompt-only probe is what published all three as `conforms`. CI checks completeness, not freshness - see the models-rest validator in scripts/verify-agent-endpoints.mjs.",
+  "probedAt": "2026-08-05T15:04:33.139Z",
   "models": [
     {
-      "id": "qwen3-next-80b-a3b-instruct",
-      "owner": "alibaba",
+      "id": "claude-fable-5",
+      "owner": "anthropic",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
+      ],
+      "nativeDialect": "anthropic",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "claude-haiku-4-5",
+      "owner": "anthropic",
       "entitled": true,
       "chat": "conforms",
       "deviations": [],
-      "nativeDialect": "none",
+      "nativeDialect": "anthropic",
       "responses": false,
       "webSearch": false,
       "imageGeneration": false
     },
     {
-      "id": "qwen35-122b-a10b",
-      "owner": "alibaba",
+      "id": "claude-opus-4-1",
+      "owner": "anthropic",
       "entitled": true,
-      "chat": "array-content",
-      "deviations": ["content is array[2] of {summary/text/type}, spec requires string"],
-      "nativeDialect": "none",
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "anthropic",
       "responses": false,
       "webSearch": false,
       "imageGeneration": false
     },
     {
-      "id": "gpt-oss-120b",
-      "owner": "databricks",
+      "id": "claude-opus-4-5",
+      "owner": "anthropic",
       "entitled": true,
-      "chat": "array-content",
-      "deviations": ["content is array[2] of {summary/text/type}, spec requires string"],
-      "nativeDialect": "none",
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "anthropic",
       "responses": false,
       "webSearch": false,
       "imageGeneration": false
     },
     {
-      "id": "gpt-oss-20b",
-      "owner": "databricks",
+      "id": "claude-opus-4-6",
+      "owner": "anthropic",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "anthropic",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "claude-opus-4-7",
+      "owner": "anthropic",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "anthropic",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "claude-opus-4-8",
+      "owner": "anthropic",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "anthropic",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "claude-opus-5",
+      "owner": "anthropic",
       "entitled": true,
       "chat": "array-content",
-      "deviations": ["content is array[2] of {summary/text/type}, spec requires string"],
-      "nativeDialect": "none",
+      "deviations": [
+        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
+      ],
+      "nativeDialect": "anthropic",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "claude-sonnet-4-5",
+      "owner": "anthropic",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "anthropic",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "owner": "anthropic",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "anthropic",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "claude-sonnet-5",
+      "owner": "anthropic",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
+      ],
+      "nativeDialect": "anthropic",
       "responses": false,
       "webSearch": false,
       "imageGeneration": false
@@ -53,10 +136,10 @@
       "entitled": true,
       "chat": "array-content",
       "deviations": [
-        "id is null, spec requires string",
-        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
-        "usage.total_tokens is 170, but prompt + completion = 11",
-        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+        "`id` is null; the spec requires a string",
+        "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
+        "`usage.total_tokens` is 344, but prompt + completion is 205",
+        "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
       "responses": false,
@@ -69,10 +152,10 @@
       "entitled": true,
       "chat": "array-content",
       "deviations": [
-        "id is null, spec requires string",
-        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
-        "usage.total_tokens is 252, but prompt + completion = 11",
-        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+        "`id` is null; the spec requires a string",
+        "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
+        "`usage.total_tokens` is 595, but prompt + completion is 248",
+        "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
       "responses": false,
@@ -85,10 +168,10 @@
       "entitled": true,
       "chat": "array-content",
       "deviations": [
-        "id is null, spec requires string",
-        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
-        "usage.total_tokens is 309, but prompt + completion = 11",
-        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+        "`id` is null; the spec requires a string",
+        "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
+        "`usage.total_tokens` is 593, but prompt + completion is 232",
+        "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
       "responses": false,
@@ -101,10 +184,10 @@
       "entitled": true,
       "chat": "array-content",
       "deviations": [
-        "id is null, spec requires string",
-        "content is array[1] of {text/thoughtSignature/type}, spec requires string",
-        "usage.total_tokens is 119, but prompt + completion = 11",
-        "usage.reasoning_tokens is top-level; spec nests it under completion_tokens_details"
+        "`id` is null; the spec requires a string",
+        "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
+        "`usage.total_tokens` is 588, but prompt + completion is 221",
+        "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
       "responses": false,
@@ -123,30 +206,8 @@
       "imageGeneration": false
     },
     {
-      "id": "llama-4-maverick",
-      "owner": "meta",
-      "entitled": true,
-      "chat": "conforms",
-      "deviations": [],
-      "nativeDialect": "none",
-      "responses": false,
-      "webSearch": false,
-      "imageGeneration": false
-    },
-    {
-      "id": "meta-llama-3-1-8b-instruct",
-      "owner": "meta",
-      "entitled": true,
-      "chat": "conforms",
-      "deviations": [],
-      "nativeDialect": "none",
-      "responses": false,
-      "webSearch": false,
-      "imageGeneration": false
-    },
-    {
-      "id": "meta-llama-3-3-70b-instruct",
-      "owner": "meta",
+      "id": "glm-5-2",
+      "owner": "zhipu",
       "entitled": true,
       "chat": "conforms",
       "deviations": [],
@@ -233,6 +294,61 @@
       "imageGeneration": true
     },
     {
+      "id": "gpt-5-5",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-5-pro",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "not-served",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-6-luna",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-6-sol",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
+      "id": "gpt-5-6-terra",
+      "owner": "openai",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "openai-responses",
+      "responses": true,
+      "webSearch": true,
+      "imageGeneration": true
+    },
+    {
       "id": "gpt-5-mini",
       "owner": "openai",
       "entitled": true,
@@ -253,6 +369,100 @@
       "responses": true,
       "webSearch": true,
       "imageGeneration": true
+    },
+    {
+      "id": "gpt-oss-120b",
+      "owner": "databricks",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
+      ],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gpt-oss-20b",
+      "owner": "databricks",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
+      ],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "inkling",
+      "owner": "databricks",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "llama-4-maverick",
+      "owner": "meta",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "meta-llama-3-1-8b-instruct",
+      "owner": "meta",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "meta-llama-3-3-70b-instruct",
+      "owner": "meta",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "qwen3-next-80b-a3b-instruct",
+      "owner": "alibaba",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "qwen35-122b-a10b",
+      "owner": "alibaba",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
+      ],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
     }
   ]
 }

--- a/src/app/models/examples.js
+++ b/src/app/models/examples.js
@@ -183,10 +183,10 @@ const curlChat = (model, nativeDialect, responsesOnly, arrayContent) => {
     return shExample({
       id: 'curl',
       title: 'cURL',
-      endpoint: `/ai-gateway/gemini/v1beta/models/${model}:generateContent`,
+      endpoint: `/v1/gemini/v1beta/models/${model}:generateContent`,
       variantReason:
         'The native Gemini dialect returns a conforming body; /v1/chat/completions does not.',
-      content: `curl "\${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini/v1beta/models/${model}:generateContent" \\
+      content: `curl "\${NEON_AI_GATEWAY_BASE_URL}/v1/gemini/v1beta/models/${model}:generateContent" \\
   -H "Authorization: Bearer \${NEON_AI_GATEWAY_TOKEN}" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/src/app/models/examples.js
+++ b/src/app/models/examples.js
@@ -174,8 +174,12 @@ print(resp.choices[0].message.content)
 `,
   });
 
-const curlChat = (model, nativeDialect, responsesOnly) => {
-  if (nativeDialect === 'gemini') {
+// cURL swaps to a provider-native dialect only when the unified route is the broken one.
+// A native dialect on its own is not a reason to leave `/v1/chat/completions` — the eight
+// conforming Claude models are served at /anthropic/v1/messages too, and showing that
+// instead would trade a portable snippet for a vendor-specific one to fix nothing.
+const curlChat = (model, nativeDialect, responsesOnly, arrayContent) => {
+  if (arrayContent && nativeDialect === 'gemini') {
     return shExample({
       id: 'curl',
       title: 'cURL',
@@ -189,6 +193,25 @@ const curlChat = (model, nativeDialect, responsesOnly) => {
     "contents": [
       {"role": "user", "parts": [{"text": "${CHAT_PROMPT}"}]}
     ]
+  }'
+`,
+    });
+  }
+
+  if (arrayContent && nativeDialect === 'anthropic') {
+    return shExample({
+      id: 'curl',
+      title: 'cURL',
+      endpoint: '/anthropic/v1/messages',
+      variantReason:
+        'The native Anthropic Messages dialect returns a conforming body; /v1/chat/completions returns array content once this model reasons.',
+      content: `curl "\${NEON_AI_GATEWAY_BASE_URL}/anthropic/v1/messages" \\
+  -H "Authorization: Bearer \${NEON_AI_GATEWAY_TOKEN}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${model}",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "${CHAT_PROMPT}"}]
   }'
 `,
     });
@@ -244,7 +267,7 @@ const chatExamples = (model, caps) => {
     examples.push(openaiTsChat(model, responsesOnly), openaiPyChat(model, responsesOnly));
   }
 
-  examples.push(curlChat(model, caps.nativeDialect, responsesOnly));
+  examples.push(curlChat(model, caps.nativeDialect, responsesOnly, arrayContent));
   return examples;
 };
 

--- a/src/app/models/route.test.js
+++ b/src/app/models/route.test.js
@@ -63,7 +63,7 @@ describe('GET /models', () => {
       const { model } = await body(res);
       const curl = model.examples.find((e) => e.id === 'curl');
 
-      expect(curl.endpoint).toContain('/ai-gateway/gemini/v1beta');
+      expect(curl.endpoint).toContain('/v1/gemini/v1beta');
       expect(curl.variantReason).toBeTruthy();
     });
 

--- a/src/app/models/route.test.js
+++ b/src/app/models/route.test.js
@@ -76,6 +76,31 @@ describe('GET /models', () => {
       expect(curl.endpoint).toBe('/v1/chat/completions');
     });
 
+    it('points cURL at Anthropic Messages for a Claude model that returns array content', async () => {
+      const res = await GET(request('?model=claude-opus-5'));
+      const { model } = await body(res);
+      const ids = model.examples.map((e) => e.id);
+      const curl = model.examples.find((e) => e.id === 'curl');
+
+      // Only when it reasons, but the OpenAI SDKs cannot express "sometimes a string".
+      expect(model.capabilities.chat).toBe('array-content');
+      expect(ids).not.toContain('typescript');
+      expect(ids).not.toContain('python');
+      expect(curl.endpoint).toBe('/anthropic/v1/messages');
+      expect(curl.variantReason).toBeTruthy();
+    });
+
+    it('keeps cURL on chat completions for a conforming Claude model', async () => {
+      const res = await GET(request('?model=claude-haiku-4-5'));
+      const { model } = await body(res);
+      const curl = model.examples.find((e) => e.id === 'curl');
+
+      // A native dialect alone is not a reason to leave the portable route.
+      expect(model.capabilities.chat).toBe('conforms');
+      expect(model.capabilities.native_dialect).toBe('anthropic');
+      expect(curl.endpoint).toBe('/v1/chat/completions');
+    });
+
     it('gives Mastra a provider instance when the neon/ string cannot work', async () => {
       const res = await GET(request('?model=gemini-3-5-flash'));
       const { model } = await body(res);

--- a/src/components/pages/doc/ai-gateway-model-index/model-examples.test.js
+++ b/src/components/pages/doc/ai-gateway-model-index/model-examples.test.js
@@ -29,7 +29,7 @@ describe('AI Gateway model examples', () => {
       'npm i @mastra/core ai @neondatabase/ai-sdk-provider'
     );
     expect(languages.find(({ key }) => key === 'curl')?.code).toContain(
-      '/ai-gateway/gemini/v1beta/models/gemini-3-5-flash:generateContent'
+      '/v1/gemini/v1beta/models/gemini-3-5-flash:generateContent'
     );
   });
 

--- a/src/components/pages/doc/ai-gateway-model-index/model-rows.js
+++ b/src/components/pages/doc/ai-gateway-model-index/model-rows.js
@@ -9,7 +9,15 @@
  * each model already carries its underlying maker in `provider`.
  */
 
-const PROVIDER_ORDER = ['anthropic', 'openai', 'google', 'meta', 'alibaba'];
+const PROVIDER_ORDER = [
+  'anthropic',
+  'openai',
+  'google',
+  'meta',
+  'alibaba',
+  'zhipuai',
+  'thinkingmachines',
+];
 
 const PROVIDER_LABELS = {
   anthropic: 'Anthropic',
@@ -17,6 +25,8 @@ const PROVIDER_LABELS = {
   google: 'Google',
   meta: 'Meta',
   alibaba: 'Alibaba',
+  zhipuai: 'Zhipu AI',
+  thinkingmachines: 'Thinking Machines',
 };
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -64,6 +74,7 @@ const deriveEndpoints = (capability) => {
   const endpoints = [];
   if (capability.chat !== 'not-served') endpoints.push('chat/completions');
   if (capability.nativeDialect === 'gemini') endpoints.push('gemini');
+  if (capability.nativeDialect === 'anthropic') endpoints.push('anthropic/messages');
   if (capability.responses) endpoints.push('openai/responses');
   return endpoints;
 };

--- a/src/scripts/generate-models-json.js
+++ b/src/scripts/generate-models-json.js
@@ -69,9 +69,22 @@ const KEY_ORDER = [
 ];
 
 // Sort order for providers in the output.
-const PROVIDER_ORDER = ['anthropic', 'openai', 'google', 'meta', 'alibaba'];
+const PROVIDER_ORDER = [
+  'anthropic',
+  'openai',
+  'google',
+  'meta',
+  'alibaba',
+  'zhipuai',
+  'thinkingmachines',
+];
 
 // Derive the underlying model provider from family (falling back to id).
+//
+// This is the organisation that *made* the model, matching the models.dev provider
+// ids, not the `owned_by` the gateway reports — the gateway serves `inkling` as
+// `databricks` and `glm-5-2` as `zhipu` because Databricks Model Serving hosts them.
+// Both fields are published: this one on /models.json, `owned_by` on /v1/models.
 function providerFor(model) {
   const family = typeof model.family === 'string' ? model.family : '';
   const id = typeof model.id === 'string' ? model.id : '';
@@ -86,7 +99,11 @@ function providerFor(model) {
             ? 'meta'
             : s.startsWith('qwen')
               ? 'alibaba'
-              : undefined;
+              : s.startsWith('glm')
+                ? 'zhipuai'
+                : s === 'ling' || s.startsWith('inkling')
+                  ? 'thinkingmachines'
+                  : undefined;
   return match(family) || match(id) || (id.includes('llama') ? 'meta' : undefined);
 }
 


### PR DESCRIPTION
## The problem

The published catalog described a gateway that no longer existed. `/models.json` carried 27
models and `/models` 21, while the gateway served **39**. The committed probe behind `/models`
was stamped `2026-07-28`.

Depends on [anomalyco/models.dev#4087](https://github.com/anomalyco/models.dev/pull/4087), now
merged and deployed — `data.json` is generated from it, so this could not land first.

- **Added (18):** eleven Anthropic ids returning from the temporary removal, plus `gpt-5-5`,
  `gpt-5-5-pro`, `gpt-5-6-luna`, `gpt-5-6-sol`, `gpt-5-6-terra`, `glm-5-2` (Zhipu AI) and
  `inkling` (Thinking Machines).
- **Removed (7):** `claude-sonnet-4`, `gemini-2-5-flash`, `gemini-2-5-pro`, `gemini-3-pro`,
  `gpt-5-1-codex-max`, `gpt-5-1-codex-mini`, `gpt-5-2-codex` — confirmed gone on every route.

## Three models changed verdict, and that is the interesting part

`claude-opus-5`, `claude-sonnet-5` and `claude-fable-5` return `content` as an `array[2]` of
`{reasoning, text}` — **but only when the request actually makes them reason.** For a trivial
prompt all three return a spec-compliant string.

The probe that produced the old `capabilities.json` sent exactly one trivial prompt, which is how
all three would have been published as `conforms`. `capabilities.json` is now generated from the
conformance record in `neondatabase/neon-console-code-examples`, which sends a trivial *and* a
reasoning prompt and takes the worse shape. One measurement, two consumers, so the console and
`/models` cannot disagree.

They are therefore treated as array-content models: **the OpenAI SDK examples are omitted.** An
intermittent type violation is worse for a typed SDK than a constant one — the snippet works until
the model decides to think.

## The user-facing API

`GET /models` gains `native_dialect: "anthropic"`, a value nothing consumed before. cURL follows
the rule Gemini already established — *a native dialect is a reason to leave the unified route
only when the unified route is the broken one*:

```jsonc
// GET /models?model=claude-opus-5   → array content when reasoning
{ "capabilities": { "chat": "array-content", "native_dialect": "anthropic" },
  "examples": [ "ai-sdk", "mastra", "curl" ] }            // typescript + python omitted
```

```bash
# the cURL example those three now get
curl "${NEON_AI_GATEWAY_BASE_URL}/anthropic/v1/messages" \
  -H "Authorization: Bearer ${NEON_AI_GATEWAY_TOKEN}" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-opus-5","max_tokens":1024,
       "messages":[{"role":"user","content":"..."}]}'
```

```jsonc
// GET /models?model=claude-haiku-4-5   → conforms, so it keeps the portable snippet
{ "capabilities": { "chat": "conforms", "native_dialect": "anthropic" },
  "examples": [ "ai-sdk", "mastra", "typescript", "python", "curl" ] }
```

`deriveEndpoints` now reports `anthropic/messages`, so the docs table and the LLM markdown mirror
list it too.

## Docs

Restores `content/docs/ai-gateway/anthropic-messages.md`, removed in #5313 when the models were
pulled. `/anthropic/v1/messages` returns 200 for all eleven ids again. The page is back in the
APIs nav, its model list is current, and the `redirectFrom` on `chat-completions.md` is dropped.

It documents a trap worth knowing about, verified on **both** the native and unified routes:

```
"thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking.
```

The Claude 5 models reject the `enabled` + `budget_tokens` form the 4.x models use.
`claude-fable-5` additionally rejects `disabled` — it always thinks adaptively.

`openai-responses.md`'s hand-written table gains the five new OpenAI ids, with `gpt-5-5-pro`
marked "Requires this endpoint" like `gpt-5-3-codex`.

## What the table looks like now

The model index renders all 39 rows with the two new providers labelled "Zhipu AI" and
"Thinking Machines", and the Anthropic Messages API page is back in the APIs nav. Verified in a
browser against the dev server rather than from the unit tests. Screenshots attached in a comment
below.

## Verification

- `npm run generate:models` — **the generator refused to run** until `providerFor()` learned the
  two new families. It exits non-zero rather than guessing, which is the behaviour you want; it
  now derives `zhipuai` and `thinkingmachines`.
- `npm run check:models-sync` — in sync, 39 models match upstream.
- `npm run verify:agent-endpoints` — 8/8 endpoints, 29/29 checks.
- `npm run test:unit:run` — 679 passed, including two new cases covering the Anthropic branch and
  the conforming-Claude case that must *not* take it.
- `npm run check:skills-sync` — all 9 skills match upstream.
- `npm run lint:js` — 0 errors (13 pre-existing warnings).
- **Ran locally against the dev server**, not just tested: `/models` returns 39 with correct
  dialects and example sets, and `/docs/ai-gateway/anthropic-messages`, `/models` and
  `/openai-responses` all render 200 with the new content.

## Flagging

- **`gpt-5-5-pro` and `inkling` have no pricing.** models.dev ships them without `[cost]` because
  neither has a Databricks serving price published and the first-party numbers describe a
  different product. The table renders `—` for them.
- **No provider logo for Zhipu AI or Thinking Machines.** Neither is in `react-icons/si` and I did
  not want to hand-draw brand marks. `ProviderLogo` already returns `null` when an icon is
  missing, so those rows render label-only — a small visual inconsistency, not a break.
- `provider` on `/models.json` is the model's *maker*; `owned_by` on the gateway's `/v1/models` is
  the serving owner. They now visibly disagree for `inkling` (`thinkingmachines` vs `databricks`)
  and `glm-5-2` (`zhipuai` vs `zhipu`). Both are published and the generator comment explains
  which is which, but it is worth a second opinion.
- `check:models-endpoint-sync` is a live check against production and will only be meaningful
  after this deploys.
