### PR TITLE
Add kimi-k3, gemini-3-6-flash and gemini-3-5-flash-lite

### DIFF
--- a/content/docs/ai-gateway/gemini.md
+++ b/content/docs/ai-gateway/gemini.md
@@ -6,7 +6,7 @@ summary: >-
   streamGenerateContent APIs through Neon AI Gateway. Use the google-genai SDK
   with a custom base URL.
 enableTableOfContents: true
-updatedOn: '2026-08-06T17:43:14.909Z'
+updatedOn: '2026-08-07T13:59:02.632Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -38,7 +38,9 @@ This endpoint accepts Google models only:
 
 | Model ID                | Notes |
 | ----------------------- | ----- |
+| `gemini-3-6-flash`      |       |
 | `gemini-3-5-flash`      |       |
+| `gemini-3-5-flash-lite` |       |
 | `gemini-3-1-pro`        |       |
 | `gemini-3-1-flash-lite` |       |
 | `gemini-3-flash`        |       |

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -2,9 +2,10 @@
 title: AI Gateway models
 subtitle: Available models and how to specify them
 summary: >-
-  Neon AI Gateway serves Databricks-hosted foundation models from
-  OpenAI, Google, Meta, Databricks, and Alibaba. Use short model IDs
-  like gpt-5-mini or gemini-3-flash. The databricks- prefix is also accepted.
+  Neon AI Gateway serves Databricks-hosted foundation models from Anthropic,
+  OpenAI, Google, Meta, Alibaba, Zhipu AI, Moonshot AI, and Thinking Machines.
+  Use short model IDs like gpt-5-mini or gemini-3-flash. The databricks- prefix
+  is also accepted.
 enableTableOfContents: true
 updatedOn: '2026-08-07T14:53:45.186Z'
 ---

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -61,14 +61,14 @@ Most models work with the [Chat completions](/docs/ai-gateway/chat-completions) 
 
 All paths below are appended to your branch's bare AI Gateway host (`NEON_AI_GATEWAY_BASE_URL`).
 
-| Provider                                   | Recommended endpoint   | Notes                                                                                        |
-| ------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------- |
-| OpenAI (most models)                       | `/v1/chat/completions` | Use `/openai/v1/responses` for Responses API features                                        |
-| OpenAI (`gpt-5-3-codex`, `gpt-5-5-pro`)    | `/openai/v1/responses` | These models require the Responses API and don't work with chat/completions                  |
-| Anthropic Claude                           | `/v1/chat/completions` | Use `/anthropic/v1/messages` with the Anthropic SDK for extended thinking and prompt caching |
-| Google Gemini                              | `/v1/chat/completions` | Use `/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK                |
-| Google Gemma 3 12B                         | `/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                               |
-| Meta, Alibaba, Zhipu AI, Thinking Machines | `/v1/chat/completions` | Chat completions only                                                                        |
+| Provider                                                | Recommended endpoint   | Notes                                                                                        |
+| ------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------- |
+| OpenAI (most models)                                    | `/v1/chat/completions` | Use `/openai/v1/responses` for Responses API features                                        |
+| OpenAI (`gpt-5-3-codex`, `gpt-5-5-pro`)                 | `/openai/v1/responses` | These models require the Responses API and don't work with chat/completions                  |
+| Anthropic Claude                                        | `/v1/chat/completions` | Use `/anthropic/v1/messages` with the Anthropic SDK for extended thinking and prompt caching |
+| Google Gemini                                           | `/v1/chat/completions` | Use `/gemini/v1beta/models/{model}:generateContent` with the google-genai SDK                |
+| Google Gemma 3 12B                                      | `/v1/chat/completions` | Chat completions only. Doesn't support the Gemini SDK endpoint                               |
+| Meta, Alibaba, Zhipu AI, Thinking Machines, Moonshot AI | `/v1/chat/completions` | Chat completions only                                                                        |
 
 <Admonition type="warning" title="Content shape varies by model">
 For most models, `message.content` in a chat completions response is a plain string. For some models, confirmed on Gemini 3.x (`gemini-3-5-flash`, `gemini-3-1-pro`), `gpt-oss-120b`, and `qwen35-122b-a10b`, it's an array of typed content blocks instead (`{ type: 'reasoning', ... }`, `{ type: 'text', text: ... }`), matching how those models represent output natively. A low `max_tokens` value can also cut a response off before the `text` block appears, leaving only a `reasoning` block. Handle both shapes:

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../neondatabase/website/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../neondatabase/website/node_modules

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -4,7 +4,10 @@
     "name": "Neon",
     "npm": "@ai-sdk/openai-compatible",
     "api": "${NEON_AI_GATEWAY_BASE_URL}/v1",
-    "env": ["NEON_AI_GATEWAY_BASE_URL", "NEON_AI_GATEWAY_TOKEN"],
+    "env": [
+      "NEON_AI_GATEWAY_BASE_URL",
+      "NEON_AI_GATEWAY_TOKEN"
+    ],
     "doc": "https://neon.com/docs/ai-gateway/models",
     "models": {
       "claude-fable-5": {
@@ -17,7 +20,13 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -27,8 +36,14 @@
         "release_date": "2026-06-09",
         "last_updated": "2026-06-09",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -65,8 +80,14 @@
         "release_date": "2025-10-15",
         "last_updated": "2025-10-15",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 200000,
@@ -103,8 +124,14 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 200000,
@@ -141,8 +168,14 @@
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 200000,
@@ -179,8 +212,14 @@
         "release_date": "2026-02-05",
         "last_updated": "2026-03-13",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -206,7 +245,13 @@
           },
           {
             "type": "effort",
-            "values": ["low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -216,8 +261,14 @@
         "release_date": "2026-04-16",
         "last_updated": "2026-04-16",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -243,7 +294,13 @@
           },
           {
             "type": "effort",
-            "values": ["low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -253,8 +310,14 @@
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -280,7 +343,13 @@
           },
           {
             "type": "effort",
-            "values": ["low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -290,8 +359,14 @@
         "release_date": "2026-07-24",
         "last_updated": "2026-07-24",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -328,8 +403,14 @@
         "release_date": "2025-09-29",
         "last_updated": "2025-09-29",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 200000,
@@ -366,8 +447,14 @@
         "release_date": "2026-02-17",
         "last_updated": "2026-03-13",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -393,7 +480,13 @@
           },
           {
             "type": "effort",
-            "values": ["low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -403,8 +496,14 @@
         "release_date": "2026-06-30",
         "last_updated": "2026-06-30",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -427,7 +526,11 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["low", "medium", "high"]
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -437,8 +540,12 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 131072,
@@ -459,7 +566,11 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["low", "medium", "high"]
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -469,8 +580,12 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 131072,
@@ -491,7 +606,12 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["minimal", "low", "medium", "high"]
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -502,8 +622,14 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -526,7 +652,12 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["minimal", "low", "medium", "high"]
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -537,8 +668,14 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -561,7 +698,12 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["minimal", "low", "medium", "high"]
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -572,8 +714,14 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -596,19 +744,30 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
-        "temperature": false,
+        "temperature": true,
         "structured_output": true,
         "open_weights": false,
         "knowledge": "2024-09-30",
         "release_date": "2025-11-13",
         "last_updated": "2025-11-13",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -631,19 +790,31 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
         ],
         "tool_call": true,
-        "temperature": false,
+        "temperature": true,
         "structured_output": true,
         "open_weights": false,
         "knowledge": "2025-08-31",
         "release_date": "2025-12-11",
         "last_updated": "2025-12-11",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -666,19 +837,32 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
         ],
         "tool_call": true,
-        "temperature": false,
+        "temperature": true,
         "structured_output": true,
         "open_weights": false,
         "knowledge": "2025-08-31",
         "release_date": "2026-02-05",
         "last_updated": "2026-02-05",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -701,19 +885,32 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
         ],
         "tool_call": true,
-        "temperature": false,
+        "temperature": true,
         "structured_output": true,
         "open_weights": false,
         "knowledge": "2025-08-31",
         "release_date": "2026-03-05",
         "last_updated": "2026-03-05",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 1050000,
@@ -752,19 +949,31 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
         ],
         "tool_call": true,
-        "temperature": false,
+        "temperature": true,
         "structured_output": true,
         "open_weights": false,
         "knowledge": "2025-08-31",
         "release_date": "2026-03-17",
         "last_updated": "2026-03-17",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -787,19 +996,31 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
         ],
         "tool_call": true,
-        "temperature": false,
+        "temperature": true,
         "structured_output": true,
         "open_weights": false,
         "knowledge": "2025-08-31",
         "release_date": "2026-03-17",
         "last_updated": "2026-03-17",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 400000,
@@ -822,7 +1043,13 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
         ],
         "tool_call": true,
@@ -833,8 +1060,15 @@
         "release_date": "2026-04-23",
         "last_updated": "2026-04-23",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 1050000,
@@ -873,7 +1107,11 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["medium", "high", "xhigh"]
+            "values": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
         ],
         "tool_call": true,
@@ -884,8 +1122,15 @@
         "release_date": "2026-04-23",
         "last_updated": "2026-04-23",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 1050000,
@@ -921,7 +1166,14 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -932,8 +1184,15 @@
         "release_date": "2026-07-09",
         "last_updated": "2026-07-09",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 1050000,
@@ -972,7 +1231,14 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -983,8 +1249,15 @@
         "release_date": "2026-07-09",
         "last_updated": "2026-07-09",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 1050000,
@@ -1023,7 +1296,14 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -1034,8 +1314,15 @@
         "release_date": "2026-07-09",
         "last_updated": "2026-07-09",
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
         },
         "limit": {
           "context": 1050000,
@@ -1074,7 +1361,11 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["low", "medium", "high"]
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -1085,8 +1376,16 @@
         "release_date": "2025-12-17",
         "last_updated": "2025-12-17",
         "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,
@@ -1109,7 +1408,11 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["low", "medium", "high"]
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -1120,8 +1423,16 @@
         "release_date": "2026-03-03",
         "last_updated": "2026-03-03",
         "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,
@@ -1144,7 +1455,11 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["low", "medium", "high"]
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -1155,8 +1470,16 @@
         "release_date": "2026-02-19",
         "last_updated": "2026-02-19",
         "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,
@@ -1194,7 +1517,12 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["minimal", "low", "medium", "high"]
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -1205,8 +1533,16 @@
         "release_date": "2026-05-19",
         "last_updated": "2026-05-19",
         "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,
@@ -1229,7 +1565,12 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["minimal", "low", "medium", "high"]
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -1240,8 +1581,16 @@
         "release_date": "2026-07-21",
         "last_updated": "2026-07-21",
         "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,
@@ -1263,7 +1612,12 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["minimal", "low", "medium", "high"]
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -1274,8 +1628,16 @@
         "release_date": "2026-07-21",
         "last_updated": "2026-07-21",
         "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,
@@ -1303,8 +1665,13 @@
         "release_date": "2025-03-13",
         "last_updated": "2025-03-13",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 131072,
@@ -1330,8 +1697,12 @@
         "release_date": "2024-07-23",
         "last_updated": "2024-07-23",
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 131072,
@@ -1356,8 +1727,13 @@
         "release_date": "2025-04-05",
         "last_updated": "2025-04-05",
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -1382,8 +1758,12 @@
         "release_date": "2024-12-06",
         "last_updated": "2024-12-06",
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 128000,
@@ -1408,8 +1788,12 @@
         "release_date": "2025-09",
         "last_updated": "2025-09",
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 131072,
@@ -1430,7 +1814,12 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": ["none", "low", "medium", "high"]
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           }
         ],
         "tool_call": true,
@@ -1440,8 +1829,12 @@
         "release_date": "2026-02-23",
         "last_updated": "2026-02-23",
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 262144,
@@ -1465,7 +1858,14 @@
           },
           {
             "type": "effort",
-            "values": ["none", "minimal", "low", "medium", "high", "max"]
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -1475,8 +1875,12 @@
         "release_date": "2026-06-13",
         "last_updated": "2026-06-13",
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1000000,
@@ -1501,7 +1905,14 @@
           },
           {
             "type": "effort",
-            "values": ["none", "minimal", "low", "medium", "high", "max"]
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -1510,8 +1921,14 @@
         "release_date": "2026-07-15",
         "last_updated": "2026-07-15",
         "modalities": {
-          "input": ["text", "image", "audio"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,
@@ -1531,18 +1948,31 @@
           },
           {
             "type": "effort",
-            "values": ["none", "minimal", "low", "medium", "high", "max"]
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
-        "temperature": false,
+        "temperature": true,
         "structured_output": true,
         "open_weights": true,
         "release_date": "2026-07-16",
         "last_updated": "2026-07-16",
         "modalities": {
-          "input": ["text", "image", "video"],
-          "output": ["text"]
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
         },
         "limit": {
           "context": 1048576,

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -1136,6 +1136,24 @@
           "context": 1050000,
           "input": 922000,
           "output": 128000
+        },
+        "cost": {
+          "input": 30,
+          "output": 180,
+          "tiers": [
+            {
+              "input": 60,
+              "output": 270,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          }
         }
       },
       "gpt-5-6-luna": {

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -1537,6 +1537,101 @@
           "input_audio": 1.5
         }
       },
+      "gemini-3-5-flash-lite": {
+        "id": "gemini-3-5-flash-lite",
+        "name": "Gemini 3.5 Flash Lite",
+        "provider": "google",
+        "family": "gemini-flash-lite",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "structured_output": true,
+        "open_weights": false,
+        "knowledge": "2026-03",
+        "release_date": "2026-07-21",
+        "last_updated": "2026-07-21",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.03
+        }
+      },
+      "gemini-3-6-flash": {
+        "id": "gemini-3-6-flash",
+        "name": "Gemini 3.6 Flash",
+        "provider": "google",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "structured_output": true,
+        "open_weights": false,
+        "knowledge": "2026-03",
+        "release_date": "2026-07-21",
+        "last_updated": "2026-07-21",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.5,
+          "output": 7.5,
+          "cache_read": 0.15,
+          "input_audio": 1.5
+        }
+      },
       "gemma-3-12b": {
         "id": "gemma-3-12b",
         "name": "Gemma 3 12B",
@@ -1820,6 +1915,55 @@
         "limit": {
           "context": 1048576,
           "output": 1048576
+        }
+      },
+      "kimi-k3": {
+        "id": "kimi-k3",
+        "name": "Kimi K3",
+        "provider": "moonshotai",
+        "family": "kimi-k3",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "structured_output": true,
+        "open_weights": true,
+        "release_date": "2026-07-16",
+        "last_updated": "2026-07-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3
         }
       }
     }

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -4,10 +4,7 @@
     "name": "Neon",
     "npm": "@ai-sdk/openai-compatible",
     "api": "${NEON_AI_GATEWAY_BASE_URL}/v1",
-    "env": [
-      "NEON_AI_GATEWAY_BASE_URL",
-      "NEON_AI_GATEWAY_TOKEN"
-    ],
+    "env": ["NEON_AI_GATEWAY_BASE_URL", "NEON_AI_GATEWAY_TOKEN"],
     "doc": "https://neon.com/docs/ai-gateway/models",
     "models": {
       "claude-fable-5": {
@@ -20,13 +17,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -36,14 +27,8 @@
         "release_date": "2026-06-09",
         "last_updated": "2026-06-09",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -80,14 +65,8 @@
         "release_date": "2025-10-15",
         "last_updated": "2025-10-15",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 200000,
@@ -124,14 +103,8 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 200000,
@@ -168,14 +141,8 @@
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 200000,
@@ -212,14 +179,8 @@
         "release_date": "2026-02-05",
         "last_updated": "2026-03-13",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -245,13 +206,7 @@
           },
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -261,14 +216,8 @@
         "release_date": "2026-04-16",
         "last_updated": "2026-04-16",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -294,13 +243,7 @@
           },
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -310,14 +253,8 @@
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -343,13 +280,7 @@
           },
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -359,14 +290,8 @@
         "release_date": "2026-07-24",
         "last_updated": "2026-07-24",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -403,14 +328,8 @@
         "release_date": "2025-09-29",
         "last_updated": "2025-09-29",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 200000,
@@ -447,14 +366,8 @@
         "release_date": "2026-02-17",
         "last_updated": "2026-03-13",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -480,13 +393,7 @@
           },
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -496,14 +403,8 @@
         "release_date": "2026-06-30",
         "last_updated": "2026-06-30",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -526,11 +427,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -540,12 +437,8 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "limit": {
           "context": 131072,
@@ -566,11 +459,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -580,12 +469,8 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "limit": {
           "context": 131072,
@@ -606,12 +491,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["minimal", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -622,14 +502,8 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -652,12 +526,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["minimal", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -668,14 +537,8 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -698,12 +561,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["minimal", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -714,14 +572,8 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -744,12 +596,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["none", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -760,14 +607,8 @@
         "release_date": "2025-11-13",
         "last_updated": "2025-11-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -790,13 +631,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh"]
           }
         ],
         "tool_call": true,
@@ -807,14 +642,8 @@
         "release_date": "2025-12-11",
         "last_updated": "2025-12-11",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -837,13 +666,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh"]
           }
         ],
         "tool_call": true,
@@ -854,15 +677,8 @@
         "release_date": "2026-02-05",
         "last_updated": "2026-02-05",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -885,13 +701,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh"]
           }
         ],
         "tool_call": true,
@@ -902,15 +712,8 @@
         "release_date": "2026-03-05",
         "last_updated": "2026-03-05",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 1050000,
@@ -949,13 +752,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh"]
           }
         ],
         "tool_call": true,
@@ -966,14 +763,8 @@
         "release_date": "2026-03-17",
         "last_updated": "2026-03-17",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -996,13 +787,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh"]
           }
         ],
         "tool_call": true,
@@ -1013,14 +798,8 @@
         "release_date": "2026-03-17",
         "last_updated": "2026-03-17",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 400000,
@@ -1043,13 +822,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh"]
           }
         ],
         "tool_call": true,
@@ -1060,15 +833,8 @@
         "release_date": "2026-04-23",
         "last_updated": "2026-04-23",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 1050000,
@@ -1107,11 +873,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "values": ["medium", "high", "xhigh"]
           }
         ],
         "tool_call": true,
@@ -1122,15 +884,8 @@
         "release_date": "2026-04-23",
         "last_updated": "2026-04-23",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 1050000,
@@ -1166,14 +921,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -1184,15 +932,8 @@
         "release_date": "2026-07-09",
         "last_updated": "2026-07-09",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 1050000,
@@ -1231,14 +972,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -1249,15 +983,8 @@
         "release_date": "2026-07-09",
         "last_updated": "2026-07-09",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 1050000,
@@ -1296,14 +1023,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
           }
         ],
         "tool_call": true,
@@ -1314,15 +1034,8 @@
         "release_date": "2026-07-09",
         "last_updated": "2026-07-09",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text",
-            "image"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "limit": {
           "context": 1050000,
@@ -1361,11 +1074,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -1376,16 +1085,8 @@
         "release_date": "2025-12-17",
         "last_updated": "2025-12-17",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video",
-            "audio",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,
@@ -1408,11 +1109,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -1423,16 +1120,8 @@
         "release_date": "2026-03-03",
         "last_updated": "2026-03-03",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video",
-            "audio",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,
@@ -1455,11 +1144,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -1470,16 +1155,8 @@
         "release_date": "2026-02-19",
         "last_updated": "2026-02-19",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video",
-            "audio",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,
@@ -1517,12 +1194,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["minimal", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -1533,16 +1205,8 @@
         "release_date": "2026-05-19",
         "last_updated": "2026-05-19",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video",
-            "audio",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,
@@ -1565,12 +1229,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["minimal", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -1581,16 +1240,8 @@
         "release_date": "2026-07-21",
         "last_updated": "2026-07-21",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video",
-            "audio",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,
@@ -1612,32 +1263,19 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["minimal", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
-        "temperature": true,
+        "temperature": false,
         "structured_output": true,
         "open_weights": false,
         "knowledge": "2026-03",
         "release_date": "2026-07-21",
         "last_updated": "2026-07-21",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video",
-            "audio",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,
@@ -1665,13 +1303,8 @@
         "release_date": "2025-03-13",
         "last_updated": "2025-03-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "limit": {
           "context": 131072,
@@ -1697,12 +1330,8 @@
         "release_date": "2024-07-23",
         "last_updated": "2024-07-23",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "limit": {
           "context": 131072,
@@ -1727,13 +1356,8 @@
         "release_date": "2025-04-05",
         "last_updated": "2025-04-05",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -1758,12 +1382,8 @@
         "release_date": "2024-12-06",
         "last_updated": "2024-12-06",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "limit": {
           "context": 128000,
@@ -1788,12 +1408,8 @@
         "release_date": "2025-09",
         "last_updated": "2025-09",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "limit": {
           "context": 131072,
@@ -1814,12 +1430,7 @@
         "reasoning_options": [
           {
             "type": "effort",
-            "values": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "values": ["none", "low", "medium", "high"]
           }
         ],
         "tool_call": true,
@@ -1829,12 +1440,8 @@
         "release_date": "2026-02-23",
         "last_updated": "2026-02-23",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "limit": {
           "context": 262144,
@@ -1858,14 +1465,7 @@
           },
           {
             "type": "effort",
-            "values": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "values": ["none", "minimal", "low", "medium", "high", "max"]
           }
         ],
         "tool_call": true,
@@ -1875,12 +1475,8 @@
         "release_date": "2026-06-13",
         "last_updated": "2026-06-13",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1000000,
@@ -1905,14 +1501,7 @@
           },
           {
             "type": "effort",
-            "values": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "values": ["none", "minimal", "low", "medium", "high", "max"]
           }
         ],
         "tool_call": true,
@@ -1921,14 +1510,8 @@
         "release_date": "2026-07-15",
         "last_updated": "2026-07-15",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "audio"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "audio"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,
@@ -1948,14 +1531,7 @@
           },
           {
             "type": "effort",
-            "values": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "values": ["none", "minimal", "low", "medium", "high", "max"]
           }
         ],
         "tool_call": true,
@@ -1965,14 +1541,8 @@
         "release_date": "2026-07-16",
         "last_updated": "2026-07-16",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "video"],
+          "output": ["text"]
         },
         "limit": {
           "context": 1048576,

--- a/src/app/models/capabilities.json
+++ b/src/app/models/capabilities.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Measured behaviour of every model the Neon AI Gateway serves. Produced by calling each model on /v1/chat/completions, its provider-native dialect, and /openai/v1/responses with the web_search and image_generation tools. This is what the gateway DID; models.json is what each model CLAIMS. /models needs both to know which code examples are correct.",
   "$howToRegenerate": "Generated from the conformance record in neondatabase/neon-console-code-examples: run `bun run probe:conformance` there, then copy its conformance.json into the shape below. One probe feeds both repos so the console and /models cannot disagree. Fields per model: id, owner, entitled, chat (conforms | array-content | not-served | not-entitled), deviations[], nativeDialect (anthropic | openai-responses | gemini | none), responses, webSearch, imageGeneration. Conformance MUST be measured with a prompt that makes the model reason as well as a trivial one, taking the worse shape: claude-opus-5, claude-sonnet-5 and claude-fable-5 return a compliant string for a trivial prompt and an array of {reasoning, text} parts once they think, and an easy-prompt-only probe is what published all three as `conforms`. CI checks completeness, not freshness - see the models-rest validator in scripts/verify-agent-endpoints.mjs.",
-  "probedAt": "2026-08-05T15:04:33.139Z",
+  "probedAt": "2026-08-07T13:40:27.012Z",
   "models": [
     {
       "id": "claude-fable-5",
@@ -138,7 +138,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 344, but prompt + completion is 205",
+        "`usage.total_tokens` is 356, but prompt + completion is 212",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -154,7 +154,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 595, but prompt + completion is 248",
+        "`usage.total_tokens` is 585, but prompt + completion is 240",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -170,7 +170,39 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 593, but prompt + completion is 232",
+        "`usage.total_tokens` is 469, but prompt + completion is 217",
+        "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
+      ],
+      "nativeDialect": "gemini",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gemini-3-5-flash-lite",
+      "owner": "google",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "`id` is null; the spec requires a string",
+        "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
+        "`usage.total_tokens` is 572, but prompt + completion is 218",
+        "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
+      ],
+      "nativeDialect": "gemini",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "gemini-3-6-flash",
+      "owner": "google",
+      "entitled": true,
+      "chat": "array-content",
+      "deviations": [
+        "`id` is null; the spec requires a string",
+        "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
+        "`usage.total_tokens` is 387, but prompt + completion is 195",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -186,7 +218,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 588, but prompt + completion is 221",
+        "`usage.total_tokens` is 619, but prompt + completion is 225",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -399,6 +431,17 @@
     {
       "id": "inkling",
       "owner": "databricks",
+      "entitled": true,
+      "chat": "conforms",
+      "deviations": [],
+      "nativeDialect": "none",
+      "responses": false,
+      "webSearch": false,
+      "imageGeneration": false
+    },
+    {
+      "id": "kimi-k3",
+      "owner": "moonshot",
       "entitled": true,
       "chat": "conforms",
       "deviations": [],

--- a/src/components/pages/doc/ai-gateway-model-index/model-rows.js
+++ b/src/components/pages/doc/ai-gateway-model-index/model-rows.js
@@ -17,6 +17,7 @@ const PROVIDER_ORDER = [
   'alibaba',
   'zhipuai',
   'thinkingmachines',
+  'moonshotai',
 ];
 
 const PROVIDER_LABELS = {
@@ -27,6 +28,7 @@ const PROVIDER_LABELS = {
   alibaba: 'Alibaba',
   zhipuai: 'Zhipu AI',
   thinkingmachines: 'Thinking Machines',
+  moonshotai: 'Moonshot AI',
 };
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];


### PR DESCRIPTION
## The problem

The release making the full AI Gateway catalog available shipped this morning. `GET /v1/models`
went from 25 to **42**, and three of those are models nothing downstream knew about:

| Model | Owner | Chat completions | Native dialect |
| --- | --- | --- | --- |
| `kimi-k3` | moonshot | ✅ conforms | — |
| `gemini-3-6-flash` | google | ❌ array `content` | gemini |
| `gemini-3-5-flash-lite` | google | ❌ array `content` | gemini |

The other 16 in that jump were already served and merely unlisted, so they are unaffected.

Separately, `gpt-5-5-pro` was published with no price at all. That was reported as missing data on
`neon.com/models`, and it matters more than a cosmetic gap because the Neon console renders this
`cost` field.

## The change

`providerFor()` **refused to run** on `kimi-k3`, which is what it is supposed to do — it exits
non-zero rather than guessing a provider, and has now caught every new family in turn. It derives
`moonshotai`, and `model-rows.js` gains the label and sort position so the docs table and the LLM
markdown mirror render it.

`capabilities.json` is regenerated from the measured record in `neon-console-code-examples`, so
`/models` and the console cannot disagree about what a model does.

## Interface

```jsonc
// GET /models?model=kimi-k3   → conforms, so it gets the full example set
{ "provider": "moonshotai",
  "capabilities": { "chat": "conforms", "native_dialect": "none" },
  "examples": [ "ai-sdk", "mastra", "typescript", "python", "curl" ] }

// GET /models?model=gemini-3-6-flash   → array content, same as the rest of Gemini 3.x
{ "capabilities": { "chat": "array-content", "native_dialect": "gemini" },
  "examples": [ "ai-sdk", "mastra", "curl" ] }   // typescript + python omitted
```

```jsonc
// GET /models.json → gpt-5-5-pro now carries a price
{ "cost": { "input": 30, "output": 180,
            "tiers": [ { "tier": { "type": "context", "size": 272000 },
                         "input": 60, "output": 270 } ] } }
```

`gemini-3-6-flash` is published with **`temperature: false`**. It inherits `temperature: true`
from the models.dev base entry for `google/gemini-3.6-flash`, which is right for Google's own API
and wrong for ours — the gateway answers `BAD_REQUEST: Model gemini-3.6-flash does not support
the temperature parameter`. Its siblings are unaffected and keep the inherited value.

The two Gemini models carry the family's usual deviations — `id` null, `content` an `array[1]`
with `thoughtSignature`, `usage.total_tokens` not equal to prompt + completion — so they inherit
existing handling rather than needing new rules. Twelve of 42 models now break the contract, up
from ten of 39; the ratio is unchanged, the catalog just grew.

Hand-written tables that do not regenerate are updated: `gemini.md` goes from four supported
models to six, and the provider table in `models.md` gains Moonshot AI.

## Verification

- `npm run generate:models` against the **deployed** models.dev — 42 models, and byte-identical
  to the file already on this branch, which was produced from a local build of the upstream
  branch before it merged.
- `npm run check:models-sync` — `[OK] In sync — 42 models match.`
- `npm run test:unit:run` — 682 passed.
- `npm run verify:agent-endpoints` — 8/8 endpoints, 29/29 checks.
- `npx markdownlint content/docs/ai-gateway/*.md` — clean.
- `npm run lint:js` — 0 errors (13 pre-existing warnings).
- Every capability measured against a live branch with a reasoning-triggering prompt, not a
  trivial one.

## Notes

The models.dev dependency this PR originally carried is **resolved** —
[anomalyco/models.dev#4324](https://github.com/anomalyco/models.dev/pull/4324) merged and
redeployed, which is why regenerating from the live catalog reproduces this branch exactly.

**Ordering: [#5474](https://github.com/neondatabase/website/pull/5474) merges first, then this
one rebases onto it.** That reversed while this PR was in review. The `temperature: false`
correction above means `data.json` deliberately disagrees with the deployed mirror on one field,
and the current equality-based `check:models-sync` fails on any difference — so on today's `main`
this PR would turn the daily job red. #5474 replaces that with a direction-aware check which
classifies a field we have corrected ahead of the mirror as sync debt and exits 0.

The mirror is fixed by [anomalyco/models.dev#4329](https://github.com/anomalyco/models.dev/pull/4329),
which adds the same override upstream. Nothing here waits for it — which is the point of #5474.

`inkling` is still the one model published without a price. Databricks does not list it on either
DBU pricing table and Thinking Machines sells it only through Tinker's prefill/sample/train
meters, so there is no rate to copy that is actually Neon's. It needs a number from someone with
access to the real rate card rather than a guess.
