### PR TITLE
docs: describe layered compute cache on monitoring page

### DIFF
--- a/content/docs/introduction/monitoring-page.md
+++ b/content/docs/introduction/monitoring-page.md
@@ -7,7 +7,7 @@ summary: >-
   connection saturation, cache misses, or replication lag, and decide whether
   to scale up or enable pooling. Historical data retention depends on your plan.
 enableTableOfContents: true
-updatedOn: '2026-08-07T13:46:01.605Z'
+updatedOn: '2026-08-13T11:04:48.562Z'
 ---
 
 The **Monitoring** dashboard in the Neon console provides several graphs for monitoring system and database metrics. You can access the **Monitoring** dashboard from the sidebar in the Neon Console. Observable metrics include:
@@ -201,8 +201,15 @@ The **Replication delay seconds** graph shows the time delay, in seconds, betwee
 
 ![compute cache hit rate graph](/docs/introduction/compute_cache_hit_rate.png)
 
-The **Compute cache hit rate** graph shows the percentage of read requests served from your compute's cache.
-Queries not served from the compute cache retrieve data from storage, which is more costly and can result in slower query performance. To learn more about how Neon caches data, see [Monitoring compute cache usage](/docs/extensions/neon#monitoring-compute-cache-usage).
+The **Compute cache hit rate** graph shows the percentage of read requests served from your compute's cache rather than from storage. Your compute cache is layered: a read first checks Postgres [shared buffers](/docs/reference/glossary#shared-buffers), then the [local file cache](/docs/reference/glossary#compute-cache), and only reads from storage if the data isn't in either. Reads served from storage are more costly and can result in slower query performance.
+
+The graph plots three lines:
+
+- **Local file cache**: The hit rate for the local file cache.
+- **Shared buffers**: The hit rate for Postgres shared buffers.
+- **Total**: The overall hit rate pooled across both caches.
+
+To learn more about how Neon caches data, see [Monitoring compute cache usage](/docs/extensions/neon#monitoring-compute-cache-usage).
 
 ## Working set size
 
@@ -215,9 +222,10 @@ The **Working set size** graph visualizes the amount of data accessed (calculate
 - **5m** (5 minutes): This line shows the data accessed in the last 5 minutes.
 - **15m** (15 minutes): Similar to the 5-minute window, this metric tracks the data accessed in the last 15 minutes.
 - **1h** (1 hour): This line represents the data accessed in the last hour.
-- **Compute cache size**: This is the size of your compute cache, which is determined by the size of your compute. Larger computes have larger caches. For cache sizes, see [How to size your compute](/docs/manage/computes#how-to-size-your-compute).
-  For optimal performance the compute cache should be larger than your working set size for a given time interval.
-  If your working set size is larger than the compute cache size it is recommended to increase the maximum size of the compute to improve the cache hit rate and achieve good performance.
+- **Local file cache size**: The size of the local file cache, determined by the size of your compute. Larger computes have larger caches. For cache sizes, see [How to size your compute](/docs/manage/computes#how-to-size-your-compute).
+- **Shared buffers size**: The size of Postgres shared buffers, which also scales with your compute size.
+
+For optimal performance your compute cache should be larger than your working set size for a given time interval. If your working set size is larger than the compute cache size it is recommended to increase the maximum size of the compute to improve the cache hit rate and achieve good performance.
 
 If your workload pattern doesn't change much over time it is recommended to compare the 1h time interval working set size with the compute cache size and make sure that working set size is smaller than the compute cache size.
 


### PR DESCRIPTION
## What

Follow-up to the compute cache rebranding (#5472). The **Compute cache hit rate** and **Working set size** graphs on the Monitoring page now show the compute cache as a *layered* cache (Postgres shared buffers + local file cache), but the prose still described a single cache. This updates the prose to match what the graphs display.

## Why

The rename to "Compute cache hit rate" is driven by the shared-buffers monitoring feature (`use_shared_buffers_monitoring`), which changes the graph from a single local-file-cache line to a pooled, three-line view:

- **Compute cache hit rate** now plots **Local file cache**, **Shared buffers**, and **Total** (the pooled rate across both).
- **Working set size** now plots both a **Local file cache size** and a **Shared buffers size** line.

The images were already updated to the layered version; only the surrounding text was stale.

## Changes

- Rewrite the **Compute cache hit rate** description to explain the layered read path (shared buffers -> local file cache -> storage) and document the three lines.
- Replace the single **Compute cache size** bullet under **Working set size** with **Local file cache size** and **Shared buffers size** to match the graph legend.

## Notes

- Prose-only; no image changes (existing images already show the layered graphs).
- Mirrors the equivalent Lakebase docs update in the `universe` repo. Same shared codebase and `CacheHitChart` component underlies both products.

This pull request and its description were written by Isaac.