### PR TITLE
Upgrade /humanize command with pattern catalog and self-audit

### DIFF
--- a/.claude/commands/humanize.md
+++ b/.claude/commands/humanize.md
@@ -1,10 +1,12 @@
 ---
-description: 'Make a documentation page sound like a human explaining something to another human. Removes AI writing patterns and applies Neon voice: contractions, active voice, direct address, concise sentences.'
+description: 'Make a documentation page sound like a human explaining something to another human. Detects AI writing patterns across 5 categories, runs a two-pass self-audit rewrite, then applies Neon voice: contractions, active voice, direct address, concise sentences.'
 ---
 
 # Humanize
 
-Transform a documentation page to sound like one human explaining something to another — the Neon voice. This command does two things: removes AI writing patterns, and applies Neon style conventions where they're missing.
+Transform a documentation page to sound like one human explaining something to another — the Neon voice. This command does three things: detects AI writing patterns using a categorized catalog, rewrites and then self-audits the result, and applies Neon style conventions where they're missing.
+
+Pattern taxonomy informed by Wikipedia's "Signs of AI writing" analysis. It goes beyond phrase-swapping: the goal is human, not just clean.
 
 ## Usage
 
@@ -15,71 +17,90 @@ Transform a documentation page to sound like one human explaining something to a
 
 ---
 
-## Part 1: Remove AI writing patterns
+## Part 1: Detect and remove AI writing patterns
 
-### Filler and throat-clearing
+Scan the text against all 5 categories below. For each detected pattern, note the specific instance and its location.
 
-- Opening with "In this guide/article/document, you will..." → cut or rewrite to lead with the content
-- "It's worth noting that..." / "It's important to note that..." → cut the preamble
-- "As mentioned above/earlier/previously..." → cut or rewrite without the callback
-- "At the end of the day..." / "In the grand scheme of things..." → cut
-- Restating the section heading verbatim in the first sentence of the section → rewrite to add content, not repeat it
+### Category 1: Content patterns
 
-### Hedging language
+What the text says — substance, structure, depth.
 
-- "It is possible that..." → state directly or cut
-- "In some cases..." / "In certain scenarios..." → be specific or cut
-- "Generally speaking..." / "For the most part..." → cut
-- "May or may not..." → pick one or rewrite
-- "It should be noted that..." → cut the preamble, lead with the fact
+- **Significance inflation** — "pivotal", "groundbreaking", "game-changer", "revolutionary", "transformative", "paradigm shift". Ordinary things inflated into momentous ones. State what actually happened.
+  - Before: "This groundbreaking partnership represents a pivotal moment."
+  - After: "The partnership gives the company European distribution for the first time."
+- **Surface-level analysis** — "symbolizing", "reflecting broader trends", "speaks to", "emblematic of", "underscores". Gestures at meaning without analyzing. Name specifics.
+- **Missing specificity** — "various", "numerous", "significant", "substantial", "a number of", "wide range of". Vague quantifiers instead of numbers, names, evidence. Use the real figure.
+  - Before: "significant growth across numerous markets"
+  - After: "grew 34% in Southeast Asia last quarter"
+- **Promotional tone** — "boasts", "nestled", "vibrant", "stunning", "world-class", "state-of-the-art", "unparalleled". Brochure language. Describe, don't flatter; acknowledge trade-offs.
+- **Vague attribution** — "experts believe", "studies show", "research indicates", "it is widely acknowledged". Unnamed authorities. Cite the real source or own the claim.
+- **Formulaic challenges** — "Despite challenges", "not without its challenges", "continues to thrive", "remains resilient". Acknowledges difficulty with a stock phrase, then dismisses it. Explain concretely or skip.
+- **Over-summarization** — "In summary", "To summarize", "In conclusion", "All in all", "Overall", "As we've seen". Compulsive recaps. If the conclusion just restates the intro, delete it.
 
-### Over-formal constructions
+### Category 2: Language and grammar patterns
 
-- "Utilize" → "use"
-- "Leverage" → "use" or be specific about what's being used
-- "Facilitate" → "help", "enable", or be specific
-- "Implement" when "add", "set up", or "write" is clearer → use the clearer word
-- "In order to" → "to"
-- "Due to the fact that" → "because"
-- "At this point in time" → "now"
-- "On a regular basis" → "regularly"
-- Em dashes (—) → rewrite using a comma, parentheses, or a new sentence. Never introduce a new em dash in a rewrite.
+Word choice, sentence construction, grammatical habits.
 
-### AI-specific tells
+- **AI vocabulary** — "additionally", "furthermore", "moreover", "landscape", "utilize", "leverage", "robust", "facilitate", "encompass", "testament", "intricate", "underscore", "showcase", "foster", "delve". Individually fine, but they cluster in AI text. Use plain words: "use", "help", "connects to".
+- **Copula avoidance** — "serves as", "acts as", "functions as", "stands as", "features", "boasts", "represents". Avoids plain "is" and "has". A building doesn't "serve as the headquarters" — it *is* the headquarters.
+- **Negative parallelism** — "It's not just X, it's Y", "This isn't X. This is Y.", "Forget X — this is Y", "Less X, more Y". Overused LLM rhetorical move. Just state the positive claim.
+- **Forced rule of three** — three-item lists where one or two would do. Use whatever number is natural.
+- **Synonym cycling** — rotating terms for the same thing ("the platform" → "the solution" → "the tool" → "the system"). Repeat the term when clarity demands it.
+- **False ranges** — "from X to Y" / "everything from X to Y" with unrelated or absurdly broad endpoints. Sounds comprehensive, says nothing. Be specific.
+- **Passive voice and subjectless fragments** — "can be seen as", "is considered", "has been noted", "No configuration needed", "Designed to", "Built for". Removes the actor. Name who does what. (Some passive in reference docs is intentional — leave it.)
 
-- Sentences opening with "Certainly!" / "Absolutely!" / "Of course!" / "Sure!" → cut
-- Overuse of "seamlessly", "robust", "straightforward", "powerful", "comprehensive" → cut or replace with specifics
-- Closing sentences that restate the page title ("In this guide, you learned how to...") → cut
-- Transition sentences that only summarize the previous paragraph ("In summary...") → cut
-- Introducing abbreviations without expanding them first → spell out in full on first use, with the abbreviation in parentheses. For example: "natural language processing (NLP)", not just "NLP". Do not introduce an abbreviation that wasn't already present in the original text.
+### Category 3: Style patterns
 
-### Minimizing language
+Formatting, rhythm, visual presentation.
 
-- "Simply", "just", "easily", "quick" before a step → cut; let the steps speak
-- Saying "easy" or "straightforward" when complexity follows → cut
+- **Em dash overuse** — multiple em dashes (—) per paragraph, nested asides. Rewrite with commas, colons, periods, or parentheses. **Never introduce a new em dash in a rewrite.**
+- **Bold overuse** — multiple **bolded** terms per paragraph. Bold one or two critical points per section, max. When everything is bold, nothing is.
+- **Inline-header lists** — the "**Label:** Description" pattern repeated vertically. Use real sentences, bullets, or a table instead.
+- **Title case in headings** — "Strategic Partnerships And Key Deliverables". Use sentence case.
+- **Emoji pollution** — emojis in professional/technical content (rockets, lightbulbs, checkmarks, fire). Remove them.
+- **Curly quote misuse** — curly quotes in code, config, or technical contexts where they break things. Use straight quotes.
+
+### Category 4: Communication patterns
+
+How the text addresses the reader.
+
+- **Chatbot artifacts** — "I hope this helps!", "Let me know if you need anything", "Feel free to ask", "Happy to help!". Chat-training residue. Remove entirely.
+- **Knowledge-cutoff disclaimers** — "As of my last update", "While specific details may vary", "Based on available information". Docs shouldn't carry disclaimers about the author's training data. Verify the fact or state uncertainty concretely.
+- **Sycophantic tone** — "Great question!", "That's an excellent point!", "You're absolutely right!". Don't validate the reader. Just answer.
+
+### Category 5: Filler and hedging patterns
+
+Padding that adds no meaning.
+
+- **Filler phrases** — "In order to" ("to"), "Due to the fact that" ("because"), "It is worth noting that", "It is important to note", "In today's rapidly evolving", "At the end of the day", "When it comes to". Verbal throat-clearing. Cut.
+- **Excessive hedging** — "could potentially", "might possibly", "it seems that perhaps", "may or may not", "to some extent". One hedge is human; three stacked is AI. Pick one or commit.
+- **Generic positive conclusions** — "The future looks bright", "exciting times ahead", "poised for success", "well-positioned to", "stands to benefit". Empty optimism. Make a specific claim, raise an open question, or acknowledge real uncertainty.
+- **Hyphenated buzzword clusters** — "cross-functional", "data-driven", "mission-critical", "enterprise-grade", "cloud-native" appearing together. One is fine; three in a sentence is a tell.
+- **Persuasive authority tropes** — "At its core", "What really matters is", "The key takeaway", "Here's the truth", "The bottom line". Authoritative framing for ordinary claims. Drop the frame, state the point.
+- **Signposting announcements** — "Let's dive in", "Here's what you need to know", "Without further ado", "Let's explore", "Let's unpack". Announces the action instead of doing it. Just do it.
+- **Fragmented headers** — a heading followed by a one-line restatement of the heading. Jump into the actual content.
+- **Excessive enumeration** — "Firstly", "Secondly", "Thirdly"; numbered lists where flowing prose is clearer. Not everything needs to be a list.
+
+### Minimizing language (Neon-specific)
+
+- "Simply", "just", "easily", "quick" before a step → cut; let the steps speak.
+- Saying "easy" or "straightforward" when complexity follows → cut.
+
+### Abbreviations (Neon-specific)
+
+- Spell out in full on first use, with the abbreviation in parentheses: "natural language processing (NLP)", not just "NLP". Do not introduce an abbreviation that wasn't already in the original text.
 
 ---
 
 ## Part 2: Apply Neon voice
 
-These are positive additions, not just removals. Apply where the text is technically correct but sounds impersonal or stiff.
+Positive additions, not just removals. Apply where the text is technically correct but sounds impersonal or stiff.
 
 ### Use contractions
 
-Where a contraction sounds natural, use it:
-
-- "it is" → "it's"
-- "do not" → "don't"
-- "you will" → "you'll"
-- "they are" → "they're"
-- "cannot" → "can't"
-- "does not" → "doesn't"
-
-Do not force contractions where they would sound awkward or change emphasis (e.g. in a technical definition).
+Where a contraction sounds natural: "it is" → "it's", "do not" → "don't", "you will" → "you'll", "they are" → "they're", "cannot" → "can't", "does not" → "doesn't". Don't force contractions where they'd sound awkward or change emphasis (e.g. in a technical definition).
 
 ### Address the reader as "you"
-
-Rewrite impersonal or third-person constructions:
 
 - "Users can configure..." → "You can configure..."
 - "Developers should ensure..." → "Make sure..."
@@ -92,11 +113,22 @@ Rewrite impersonal or third-person constructions:
 - "A branch can be created using..." → "You can create a branch using..."
 - "Errors are displayed in the console" → "The console displays errors"
 
-Only switch to active where it reads naturally. Some passive constructions (especially in reference docs) are intentional.
+Only switch where it reads naturally. Some passive constructions (especially in reference docs) are intentional.
 
 ### Break up long sentences
 
-If a sentence runs longer than ~25 words and has a natural split point, break it into two sentences. Do not split if the break would sound choppy or lose meaning.
+If a sentence runs longer than ~25 words and has a natural split point, break it into two. Don't split if the break would sound choppy or lose meaning.
+
+### Add personality where the page allows
+
+Pattern removal alone produces sterile text. Where the page is a guide or conceptual explanation (not a strict reference), inject:
+
+- **A point of view** — "This approach is better because..." not "This approach may offer advantages."
+- **Varied rhythm** — follow a long sentence with a short one. Or a fragment.
+- **Acknowledged complexity** — if something is genuinely complicated, say so. Don't flatten it into false simplicity.
+- **Concrete imagery** — "The deploy took 47 minutes" not "The deployment was time-consuming."
+
+The litmus test: could a specific human have written this? If it could have been written by anyone, it still sounds like AI.
 
 ---
 
@@ -106,15 +138,23 @@ If a sentence runs longer than ~25 words and has a natural split point, break it
 
 Read the target file in full.
 
-### 2. Identify all findings
+### 2. First-pass scan and rewrite
 
-Go through both Part 1 and Part 2. For each finding note:
+Go through both Part 1 (all 5 categories) and Part 2. For each finding note the original passage, the pattern or rule it matches, and a proposed rewrite. Don't just swap synonyms — restructure or delete sentences that exist only to pad.
 
-- The original sentence or passage
-- Which pattern or rule it matches
-- A proposed rewrite
+### 3. Self-audit (the critical step)
 
-### 3. Present findings
+Re-read your proposed rewrite cold and ask: **"If I read this with no context, what would make me think an AI wrote it?"** The first rewrite often introduces new AI patterns while fixing old ones. Check for:
+
+- **Residual pattern matches** — re-scan against all 5 categories.
+- **Uniform sentence length** — vary it; mix short and long.
+- **Too-clean structure** — if every paragraph follows the same shape, break it up.
+- **Excessive balance** — if it gives equal weight to both sides of everything, pick the stronger side.
+- **Perfect transitions** — real writing sometimes just starts the next point.
+
+Fold any audit findings into the proposed rewrites before presenting.
+
+### 4. Present findings
 
 Group by category. For each:
 
@@ -128,18 +168,22 @@ Then ask:
 
 > "Apply all fixes, review individually, or cancel? (all / review / cancel)"
 
-### 4. Apply
+### 5. Apply
 
 - **All**: apply every suggested fix and save the file
 - **Review**: walk through each finding one at a time, waiting for approval before applying
 - **Cancel**: do nothing
 
-### 5. Run the auto-fixer
+### 6. Format only the edited file
+
+Format only the file(s) you edited, not the whole `content/` tree. Pass the target path(s) to Prettier directly:
 
 ```bash
-npm run fix:md
+npx prettier --write --log-level warn "<path-to-edited-file>"
 ```
 
-### 6. Report
+Do not run `npm run fix:md` — it reformats every file under `content/` and would pollute the diff with unrelated changes.
 
-Summarize how many findings were in each category and how many were applied.
+### 7. Report
+
+Summarize how many findings were in each category, what the self-audit caught, how many fixes were applied, and the approximate word count change.

--- a/content/changelog/2026-08-07.md
+++ b/content/changelog/2026-08-07.md
@@ -50,7 +50,7 @@ Then ask your assistant to get started with Neon. See the [backend beta guide](/
 
 [Last week](/docs/changelog/2026-07-31#project-level-permissions) we introduced project-level permissions to newly created organizations. Existing organizations are now supported, so every team on Neon has the four organization roles (**Admin**, **Editor**, **Viewer**, and **Collaborator**) and per-project permissions.
 
-See [Neon now has per-project permissions](/blog/neon-now-has-per-project-permissions) for the annoucement, and [User permissions](/docs/manage/user-permissions) for the complete documentation.
+See [Neon now has per-project permissions](/blog/neon-now-has-per-project-permissions) for the announcement, and [User permissions](/docs/manage/user-permissions) for the complete documentation.
 
 <Admonition type="tip" title="Get started with project permissions">
 Go from everyone-sees-everything to scoped access in about five minutes. [Read the guide](/docs/manage/project-permissions-get-started).


### PR DESCRIPTION
## Summary

Two changes:

1. **Upgrade the `/humanize` command** (`.claude/commands/humanize.md`) to match the Databricks internal humanizer plugin, while keeping the Neon-specific parts:
   - Adds the full 5-category / 29-pattern AI-writing catalog (Content, Language & Grammar, Style, Communication, Filler & Hedging) with words-to-watch and before/after examples.
   - Adds a two-pass **self-audit** step: after the first rewrite, re-read cold and check for residual AI patterns, uniform sentence length, too-clean structure, excessive balance, and mechanical transitions.
   - Scopes the auto-formatter to **only the edited file** (`npx prettier --write "<path>"`) instead of `npm run fix:md`, which reformats the whole `content/` tree and would pollute the diff.
   - Preserves the Neon voice section (contractions, "you", active voice, ~25-word splits), the interactive all/review/cancel workflow, and Neon abbreviation rules.
   - Stays per-file (no directory or PR-wide mode).

2. **Fix a typo** in the 2026-08-07 changelog: "annoucement" → "announcement". Caught while test-running the upgraded command on that page.

## Testing

Ran the upgraded command on two pages (`manage/project-permissions-get-started.md` and `changelog/2026-08-07.md`). Both were already clean of AI patterns; the only actionable finding was the changelog typo. Verified the scoped Prettier step runs correctly and touches only the target file.

This pull request and its description were written by Isaac.