### PR TITLE
docs(storage): correct S3 endpoint host in credentials example

### DIFF
--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -28,7 +28,7 @@ In the Neon Console, select your branch and click **Credentials** under **APP BA
 After creation, the credentials are shown once. Copy the snippet or click **Download .env** before closing:
 
 ```text
-AWS_ENDPOINT_URL_S3=https://br-cool-darkness-a1b2c3d4.storage.c-1.us-east-2.aws.neon.build
+AWS_ENDPOINT_URL_S3=https://br-cool-darkness-a1b2c3d4.storage.c-1.us-east-2.aws.neon.tech
 AWS_ACCESS_KEY_ID=nak_live_...
 AWS_SECRET_ACCESS_KEY=nsk_live_...
 AWS_REGION=us-east-2


### PR DESCRIPTION
## What

Corrects the S3 endpoint host in the Object Storage **authentication** credentials example.

The copy-paste snippet showed an endpoint whose host ended in a non-production (dev/staging) domain, right next to production credential tokens. A reader or coding agent copying it verbatim would point their S3 client at a host that isn't the production service.

**Before**

```text
AWS_ENDPOINT_URL_S3=https://br-cool-darkness-a1b2c3d4.storage.c-1.us-east-2.aws.neon.build
```

**After**

```text
AWS_ENDPOINT_URL_S3=https://br-cool-darkness-a1b2c3d4.storage.c-1.us-east-2.aws.neon.tech
```

This matches the production endpoint suffix used on every other storage page (e.g. `storage/get-started`).

## Scope

One-line change to `content/docs/storage/authentication.md`. Only the host suffix changed; the example credentials, region, and cell are untouched.

## Testing

Not live-tested in this run (out of scope for the validation run that produced this). The value is confirmed against the platform config that defines the production vs. dev endpoint domains.

## Ticket

LKB-16164
