### PR TITLE
[experimental] Agent-facing Lakebase disambiguation via summary frontmatter (harness prototype)

### DIFF
--- a/content/docs/get-started/full-backend-quickstart.md
+++ b/content/docs/get-started/full-backend-quickstart.md
@@ -9,6 +9,10 @@ summary: >-
   when building a Next.js project that needs a type-safe Postgres data layer plus
   serverless storage and long-running AI, without stitching together separate
   providers.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 enableTableOfContents: true
 layout: wide
 ---

--- a/content/docs/get-started/why-neon.md
+++ b/content/docs/get-started/why-neon.md
@@ -8,12 +8,16 @@ summary: >-
   autoscaling, scale-to-zero, and point-in-time restore intrinsic rather than
   add-ons. Neon also includes Managed Better Auth, Object Storage, Functions,
   and AI Gateway.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 enableTableOfContents: true
 redirectFrom:
   - /docs/cloud/about
   - /docs/introduction/about
   - /docs/get-started-with-neon/why-neon
-updatedOn: '2026-08-03T18:51:52.937Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 ## Our mission

--- a/content/docs/import/migrate-intro.md
+++ b/content/docs/import/migrate-intro.md
@@ -12,10 +12,14 @@ summary: >-
   SQLite. Also indexes provider-specific migration paths for Heroku, Supabase,
   PlanetScale, RDS, Cloud SQL, and Azure, plus guidance for region migration and
   Neon-to-Neon moves.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 redirectFrom:
   - /docs/import/import-intro
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 This guide helps you choose the best migration method based on your database size, downtime tolerance, source database type, and technical requirements.

--- a/content/docs/introduction/architecture-overview.md
+++ b/content/docs/introduction/architecture-overview.md
@@ -12,11 +12,15 @@ summary: >-
   autoscaling including scale-to-zero, all as metadata operations rather than
   data copies. Lakebase Postgres on Neon and on Databricks both run on this
   architecture.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 redirectFrom:
   - /docs/storage-engine/architecture-overview
   - /docs/conceptual-guides/architecture-overview
   - /docs/guides/neon-features
-updatedOn: '2026-08-04T04:07:29.373Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 ## Top level overview

--- a/content/docs/introduction/autoscaling.md
+++ b/content/docs/introduction/autoscaling.md
@@ -8,8 +8,12 @@ summary: >-
   any primary compute or read replica; the maximum permitted autoscaling range
   is 8 CU. Use this page to understand how autoscaling works and to find the
   configuration steps before reading the full enablement guide.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 Neon's _Autoscaling_ feature dynamically adjusts the amount of compute resources allocated to a Neon compute in response to the current load, eliminating the need for manual intervention or restarts.

--- a/content/docs/introduction/branching.md
+++ b/content/docs/introduction/branching.md
@@ -7,13 +7,17 @@ summary: >-
   Use branching to spin up isolated development or test environments pre-loaded
   with production data, or run parallel CI/CD pipelines. You can also recover
   from data loss by rolling back to any point within your history window.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 enableTableOfContents: true
 redirectFrom:
   - /docs/conceptual-guides/branches
   - /docs/conceptual-guides/branching
   - /docs/concepts/branching
   - /docs/introduction/point-in-time-restore
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 With Neon, you can quickly branch your data for development, testing, and various other purposes, enabling you to improve developer productivity and optimize continuous integration and delivery (CI/CD) pipelines.

--- a/content/docs/introduction/neon-and-lakebase.md
+++ b/content/docs/introduction/neon-and-lakebase.md
@@ -8,11 +8,15 @@ summary: >-
   and agent platforms, and on Databricks, the Data and AI platform for
   businesses. Same infrastructure, same technology, same core feature set. Use
   this page to understand the lakebase architecture and decide where to run it.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 redirectFrom:
   - /docs/storage-engine/architecture-overview
   - /docs/conceptual-guides/architecture-overview
   - /docs/guides/neon-features
-updatedOn: '2026-08-03T22:20:54.355Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 In 2025, Neon joined Databricks. The serverless Postgres architecture that Neon pioneered is now the foundation of Lakebase Postgres, a database you can run in two places: on Neon and on Databricks. Wherever you run it, it's the same infrastructure, the same technology, and the same core feature set. What differs is what's built around the database. This page explains the [lakebase category](https://www.databricks.com/blog/what-is-a-lakebase), what's the same in both places, and how to choose between them.

--- a/content/docs/introduction/read-replicas.md
+++ b/content/docs/introduction/read-replicas.md
@@ -10,8 +10,12 @@ summary: >-
   affecting write performance. Read replicas are asynchronous and support
   Autoscaling and Scale to Zero. Cross-region replicas require logical
   replication to a separate Neon project.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 Neon read replicas are independent computes designed to perform read operations on the same data as your primary read-write compute. Neon's read replicas do not replicate or duplicate data. Instead, read requests are served from the same storage, as shown in the diagram below. While your read-write queries are directed through your primary compute, read queries can be offloaded to one or more read replicas.

--- a/content/docs/introduction/scale-to-zero.md
+++ b/content/docs/introduction/scale-to-zero.md
@@ -8,8 +8,12 @@ summary: >-
   production databases where always-on compute is unnecessary. Free plan users
   cannot disable it, but paid plan users can. Very large computes remain always
   active and are not eligible for scale to zero.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-06T18:56:08.972Z'
 ---
 
 Neon's _Scale to Zero_ feature suspends the Neon compute that runs your Postgres database after a period of inactivity, which minimizes costs for databases that aren’t always active, such as development or test environment databases, and even production databases that aren't used 24/7.

--- a/content/docs/postgres/overview.md
+++ b/content/docs/postgres/overview.md
@@ -7,6 +7,10 @@ summary: >-
   autoscaling, scale to zero, database branching, instant point-in-time
   restore, and read replicas. Use this page as a starting point to create a
   project, connect an application, or explore Neon-specific features.
+  This page documents Lakebase Postgres managed by Neon (Neon's standalone
+  serverless Postgres platform). If you are working with Lakebase Postgres managed by Databricks — the
+  Postgres offering integrated into the Databricks platform — use the Databricks
+  documentation instead: https://docs.databricks.com/aws/en/oltp/projects/.
 enableTableOfContents: true
 ---
 


### PR DESCRIPTION
## Experimental: agent-facing Lakebase disambiguation (harness prototype)

**Status: DRAFT / experimental — for agent-testing-harness evaluation, not for merge yet.**

### Why
The Neon Postgres product is now also branded **Lakebase Postgres**, and there are two distinct offerings that share the name and can confuse AI agents (and the coding agents that read our docs):

- **Lakebase Postgres managed by Neon** — Neon's standalone serverless Postgres platform (this docset).
- **Lakebase Postgres managed by Databricks** — the Postgres offering integrated into the Databricks platform (the other docset).

This PR adds an **agent-facing, NOT human-visible** disambiguation note to a representative sample of pages so we can measure — via the agent-testing harness pointed at this PR's preview — whether such a note improves agent task-flow (does the agent land on / redirect to the correct product's docs).

### Mechanism — `summary` frontmatter (agent-only channel)
On the main docs route, the `summary` frontmatter field is emitted **only into the per-page `.md` mirror that AI agents consume** (`> Summary: …`), served to detected agents. It is **not** rendered in the human page body, and **not** used as the HTML meta description on this route. So extending `summary` reaches agents without any human-visible change.

Each touched page **appends** a disambiguation clause to its existing `summary` (the useful existing summary is preserved). Wording is identical across pages, with the canonical cross-link to the Databricks OLTP docs.

**Caveat honored:** the API-reference route (`/docs/reference/api/**`) is the one place `summary` *does* become a visible meta description — **no pages under that route are touched**.

### Pages touched (10, spanning page types)
- `content/docs/get-started/full-backend-quickstart.md`
- `content/docs/get-started/why-neon.md`
- `content/docs/import/migrate-intro.md`
- `content/docs/introduction/architecture-overview.md`
- `content/docs/introduction/autoscaling.md`
- `content/docs/introduction/branching.md`
- `content/docs/introduction/neon-and-lakebase.md`
- `content/docs/introduction/read-replicas.md`
- `content/docs/introduction/scale-to-zero.md`
- `content/docs/postgres/overview.md`

### Validation
- `prettier --check` on all changed files: **pass**.
- Frontmatter-only edits; zero human-visible body changes.

### Cross-link used
`https://docs.databricks.com/aws/en/oltp/projects/`

### Rollout
If the harness shows this helps agent flows, scaling to all Lakebase pages is a mechanical follow-up (same one-line `summary` clause).
