### PR TITLE
docs: clean up remaining spending-limit wording and tidy consumption-limits

### DIFF
--- a/content/docs/guides/consumption-limits.md
+++ b/content/docs/guides/consumption-limits.md
@@ -15,10 +15,12 @@ redirectFrom:
   - /docs/guides/partner-billing
   - /docs/guides/partner-consumption-limits
 isDraft: false
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-07T17:04:50.326Z'
 ---
 
 When setting up your integration's billing solution with Neon, you may want to impose some hard limits on how much storage or compute resources a given project can consume. For example, you may want to cap how much usage your free plan users can consume versus pro or enterprise users. With the Neon API, you can use the `quota` key to set usage limits for a variety of consumption metrics. These limits act as thresholds after which all active computes for a project are [suspended](#suspending-active-computes).
+
+Consumption limits actively enforce usage caps: when a project hits a quota, Neon suspends its computes. They apply per project and per consumption metric (compute, storage, and data transfer). If you instead want email alerts when your organization's total monthly charges approach a dollar amount, without stopping usage, see [Spending notifications](/docs/introduction/spending-notifications).
 
 ## Metrics and quotas
 
@@ -51,16 +53,16 @@ You can set quotas for these consumption metrics per project using the `quota` s
 
 The `quota` object includes an array of parameters used to set threshold limits. Their names generally match their corresponding metric:
 
-- `active_time_seconds` &#8212; Sets the maximum amount of time your project's computes are allowed to be active during the current billing period. It excludes time when computes are in an idle state due to [scale to zero](/docs/reference/glossary#scale-to-zero).
-- `compute_time_seconds` &#8212; Sets the maximum amount of CPU seconds allowed in total across all of a project's computes. This includes any computes deleted during the current billing period. Note that the larger the compute size per endpoint, the faster the project consumes `compute_time_seconds`. For example, 1 second at .25 CU costs .25 compute seconds, while 1 second at 4 CU costs 4 compute seconds.
+- `active_time_seconds`: Sets the maximum amount of time your project's computes are allowed to be active during the current billing period. It excludes time when computes are in an idle state due to [scale to zero](/docs/reference/glossary#scale-to-zero).
+- `compute_time_seconds`: Sets the maximum amount of CPU seconds allowed in total across all of a project's computes. This includes any computes deleted during the current billing period. Note that the larger the compute size per endpoint, the faster the project consumes `compute_time_seconds`. For example, 1 second at .25 CU costs .25 compute seconds, while 1 second at 4 CU costs 4 compute seconds.
 
   | CU   | active_time_seconds | compute_time_seconds |
   | :--- | :------------------ | :------------------- |
   | 0.25 | 1                   | 0.25                 |
   | 4    | 1                   | 4                    |
 
-- `written_data_bytes` &#8212; Sets the maximum amount of data in total, measured in bytes, that can be written across all of a project's branches for the month.
-- `data_transfer_bytes` &#8212; Sets the maximum amount of egress data, measured in bytes, that can be transferred out of Neon from across all of a project's branches using the proxy.
+- `written_data_bytes`: Sets the maximum amount of data in total, measured in bytes, that can be written across all of a project's branches for the month.
+- `data_transfer_bytes`: Sets the maximum amount of egress data, measured in bytes, that can be transferred out of Neon from across all of a project's branches using the proxy.
 
 There is one additional `quota` parameter, `logical_size_bytes`, which applies to individual branches, not to the overall project. You can use `logical_size_bytes` to set the maximum size (measured in bytes) that any one individual branch is allowed to reach. Once this threshold is met, the compute for that particular branch (and _only_ that particular branch) is suspended. Note that this limit is _not_ refreshed once per month: it is a strict size limit that applies for the life of the branch.
 
@@ -83,7 +85,7 @@ Let's say you want to set limits for an application with two tiers, Trial and Pr
 
 ### Guidelines
 
-Generally, the most effective quotas for controlling spend per project are those controlling maximum compute (`active_time_seconds` and `compute_time_seconds`) and maximum written storage (`written_data_bytes`). In practice, it is possible that `data_transfer_bytes` could introduce unintended logical constraints against your usage. For example, let's say you want to run a cleanup operation to reduce your storage. If part of this cleanup operation involves moving data across the network (for instance, to create an offsite backup before deletion), the `data_transfer_bytes` limit could prevent you from completing the operation &#8212; an undesirable situation where two measures meant to control cost interfere with one another.
+Generally, the most effective quotas for controlling spend per project are those controlling maximum compute (`active_time_seconds` and `compute_time_seconds`) and maximum written storage (`written_data_bytes`). In practice, it is possible that `data_transfer_bytes` could introduce unintended logical constraints against your usage. For example, let's say you want to run a cleanup operation to reduce your storage. If part of this cleanup operation involves moving data across the network (for instance, to create an offsite backup before deletion), the `data_transfer_bytes` limit could prevent you from completing the operation. This is an undesirable situation where two measures meant to control cost interfere with one another.
 
 ### Neon default limits
 
@@ -98,7 +100,7 @@ These limits are not directly configurable. You can query the limits by running 
 
 _**What happens when a quota is met?**_
 
-When any configured metric reaches its quota limit, all active computes for that project are automatically suspended. It is important to understand, this suspension is persistent. It works differently than the inactivity-based [scale to zero](/docs/guides/scale-to-zero-guide), where computes restart at the next interaction: this suspend will _not_ restart at the next API call or incoming connection. If you don't take explicit action otherwise, the suspension remains in place until the end of the current billing period starts (`consumption_period_end`).
+When any configured metric reaches its quota limit, all active computes for that project are automatically suspended. It is important to understand, this suspension is persistent. It works differently than the inactivity-based [scale to zero](/docs/guides/scale-to-zero-guide), where computes restart at the next interaction: this suspend will _not_ restart at the next API call or incoming connection. If you don't take explicit action otherwise, the suspension remains in place until the next billing period starts (`consumption_period_end`).
 
 See [Querying metrics and quotas](#querying-metrics-and-quotas) to find the reset date, billing period, and other values related to a project's consumption.
 
@@ -143,7 +145,7 @@ curl --request POST \
 
 ### Update an existing project
 
-If you need to change the quota limits for an existing project &#8212; for example, if a user switches their plan to a higher usage tier &#8212; you can reset those limits via `PATCH` request. See [Update a project](/docs/reference/api/projects/update-project) in the Neon API.
+If you need to change the quota limits for an existing project (for example, if a user switches their plan to a higher usage tier), you can reset those limits via `PATCH` request. See [Update a project](/docs/reference/api/projects/update-project) in the Neon API.
 
 Here is a sample `PATCH` that updates both the `active_time_seconds` and `compute_time_seconds` quotas to 30 hours (108,000):
 
@@ -179,15 +181,15 @@ Alternatively, you can actively reset a suspended compute by changing the impact
 
 ### Using quotas to actively suspend a user
 
-If you want to suspend a user for any reason &#8212; for example, suspicious activity or payment issues &#8212; you can use these quotas to actively suspend a given user. For example, setting `active_time_limit` to a very low threshold (for example, `1`) will force a suspension if the user has 1 second of active compute for that month. To remove this suspension, you can set the threshold temporarily to `0` (infinite) or some value larger than their currently consumed usage.
+If you want to suspend a user for any reason (for example, suspicious activity or payment issues), you can use these quotas to actively suspend a given user. For example, setting `active_time_seconds` to a very low threshold (for example, `1`) will force a suspension if the user has 1 second of active compute for that month. To remove this suspension, you can set the threshold temporarily to `0` (infinite) or some value larger than their currently consumed usage.
 
 ## Other consumption related settings
 
 In addition to setting quota limits against the project as a whole, there are other sizing-related settings you might want to use to control the amount of resources any particular endpoint is able to consume:
 
-- `autoscaling_limit_min_cu` &#8212; Sets the minimum compute size for the endpoint. The default minimum is .25 CU but can be increased if your user's project could benefit from a larger compute start size.
-- `autoscaling_limit_max_cu` &#8212; Sets a hard limit on how much compute an endpoint can consume in response to increased demand. For more info on min and max cpu limits, see [Autoscaling](/docs/guides/autoscaling-guide).
-- `suspend_timeout_seconds` &#8212; Sets how long an endpoint's allotted compute will remain active with no current demand. After the timeout period, the endpoint is suspended until demand picks up. For more info, see [Scale to Zero](/docs/guides/scale-to-zero-guide).
+- `autoscaling_limit_min_cu`: Sets the minimum compute size for the endpoint. The default minimum is .25 CU but can be increased if your user's project could benefit from a larger compute start size.
+- `autoscaling_limit_max_cu`: Sets a hard limit on how much compute an endpoint can consume in response to increased demand. For more info on min and max cpu limits, see [Autoscaling](/docs/guides/autoscaling-guide).
+- `suspend_timeout_seconds`: Sets how long an endpoint's allotted compute will remain active with no current demand. After the timeout period, the endpoint is suspended until demand picks up. For more info, see [Scale to Zero](/docs/guides/scale-to-zero-guide).
 
 There are several ways you can set these endpoint settings using the Neon API: you can set project-level defaults that apply for any new computes created in the project, you can define the endpoint settings when creating a new branch, or you can adjust these settings when creating or updating an endpoint for an existing branch.
 

--- a/content/docs/introduction/spending-notifications.md
+++ b/content/docs/introduction/spending-notifications.md
@@ -90,13 +90,15 @@ When your organization's monthly charges reach the threshold:
 
 Projects continue to run, and charges continue to accumulate, until you raise the threshold or the billing cycle resets at the start of the next month. Automatic project suspension is coming soon and will stop compute charges at the threshold.
 
+Spending notifications only send alerts; they don't stop usage. If you need Neon to actively suspend computes when a limit is reached, you can set per-project consumption quotas with the Neon API. These work per project and per consumption metric (compute, storage, and data transfer) rather than on total dollar spend. See [Configure consumption limits](/docs/guides/consumption-limits).
+
 <Admonition type="note">
 A spending notification threshold applies to the organization's total monthly Neon charges across all projects in that organization. If you belong to multiple organizations, set a separate threshold for each.
 </Admonition>
 
 ## Manage spending notifications with the Neon API
 
-The Management API exposes spending limits at:
+You can manage spending notifications through the Management API at:
 
 `https://console.neon.tech/api/v2/organizations/{org_id}/billing/spending_limit`
 
@@ -104,9 +106,9 @@ Replace `{org_id}` with your organization ID (see [Finding your org_id](/docs/ma
 
 | Action                      | Method                                                                                                                  | Who can use it                                               |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Read the current threshold  | [Retrieve the organization's monthly spending limit](/docs/reference/api/organizations/get-organization-spending-limit) | Organization members with **read** access (Launch and Scale) |
-| Set or change the threshold | [Set the organization's monthly spending limit](/docs/reference/api/organizations/set-organization-spending-limit)      | **Organization admins** only (Launch and Scale)              |
-| Remove the threshold        | [Clear the organization's monthly spending limit](/docs/reference/api/organizations/delete-organization-spending-limit) | **Organization admins** only (Launch and Scale)              |
+| Read the current threshold  | [Retrieve the organization's notification threshold](/docs/reference/api/organizations/get-organization-spending-limit) | Organization members with **read** access (Launch and Scale) |
+| Set or change the threshold | [Set the organization's notification threshold](/docs/reference/api/organizations/set-organization-spending-limit)      | **Organization admins** only (Launch and Scale)              |
+| Remove the threshold        | [Clear the organization's notification threshold](/docs/reference/api/organizations/delete-organization-spending-limit) | **Organization admins** only (Launch and Scale)              |
 
 **Request body (`PUT`):** send `spending_limit_cents` as a positive integer (monthly threshold in **cents**; minimum **1**). For example, `$100.00` per month is `10000`. Values **`0`** and **`null`** are rejected; to clear a threshold, call **`DELETE`** on the same path (idempotent when no threshold is configured).
 


### PR DESCRIPTION
Follow-up to the spending-notifications rename, cleaning up a few spots that still said "spending limit":

- **spending-notifications**: reword the API section and table (the endpoint path and `spending_limit_cents` field stay, since that's the real API); add a pointer to consumption limits for actual enforcement.
- **consumption-limits**: cross-link back to spending notifications, fix an `active_time_limit` -> `active_time_seconds` typo, and remove em dashes.

This pull request and its description were written by Isaac.