### PR TITLE
docs: document Kimi Code plugin install for skills and MCP

### DIFF
--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -10,7 +10,7 @@ summary: >-
   with `npx skills add neondatabase/agent-skills -y`, a single skill with `-s`,
   `neon init`, or editor plugins at project level or globally.
 enableTableOfContents: true
-updatedOn: '2026-07-31T16:04:44.241Z'
+updatedOn: '2026-08-10T20:46:10.540Z'
 redirectFrom:
   - /docs/ai/ai-rules
   - /docs/ai/ai-rules-neon-toolkit
@@ -83,6 +83,16 @@ If you're using OpenAI Codex, install the **Neon** plugin from the [Codex plugin
 
 See [Codex plugin for Neon](/docs/ai/ai-codex-plugin) for details.
 
+### Kimi Code plugin
+
+If you're using Kimi Code, install the repository directly as a plugin. Kimi reads its own manifest (`kimi.plugin.json`), which points at the skills and declares the Neon MCP Server, so this one command sets up both skills and MCP integration:
+
+```text
+/plugins install https://github.com/neondatabase/agent-skills
+```
+
+Plugin changes apply to new sessions, so run `/new` afterward.
+
 ### neon init
 
 The `neon init` command sets up your project to use Neon with your AI coding assistant. It authenticates via OAuth, creates an API key, configures the MCP server, installs the Neon extension for Cursor and VS Code where applicable, and installs agent skills at the project level:
@@ -106,17 +116,17 @@ Start here for platform overview and Postgres development.
 | Skill                                                                        | Description                                                                                                                 |
 | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | [`neon`](https://skills.sh/neondatabase/agent-skills/neon)                   | Platform overview for apps and agents: Postgres, Auth, Data API, Functions, Storage, and AI Gateway, and how to get started |
-| [`neon-postgres`](https://skills.sh/neondatabase/agent-skills/neon-postgres) | Comprehensive index of Neon Serverless Postgres documentation and best practices                                            |
+| [`neon-postgres`](https://skills.sh/neondatabase/agent-skills/neon-postgres) | Full index of Neon Serverless Postgres documentation and best practices                                                     |
 
 ### Database workflows
 
 Provision, branch, and optimize Postgres projects.
 
-| Skill                                                                                                          | Description                                                                                                       |
-| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| [`claimable-postgres`](https://skills.sh/neondatabase/agent-skills/claimable-postgres)                         | Instant temporary Postgres via [Claimable Postgres](/docs/reference/claimable-postgres) — no login or credit card |
-| [`neon-postgres-branches`](https://skills.sh/neondatabase/agent-skills/neon-postgres-branches)                 | Choose and create the right branch type for migrations, schema-only branches, and reset-from-parent workflows     |
-| [`neon-postgres-egress-optimizer`](https://skills.sh/neondatabase/agent-skills/neon-postgres-egress-optimizer) | Diagnose and fix excessive Postgres egress and query overfetching                                                 |
+| Skill                                                                                                          | Description                                                                                                               |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [`claimable-postgres`](https://skills.sh/neondatabase/agent-skills/claimable-postgres)                         | Instant temporary Postgres via [Claimable Postgres](/docs/reference/claimable-postgres), no login or credit card required |
+| [`neon-postgres-branches`](https://skills.sh/neondatabase/agent-skills/neon-postgres-branches)                 | Choose and create the right branch type for migrations, schema-only branches, and reset-from-parent workflows             |
+| [`neon-postgres-egress-optimizer`](https://skills.sh/neondatabase/agent-skills/neon-postgres-egress-optimizer) | Diagnose and fix excessive Postgres egress and query overfetching                                                         |
 
 ### Neon Platform
 

--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -10,7 +10,7 @@ summary: >-
   with `npx skills add neondatabase/agent-skills -y`, a single skill with `-s`,
   `neon init`, or editor plugins at project level or globally.
 enableTableOfContents: true
-updatedOn: '2026-08-10T20:46:10.540Z'
+updatedOn: '2026-08-10T23:01:57.354Z'
 redirectFrom:
   - /docs/ai/ai-rules
   - /docs/ai/ai-rules-neon-toolkit
@@ -85,9 +85,9 @@ See [Codex plugin for Neon](/docs/ai/ai-codex-plugin) for details.
 
 ### Kimi Code plugin
 
-If you're using Kimi Code, install the repository directly as a plugin. Kimi reads its own manifest (`kimi.plugin.json`), which points at the skills and declares the Neon MCP Server, so this one command sets up both skills and MCP integration:
+If you're using Kimi Code, install the Neon plugin for skills and MCP integration. In the Kimi CLI chat, run:
 
-```text
+```bash
 /plugins install https://github.com/neondatabase/agent-skills
 ```
 

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -15,7 +15,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-10T20:46:10.540Z'
+updatedOn: '2026-08-17T11:33:55.500Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -429,7 +429,7 @@ For more details, including workflow examples and troubleshooting, see [Get star
 
 Kimi Code doesn't use `add-mcp`. Instead, install Neon's [agent skills](https://github.com/neondatabase/agent-skills) repository as a plugin. Kimi reads its own manifest (`kimi.plugin.json`), which declares the Neon MCP Server, so this one command wires up the MCP connection along with the skills:
 
-```text
+```bash
 /plugins install https://github.com/neondatabase/agent-skills
 ```
 

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -15,10 +15,10 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-04T05:05:30.414Z'
+updatedOn: '2026-08-10T20:46:10.540Z'
 ---
 
-This guide covers connecting MCP clients to the Neon MCP Server for natural language interaction with your Lakebase Postgres databases.
+Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
 
 <Admonition type="important" title="Security">
 The Neon MCP Server is intended for **development and testing only**. Always review LLM-requested actions before execution. See [MCP security guidance](/docs/ai/neon-mcp-server#mcp-security-guidance).
@@ -424,6 +424,16 @@ For more details, including workflow examples and troubleshooting, see [Get star
 2. Go to [jules.google.com](https://jules.google.com) > **Settings** > **MCP** (or use [this direct link](https://jules.google.com/settings/mcp)).
 3. Click **Connect** on the Neon server and paste your API key when prompted.
 4. Run a task invoking the Neon MCP server to verify the connection.
+
+## Kimi Code
+
+Kimi Code doesn't use `add-mcp`. Instead, install Neon's [agent skills](https://github.com/neondatabase/agent-skills) repository as a plugin. Kimi reads its own manifest (`kimi.plugin.json`), which declares the Neon MCP Server, so this one command wires up the MCP connection along with the skills:
+
+```text
+/plugins install https://github.com/neondatabase/agent-skills
+```
+
+Plugin changes apply to new sessions, so run `/new` afterward. See [Agent Skills](/docs/ai/agent-skills) for more on what's included.
 
 ## Other MCP clients
 


### PR DESCRIPTION
## What

Documents Kimi Code support (added upstream in [neondatabase/agent-skills#85](https://github.com/neondatabase/agent-skills/pull/85)) on the two AI docs pages requested in Slack:

- **`content/docs/ai/agent-skills.md`** — new **Kimi Code plugin** install subsection.
- **`content/docs/ai/connect-mcp-clients-to-neon.md`** — new **Kimi Code** section.

Kimi reads its own manifest (`kimi.plugin.json`), which points at the `skills/` directory and declares the Neon MCP Server inline. Unlike the other clients, it doesn't use `add-mcp`/`mcp.json`, so a single `/plugins install` wires up both skills and the MCP connection.

## Also

Applied `/humanize` findings while touching these pages:

- Removed an em dash and the AI tell "comprehensive" in `agent-skills.md`.
- Rewrote the throat-clearing "This guide covers..." opener on the MCP page to lead with the content.

No skill source files were touched, so the Skills Read-Only check is unaffected.

This pull request and its description were written by Isaac.