### PR TITLE
feat: update castform cover

### DIFF
--- a/content/blog/posts/how-castform-neon-beats-frontier-models-on-price-and-efficiency.md
+++ b/content/blog/posts/how-castform-neon-beats-frontier-models-on-price-and-efficiency.md
@@ -17,7 +17,7 @@ authors:
   - ying-hang-seah
   - angel-pan
 cover:
-  image: 'https://cdn.neonapi.io/public/images/pages/blog/how-castform-neon-beats-frontier-models-on-price-and-efficiency/cover.jpg'
+  image: 'https://cdn.neonapi.io/public/images/pages/blog/how-castform-neon-beats-frontier-models-on-price-and-efficiency/cover-1.jpg'
   alt: Training 100x Cheaper Retrieval models Neon and Castform
 isFeatured: false
 seo:
@@ -31,7 +31,7 @@ seo:
   ogDescription: >-
     A 4B open-source model post-trained with Castform retrieved search results
     as accurately as GPT-5.6 Sol, while costing 100x less.
-  image: 'https://cdn.neonapi.io/public/images/pages/blog/how-castform-neon-beats-frontier-models-on-price-and-efficiency/social.jpg'
+  image: 'https://cdn.neonapi.io/public/images/pages/blog/how-castform-neon-beats-frontier-models-on-price-and-efficiency/social-1.jpg'
 ---
 
 ![Comparison of Castform fine-tune and frontier models by inference cost and mean evaluation reward](https://cdn.neonapi.io/public/images/pages/blog/how-castform-neon-beats-frontier-models-on-price-and-efficiency/diagram-1.jpg)


### PR DESCRIPTION
Updates the Castform blog post to use the refreshed CDN cover and social assets under cache-safe filenames. The existing CDN assets remain available, while the post and social metadata now render the new artwork.

Validation:
- Verified `cover-1.jpg` and `social-1.jpg` through the blog CDN tooling
- `npx prettier --check content/blog/posts/how-castform-neon-beats-frontier-models-on-price-and-efficiency.md`
- `npm run test:unit:run` (40 test files, 682 tests)
