### PR TITLE
docs: modernize the Nuxt guide to use the Neon CLI

### DIFF
--- a/content/docs/guides/nuxt.md
+++ b/content/docs/guides/nuxt.md
@@ -9,7 +9,7 @@ summary: >-
   covering CLI setup, driver selection (Neon serverless driver, node-postgres,
   or postgres.js), and reading the connection string in server code.
 enableTableOfContents: true
-updatedOn: '2026-08-11T21:10:25.139Z'
+updatedOn: '2026-08-11T22:46:22.787Z'
 ---
 
 <CopyPrompt src="/prompts/nuxt-neon-prompt.md"
@@ -36,6 +36,8 @@ neon auth
 neon projects create --name my-app
 ```
 
+If you belong to more than one organization, the CLI prompts you to choose one. To skip the prompt, pass `--org-id <id>` (find it with `neon orgs list`).
+
 You'll link this project and pull its credentials in a later step.
 
 </TabItem>
@@ -52,7 +54,15 @@ You'll link this project and pull its credentials in a later step.
 
 ## Create a Nuxt project and add dependencies
 
-1. Create a Nuxt project if you do not have one, then change into its directory. `npm create nuxt@latest my-app && cd my-app` scaffolds a new app and enters it; see [Create a Nuxt Project](https://nuxt.com/docs/getting-started/installation#new-project) for details. The CLI commands in the next step run from this directory.
+1. Create a Nuxt project if you do not have one, then change into its directory. The scaffolder is interactive (it asks about the template, package manager, git, and modules); for CI or an AI agent, pass those as flags to run non-interactively. See [Create a Nuxt Project](https://nuxt.com/docs/getting-started/installation#new-project) for details. The CLI commands in the next step run from this directory.
+
+   ```bash filename="Terminal"
+   # Interactive (human):
+   npm create nuxt@latest my-app && cd my-app
+
+   # Non-interactive (CI / AI agents):
+   npm create nuxt@latest my-app -- --template minimal --packageManager npm --no-gitInit --modules "" && cd my-app
+   ```
 
 2. Add a Postgres driver. This guide's examples use the Neon serverless driver, which suits serverless and edge deployments; for long-lived servers, `pg` or `postgres.js` are recommended. See [Choosing your connection method](/docs/connect/choose-connection).
 
@@ -84,11 +94,15 @@ From your project directory, link the app to your Neon project and pull its conn
 
 ```bash filename="Terminal"
 neon link                    # connects this directory to your project (writes .neon)
-neon checkout main           # pins the branch
-neon env pull --file .env    # writes DATABASE_URL into .env
+neon env pull --file .env    # writes DATABASE_URL from your default branch into .env
 ```
 
-If you haven't signed in to the CLI yet, run `neon auth` first. CLI-created projects get a default branch named `main`; if yours differs (Console-created projects use `production`), run `neon branches list` to check. `neon env pull` defaults to `.env.local`, but `nuxt dev` only loads `.env`, so pass `--file .env`.
+Notes:
+
+- Not signed in yet? Run `neon auth` first.
+- `neon link` prompts for an org and project. To skip the prompts, pass `--project-id <id>` (find IDs with `neon projects list`).
+- For Nuxt, pass in `--file .env` to `neon env pull` as it writes to `.env.local` by default, and `nuxt dev` only reads `.env` by default.
+- Which branch? `neon env pull` uses your project's default branch: `main` for CLI-created projects, `production` for Console-created ones (`neon branches list` shows yours). To use a different branch, run `neon checkout <branch>` first; it re-pins the branch in `.neon` so the next `env pull` reads from it.
 
 </TabItem>
 
@@ -137,7 +151,7 @@ Start the dev server:
 npm run dev
 ```
 
-Then open [localhost:3000/api/version](http://localhost:3000/api/version). The route returns your Postgres version, confirming the connection:
+Then open `localhost:3000/api/version`. The route returns your Postgres version, confirming the connection:
 
 ```json
 { "version": "PostgreSQL 18.4 on aarch64-unknown-linux-gnu, compiled by gcc ..." }

--- a/content/docs/guides/nuxt.md
+++ b/content/docs/guides/nuxt.md
@@ -2,15 +2,14 @@
 title: Connect Nuxt to Postgres on Neon
 subtitle: Learn how to make server-side queries to Postgres using Nitro API routes
 summary: >-
-  Connecting Nuxt (Vue meta-framework) to a serverless Postgres database on
-  Neon requires wiring the connection string through Nuxt runtime config and
-  running SQL inside a Nitro server-side API route using `defineCachedEventHandler`.
-  Choose this guide when building a full-stack Nuxt app that needs server-side
-  Postgres queries, covering driver selection (Neon serverless driver,
-  node-postgres, or postgres.js), `.env` credential storage, and
-  `nuxt.config.js` setup.
+  Connect Nuxt (Vue meta-framework) to serverless Postgres on Neon: use the Neon
+  CLI to create the project and pull DATABASE_URL into your .env, then run SQL
+  from a Nitro server route with the Neon serverless driver. Choose this guide
+  when building a full-stack Nuxt app that needs server-side Postgres queries,
+  covering CLI setup, driver selection (Neon serverless driver, node-postgres,
+  or postgres.js), and reading the connection string in server code.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-08-11T21:10:25.139Z'
 ---
 
 <CopyPrompt src="/prompts/nuxt-neon-prompt.md"
@@ -24,22 +23,43 @@ To create a Neon project and access it from a Nuxt.js application:
 
 ## Create a Neon project
 
-If you do not have one already, create a Neon project. Save your connection details including your password. They are required when defining connection settings.
+Create a Neon project with the [Neon CLI](/docs/cli/install) or the Console.
+
+<Tabs labels={["Neon CLI", "Console"]}>
+
+<TabItem>
+
+Install the CLI (`npm i -g neon`), then sign in and create the project:
+
+```bash filename="Terminal"
+neon auth
+neon projects create --name my-app
+```
+
+You'll link this project and pull its credentials in a later step.
+
+</TabItem>
+
+<TabItem>
 
 1. Navigate to the [Projects](https://console.neon.tech/app/projects) page in the Neon Console.
 2. Click **New Project**.
 3. Specify your project settings and click **Create Project**.
 
+</TabItem>
+
+</Tabs>
+
 ## Create a Nuxt project and add dependencies
 
-1. Create a Nuxt project if you do not have one. For instructions, see [Create a Nuxt Project](https://nuxt.com/docs/getting-started/installation#new-project), in the Nuxt documentation.
+1. Create a Nuxt project if you do not have one, then change into its directory. `npm create nuxt@latest my-app && cd my-app` scaffolds a new app and enters it; see [Create a Nuxt Project](https://nuxt.com/docs/getting-started/installation#new-project) for details. The CLI commands in the next step run from this directory.
 
-2. Add project dependencies using one of the following commands:
+2. Add a Postgres driver. This guide's examples use the Neon serverless driver, which suits serverless and edge deployments; for long-lived servers, `pg` or `postgres.js` are recommended. See [Choosing your connection method](/docs/connect/choose-connection).
 
-   <CodeTabs reverse={true} labels={["node-postgres", "postgres.js", "Neon serverless driver"]}>
+   <CodeTabs labels={["Neon serverless driver", "postgres.js", "node-postgres"]}>
 
    ```shell
-   npm install pg
+   npm install @neondatabase/serverless
    ```
 
    ```shell
@@ -47,63 +67,80 @@ If you do not have one already, create a Neon project. Save your connection deta
    ```
 
    ```shell
-   npm install @neondatabase/serverless
+   npm install pg
    ```
 
    </CodeTabs>
 
 ## Store your Neon credentials
 
-Add a `.env` file to your project directory and add your Neon connection string to it. You can find your connection string by clicking the **Connect** button on your **Project Dashboard** to open the **Connect to your database** modal. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
+Get your `DATABASE_URL` into a `.env` file the app can read.
 
-```shell shouldWrap
-NUXT_DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech:<port>/<dbname>?sslmode=require&channel_binding=require"
+<Tabs labels={["Neon CLI", "Console"]}>
+
+<TabItem>
+
+From your project directory, link the app to your Neon project and pull its connection string:
+
+```bash filename="Terminal"
+neon link                    # connects this directory to your project (writes .neon)
+neon checkout main           # pins the branch
+neon env pull --file .env    # writes DATABASE_URL into .env
 ```
+
+If you haven't signed in to the CLI yet, run `neon auth` first. CLI-created projects get a default branch named `main`; if yours differs (Console-created projects use `production`), run `neon branches list` to check. `neon env pull` defaults to `.env.local`, but `nuxt dev` only loads `.env`, so pass `--file .env`.
+
+</TabItem>
+
+<TabItem>
+
+Add a `.env` file and paste your connection string, which you can copy from the **Connect** button on your **Project Dashboard**. For more information, see [Connect from any application](/docs/connect/connect-from-any-app).
+
+```shell filename=".env" shouldWrap
+DATABASE_URL="postgresql://<user>:<password>@<endpoint_hostname>.neon.tech/<dbname>?sslmode=require&channel_binding=require"
+```
+
+</TabItem>
+
+</Tabs>
 
 ## Configure the Postgres client
 
-First, make sure you load the `NUXT_DATABASE_URL` from your .env file in Nuxt’s runtime configuration:
+The connection string is a server-side secret, so query it from Nitro server code, which reads `process.env.DATABASE_URL` directly (no `runtimeConfig` needed).
 
-In `nuxt.config.js`:
+This example uses the Neon serverless driver (`@neondatabase/serverless`). Create a server utility that holds the database client:
 
-```javascript
-export default defineNuxtConfig({
-  runtimeConfig: {
-    databaseUrl: ‘’,
-  },
+```typescript filename="server/utils/db.ts"
+import { neon } from '@neondatabase/serverless';
+
+export const sql = neon(process.env.DATABASE_URL!);
+```
+
+Then use it in a server API route. Files in `server/utils/` are auto-imported, so `sql` is available without an import:
+
+```typescript filename="server/api/version.get.ts"
+export default defineEventHandler(async () => {
+  const [row] = await sql`SELECT version()`;
+  return row;
 });
 ```
 
-Next, use the Neon serverless driver to create a database connection. Here’s an example configuration:
-
-```javascript
-import { neon } from '@neondatabase/serverless';
-
-export default defineCachedEventHandler(
-  async (event) => {
-    const { databaseUrl } = useRuntimeConfig();
-    const db = neon(databaseUrl);
-    const result = await db`SELECT version()`;
-    return result;
-  },
-  {
-    maxAge: 60 * 60 * 24, // cache it for a day
-  }
-);
-```
-
 <Admonition type="note">
-- This example demonstrates using the Neon serverless driver to run a simple query. The `useRuntimeConfig` method accesses the `databaseUrl` set in your Nuxt runtime configuration.
-- Async Handling: Make sure the handler is async if you are awaiting the database query result.
-- Make sure `maxAge` caching fits your application’s needs. In this example, it’s set to cache results for a day. Adjust as necessary.
+Keep the database client in `server/` only. Never import `server/utils/db.ts` from a Vue component or `app/` code; the connection string must stay server-side.
 </Admonition>
 
 ## Run the app
 
-When you run `npm run dev` you can expect to see the following on [localhost:3000](localhost:3000):
+Start the dev server:
 
-```shell shouldWrap
-PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
+```bash filename="Terminal"
+npm run dev
+```
+
+Then open [localhost:3000/api/version](http://localhost:3000/api/version). The route returns your Postgres version, confirming the connection:
+
+```json
+{ "version": "PostgreSQL 18.4 on aarch64-unknown-linux-gnu, compiled by gcc ..." }
 ```
 
 </Steps>

--- a/public/prompts/nuxt-neon-prompt.md
+++ b/public/prompts/nuxt-neon-prompt.md
@@ -2,7 +2,7 @@
 
 **Role:** You are an expert software agent specializing in TypeScript and the Nuxt.js framework. Your task is to configure the current Nuxt.js project to connect to a Neon Postgres database.
 
-**Purpose:** To connect the current Nuxt.js project to Neon Postgres by installing a database driver, securely configuring environment variables via runtime config, creating a server-only database module, and implementing both a server-rendered page and an API route to validate the connection.
+**Purpose:** To connect the current Nuxt.js project to Neon Postgres by installing a database driver, storing the connection string in `.env` as `DATABASE_URL`, creating a server-only database module that reads it from `process.env`, and implementing both a server-rendered page and an API route to validate the connection.
 
 **Scope:**
 - Must be run inside an existing Nuxt.js project directory.
@@ -31,13 +31,12 @@ When this prompt is triggered, automatically configure the open Nuxt.js project 
 
 ### 1. Install Dependencies
 
-1.  **Prompt the user to select a PostgreSQL driver.** Present the following options:
+1.  **Prompt the user to select a PostgreSQL driver.** The best choice depends on where they deploy:
 
-    -   **`@neondatabase/serverless` (Recommended):** Optimized for serverless and edge functions with HTTP connections. The ideal choice for Nuxt applications deployed on Vercel or Netlify.
-    -   **`postgres` (postgres.js):** A fast, full-featured client, excellent for long-running Node.js server environments.
-    -   **`pg` (node-postgres):** The classic, widely-used driver for Node.js.
+    -   **`@neondatabase/serverless`:** Connects over HTTP/WebSocket. Best for serverless and edge platforms without their own pooling (Netlify, Deno Deploy, Cloudflare Workers).
+    -   **`postgres` (postgres.js) or `pg` (node-postgres):** Standard TCP drivers. Best for long-lived servers (Railway, Render, a VPS, Docker), and for Vercel/Cloudflare with their platform pooling.
 
-    Make sure to ask the user to choose one of the above options and do not proceed until they provide their choice. Clearly explain the pros of each option to help them decide.
+    Ask the user to choose one and do not proceed until they do. For a full breakdown, point them to https://neon.com/docs/connect/choose-connection.
 
 2.  Based on the user's selection, run the corresponding installation command:
 
@@ -57,23 +56,14 @@ When this prompt is triggered, automatically configure the open Nuxt.js project 
 ### 2. Configure Environment Variables
 
 1.  Check for the presence of a `.env` file at the root of the project. If it doesn't exist, create one.
-2.  Add the following `NUXT_DATABASE_URL` parameter to the `.env` file and **prompt the user to replace the placeholder value** with their complete connection string from Neon.
+2.  Add the following `DATABASE_URL` parameter to the `.env` file and **prompt the user to replace the placeholder value** with their complete connection string from Neon.
 
     ```dotenv title=".env"
-    NUXT_DATABASE_URL="postgresql://user:password@endpoint.neon.tech/neondb?sslmode=require&channel_binding=require"
+    DATABASE_URL="postgresql://user:password@endpoint.neon.tech/neondb?sslmode=require&channel_binding=require"
     ```
 
-3.  Direct the user to find this value in the **Neon Console → Project → Connect**.
-4.  **Update the Nuxt configuration** to expose the environment variable securely to the server side. Open `nuxt.config.ts` and add the `runtimeConfig` block:
-
-    ```typescript title="nuxt.config.ts"
-    export default defineNuxtConfig({
-      // Other config...
-      runtimeConfig: {
-        databaseUrl: process.env.NUXT_DATABASE_URL,
-      },
-    })
-    ```
+3.  Direct the user to find this value in the **Neon Console → Project → Connect**, or by running `neon env pull --file .env` from a linked project directory. (`neon env pull` defaults to `.env.local`, but `nuxt dev` only loads `.env`, so pass `--file .env`.)
+4.  No `nuxt.config.ts` change is needed. The connection string is a server-side secret, so the server code below reads `process.env.DATABASE_URL` directly. Do not route it through `runtimeConfig`: a server-only value doesn't need it, and Nuxt does not replace a `runtimeConfig` default set from a differently named `process.env` variable at runtime.
 
 ---
 
@@ -83,15 +73,14 @@ To manage the database connection according to Nuxt conventions, create a server
 
 1.  Ensure the `server/utils/` directory exists. If not, create it.
 2.  Create a new file at `server/utils/db.ts`.
-3.  **Use the code block that corresponds to the driver selected in Step 1** to populate this file. This module will initialize and export the database client.
+3.  **Use the code block that corresponds to the driver selected in Step 1** to populate this file. Each reads `process.env.DATABASE_URL` directly and exports the database client.
 
     #### Option A: Using `@neondatabase/serverless`
 
     ```typescript title="server/utils/db.ts"
     import { neon } from '@neondatabase/serverless';
 
-    const config = useRuntimeConfig();
-    export const sql = neon(config.databaseUrl);
+    export const sql = neon(process.env.DATABASE_URL!);
     ```
 
     #### Option B: Using `postgres` (postgres.js)
@@ -99,8 +88,7 @@ To manage the database connection according to Nuxt conventions, create a server
     ```typescript title="server/utils/db.ts"
     import postgres from 'postgres';
 
-    const config = useRuntimeConfig();
-    export const sql = postgres(config.databaseUrl);
+    export const sql = postgres(process.env.DATABASE_URL!);
     ```
 
     #### Option C: Using `pg` (node-postgres)
@@ -108,9 +96,8 @@ To manage the database connection according to Nuxt conventions, create a server
     ```typescript title="server/utils/db.ts"
     import { Pool } from 'pg';
 
-    const config = useRuntimeConfig();
     export const pool = new Pool({
-      connectionString: config.databaseUrl,
+      connectionString: process.env.DATABASE_URL,
     });
     ```
 
@@ -183,7 +170,7 @@ const { data, error } = await useFetch('/api/version');
 
 Once the file modifications are complete:
 
-1.  Verify the user has correctly set their `NUXT_DATABASE_URL` in the `.env` file. Do not proceed if placeholder values are still present.
+1.  Verify the user has correctly set their `DATABASE_URL` in the `.env` file. Do not proceed if placeholder values are still present.
 2.  Start the Nuxt.js development server:
     ```bash
     npm run dev
@@ -198,14 +185,14 @@ Once the file modifications are complete:
 
 Before suggesting code or making edits, ensure:
 - The project has `nuxt`, and a supported PostgreSQL driver installed.
-- A `.env` file is present or has been created with a `NUXT_DATABASE_URL` key.
-- `nuxt.config.ts` correctly defines a `runtimeConfig.databaseUrl`.
-- A server utility exists at `server/utils/db.ts` and correctly uses `useRuntimeConfig`.
+- A `.env` file is present or has been created with a `DATABASE_URL` key.
+- A server utility exists at `server/utils/db.ts` and reads `process.env.DATABASE_URL`.
 - An API route exists at `server/api/version.get.ts` and uses the database client.
 
 ---
 
 ## ❌ Do Not
 
-- **Do not hardcode credentials** or sensitive information in any source code file. Always use Nuxt's `runtimeConfig` and an `.env` file.
+- **Do not hardcode credentials** or sensitive information in any source code file. Always read `process.env.DATABASE_URL` from an `.env` file.
+- **Do not import `server/utils/db.ts` from a Vue component or `app/` code.** The connection string must stay server-side.
 - **Do not output the user's connection string** in any response or log.


### PR DESCRIPTION
## Overview

Modernizes the Nuxt guide's connect flow to use the Neon CLI. Instead of copying a connection string from the Console, readers run `neon link` and `neon env pull` to get `DATABASE_URL` into `.env`, then read it from `process.env` in a Nitro server route. This drops the older `runtimeConfig` / `NUXT_` prefix setup, which isn't needed for a server-side secret.

The guide leads with the Neon serverless driver and links to the connection-method guide for choosing between drivers. The companion CopyPrompt file is updated to match.

Verified end-to-end against a live Neon database (all three drivers).

This pull request and its description were written by Isaac.
