### PR TITLE
Add Search to Product nav before Instant Restore

### DIFF
--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -56,6 +56,7 @@ export default {
   docsMigration: '/docs/import/import-data-assistant',
   docsPgvector: '/docs/extensions/pgvector',
   instantRestore: '/docs/introduction/branch-restore',
+  lakebaseSearch: '/docs/ai/lakebase-search',
   manageBilling: '/docs/introduction/manage-billing',
   migrationIntro: '/docs/import/migrate-intro',
   docsExtensionsPgVector: '/docs/extensions/pgvector',

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -54,6 +54,11 @@ export default {
               description: 'Faster Postgres workflows',
             },
             {
+              title: 'Search',
+              to: LINKS.lakebaseSearch,
+              description: 'Vector, keyword, and hybrid search',
+            },
+            {
               title: 'Instant Restore',
               to: LINKS.instantRestore,
               description: 'Instant recovery when mistakes happen',


### PR DESCRIPTION
## Summary
- Add Search to the Product → Features header menu, before Instant Restore
- Link to `/docs/ai/lakebase-search` via a new `lakebaseSearch` constant

## Test plan
- [ ] Open the site header Product menu and confirm Search appears before Instant Restore
- [ ] Confirm Search navigates to `/docs/ai/lakebase-search`
- [ ] Spot-check mobile Product menu for the same order and link