### PR TITLE
docs: document JWT organization claim

### DIFF
--- a/content/docs/auth/guides/plugins/jwt.md
+++ b/content/docs/auth/guides/plugins/jwt.md
@@ -82,7 +82,7 @@ await authClient.getSession({
 
 ### Example decoded JWT payload
 
-A typical decoded JWT payload looks like this:
+For a session with an active organization, a decoded JWT payload looks like this:
 
 ```json
 {
@@ -98,12 +98,19 @@ A typical decoded JWT payload looks like this:
   "banReason": null,
   "banExpires": null,
   "id": "860dc360-609f-4b7d-9e70-ec93fe6414d3",
+  "o": {
+    "id": "org-123",
+    "slug": "my-org",
+    "role": "owner"
+  },
   "sub": "860dc360-609f-4b7d-9e70-ec93fe6414d3",
   "exp": 1766321585,
   "iss": "<YOUR_NEON_AUTH_URL_ORIGIN>",
   "aud": "<YOUR_NEON_AUTH_URL_ORIGIN>"
 }
 ```
+
+The `o` claim contains the active organization ID (`id`), slug (`slug`), and the user's organization membership role (`role`). It appears only when the session has an active organization and the **Organization plugin** is enabled for the project. The plugin is controlled by a per-project configuration toggle, not a rollout flag. The `role` value is a snapshot of the user's organization role when the token is issued and does not update in an already-issued token.
 
 ## Verify a token
 

--- a/content/docs/auth/guides/plugins/jwt.md
+++ b/content/docs/auth/guides/plugins/jwt.md
@@ -82,7 +82,7 @@ await authClient.getSession({
 
 ### Example decoded JWT payload
 
-For a session with an active organization, a decoded JWT payload looks like this:
+A typical decoded JWT payload looks like this:
 
 ```json
 {
@@ -98,11 +98,6 @@ For a session with an active organization, a decoded JWT payload looks like this
   "banReason": null,
   "banExpires": null,
   "id": "860dc360-609f-4b7d-9e70-ec93fe6414d3",
-  "o": {
-    "id": "org-123",
-    "slug": "my-org",
-    "role": "owner"
-  },
   "sub": "860dc360-609f-4b7d-9e70-ec93fe6414d3",
   "exp": 1766321585,
   "iss": "<YOUR_NEON_AUTH_URL_ORIGIN>",
@@ -110,7 +105,21 @@ For a session with an active organization, a decoded JWT payload looks like this
 }
 ```
 
-The `o` claim contains the active organization ID (`id`), slug (`slug`), and the user's organization membership role (`role`). It appears only when the session has an active organization and the **Organization plugin** is enabled for the project. The plugin is controlled by a per-project configuration toggle, not a rollout flag. The `role` value is a snapshot of the user's organization role when the token is issued and does not update in an already-issued token.
+### Organization claim
+
+When the session has an active organization and the **Organization plugin** is enabled for the project, the JWT includes an `o` claim with the following structure:
+
+```json
+{
+  "o": {
+    "id": "org-123",
+    "slug": "my-org",
+    "role": "owner"
+  }
+}
+```
+
+The Organization plugin is controlled by a per-project configuration toggle, not a rollout flag. The `role` value is snapshotted from the user's organization membership when the token is issued and does not update in an already-issued token.
 
 ## Verify a token
 


### PR DESCRIPTION
## Summary
Documents the JWT `o` (organization) claim that was completely missing from the Neon Auth docs.

**Changes:**
- Adds a new **Organization claim** subsection after the JWT example in `jwt.md`
- Documents the `o` claim structure: `id`, `slug`, and `role` fields
- Explains when it appears: only when session has an active organization AND the Organization plugin is enabled
- Notes that it's a per-project config toggle (not a rollout flag)
- Clarifies that the `role` value is snapshotted at token issue time

**Why:** Developers inspecting real tokens see an `o` claim that was completely undocumented. No page explained its structure or when it appears. This creates a discoverable reference without cluttering the main JWT example with a conditional case.

## Origin
Found by the `neon-docs-drift` periodic audit (2026-07-20 run).

**Jira:** [LKB-15134](https://databricks.atlassian.net/browse/LKB-15134)

## Validation
- `git diff --check` passes
- Full Markdown lint/content checks could not run because `npm ci --ignore-scripts` was blocked by the environment npm proxy with HTTP 403 for `@neon/sdk`