### PR TITLE
docs: recommend direct connections for migrations, pg_dump, and logical replication

### DIFF
--- a/content/docs/connect/connection-errors.md
+++ b/content/docs/connect/connection-errors.md
@@ -13,7 +13,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/how-to-guides/connectivity-issues
   - /docs/connect/connectivity-issues
-updatedOn: '2026-06-19T14:28:23.449Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 This topic describes how to resolve connection errors you may encounter when using Neon. The errors covered include:
@@ -28,6 +28,7 @@ This topic describes how to resolve connection errors you may encounter when usi
 - [You have exceeded the limit of concurrently active endpoints](#you-have-exceeded-the-limit-of-concurrently-active-endpoints)
 - [Remaining connection slots are reserved for roles with the SUPERUSER attribute](#remaining-connection-slots-are-reserved-for-roles-with-the-superuser-attribute)
 - [Relation not found](#relation-not-found)
+- [cannot execute ... in a read-only transaction (SQLSTATE 25006)](#error-read-only-transaction)
 - [Postgrex: DBConnection ConnectionError ssl send: closed](#postgrex-dbconnection-connectionerror-ssl-send-closed)
 - [query_wait_timeout SSL connection has been closed unexpectedly](#querywaittimeout-ssl-connection-has-been-closed-unexpectedly)
 - [The request could not be authorized due to an internal error](#the-request-could-not-be-authorized-due-to-an-internal-error)
@@ -232,6 +233,32 @@ If you are already using connection pooling, you may need to reach out to Neon S
 ## Relation not found
 
 This error is often encountered when attempting to set the Postgres `search_path` session variable using a `SET search_path` statement over a pooled connection. For more information and workarounds, please see [Connection pooling in transaction mode](/docs/connect/connection-pooling#connection-pooling-in-transaction-mode).
+
+## cannot execute ... in a read-only transaction (SQLSTATE 25006) (#error-read-only-transaction)
+
+You attempted a write (`INSERT`, `UPDATE`, `DELETE`, `MERGE`, `COPY ... FROM`, or DDL such as `CREATE`, `ALTER`, `DROP`, or `TRUNCATE`) in a transaction that Postgres treats as read-only. The error looks like this:
+
+```text
+ERROR: cannot execute INSERT in a read-only transaction (SQLSTATE 25006)
+```
+
+Postgres raises this error (error code `25006`, `read_only_sql_transaction`) in three situations:
+
+**1. You're connected to a read replica.** A [read replica](/docs/introduction/read-replicas) runs on a compute in recovery, which forces every transaction to be read-only. This is the most common cause. Writes must go to your read/write (primary) compute.
+
+- Confirm which compute you're connected to. If your connection string points at a read replica compute, switch to your read/write compute for writes.
+- If your framework routes reads and writes separately, make sure write and transaction queries target the primary. See [Use read replicas with Prisma](/docs/guides/read-replica-prisma) for an example.
+- You can check whether the current connection is a replica by running `SELECT pg_is_in_recovery();`. A result of `t` means you're on a read replica.
+
+**2. The session or transaction was set read-only.** An explicit `BEGIN TRANSACTION READ ONLY`, `SET TRANSACTION READ ONLY`, or `SET default_transaction_read_only = on` makes writes fail with this error.
+
+- Check the setting with `SHOW default_transaction_read_only;`. If it's `on`, reset it with `RESET default_transaction_read_only;` (or `SET default_transaction_read_only = off;`).
+- Prefer scoping read-only mode to individual transactions (`BEGIN TRANSACTION READ ONLY`) rather than setting it at the session, database, or role level.
+
+**3. A pooled connection inherited a read-only setting from a previous session.** Neon's [pooled connection](/docs/connect/connection-pooling) uses PgBouncer in transaction mode, where backend connections are reused across clients. If one client sets `default_transaction_read_only = on` (or `SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY`) and doesn't reset it, a later client that reuses the same backend can inherit the read-only state and hit this error intermittently.
+
+- Audit your application code, migrations, and scheduled jobs for session-level `SET default_transaction_read_only` or `SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY`. Replace them with transaction-scoped `BEGIN TRANSACTION READ ONLY`, or run `RESET default_transaction_read_only` / `DISCARD ALL` before returning the connection.
+- Run schema migrations, `pg_dump`, `pg_restore`, and other administrative tasks over a [direct (unpooled) connection string](/docs/connect/connection-pooling#when-to-use-pooled-vs-direct-connections) so session state can't leak into the pool. Note that the pooled endpoint does not route you to a read replica; it targets your read/write compute.
 
 ## Postgrex: DBConnection ConnectionError ssl send: closed
 

--- a/content/docs/guides/better-drizzle.md
+++ b/content/docs/guides/better-drizzle.md
@@ -7,7 +7,7 @@ summary: >-
   configure a Better Drizzle client, define schema relations, seed data, run
   CRUD queries, use plugins, and manage transactions with savepoints.
 enableTableOfContents: true
-updatedOn: '2026-08-04T05:18:26.469Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 <InfoBlock>
@@ -81,6 +81,10 @@ Create a `.env` file in your project's root directory and add the connection str
 ```text shouldWrap
 DATABASE_URL="postgresql://[user]:[password]@[neon_hostname]/[dbname]?sslmode=require&channel_binding=require"
 ```
+
+<Admonition type="note">
+Neon supports both direct and pooled connection strings, which you can find by clicking the **Connect** button on your **Project Dashboard**. A pooled connection string (the hostname includes `-pooler`) routes through a PgBouncer connection pool, which is ideal for your application at runtime. However, using a pooled connection string for migrations can lead to errors. Use a direct (non-pooled) connection when running Drizzle Kit migrations. For more information, see [Connection pooling](/docs/connect/connection-pooling) and [Schema migration with Drizzle ORM](/docs/guides/drizzle-migrations).
+</Admonition>
 
 ## Install dependencies
 

--- a/content/docs/guides/drizzle.md
+++ b/content/docs/guides/drizzle.md
@@ -10,7 +10,7 @@ summary: >-
   guide also shows how to point Drizzle at different Neon branches per
   environment by selecting a connection string based on NODE_ENV.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 <CopyPrompt src="/prompts/drizzle-prompt.md" 
@@ -70,6 +70,10 @@ Create a `.env` file in your project's root directory and add the connection str
 ```text shouldWrap
 DATABASE_URL="postgresql://[user]:[password]@[neon_hostname]/[dbname]?sslmode=require&channel_binding=require"
 ```
+
+<Admonition type="note">
+Neon supports both direct and pooled connection strings, which you can find by clicking the **Connect** button on your **Project Dashboard**. A pooled connection string (the hostname includes `-pooler`) routes through a PgBouncer connection pool, which is ideal for your application at runtime. However, using a pooled connection string for migrations can lead to errors. Use a direct (non-pooled) connection when running Drizzle Kit migrations. For more information, see [Connection pooling](/docs/connect/connection-pooling) and [Schema migration with Drizzle ORM](/docs/guides/drizzle-migrations).
+</Admonition>
 
 ## Install Drizzle and a driver
 

--- a/content/docs/guides/flyway-multiple-environments.md
+++ b/content/docs/guides/flyway-multiple-environments.md
@@ -11,7 +11,7 @@ summary: >-
   environments and want to integrate Neon branch creation with Flyway migration
   ordering.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 With Flyway, you can manage and track changes to your database schema, ensuring that the database evolves consistently across different environments.
@@ -115,6 +115,10 @@ Your connection strings should look something like the ones shown below. Note th
   ```bash shouldWrap
   jdbc:postgresql://ep-shrill-shape-27763949.us-east-2.aws.neon.tech/neondb?user=alex&password=AbC123dEf
   ```
+
+<Admonition type="important">
+Use direct (non-pooled) connection strings with Flyway. Neon's pooled connection uses PgBouncer in transaction mode, which doesn't support all session-level operations that schema migration tools rely on, so running migrations over a pooled connection can lead to errors. Make sure none of the hostnames include the `-pooler` suffix (turn the **Connection pooling** toggle off in the **Connect** modal). See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## Configure flyway to connect each environment
 

--- a/content/docs/guides/flyway.md
+++ b/content/docs/guides/flyway.md
@@ -10,7 +10,7 @@ summary: >-
   migration workflow across multiple Neon branches or environments, see the
   companion guide on multiple database environments.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Flyway is a database migration tool that provides version control for databases. It allows developers to manage and track changes to the database schema, ensuring that the database evolves consistently across different environments.
@@ -70,6 +70,10 @@ Your Java connection string should look something like this:
 ```bash shouldWrap
 jdbc:postgresql://ep-cool-darkness-123456.us-east-2.aws.neon.tech/neondb?user=alex&password=AbC123dEf
 ```
+
+<Admonition type="important">
+Use a direct (non-pooled) connection string with Flyway. Neon's pooled connection uses PgBouncer in transaction mode, which doesn't support all session-level operations that schema migration tools rely on, so running migrations over a pooled connection can lead to errors. Make sure the hostname does not include the `-pooler` suffix (turn the **Connection pooling** toggle off in the **Connect** modal). See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## Configure flyway
 

--- a/content/docs/guides/knex.md
+++ b/content/docs/guides/knex.md
@@ -8,7 +8,7 @@ summary: >-
   also improve performance by switching to `pg-native` via the
   `NODE_PG_FORCE_NATIVE` environment variable.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Knex is an open-source SQL query builder for Postgres. This guide covers the following topics:
@@ -54,6 +54,10 @@ DATABASE_URL="postgresql://alex:AbC123dEf@ep-cool-darkness-123456-pooler.us-east
 ```
 
 A pooled Neon connection string adds `-pooler` to the endpoint ID, which tells Neon to use a pooled connection. You can add `-pooler` to your connection string manually or copy a pooled connection string by clicking the **Connect** button on your **Project Dashboard** to open the **Connect to your database** modal. Enable the **Connection pooling** toggle to add the `-pooler` suffix.
+
+<Admonition type="important">
+Use a pooled connection string for your application at runtime, but use a direct (non-pooled) connection string when running Knex migrations. Neon's pooled connection uses PgBouncer in transaction mode, which doesn't support all session-level operations that migration tools rely on, so running migrations over a pooled connection can lead to errors. See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## Performance tips
 

--- a/content/docs/guides/liquibase-workflow.md
+++ b/content/docs/guides/liquibase-workflow.md
@@ -9,7 +9,7 @@ summary: >-
   setup. Neon's copy-on-write branching keeps development changes isolated
   until explicitly promoted.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Liquibase is an open-source database-independent library for tracking, managing, and applying database schema changes. To learn more about Liquibase, refer to the [Liquibase documentation](https://docs.liquibase.com/home.html).
@@ -98,6 +98,10 @@ The target database is the database on your `feature/blog-schema` branch where y
    ```
 
 Be careful not to mix up your connection strings. You'll see that the hostname (the part starting with `ep-` and ending in `neon.tech`) differs. This is because the `feature/blog-schema` branch is a separate instance of Postgres, hosted on its own compute.
+
+<Admonition type="important">
+Use direct (non-pooled) connection strings with Liquibase. Neon's pooled connection uses PgBouncer in transaction mode, which doesn't support all session-level operations that schema migration tools rely on, so running migrations over a pooled connection can lead to errors. Make sure your connection strings do not include the `-pooler` suffix (turn the **Connection pooling** toggle off in the **Connect** modal). See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## Update your liquibase.properties file
 

--- a/content/docs/guides/liquibase.md
+++ b/content/docs/guides/liquibase.md
@@ -9,7 +9,7 @@ summary: >-
   JDBC URL format for Neon and demonstrates the update and rollbackCount
   commands.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Liquibase is an open-source library for tracking, managing, and applying database schema changes. To learn more about Liquibase, refer to the [Liquibase documentation](https://docs.liquibase.com/home.html).
@@ -116,6 +116,10 @@ Your Java connection string should look something like the one shown below.
 ```bash shouldWrap
 jdbc:postgresql://ep-cool-darkness-123456.us-east-2.aws.neon.tech/blog?user=alex&password=AbC123dEf
 ```
+
+<Admonition type="important">
+Use a direct (non-pooled) connection string with Liquibase. Neon's pooled connection uses PgBouncer in transaction mode, which doesn't support all session-level operations that schema migration tools rely on, so running migrations over a pooled connection can lead to errors. Make sure the hostname does not include the `-pooler` suffix (turn the **Connection pooling** toggle off in the **Connect** modal). See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## Connect from Liquibase to your Neon database
 

--- a/content/docs/guides/logical-replication-airbyte-snowflake.md
+++ b/content/docs/guides/logical-replication-airbyte-snowflake.md
@@ -9,7 +9,7 @@ summary: >-
   wal_level to logical for all databases in the Neon project.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations. In this guide, you will learn how to define your Lakebase Postgres database as a data source in Airbyte so that you can stream data to Snowflake.
@@ -170,7 +170,7 @@ The Airbyte UI currently allows selecting any table for Change Data Capture (CDC
 ## Create a Postgres source in Airbyte
 
 1. From your Airbyte Cloud account, select **Sources** from the left navigation bar, search for **Postgres**, and then create a new Postgres source.
-2. Enter the connection details for your Neon database. You can find your database connection details by clicking the **Connect** button on your **Project Dashboard**.
+2. Enter the connection details for your Neon database. You can find your database connection details by clicking the **Connect** button on your **Project Dashboard**. Use a direct connection to your compute endpoint, not a pooled connection. Logical replication requires a persistent connection and is not compatible with connection poolers, so make sure the connection string does not include `-pooler` in the hostname. See [Connection pooling](/docs/connect/connection-pooling).
    For example, given a connection string like this:
 
    ```bash shouldWrap

--- a/content/docs/guides/logical-replication-concepts.md
+++ b/content/docs/guides/logical-replication-concepts.md
@@ -11,7 +11,7 @@ summary: >-
   alongside the standard pgoutput plugin.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Logical Replication is a method of replicating data between databases or between your database and other data services or platforms. It differs from physical replication in that it replicates transactional changes rather than copying the entire database byte-for-byte. This approach allows for selective replication, where users can choose specific tables or rows for replication. It works by capturing DML operations in the source database and applying these changes to the target, which could be another Postgres database or data platform.
@@ -76,6 +76,10 @@ PUBLICATION users_publication;
 ```
 
 A subscription requires a unique name, a database connection string, the name and password of your replication role, and the name of the publication it subscribes to.
+
+<Admonition type="note">
+When the connection string points at a Neon database, use a direct connection, not a pooled one. Logical replication requires a persistent connection and is not compatible with connection poolers, so the hostname must not include the `-pooler` suffix. See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## How does it work under the hood?
 

--- a/content/docs/guides/logical-replication-databricks.md
+++ b/content/docs/guides/logical-replication-databricks.md
@@ -12,7 +12,7 @@ summary: >-
   supported.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Neon's logical replication feature lets you stream changes from your Lakebase Postgres database into external systems. This guide shows how to use Databricks Lakeflow Connect's PostgreSQL connector to replicate data from Lakebase Postgres into Databricks Lakehouse using PostgreSQL logical replication.
@@ -185,7 +185,7 @@ Lakeflow Connect uses Unity Catalog connections to store JDBC connection details
 3. Enter a **Connection name**.
    Choose **PostgreSQL** as the connection type.
 4. For Auth type, select `Username and password`.
-5. Enter your Neon connection details (from the **Connect** button on your Neon project dashboard):
+5. Enter your Neon connection details (from the **Connect** button on your Neon project dashboard). Use your direct Neon host, not the pooled host. Logical replication requires a persistent connection and is not compatible with connection poolers, so the host must not include the `-pooler` suffix. See [Connection pooling](/docs/connect/connection-pooling).
    - **Host**: your Neon host (e.g. `ep-cool-darkness-123456.us-east-2.aws.neon.tech`)
    - **Port**: 5432
    - **Database**: your Neon database name

--- a/content/docs/guides/logical-replication-inngest.md
+++ b/content/docs/guides/logical-replication-inngest.md
@@ -11,7 +11,7 @@ summary: >-
   credentials to the Inngest integration wizard (credentials are not stored).
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -50,7 +50,7 @@ The Inngest Integration requires Postgres admin credentials to complete its setu
 
 ![Neon authorization step inside the Inngest integrations page](/docs/guides/inngest-integration-neon-authorize-step.png)
 
-You can find your admin Neon database connection credentials by clicking the **Connect** button on your **Project Dashboard** to open the **Connect to your database** modal. For details, see [Connect from any application](/docs/connect/connect-from-any-app).
+You can find your admin Neon database connection credentials by clicking the **Connect** button on your **Project Dashboard** to open the **Connect to your database** modal. For details, see [Connect from any application](/docs/connect/connect-from-any-app). Use a direct connection, not a pooled connection. Logical replication requires a persistent connection and is not compatible with connection poolers, so make sure the connection string does not include `-pooler` in the hostname. See [Connection pooling](/docs/connect/connection-pooling).
 
 ## Example: Replicating data to Amplitude
 

--- a/content/docs/guides/logical-replication-neon-to-neon.md
+++ b/content/docs/guides/logical-replication-neon-to-neon.md
@@ -13,7 +13,7 @@ summary: >-
   project and the change cannot be reverted.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from one Neon project to another. This enables different usage scenarios, including:
@@ -127,7 +127,7 @@ After creating a publication on the source database, you need to create a subscr
    ```
 
    - `subscription_name`: A name you chose for the subscription.
-   - `connection_string`: The connection string for the source Neon database where you defined the publication.
+   - `connection_string`: The connection string for the source Neon database where you defined the publication. Use a direct connection string, not a pooled one. Logical replication requires a persistent connection and is not compatible with connection poolers, so the hostname must not include the `-pooler` suffix. See [Connection pooling](/docs/connect/connection-pooling).
    - `publication_name`: The name of the publication you created on the source Neon database.
 
 3. Verify the subscription was created by running the following command:

--- a/content/docs/guides/logical-replication-neon.md
+++ b/content/docs/guides/logical-replication-neon.md
@@ -11,7 +11,7 @@ summary: >-
   `pgoutput` and `wal2json`.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-22T13:42:19.210Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 This topic outlines information about logical replication specific to Neon, including important notices.
@@ -140,6 +140,10 @@ WHERE rolname = '<role_name>';
 ## Subscriber access
 
 A subscriber must be able to access the Neon database that is acting as a publisher. In Neon, no action is required unless you use Neon's **IP Allow** feature to limit IP addresses that can connect to Neon.
+
+<Admonition type="important">
+When a subscriber connects to a Neon publisher, use a direct connection string, not a pooled one. Logical replication requires a persistent connection and is not compatible with connection poolers. Make sure the connection string you give the subscriber does not include the `-pooler` suffix in the hostname. See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 If you use Neon's **IP Allow** feature:
 

--- a/content/docs/guides/logical-replication-prisma-pulse.md
+++ b/content/docs/guides/logical-replication-prisma-pulse.md
@@ -12,7 +12,7 @@ summary: >-
   `PrismaNeon` driver adapter.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Neon's Logical Replication feature enables you to subscribe to changes in your database, supporting things like replication or creating event-driven functionality.
@@ -64,7 +64,7 @@ SHOW wal_level;
 1. If you haven't already done so, create a new account or sign in on the [Prisma Data Platform](https://pris.ly/pdp?utm_source=neon&utm_medium=pulse-guide).
 2. In the [Prisma Data Platform Console](https://console.prisma.io?utm_source=neon&utm_medium=pulse-guide) create a new project by clicking the **New project** button.
 3. In the **New project** configuration, select **Pulse** as your starting point.
-4. Copy your database connection string from Neon into the database connection input field on the Platform Console.
+4. Copy your database connection string from Neon into the database connection input field on the Platform Console. Use a direct connection to your compute endpoint, not a pooled connection. Logical replication requires a persistent connection and is not compatible with connection poolers, so make sure the connection string does not include `-pooler` in the hostname. See [Connection pooling](/docs/connect/connection-pooling).
 5. Choose a region that is closest to your Neon database.
 6. Click **Create project**.
 7. We recommend leaving **Event persistence** switched **on** (default). This means Prisma Pulse will automatically store events in the case your server goes down, allowing you to resume again with zero data loss.

--- a/content/docs/guides/read-replica-prisma.md
+++ b/content/docs/guides/read-replica-prisma.md
@@ -10,7 +10,7 @@ summary: >-
   to be a separate PrismaClient instance with a PrismaNeon adapter. Multiple
   replicas are selected randomly per query.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 A Neon read replica is an independent read-only compute that performs read operations on the same data as your primary read-write compute, which means adding a read replica to a Neon project requires no additional storage.
@@ -170,6 +170,10 @@ Notice that the `endpoint_id` (`ep-damp-cell-123456`) for the read replica compu
    When your application runs, read operations are sent to the read replica. If you specify multiple read replicas, a read replica is selected randomly.
 
    All write and `$transaction` queries are sent to the primary compute defined by `DATABASE_URL`, which is your read/write compute.
+
+   <Admonition type="warning">
+   Read replicas are read-only. Sending a write (`INSERT`, `UPDATE`, `DELETE`, or DDL) to a read replica fails with `ERROR: cannot execute INSERT in a read-only transaction (SQLSTATE 25006)`. Make sure `DATABASE_REPLICA_URL` points at a read replica compute and `DATABASE_URL` points at your read/write compute so writes are routed to the primary. See [cannot execute ... in a read-only transaction](/docs/connect/connection-errors#error-read-only-transaction).
+   </Admonition>
 
    If you want to read from the primary compute and bypass read replicas, you can use the `$primary()` method in your extended Prisma Client instance:
 

--- a/content/docs/guides/rls-drizzle.md
+++ b/content/docs/guides/rls-drizzle.md
@@ -12,7 +12,7 @@ summary: >-
   running queries that respect those policies at runtime, see the companion page
   on RLS query execution with Drizzle.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 redirectFrom:
   - /docs/guides/neon-rls-authorize-drizzle
   - /docs/guides/neon-authorize-drizzle
@@ -101,7 +101,7 @@ export const todos = pgTable(
 ```
 
 <Admonition type="note">
-**About Drizzle's role:** Drizzle is used to **declare and migrate RLS policies** in TypeScript. When migrations are run, these policies are created in your Postgres database and enforced automatically regardless of how queries are executed.
+**About Drizzle's role:** Drizzle is used to **declare and migrate RLS policies** in TypeScript. When migrations are run, these policies are created in your Postgres database and enforced automatically regardless of how queries are executed. Run these migrations over a direct (non-pooled) connection string, not a pooled one. See [Schema migration with Drizzle ORM](/docs/guides/drizzle-migrations) and [Connection pooling](/docs/connect/connection-pooling).
 
 You can run queries that respect these policies using either the [Data API client](/docs/data-api/get-started#connect-and-query) (frontend) or the [Neon serverless driver](#using-drizzle-with-the-serverless-driver) using the Drizzle query builder (backend).
 </Admonition>

--- a/content/docs/guides/tortoise-orm.md
+++ b/content/docs/guides/tortoise-orm.md
@@ -12,7 +12,7 @@ summary: >-
   python-dotenv, and avoiding hanging processes by calling
   Tortoise.close_connections() or using run_async().
 enableTableOfContents: true
-updatedOn: '2026-08-04T05:18:26.469Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 <CopyPrompt src="/prompts/tortoise-orm-prompt.md" 
@@ -81,6 +81,10 @@ DATABASE_URL="postgres://[PGUSER]:[PGPASSWORD]@[PGHOST]/[PGDATABASE]?ssl=true"
 ```
 
 > Replace the placeholders `[PGUSER]`, `[PGPASSWORD]`, `[PGHOST]`, and `[PGDATABASE]` with the corresponding values from your Neon connection details. Make sure to include `ssl=true` to ensure a secure connection.
+
+<Admonition type="important">
+Use a direct (non-pooled) connection string when generating schemas or running migrations (for example, with Aerich). Neon's pooled connection uses PgBouncer in transaction mode, which doesn't support all session-level operations that schema changes rely on, so running them over a pooled connection can lead to errors. Make sure the hostname does not include the `-pooler` suffix. See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## Create the application
 

--- a/content/docs/guides/typeorm.md
+++ b/content/docs/guides/typeorm.md
@@ -9,7 +9,7 @@ summary: >-
   connections. To prevent timeouts from Lakebase Postgres idle-compute cold start (default
   5 minutes), add `connect_timeout=10` to the connection string.
 enableTableOfContents: true
-updatedOn: '2026-08-04T05:18:26.469Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 <CopyPrompt src="/prompts/typeorm-prompt.md" 
@@ -66,6 +66,10 @@ DATABASE_URL="postgresql://alex:AbC123dEf@ep-cool-darkness-123456-pooler.us-east
 ```
 
 A pooled Neon connection string adds `-pooler` to the endpoint ID, which tells Neon to use a pooled connection. You can add `-pooler` to your connection string manually or copy a pooled connection string from the **Connect to your database** modal, which you can access by clicking **Connect** on your **Project Dashboard**. Enable the **Connection pooling** toggle to add the `-pooler` suffix.
+
+<Admonition type="important">
+Use a pooled connection string for your application at runtime, but use a direct (non-pooled) connection string when running TypeORM migrations. Neon's pooled connection uses PgBouncer in transaction mode, which doesn't support all session-level operations that migration tools rely on, so running migrations over a pooled connection can lead to errors. See [Connection pooling](/docs/connect/connection-pooling).
+</Admonition>
 
 ## Connection timeouts
 

--- a/content/docs/import/import-data-assistant.md
+++ b/content/docs/import/import-data-assistant.md
@@ -11,7 +11,7 @@ summary: >-
 enableTableOfContents: true
 tag: beta
 tagTheme: blue
-updatedOn: '2026-07-13T14:20:27.525Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 redirectFrom:
   - /docs/import/migration-assistant
 ---
@@ -35,7 +35,7 @@ You'll need:
   postgresql://username:password@host:port/database?sslmode=require&channel_binding=require
   ```
 
-  If you are migrating a database from one Neon project to another, you need the connection string for the source database, which you can access from the **Connect** modal on the project dashboard.
+  If you are migrating a database from one Neon project to another, you need the connection string for the source database, which you can access from the **Connect** modal on the project dashboard. When the source is a Neon project, use a direct (unpooled) connection string, not a pooled one. Make sure the hostname does not include the `-pooler` suffix. See [Connection pooling](/docs/connect/connection-pooling).
 
 - **Admin privileges** on your source database. We recommend using a superuser if migrating from another platform, or a user with the necessary `CREATE`, `SELECT`, `INSERT`, and `REPLICATION` privileges.
 - A database **smaller than 10 GB** in size for automated import. For larger databases, use [Migrate data from Postgres with pg_dump and pg_restore](/docs/import/migrate-from-postgres).

--- a/content/docs/import/migrate-neon-to-another-region.md
+++ b/content/docs/import/migrate-neon-to-another-region.md
@@ -10,7 +10,7 @@ summary: >-
   minimal-downtime cutover on busy databases).
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-06-18T20:46:14.637Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 redirectFrom:
   - /docs/guides/migrate-neon-to-another-region
 ---
@@ -33,7 +33,7 @@ In the Neon Console, open the **[Projects](https://console.neon.tech/app/)** pag
 
 ### pg_dump and pg_restore
 
-**Best for** when you want full control of dump files and restore timing. See **[Migrate data from another Neon project](/docs/import/migrate-from-neon)**.
+**Best for** when you want full control of dump files and restore timing. See **[Migrate data from another Neon project](/docs/import/migrate-from-neon)**. Use direct (unpooled) connection strings for both the source and target; avoid running `pg_dump` or `pg_restore` over a pooled connection.
 
 ### Logical replication
 

--- a/content/docs/manage/backup-pg-dump-automate.md
+++ b/content/docs/manage/backup-pg-dump-automate.md
@@ -8,7 +8,7 @@ summary: >-
   disaster recovery, or compliance-driven backup files outside of Neon's native
   restore feature.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 Keeping regular backups of your database is critical for protecting against data loss. While Neon offers an [instant restore](/docs/introduction/branch-restore) feature (point-in-time restore) for backups of up to 30 days, there are scenarios (such as business continuity, disaster recovery, or regulatory compliance) where maintaining independent and longer-lived backup files may be necessary. In these cases, using the Postgres `pg_dump` tool to create backups and storing them on a reliable external service (like an AWS S3 bucket) gives you control over long-term retention and recovery of your data.
@@ -16,6 +16,10 @@ Keeping regular backups of your database is critical for protecting against data
 Manually performing backups can be tedious and time consuming, so automation is key to ensure you're taking backups consistently. An automated backup process also lets you enforce retention policies by automatically cleaning up old backups, saving storage, and keeping your backup repository tidy.
 
 This two-part guide walks you through setting up an automated backup pipeline using `pg_dump` and GitHub Actions. You will configure everything needed to run nightly backups and store them in S3, ensuring your data is available to restore if needed.
+
+<Admonition type="important">
+Avoid using `pg_dump` over a [pooled connection string](/docs/reference/glossary#pooled-connection-string). Use an [unpooled connection string](/docs/reference/glossary#unpooled-connection-string) (the hostname without the `-pooler` suffix) for the backup connection.
+</Admonition>
 
 <DetailIconCards>
 

--- a/content/docs/manage/backups-aws-s3-backup-part-2.md
+++ b/content/docs/manage/backups-aws-s3-backup-part-2.md
@@ -9,7 +9,7 @@ summary: >-
   number of days. Set `PG_VERSION` and `AWS_REGION` to target any Postgres
   version or AWS region.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-07T18:39:13.799Z'
 ---
 
 This guide shows you how to configure nightly Postgres backups using a scheduled GitHub Action and `pg_dump`.
@@ -35,6 +35,10 @@ Setting up a scheduled backup involves three key components:
   - The **connection string** for your database
   - The **AWS region** where your database is deployed
   - The **Postgres version** your database is running
+
+<Admonition type="important">
+Use a direct (unpooled) connection string for `DATABASE_URL`. Avoid using `pg_dump` over a [pooled connection string](/docs/reference/glossary#pooled-connection-string); use an [unpooled connection string](/docs/reference/glossary#unpooled-connection-string) instead. Make sure the hostname does not include the `-pooler` suffix.
+</Admonition>
 
 ### 3. GitHub Action
 


### PR DESCRIPTION
## Problem

Support is seeing cases where users run schema migration tools, `pg_dump`, and logical replication over a **pooled** connection string, hitting errors including `cannot execute ... in a read-only transaction (SQLSTATE 25006)`. Neon's pooled endpoint uses PgBouncer in transaction mode, which doesn't support the session-level operations these tools rely on. Many tool and workflow pages did not state the direct-connection requirement, and the 25006 error was documented only for read replicas.

## What this changes

**New troubleshooting entry**
- `connect/connection-errors.md`: added a **SQLSTATE 25006** section (anchor `#error-read-only-transaction`, added to the page ToC) covering all three real causes: read replica, session/transaction set read-only, and a pooled connection inheriting a leaked `default_transaction_read_only` setting. Each has a specific fix. Notes that the `-pooler` endpoint does not route to a read replica.

**ORM / migration tool pages** (direct-connection warning added)
- `typeorm.md`, `knex.md`, `flyway.md`, `flyway-multiple-environments.md`, `liquibase.md`, `liquibase-workflow.md`, `tortoise-orm.md`

**Prisma / Drizzle pages**
- `drizzle.md`, `better-drizzle.md`, `rls-drizzle.md`, `read-replica-prisma.md`, `logical-replication-prisma-pulse.md` (Prisma's `prisma.md` / `prisma-migrations.md` and Drizzle's `drizzle-migrations.md` already had it)

**pg_dump / import pages**
- `manage/backups-aws-s3-backup-part-2.md`, `manage/backup-pg-dump-automate.md`, `import/import-data-assistant.md`, `import/migrate-neon-to-another-region.md` (Heroku, Render, Digital Ocean, Railway, pgcopydb already covered)

**Logical replication pages** (for tools connecting *to* Neon as publisher)
- `logical-replication-neon.md` (canonical Subscriber access section), `logical-replication-concepts.md`, `logical-replication-neon-to-neon.md`, `logical-replication-databricks.md`, `logical-replication-inngest.md`, `logical-replication-airbyte-snowflake.md`

Wording reuses the existing vetted phrasing already present elsewhere in the docs. All Admonition tags are balanced and all referenced anchors resolve.

This pull request and its description were written by Isaac.