### PR TITLE
docs: minimize local file cache references on monitoring page

### DIFF
--- a/content/docs/introduction/monitoring-page.md
+++ b/content/docs/introduction/monitoring-page.md
@@ -7,7 +7,7 @@ summary: >-
   connection saturation, cache misses, or replication lag, and decide whether
   to scale up or enable pooling. Historical data retention depends on your plan.
 enableTableOfContents: true
-updatedOn: '2026-08-13T11:04:48.562Z'
+updatedOn: '2026-08-13T12:40:58.627Z'
 ---
 
 The **Monitoring** dashboard in the Neon console provides several graphs for monitoring system and database metrics. You can access the **Monitoring** dashboard from the sidebar in the Neon Console. Observable metrics include:
@@ -201,15 +201,7 @@ The **Replication delay seconds** graph shows the time delay, in seconds, betwee
 
 ![compute cache hit rate graph](/docs/introduction/compute_cache_hit_rate.png)
 
-The **Compute cache hit rate** graph shows the percentage of read requests served from your compute's cache rather than from storage. Your compute cache is layered: a read first checks Postgres [shared buffers](/docs/reference/glossary#shared-buffers), then the [local file cache](/docs/reference/glossary#compute-cache), and only reads from storage if the data isn't in either. Reads served from storage are more costly and can result in slower query performance.
-
-The graph plots three lines:
-
-- **Local file cache**: The hit rate for the local file cache.
-- **Shared buffers**: The hit rate for Postgres shared buffers.
-- **Total**: The overall hit rate pooled across both caches.
-
-To learn more about how Neon caches data, see [Monitoring compute cache usage](/docs/extensions/neon#monitoring-compute-cache-usage).
+The **Compute cache hit rate** graph shows the percentage of read requests served from your [compute cache](/docs/reference/glossary#compute-cache) rather than from storage. Reads served from storage are more costly and can result in slower query performance. To learn more about how Neon caches data, see [Monitoring compute cache usage](/docs/extensions/neon#monitoring-compute-cache-usage).
 
 ## Working set size
 
@@ -222,8 +214,7 @@ The **Working set size** graph visualizes the amount of data accessed (calculate
 - **5m** (5 minutes): This line shows the data accessed in the last 5 minutes.
 - **15m** (15 minutes): Similar to the 5-minute window, this metric tracks the data accessed in the last 15 minutes.
 - **1h** (1 hour): This line represents the data accessed in the last hour.
-- **Local file cache size**: The size of the local file cache, determined by the size of your compute. Larger computes have larger caches. For cache sizes, see [How to size your compute](/docs/manage/computes#how-to-size-your-compute).
-- **Shared buffers size**: The size of Postgres shared buffers, which also scales with your compute size.
+- **Compute cache size**: The size of your compute cache, determined by the size of your compute. Larger computes have larger caches. For cache sizes, see [How to size your compute](/docs/manage/computes#how-to-size-your-compute).
 
 For optimal performance your compute cache should be larger than your working set size for a given time interval. If your working set size is larger than the compute cache size it is recommended to increase the maximum size of the compute to improve the cache hit rate and achieve good performance.
 


### PR DESCRIPTION
## What

Follow-up to #5518. Walks back the local-file-cache / shared-buffers breakdown on the Monitoring page in favor of the **compute cache** concept.

## Why

With dynamic shared buffers (rolling out ~late Q3), the 75% compute cache splits between shared buffers and the local file cache by a compute-size-dependent formula, and the local file cache drops to 0 on large fixed-size compute. Per team guidance, public docs should:

- Attribute the 75% RAM to the **compute cache**, not the local file cache.
- Avoid exposing the shared-buffers vs. local-file-cache split or any formula.
- Remove local-file-cache **sizing** references.

#5518 had added a three-line breakdown (Local file cache / Shared buffers / Total) and a per-cache size list. This reverts that framing to describe the graph as the compute cache hit rate and a single compute cache size line.

## Changes

- **Compute cache hit rate**: describe it as the percentage served from the compute cache; drop the layered read-path explanation and the three-line breakdown.
- **Working set size**: collapse the Local file cache size and Shared buffers size bullets into a single **Compute cache size** line.

## Notes

- Prose-only. The `neon inspect db lfc-hit-rate` CLI command is left verbatim (it's a real command). `computes.md` and `compatibility.md` already use compute-cache language and need no change.
- Mirrors the equivalent Lakebase docs update (universe #2419456).

This pull request and its description were written by Isaac.

## Reference

Guidance on minimizing local file cache references in favor of the compute cache concept: [Slack thread](https://databricks.slack.com/archives/C092QJUHBEF/p1786058115306879)
