### PR TITLE
docs: add reference for the neon logs CLI command

### DIFF
--- a/content/docs/cli/env.md
+++ b/content/docs/cli/env.md
@@ -5,8 +5,9 @@ summary: >-
   The Neon CLI `neon env pull` command writes a branch's Neon environment
   variables to a local .env file. By default it targets an existing .env file,
   otherwise .env.local, and only Neon-managed variables are rewritten; other
-  lines in the file are preserved. Use --file to target a specific file and
-  --branch to pull from a specific branch.
+  lines in the file are preserved. Use --file to target a specific file,
+  --branch to pull from a specific branch, and --service to pull only selected
+  services.
 enableTableOfContents: true
 ---
 
@@ -34,4 +35,10 @@ Pull a specific branch into a specific file:
 
 ```bash
 neon env pull --branch preview --file .env.preview
+```
+
+Pull only the variables for the services you name, ignoring `neon.ts`. Repeat `--service` or comma-separate the values (`postgres`, `auth`, `data-api`, `object-storage`, `ai-gateway`):
+
+```bash
+neon env pull --service ai-gateway --service postgres
 ```

--- a/content/docs/cli/logs.md
+++ b/content/docs/cli/logs.md
@@ -1,0 +1,74 @@
+---
+title: 'Neon CLI command: logs'
+subtitle: Query the logs a branch's services emit
+summary: >-
+  The Neon CLI `neon logs` command reads the logs a branch's services emit
+  (Postgres compute, storage, and Neon Functions). Query records over a time
+  window, filter by source, severity, or OpenTelemetry attributes, run raw
+  LogQL, and list which fields and values a branch reports. Logs are in beta
+  and available only in AWS US East (Ohio) (aws-us-east-2).
+enableTableOfContents: true
+updatedOn: '2026-08-10T15:04:49.412Z'
+---
+
+<FeatureBeta />
+
+The `logs` command reads the logs a branch's services emit: the Postgres compute, storage, and Neon Functions. Query records over a time window, filter by source, severity, or OpenTelemetry attribute, and list which fields and values a branch reports so you can build precise filters.
+
+Logs are in beta and available only in **AWS US East (Ohio) (`aws-us-east-2`)**, so your project must be in that region to use them.
+
+Every subcommand resolves the project and branch from your [context](/docs/cli/set-context). Pass `--project-id` and `--branch` to target a specific branch instead.
+
+<CliSubcommands command="logs" />
+
+## neon logs query (#query)
+
+Query log records over a time window. By default it returns the last hour of logs on the default branch, newest first.
+
+<CliUsage command="logs query" />
+
+<CliOptions command="logs query" />
+
+Bound the window with `--since` (a duration like `30m` or `1h`, ending at `--end-time` or now) or with an explicit `--start-time`/`--end-time` pair. `--since` and `--start-time` are mutually exclusive, and the maximum window is 7 days.
+
+The structured content filters (`--source`, `--service-name`, `--scope-name`, `--minimum-severity`, `--severity-text`, `--body-contains`, and `--trace-id`) combine with each other. Passing `--logql` replaces all of them with a raw [LogQL](https://grafana.com/docs/loki/latest/query/) expression (stream selectors and line filters only); the window, `--limit`, `--sort-order`, and `--cursor` still apply.
+
+```bash
+neon logs query --since 30m
+```
+
+Filter Postgres compute errors on a specific branch:
+
+```bash
+neon logs query --branch main --source pg_endpoint --minimum-severity error
+```
+
+Use a raw LogQL selection instead of the structured filters:
+
+```bash
+neon logs query --since 1h --logql '{entity_type="function"} |= "timeout"'
+```
+
+When more records match than fit in one page, the command reports a pagination cursor on stderr. Re-run with the same window and filters plus `--cursor=<value>` to fetch the next page.
+
+## neon logs fields (#fields)
+
+List the log fields a branch reports. Pass any of these field names to `neon logs field-values` to see the values it carries.
+
+<CliUsage command="logs fields" />
+
+<CliOptions command="logs fields" />
+
+## neon logs field-values (#field-values)
+
+List the distinct values a single field carries over a time window, so you know what to filter on with `neon logs query`. By default it looks back six hours.
+
+<CliUsage command="logs field-values" />
+
+<CliOptions command="logs field-values" />
+
+Show the service names seen in the last six hours:
+
+```bash
+neon logs field-values service_name --since 6h
+```

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1282,6 +1282,8 @@
               items:
                 - title: inspect
                   slug: cli/inspect
+                - title: logs
+                  slug: cli/logs
         - section: API
           icon: api
           items:

--- a/scripts/docs-checks/neonctl/README.md
+++ b/scripts/docs-checks/neonctl/README.md
@@ -149,6 +149,14 @@ The TypeScript source is canonical. CI only reads `schema.json`.
   by keeping output out of bash fences entirely.)
 - **Enum-reference defaults render as source text** unless patched via
   `overrides.json`.
+- **Factory-built option specs aren't resolved.** An option whose spec is a
+  factory call rather than an object literal (e.g. `services: servicesOption({…})`
+  in `config init` and `env pull`, where `servicesOption()` lives in the
+  non-command file `neon_services.ts` and builds its `describe` from a
+  conditional + array join) falls back to `type: unknown`; both are patched in
+  `overrides.json`. `.options(…)` and `...spread` positions built from a factory
+  call *are* resolved (see `resolveOptionsObject`) — the gap is only the
+  individual-option-value position (`parseOptionSpec`).
 - **Server-side defaults** (generated branch names, default CU) exist only
   in the control plane; they are documented as verified `defaultText`
   overrides, never inferred.

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -175,6 +175,13 @@ function resolveStringValue(expr, consts) {
   const direct = stringLiteralValue(e);
   if (direct !== undefined) return direct;
   if (!e) return undefined;
+  // Bare identifier bound to a string literal — used to resolve factory-function
+  // parameters (`windowOptions(defaultWindow)`) whose value was substituted into
+  // `consts` as a string-literal node by resolveOptionsObject.
+  if (ts.isIdentifier(e) && consts && consts.has(e.text)) {
+    const bound = stringLiteralValue(consts.get(e.text));
+    if (bound !== undefined) return bound;
+  }
   if (ts.isPropertyAccessExpression(e) && ts.isIdentifier(e.name)) {
     const target = resolveSpecObject(e.expression, consts);
     if (target) {
@@ -261,6 +268,19 @@ function literalValue(expr) {
 // choices, alias, required, hidden }`. Handles internal spreads
 // (`{ ...req['key'], describe: 'override' }`) by merging the resolved
 // spread first so explicit props win.
+//
+// LIMITATION: an option spec produced by a *factory call* rather than an
+// object literal — e.g. `services: servicesOption({ ... })` in config.ts and
+// env.ts, where servicesOption() lives in the non-command file
+// neon_services.ts and composes its `describe` from a conditional plus an
+// array filter/join — is not resolved. resolveSpecObject returns undefined
+// and the option falls back to `{ type: 'unknown' }` (safe: validation just
+// skips type/choices on it). Recovering type + describe correctly would need
+// cross-file function resolution and static evaluation of the composed
+// string, so those two flags are patched in overrides.json instead
+// (config init --services, env pull --service). Contrast the `.options(...)`
+// / spread positions, which resolveOptionsObject *does* resolve through a
+// factory call.
 function parseOptionSpec(expr, consts) {
   const obj = resolveSpecObject(expr, consts);
   if (!obj) return { type: 'unknown' };
@@ -331,6 +351,47 @@ function parseOptionSpec(expr, consts) {
   return spec;
 }
 
+// Resolves an expression to an options ObjectLiteralExpression, if possible.
+// Handles inline object literals, bare identifiers bound to a module-level
+// object const (`.options(scopeOptions)`), and calls to a module-level factory
+// arrow that returns an object literal (`...windowOptions("1h")`). For a
+// factory call, the arrow's parameters are bound to the call's argument
+// expressions in a child `consts` map so the returned object's templates
+// (`Defaults to ${defaultWindow}`) resolve; the resolved map is returned
+// alongside the object so callers can parse it with the right scope.
+function resolveOptionsObject(expr, consts) {
+  const e = unwrapExpression(expr);
+  if (!e) return undefined;
+  if (ts.isObjectLiteralExpression(e)) return { obj: e, consts };
+  if (ts.isIdentifier(e) && consts && consts.has(e.text)) {
+    const target = consts.get(e.text);
+    if (target && ts.isObjectLiteralExpression(target)) return { obj: target, consts };
+  }
+  if (
+    ts.isCallExpression(e) &&
+    ts.isIdentifier(e.expression) &&
+    consts &&
+    consts.has(e.expression.text)
+  ) {
+    const fn = consts.get(e.expression.text);
+    if (fn && (ts.isArrowFunction(fn) || ts.isFunctionExpression(fn))) {
+      const body = unwrapExpression(fn.body);
+      if (body && ts.isObjectLiteralExpression(body)) {
+        // Bind each parameter name to its call-site argument expression so
+        // string interpolations inside the returned object resolve.
+        const scoped = new Map(consts);
+        fn.parameters.forEach((param, i) => {
+          if (ts.isIdentifier(param.name) && e.arguments[i]) {
+            scoped.set(param.name.text, unwrapExpression(e.arguments[i]));
+          }
+        });
+        return { obj: body, consts: scoped };
+      }
+    }
+  }
+  return undefined;
+}
+
 // Parse the argument to `.options({...})` into a map of
 // `{ name: { type, describe, default, choices, alias, required } }`.
 // `consts` resolves `...identifier` spreads and external spec references
@@ -339,9 +400,9 @@ function parseOptionsObject(obj, consts) {
   const out = {};
   for (const p of obj.properties) {
     if (ts.isSpreadAssignment(p)) {
-      const spread = unwrapExpression(p.expression);
-      if (spread && ts.isIdentifier(spread) && consts && consts.has(spread.text)) {
-        Object.assign(out, parseOptionsObject(consts.get(spread.text), consts));
+      const resolved = resolveOptionsObject(p.expression, consts);
+      if (resolved) {
+        Object.assign(out, parseOptionsObject(resolved.obj, resolved.consts));
       }
       continue;
     }
@@ -480,12 +541,12 @@ function walkBuilder(builderNode, node, consts) {
       if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)) {
         const method = callee.name.text;
         if (method === 'options') {
-          // yargs.options({...}) or .options({...}). Merge argument into
-          // accumulator.
-          const arg = e.arguments[0];
-          if (arg && ts.isObjectLiteralExpression(arg)) {
-            const parsed = parseOptionsObject(arg, consts);
-            Object.assign(node.options, parsed);
+          // yargs.options({...}) or .options({...}). The argument is an object
+          // literal, a bare identifier bound to one (`.options(scopeOptions)`),
+          // or a factory call returning one. Merge it into the accumulator.
+          const resolved = resolveOptionsObject(e.arguments[0], consts);
+          if (resolved) {
+            Object.assign(node.options, parseOptionsObject(resolved.obj, resolved.consts));
           }
         } else if (method === 'option') {
           // .option('name', { ... }) single-form.

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -17,6 +17,32 @@
     }
   },
   "commands": {
+    "config": {
+      "commands": {
+        "init": {
+          "options": {
+            "services": {
+              "_comment": "Built by the servicesOption() factory in neon_services.ts, which the static parser can't evaluate (factory call as an option-spec value, in a non-command file; the describe is composed from a conditional + array filter/join). See generate-schema.js parseOptionSpec for the limitation. type and describe verified against `neon config init --help` at neonctl 3.1.0.",
+              "type": "array",
+              "describe": "Services the scaffolded neon.ts declares: auth, functions, object-storage, ai-gateway. Pass \"none\" for the bare starter policy. Repeat the flag or comma-separate. Omitted: pick interactively on a terminal, starter policy in CI or without a TTY."
+            }
+          }
+        }
+      }
+    },
+    "env": {
+      "commands": {
+        "pull": {
+          "options": {
+            "service": {
+              "_comment": "Built by the servicesOption() factory in neon_services.ts (see config init services override). type and describe verified against `neon env pull --help` at neonctl 3.1.0.",
+              "type": "array",
+              "describe": "Pull only these services' variables: postgres, auth, data-api, object-storage, ai-gateway. Repeat the flag or comma-separate. Overrides neon.ts, and prunes only within the services you name."
+            }
+          }
+        }
+      }
+    },
     "checkout": {
       "options": {
         "env-pull": {

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "2.46.0",
+  "neonctlVersion": "3.1.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -379,7 +379,7 @@
             },
             "protected": {
               "type": "boolean",
-              "describe": "Whether the branch is protected"
+              "describe": "Whether the branch is protected. Protected branches (and their computes) cannot be deleted, archived, or reset, and block deletion of the project. Can be gated by `protected_branches_only` in the IP allowlist. Paid plans only."
             },
             "psql": {
               "type": "boolean",
@@ -659,7 +659,16 @@
               "type": "string"
             }
           ],
-          "options": {},
+          "options": {
+            "branch": {
+              "type": "string",
+              "describe": "Branch ID or name"
+            },
+            "project-id": {
+              "type": "string",
+              "describe": "Project ID"
+            }
+          },
           "commands": {},
           "describe": "Delete a bucket from a branch",
           "usage": "$0 bucket delete <name> [options]"
@@ -670,7 +679,16 @@
             "ls"
           ],
           "positionals": [],
-          "options": {},
+          "options": {
+            "branch": {
+              "type": "string",
+              "describe": "Branch ID or name"
+            },
+            "project-id": {
+              "type": "string",
+              "describe": "Project ID"
+            }
+          },
           "commands": {},
           "describe": "List the buckets on a branch",
           "usage": "$0 bucket list [options]"
@@ -932,7 +950,8 @@
               "default": true
             },
             "services": {
-              "type": "string"
+              "type": "array",
+              "describe": "Services the scaffolded neon.ts declares: auth, functions, object-storage, ai-gateway. Pass \"none\" for the bare starter policy. Repeat the flag or comma-separate. Omitted: pick interactively on a terminal, starter policy in CI or without a TTY."
             }
           },
           "commands": {},
@@ -1446,6 +1465,10 @@
             "file": {
               "type": "string",
               "describe": "Target .env file to write. Defaults to an existing .env, otherwise .env.local. Only Neon variables are updated; other lines are preserved."
+            },
+            "service": {
+              "type": "array",
+              "describe": "Pull only these services' variables: postgres, auth, data-api, object-storage, ai-gateway. Repeat the flag or comma-separate. Overrides neon.ts, and prunes only within the services you name."
             }
           },
           "commands": {},
@@ -1458,6 +1481,10 @@
             {
               "command": "$0 env pull --branch preview --file .env.preview",
               "description": "Pull a specific branch into a specific file"
+            },
+            {
+              "command": "$0 env pull -s ai-gateway -s postgres",
+              "description": "Pull only the AI Gateway and Postgres variables"
             }
           ],
           "usage": "$0 env pull [options]"
@@ -1906,6 +1933,176 @@
           "description": "Link an existing project (org is inferred); pin a branch later with 'neon checkout'"
         }
       ]
+    },
+    "logs": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "branch": {
+          "type": "string",
+          "describe": "Branch ID or name"
+        },
+        "project-id": {
+          "type": "string",
+          "describe": "Project ID"
+        }
+      },
+      "commands": {
+        "field-values": {
+          "name": "field-values",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "field",
+              "required": true,
+              "describe": "The log field to list values for. Must be one of the names `logs fields` reports.",
+              "type": "string"
+            }
+          ],
+          "options": {
+            "end-time": {
+              "type": "string",
+              "describe": "Exclusive end of the window (RFC 3339). Defaults to the current time."
+            },
+            "limit": {
+              "type": "number",
+              "describe": "Maximum number of distinct values to return (1-1000)"
+            },
+            "since": {
+              "type": "string",
+              "describe": "Length of the window, ending at --end-time or now. Defaults to 6h; the maximum window is 7d. Mutually exclusive with --start-time."
+            },
+            "source": {
+              "type": "string",
+              "describe": "Only consider records emitted by this service",
+              "choices": [
+                "function",
+                "storage",
+                "pg_endpoint"
+              ]
+            },
+            "start-time": {
+              "type": "string",
+              "describe": "Inclusive start of the window (RFC 3339, e.g. 2025-01-01T00:00:00Z). The maximum window is 7d. Mutually exclusive with --since."
+            }
+          },
+          "commands": {},
+          "describe": "List the distinct values observed for a log field",
+          "examples": [
+            {
+              "command": "$0 logs field-values service_name --since 6h",
+              "description": "Service names seen in the last six hours"
+            }
+          ]
+        },
+        "fields": {
+          "name": "fields",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {},
+          "describe": "List the log fields whose values can be discovered on a branch"
+        },
+        "query": {
+          "name": "query",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "body-contains": {
+              "type": "string",
+              "describe": "Match the case-sensitive rendered message. Structured bodies are rendered as compact JSON."
+            },
+            "cursor": {
+              "type": "string",
+              "describe": "Pagination cursor returned as next_cursor by a previous call. Repeat the same time range and filters."
+            },
+            "end-time": {
+              "type": "string",
+              "describe": "Exclusive end of the window (RFC 3339). Defaults to the current time."
+            },
+            "limit": {
+              "type": "number",
+              "describe": "Maximum number of records to return per page (1-1000)",
+              "default": 100
+            },
+            "logql": {
+              "type": "string",
+              "describe": "Raw LogQL expression (stream selectors and line filters only). Replaces the structured filters; the window, --limit, --sort-order and --cursor still apply."
+            },
+            "minimum-severity": {
+              "type": "string",
+              "describe": "Only records at or above this severity. Combines with --severity-text. If Neon reports that this filter is unsupported, use --severity-text instead.",
+              "choices": [
+                "trace",
+                "debug",
+                "info",
+                "warn",
+                "error",
+                "fatal"
+              ]
+            },
+            "scope-name": {
+              "type": "string",
+              "describe": "Match the OpenTelemetry instrumentation scope name exactly"
+            },
+            "service-name": {
+              "type": "string",
+              "describe": "Match the OpenTelemetry service.name resource attribute exactly"
+            },
+            "severity-text": {
+              "type": "string",
+              "describe": "Match the OpenTelemetry severity text exactly. Run `neon logs field-values severity_text` to discover the values present."
+            },
+            "since": {
+              "type": "string",
+              "describe": "Length of the window, ending at --end-time or now. Defaults to 1h; the maximum window is 7d. Mutually exclusive with --start-time."
+            },
+            "sort-order": {
+              "type": "string",
+              "describe": "Order records by timestamp. Defaults to desc (newest first).",
+              "choices": [
+                "asc",
+                "desc"
+              ]
+            },
+            "source": {
+              "type": "string",
+              "describe": "Only records emitted by this service",
+              "choices": [
+                "function",
+                "storage",
+                "pg_endpoint"
+              ]
+            },
+            "start-time": {
+              "type": "string",
+              "describe": "Inclusive start of the window (RFC 3339, e.g. 2025-01-01T00:00:00Z). The maximum window is 7d. Mutually exclusive with --since."
+            },
+            "trace-id": {
+              "type": "string",
+              "describe": "Match records carrying this trace ID (32 lowercase hex digits)"
+            }
+          },
+          "commands": {},
+          "describe": "Query log records on a branch",
+          "examples": [
+            {
+              "command": "$0 logs query --since 1h --logql '{entity_type=\"function\"} |= \"timeout\"'",
+              "description": "A raw LogQL selection instead of the structured filters"
+            },
+            {
+              "command": "$0 logs query --branch main --source pg_endpoint --minimum-severity error",
+              "description": "Postgres compute errors on main"
+            },
+            {
+              "command": "$0 logs query --since 30m",
+              "description": "The last 30 minutes of logs on the default branch"
+            }
+          ]
+        }
+      },
+      "describe": "Query branch logs",
+      "usage": "$0 logs <sub-command> [options]"
     },
     "me": {
       "aliases": [],

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -46,6 +46,7 @@ const GROUP_OF = {
   inspect: 'debugging',
   'api-keys': 'setup',
   profile: 'setup',
+  logs: 'debugging',
 };
 
 // Commands documented as a section of another command's page instead of a


### PR DESCRIPTION
## Overview

Documents the new `neon logs` command, which reads the logs a branch's services emit (Postgres compute, storage, and Neon Functions). The new page covers the three subcommands: `query` for reading records over a time window with source/severity/attribute filters or raw LogQL, `fields` for listing the log fields a branch reports, and `field-values` for discovering the values a field carries. It's flagged as a beta limited to AWS US East (Ohio), consistent with the other backend beta features.

Supporting the new page, this regenerates `schema.json` from neonctl 3.1.0 and extends the schema parser to resolve two constructs the logs command uses: options passed as a bare identifier (`.options(scopeOptions)`) and options built by a factory function (`...windowOptions("1h")`). That also recovers the type and description for `config init --services` and `env pull --service`, which were falling back to "unknown"; the one remaining factory-built spec the parser still can't evaluate statically is pinned in `overrides.json`. Finally, adds a `--service` example to the `env pull` page.

Verified end-to-end against the live CLI (neonctl 3.1.0) in the us-east-2 beta region: every documented flag, choice, conflict rule, and error path behaves as written, and all examples pass the schema validator.

This pull request and its description were written by Isaac.