### PR TITLE
docs: retire the MCP HTTP+SSE /sse fallback

### DIFF
--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -9,13 +9,11 @@ summary: >-
   Lakebase Postgres databases on Neon using natural language. Use this page when you need
   per-client setup instructions for `npx neon@latest init`, OAuth, or local
   API key authentication with `@neondatabase/mcp-server-neon`. Also covers
-  troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache)
-  and the deprecated SSE endpoint for clients that don't support Streamable
-  HTTP.
+  troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache).
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-04T05:05:30.414Z'
+updatedOn: '2026-08-13T10:00:00.000Z'
 ---
 
 This guide covers connecting MCP clients to the Neon MCP Server for natural language interaction with your Lakebase Postgres databases.
@@ -470,7 +468,7 @@ npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 ```
 
 <Admonition type="note">
-For clients that don't support Streamable HTTP, you can use the deprecated SSE endpoint: `https://mcp.neon.tech/sse`. SSE is not supported with API key authentication.
+The older HTTP+SSE endpoints (`/sse` and `/message`) are retired and return `410 Gone`. Use `https://mcp.neon.tech/mcp` (Streamable HTTP), or the `mcp-remote` command above for stdio-only clients.
 </Admonition>
 
 ### OAuth Authentication Errors

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -9,11 +9,12 @@ summary: >-
   Lakebase Postgres databases on Neon using natural language. Use this page when you need
   per-client setup instructions for `npx neon@latest init`, OAuth, or local
   API key authentication with `@neondatabase/mcp-server-neon`. Also covers
-  troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache).
+  troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache)
+  and the retired HTTP+SSE endpoints (`/sse`, `/message`), which return 410.
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-13T10:00:00.000Z'
+updatedOn: '2026-08-04T05:05:30.414Z'
 ---
 
 This guide covers connecting MCP clients to the Neon MCP Server for natural language interaction with your Lakebase Postgres databases.
@@ -468,7 +469,7 @@ npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 ```
 
 <Admonition type="note">
-The older HTTP+SSE endpoints (`/sse` and `/message`) are retired and return `410 Gone`. Use `https://mcp.neon.tech/mcp` (Streamable HTTP), or the `mcp-remote` command above for stdio-only clients.
+The older HTTP+SSE endpoints (`/sse` and `/message`) are retired and return `410 Gone`. Use `https://mcp.neon.tech/mcp` (Streamable HTTP). If your client only supports local stdio servers, put `npx -y mcp-remote https://mcp.neon.tech/mcp` in its MCP config.
 </Admonition>
 
 ### OAuth Authentication Errors

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -7,7 +7,7 @@ summary: >-
   `npx neon@latest init` or use the config generator. Supports OAuth and
   API key auth.
 enableTableOfContents: true
-updatedOn: '2026-08-07T16:05:20.768Z'
+updatedOn: '2026-08-13T10:00:00.000Z'
 ---
 
 The Neon MCP Server implements the Model Context Protocol (MCP), letting AI assistants interact with your Neon projects on your behalf. Your AI agent can interact with Neon via MCP tools or by running [Neon CLI](/docs/cli) commands directly.
@@ -26,7 +26,7 @@ Runs `neon init` via npx to configure MCP and other integrations for your editor
 
 ## Config generator
 
-Use the generator to build an MCP config for your editor, auth method, and transport, including the `Authorization` header for API key or remote agent setups.
+Use the generator to build an MCP config for your editor and auth method, including the `Authorization` header for API key or remote agent setups.
 
 <McpSetupConfigurator />
 
@@ -102,8 +102,12 @@ npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon).
 
 <Admonition type="note">
-For clients that don't support Streamable HTTP, you can use the deprecated SSE endpoint: `https://mcp.neon.tech/sse`. SSE is not supported with API key authentication.
+The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoints (`/sse` and `/message`) are retired and return `410 Gone`. If your client only supports local stdio servers, bridge the remote endpoint with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
 </Admonition>
+
+```bash
+npx -y mcp-remote https://mcp.neon.tech/mcp
+```
 
 ## Resources
 

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -5,9 +5,10 @@ summary: >-
   The Neon MCP Server implements the Model Context Protocol (MCP), letting AI
   assistants interact with your Neon projects on your behalf. Set up with
   `npx neon@latest init` or use the config generator. Supports OAuth and
-  API key auth.
+  API key auth. The older HTTP+SSE endpoints (`/sse`, `/message`) are retired
+  and return 410.
 enableTableOfContents: true
-updatedOn: '2026-08-13T10:00:00.000Z'
+updatedOn: '2026-08-07T16:05:20.768Z'
 ---
 
 The Neon MCP Server implements the Model Context Protocol (MCP), letting AI assistants interact with your Neon projects on your behalf. Your AI agent can interact with Neon via MCP tools or by running [Neon CLI](/docs/cli) commands directly.
@@ -101,13 +102,22 @@ npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 
 For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon).
 
-<Admonition type="note">
-The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoints (`/sse` and `/message`) are retired and return `410 Gone`. If your client only supports local stdio servers, bridge the remote endpoint with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
-</Admonition>
+### Retired HTTP+SSE transport (#retired-sse)
 
-```bash
-npx -y mcp-remote https://mcp.neon.tech/mcp
+<Admonition type="note">
+The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoints (`/sse` and `/message`) are retired and return `410 Gone`. If your client only supports local stdio servers, put this in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP:
+
+```json
+{
+  "mcpServers": {
+    "Neon": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.neon.tech/mcp"]
+    }
+  }
+}
 ```
+</Admonition>
 
 ## Resources
 


### PR DESCRIPTION
## Problem

The published MCP docs still tell readers to use a retired transport:

```text
For clients that don't support Streamable HTTP, you can use the deprecated
SSE endpoint: https://mcp.neon.tech/sse
```

That copy is live today on [Neon MCP Server overview](https://neon.com/docs/ai/neon-mcp-server) and [Connect MCP clients](https://neon.com/docs/ai/connect-mcp-clients-to-neon). After [neondatabase/mcp-server-neon#320](https://github.com/neondatabase/mcp-server-neon/pull/320) ships, `GET/POST /sse` and `/message` return `410 Gone`. A reader who follows the current note gets a dead endpoint. The 410 body itself links to the overview page, so the remediation page currently contradicts the error.

## Diagnosis

HTTP+SSE was deprecated in MCP 2025-03-26 and replaced by Streamable HTTP on a single `/mcp` URL. No popular client is HTTP+SSE-only: Cursor, VS Code Copilot, Claude Code, Claude Desktop Custom Connectors, ChatGPT, Windsurf, Continue, and Cline all speak Streamable HTTP. Stdio-only surfaces bridge with `mcp-remote` against `/mcp`. Leftover `/sse` URLs are stale configs, not a client-capability gap.

The docs kept `/sse` as a "deprecated but still available" fallback. #320 removes that fallback. The pages have to stop advertising it in the same release window.

## Interface

The hosted URL stays:

```text
https://mcp.neon.tech/mcp
```

The overview page now has an anchored heading the 410 can land on:

```text
https://neon.com/docs/ai/neon-mcp-server#retired-sse
```

Stdio-only clients get an `mcpServers` config, not a bare shell command:

```json
{
  "mcpServers": {
    "Neon": {
      "command": "npx",
      "args": ["-y", "mcp-remote", "https://mcp.neon.tech/mcp"]
    }
  }
}
```

The connect-clients troubleshooting note says `/sse` and `/message` return `410 Gone` and names the `/mcp` URL and the `mcp-remote` config command inline.

The config generator already emitted `/mcp` only. No UI change.

[mcp-server-neon#320](https://github.com/neondatabase/mcp-server-neon/pull/320) points the 410 body at `#retired-sse`.

## Also in here

- Dropped "and transport" from the overview generator sentence. Transport is no longer a choice.
- Left historical blog posts and the 2025-04-04 changelog that mention `/sse`. Those record what shipped then.

## Verification

- Confirmed the live overview page still publishes the `/sse` fallback (fetched 2026-08-13).
- Searched `content/docs` for `mcp.neon.tech/sse` and `deprecated SSE` after the edit: no remaining hits.
- Confirmed `src/components/pages/doc/mcp-setup-configurator` already hardcodes `MCP_PATH = '/mcp'`.
- Confirmed the repo already uses `### Heading (#id)` for explicit anchors.

Did not run the full website build. This worktree has no `node_modules`; the change is two Markdown pages.

## For your attention

- **Land with or immediately after [mcp-server-neon#320](https://github.com/neondatabase/mcp-server-neon/pull/320).** Merging this first makes the docs claim `/sse` is gone while production still serves it. Merging #320 first makes production return 410 while docs still send people there.
- SDK v1 `SSEClientTransport` only surfaces `SSE error: Non-200 status code (410)` and does not read the 410 JSON body. Readers on that client need `#retired-sse`, not the error payload.