### PR TITLE
fix: publish the output-token ceiling the gateway actually enforces

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -1767,7 +1767,7 @@
         },
         "limit": {
           "context": 128000,
-          "output": 4096
+          "output": 8192
         },
         "cost": {
           "input": 0.5,
@@ -1838,7 +1838,7 @@
         },
         "limit": {
           "context": 262144,
-          "output": 8000
+          "output": 25000
         },
         "cost": {
           "input": 0.22,

--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -549,7 +549,7 @@
         },
         "limit": {
           "context": 131072,
-          "output": 32768
+          "output": 25000
         },
         "cost": {
           "input": 0.072,
@@ -589,7 +589,7 @@
         },
         "limit": {
           "context": 131072,
-          "output": 32768
+          "output": 25000
         },
         "cost": {
           "input": 0.05,
@@ -1675,7 +1675,7 @@
         },
         "limit": {
           "context": 131072,
-          "output": 16384
+          "output": 8192
         },
         "cost": {
           "input": 0.15,
@@ -1706,7 +1706,7 @@
         },
         "limit": {
           "context": 131072,
-          "output": 16384
+          "output": 8192
         },
         "cost": {
           "input": 0.15,
@@ -1737,7 +1737,7 @@
         },
         "limit": {
           "context": 1000000,
-          "output": 16384
+          "output": 8192
         },
         "cost": {
           "input": 0.5,
@@ -1797,7 +1797,7 @@
         },
         "limit": {
           "context": 131072,
-          "output": 32768
+          "output": 10000
         },
         "cost": {
           "input": 0.15,
@@ -1884,7 +1884,7 @@
         },
         "limit": {
           "context": 1000000,
-          "output": 131072
+          "output": 65536
         },
         "cost": {
           "input": 1.4,
@@ -1932,7 +1932,7 @@
         },
         "limit": {
           "context": 1048576,
-          "output": 1048576
+          "output": 65536
         }
       },
       "kimi-k3": {
@@ -1976,7 +1976,7 @@
         },
         "limit": {
           "context": 1048576,
-          "output": 131072
+          "output": 65536
         },
         "cost": {
           "input": 3,


### PR DESCRIPTION
## The problem

Reported against `kimi-k3`: we advertise 131,072 output tokens, and anything over 65,536 is rejected. The report is right, and it is not one model.

```
$ curl .../v1/chat/completions -d '{"model":"kimi-k3","max_tokens":65537,...}'
400  {"error":"Upstream error: INVALID_ARGUMENT: max_tokens (65537) cannot exceed 65536.
        Please reduce the length of max output tokens generated."}
```

**Eleven of the 42 models** publish a `limit.output` that is not the ceiling their endpoint enforces. Every one is an open-weights model on the unified route, and every wrong value traces back to the upstream maker's own entry rather than to a measurement of the serving layer. The Anthropic, OpenAI and Google models are all correct, because those we set from Databricks' numbers.

**The cap is not ours.** Calling the Databricks serving endpoints directly, bypassing the Neon gateway entirely, returns the identical error at the identical values — `databricks-kimi-k3` refuses 65,537 the same way. The gateway is passing an upstream limit through faithfully; only the metadata was ever wrong. Whether Databricks should serve `kimi-k3` at half Moonshot's own 131,072 is a separate platform question and not something this PR can answer.

## The fix

Nine were overstated, so the published value 400s:

| Model | Published | Actual | |
| --- | ---: | ---: | --- |
| `inkling` | 1,048,576 | 65,536 | 16x — the context window, published as an output limit |
| `glm-5-2` | 131,072 | 65,536 | 2x |
| `kimi-k3` | 131,072 | 65,536 | 2x |
| `qwen3-next-80b-a3b-instruct` | 32,768 | 10,000 | 3x |
| `gpt-oss-120b` | 32,768 | 25,000 | |
| `gpt-oss-20b` | 32,768 | 25,000 | |
| `gemma-3-12b` | 16,384 | 8,192 | 2x |
| `llama-4-maverick` | 16,384 | 8,192 | 2x |
| `meta-llama-3-1-8b-instruct` | 16,384 | 8,192 | 2x |

Two were understated against an explicitly enforced cap, so callers were leaving output on the table:

| Model | Published | Enforced |
| --- | ---: | ---: |
| `qwen35-122b-a10b` | 8,000 | 25,000 |
| `meta-llama-3-3-70b-instruct` | 4,096 | 8,192 |

## What a consumer sees

`neon.com/models.json` and `neon.com/models` both carry `limit.output`, and the console renders it. Before, a caller who trusted it and passed it straight through got a 400 on their first request:

```js
const { limit } = (await fetch('https://neon.com/models.json').then(r => r.json()))
  .neon.models['kimi-k3'];

await openai.chat.completions.create({
  model: 'kimi-k3',
  max_tokens: limit.output,   // was 131072 -> 400; now 65536 -> 200
  messages: [{ role: 'user', content: 'hi' }],
});
```

## Verification

Every model was posted at its published `limit.output` and at one token above it, and each of the eleven candidates was then confirmed at its boundary: the new value returns 200, one token above returns 400.

That boundary exists for **36 of the 42**, which are now exact. It does not exist for the other six, and their values are unchanged and unverified rather than confirmed:

| Model | Published output | Published context | Largest `max_tokens` accepted |
| --- | ---: | ---: | ---: |
| `claude-haiku-4-5` | 64,000 | 200,000 | 200,000 |
| `claude-sonnet-4-5` | 64,000 | 200,000 | 199,992 |
| `claude-opus-4-1` | 32,000 | 200,000 | 204,800 |
| `claude-sonnet-4-6` | 64,000 | 1,000,000 | 128,000 |
| `gpt-5-3-codex` | 128,000 | 400,000 | 100,000,000 |
| `gpt-5-5-pro` | 128,000 | 1,050,000 | 100,000,000 |

None of those endpoints enforces an output cap. What they enforce is a larger request-level limit unrelated to documented output capability: only `claude-haiku-4-5` lands on its published context, `claude-sonnet-4-5` stops eight tokens short of it, `claude-opus-4-1` goes past it, and `claude-sonnet-4-6` stops at 128,000 with a million-token context. The Responses route refuses nothing at all.

Accepting a `max_tokens` value is not evidence a model can produce that many tokens, whatever the accepted number turns out to correspond to. `claude-haiku-4-5` takes 200,000 and still emits at most 64,000. Their published figures are the makers' documented output limits — Anthropic documents 64,000 for the three Claude models and 32,000 for Opus 4.1, Databricks 128,000 for both GPT models — and are left alone; raising them to the accepted value would advertise output these models cannot generate.

`output <= context` holds across all 42. `validateCatalog` passes; `npm run test:unit:run` is green (721 tests).

## Flagged

**`limit.context` is not verified by this PR.** Only the output side was measured — confirming a 1M-token context means actually sending a 1M-token prompt. The same inheritance-from-upstream that produced these eleven wrong values applies to `context` too, so treat those numbers as unaudited rather than confirmed.

**Now guarded, where it can be.** `limit.output` was the one catalog claim nothing measured, which is how eleven of them rotted — the same shape as the `temperature` bug. The daily `models-endpoint` verification now reads the enforced cap out of the endpoint's own refusal, which is exact in both directions on the unified route and silent on the six endpoints that enforce nothing.
