### PR TITLE
fix: allow cross-origin browser fetches of /models

### DIFF
--- a/src/app/models/route.js
+++ b/src/app/models/route.js
@@ -22,6 +22,8 @@ const json = (body, status = 200) =>
     headers: {
       'Content-Type': 'application/json',
       'Cache-Control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+      // Public catalog data; same policy Vercel already applies to the static /models.json sibling.
+      'Access-Control-Allow-Origin': '*',
     },
   });
 

--- a/src/app/models/route.test.js
+++ b/src/app/models/route.test.js
@@ -7,6 +7,18 @@ const request = (query = '') => ({ nextUrl: new URL(`https://neon.com/models${qu
 const body = async (res) => JSON.parse(await res.text());
 
 describe('GET /models', () => {
+  it.each(['chat', 'image-generation', 'web-search'])(
+    'allows cross-origin requests for the %s use case',
+    async (useCase) => {
+      const res = await GET(request(`?use_case=${useCase}`));
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400'
+      );
+    }
+  );
+
   it('returns every served model with chat examples by default', async () => {
     const res = await GET(request());
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- Add `Access-Control-Allow-Origin: *` to `/models` GET responses so the Neon console (`console.neon.tech`) can fetch the public model catalog from the browser.
- Leave response body, `use_case` contract, and cache headers unchanged.

## Test plan
- [ ] `curl -sSD - -o /dev/null -H 'Origin: https://console.neon.tech' 'https://neon.com/models?use_case=chat'` includes `access-control-allow-origin: *`
- [x] Confirm cache-control remains `public, max-age=3600, ...`
- [x] Unit tests for CORS headers pass