### PR TITLE
Make /models additive over the catalog instead of restating it

### DIFF
--- a/src/app/models/resolve.js
+++ b/src/app/models/resolve.js
@@ -17,24 +17,31 @@ const blendedCost = (cost) =>
     ? Math.round(((3 * cost.input + cost.output) / 4) * 1000) / 1000
     : undefined;
 
-/** models.json fields plus the measured ones. Snake_case is kept so the two line up. */
+/**
+ * The catalog entry verbatim, plus what only this endpoint knows.
+ *
+ * `/models.json` is the catalog and `/models` builds on top of it, so this **adds
+ * and never restates**. It used to hand-list sixteen fields, which failed in both
+ * directions: `attachment` and `reasoning_options` were simply never listed and so
+ * vanished from `/models` entirely, and each listed field carried a `??` fallback
+ * that invented a value the catalog had not given. `cost: entry.cost ?? {}` was the
+ * one that fired — a model with no price was published as `cost: {}`, which reads as
+ * free, and made the two endpoints disagree about the same fact.
+ *
+ * Spreading also removes the reason they could drift: a field added to the catalog
+ * now appears here without anyone remembering to add it.
+ *
+ * The other six fallbacks were dead. `validateCatalog` (scripts/lib/models-catalog.mjs)
+ * requires id, name, provider, family, attachment, reasoning, tool_call, temperature,
+ * modalities, limit, open_weights, release_date and last_updated on every PR, so there
+ * is no path on which they were reachable. Note `provider ?? caps.owner` was worse than
+ * dead: `provider` is the model's maker and `owner` is whoever hosts it, so the fallback
+ * would have substituted "databricks" for "thinkingmachines".
+ */
 function toModel(id, entry, caps) {
   return {
+    ...entry,
     id,
-    name: entry.name ?? id,
-    provider: entry.provider ?? caps.owner,
-    family: entry.family,
-    release_date: entry.release_date,
-    last_updated: entry.last_updated,
-    knowledge: entry.knowledge,
-    reasoning: Boolean(entry.reasoning),
-    tool_call: Boolean(entry.tool_call),
-    structured_output: entry.structured_output,
-    temperature: entry.temperature,
-    open_weights: entry.open_weights,
-    modalities: entry.modalities ?? { input: [], output: [] },
-    limit: entry.limit ?? {},
-    cost: entry.cost ?? {},
     blended_cost: blendedCost(entry.cost),
     capabilities: {
       entitled: caps.entitled !== false,

--- a/src/app/models/route.test.js
+++ b/src/app/models/route.test.js
@@ -6,6 +6,61 @@ import { GET } from './route.js';
 const request = (query = '') => ({ nextUrl: new URL(`https://neon.com/models${query}`) });
 const body = async (res) => JSON.parse(await res.text());
 
+import catalog from '../models.json/data.json';
+
+// /models.json is the catalog and /models builds on top of it, so /models must add
+// and never restate. This is the property, asserted rather than left as a convention:
+// the endpoint drifted from it twice at once — dropping `attachment` and
+// `reasoning_options` because nobody added them to a hand-written field list, and
+// publishing `cost: {}` for a model the catalog gives no price, which reads as free
+// and made the two endpoints disagree about the same fact.
+describe('/models is additive over /models.json', () => {
+  it('carries every catalog field through unchanged, for every model', async () => {
+    const { models } = await body(await GET(request()));
+    const served = new Map(models.map((m) => [m.id, m]));
+
+    const drift = [];
+    for (const [id, entry] of Object.entries(catalog.neon.models)) {
+      const model = served.get(id);
+      if (!model) continue; // /models is keyed on the probe; absence is its own check
+      for (const [key, value] of Object.entries(entry)) {
+        if (JSON.stringify(model[key]) !== JSON.stringify(value)) {
+          drift.push(
+            `${id}.${key}: catalog ${JSON.stringify(value)}, /models ${JSON.stringify(model[key])}`
+          );
+        }
+      }
+    }
+
+    expect(drift).toEqual([]);
+  });
+
+  it('does not invent a field the catalog withholds', async () => {
+    const { models } = await body(await GET(request()));
+
+    for (const model of models) {
+      const entry = catalog.neon.models[model.id];
+      if (!entry) continue;
+      // A price the catalog does not give must be absent here too. `{}` is not
+      // "unknown", it renders as free.
+      expect({ id: model.id, hasCost: 'cost' in model }).toEqual({
+        id: model.id,
+        hasCost: 'cost' in entry,
+      });
+    }
+  });
+
+  it('adds what only this endpoint knows', async () => {
+    const { models } = await body(await GET(request()));
+    const model = models.find((m) => m.id === 'gpt-5-2');
+
+    // The three things /models contributes on top of the catalog.
+    expect(model.capabilities).toBeDefined();
+    expect(model.examples.length).toBeGreaterThan(0);
+    expect(typeof model.blended_cost).toBe('number');
+  });
+});
+
 describe('GET /models', () => {
   it.each(['chat', 'image-generation', 'web-search'])(
     'allows cross-origin requests for the %s use case',


### PR DESCRIPTION
## The question this answers

`/models.json` is the catalog and `/models` builds on top of it, so how can the two disagree
about the same fact? They shouldn't be able to — and the reason they could is the bug.

`toModel` **hand-listed sixteen fields** rather than passing the catalog entry through. That
failed in both directions at once.

## It dropped what nobody listed

`attachment` and `reasoning_options` are in the catalog and were **absent from `/models`
entirely**. Not deprecated, not deliberately withheld — just never added to the list.
`reasoning_options` is the set of effort levels a model accepts, which is worth publishing.

## It invented what the catalog withheld

Every listed field carried a `??` fallback. One of them fired:

```js
cost: entry.cost ?? {},
```

`inkling` has no sourceable price, so `/models.json` omits the key and `/models` published
`cost: {}`. An empty object reads as **free**, not *unknown*. That is the disagreement, and it is
why `check:models-endpoint-sync` has been red on `main`.

```console
$ npm run check:models-endpoint-sync    # before
2 field(s) disagree between the endpoints:
  gpt-5-5-pro.cost
  inkling.cost

$ npm run check:models-endpoint-sync    # after
local /models vs /models.json: 42 models in sync on 14 shared fields
```

**The other six fallbacks were dead.** `validateCatalog` requires `id`, `name`, `provider`,
`family`, `attachment`, `reasoning`, `tool_call`, `temperature`, `modalities`, `limit`,
`open_weights`, `release_date` and `last_updated` on every PR, so none was reachable.

One was worse than dead: `provider: entry.provider ?? caps.owner`. `provider` is the model's
**maker** and `owner` is whoever **hosts** it — they are different concepts, and the fallback
would have substituted `databricks` for `thinkingmachines`.

## The change

```js
function toModel(id, entry, caps) {
  return {
    ...entry,                              // the catalog, verbatim
    id,
    blended_cost: blendedCost(entry.cost), // derived
    capabilities: { … },                   // measured
  };
}
```

Spreading also removes the reason the two could drift: a field added to the catalog now appears
on `/models` without anyone remembering to add it, which is exactly the failure that lost
`attachment` and `reasoning_options`.

## Interface

```jsonc
// GET /models — inkling, which the catalog gives no price
{ "id": "inkling",
  "attachment": true,                    // was absent
  "reasoning_options": [ … ],            // was absent
  // "cost" is absent, matching /models.json — was `{}`
  "blended_cost": null,
  "capabilities": { … },
  "examples": [ … ] }
```

Purely additive to the response: two fields appear, one stops being fabricated. Nothing is
removed that the catalog actually provides.

## The property is now a test

Three of them, asserting the rule rather than the instance: every catalog field appears on
`/models` unchanged for every model; a field the catalog withholds stays absent; and `/models`
still adds the three things only it knows (`capabilities`, `examples`, `blended_cost`).

That is what stops this recurring. The endpoint drifted twice from a convention nobody could
check.

## Verification

- `npm run test:unit:run` — **724 passed** (3 new).
- `npm run check:models-endpoint-sync` — passes; was red on `main`.
- `node scripts/verify-agent-endpoints.mjs` — 8/8 endpoints, 30/30 checks.
- `npm run check:models-sync` — `[OK] models.dev mirrors all 42 models`.
- `npm run build` — compiled successfully.

## Note

This clears the endpoint half of the Inkling problem. The other half — that we have no
us-east-2 rate for it at all — is unchanged and tracked separately; `inkling` remains the one
model published without a price, now honestly absent on both endpoints rather than `{}` on one.