### PR TITLE
docs: drop /v1 prefix from customer-facing Gemini endpoint

### DIFF
--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -109,7 +109,7 @@ Append the dialect path for the endpoint you need:
 ```
 NEON_AI_GATEWAY_BASE_URL + /v1            → chat completions (all providers)
 NEON_AI_GATEWAY_BASE_URL + /openai/v1     → OpenAI Responses API
-NEON_AI_GATEWAY_BASE_URL + /v1/gemini     → Gemini generateContent API
+NEON_AI_GATEWAY_BASE_URL + /gemini        → Gemini generateContent API
 ```
 
 Each inference dialect is also reachable at a longer `/ai-gateway/<dialect>/v1` path (e.g. `/ai-gateway/mlflow/v1` for chat completions, `/ai-gateway/openai/v1` for Responses, `/ai-gateway/gemini` for Gemini). Both forms behave identically and neither is deprecated. The model list is the exception: it has only `GET /v1/models`, with no `/ai-gateway/...` form. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full mapping.

--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -21,7 +21,7 @@ The Gemini endpoint exposes the [Google Gemini API](https://ai.google.dev/api/ge
 Only `generateContent` and `streamGenerateContent` are supported. Requests to other actions (such as `countTokens`) return `404 unsupported gemini action`.
 </Admonition>
 
-This endpoint also has a shorter alias with no `/ai-gateway` prefix: `https://<branch-host>/v1/gemini/v1beta/models/<model>:<action>`. Both behave identically. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full list of aliases.
+This endpoint also has a shorter alias with no `/ai-gateway` prefix: `https://<branch-host>/gemini/v1beta/models/<model>:<action>`. Both behave identically. See [Shorter paths](/docs/ai-gateway/models#shorter-v1-paths) for the full list of aliases.
 
 ## Setup
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -91,7 +91,7 @@ Use the shorter paths when you want OpenAI/OpenRouter-style URLs. Use the `/ai-g
 | ------------------------------------------------------- | ---------------------------------------------------------- |
 | `POST /v1/chat/completions`                             | `/ai-gateway/mlflow/v1/chat/completions`                   |
 | `POST /openai/v1/responses`                             | `/ai-gateway/openai/v1/responses`                          |
-| `POST /v1/gemini/v1beta/models/{model}:generateContent` | `/ai-gateway/gemini/v1beta/models/{model}:generateContent` |
+| `POST /gemini/v1beta/models/{model}:generateContent`    | `/ai-gateway/gemini/v1beta/models/{model}:generateContent` |
 
 ### List available models
 

--- a/content/docs/ai-gateway/troubleshooting.md
+++ b/content/docs/ai-gateway/troubleshooting.md
@@ -53,7 +53,7 @@ The model exists in the catalog but doesn't work with the endpoint you're callin
 **Fix:** Check which endpoint the model requires:
 
 - OpenAI codex models on `/v1/chat/completions` → use `/openai/v1/responses`
-- Google models on `/openai/v1/responses` → use `/v1/gemini/v1beta/...` or `/v1/chat/completions`
+- Google models on `/openai/v1/responses` → use `/gemini/v1beta/...` or `/v1/chat/completions`
 
 See [Which endpoint to use](/docs/ai-gateway/models#which-endpoint-to-use).
 


### PR DESCRIPTION
The customer-facing Gemini route changes from /v1/gemini/v1beta/... to /gemini/v1beta/... to match the provider-prefixed convention used by /openai/v1/* (Google's own /v1beta version stays in the path). The longer /ai-gateway/gemini/... alias is unchanged.

Companion to databricks-eng/neon-cloud#9385.

Co-authored-by: Isaac