### PR TITLE
docs: document neon open command (neonctl 3.2.0)

### DIFF
--- a/content/docs/cli/open.md
+++ b/content/docs/cli/open.md
@@ -1,0 +1,38 @@
+---
+title: 'Neon CLI command: open'
+subtitle: 'Open the linked project in the Neon Console in your browser'
+summary: >-
+  The Neon CLI `open` command opens your linked project's dashboard in the Neon
+  Console in your default browser. It resolves the project from your local `.neon`
+  context file, or from an explicit `--project-id`. Use it to jump from the
+  terminal to the Console without looking up the project URL.
+enableTableOfContents: true
+---
+
+The `open` command opens the linked project's dashboard in the [Neon Console](https://console.neon.tech) in your default browser. It resolves the project from your local `.neon` [context file](/docs/cli/set-context), so run [`neon link`](/docs/cli/link) or [`neon set-context`](/docs/cli/set-context) first, or pass `--project-id` to target a project directly. If no project is linked and you don't pass `--project-id`, the command tells you to run `neon link`.
+
+## Usage
+
+<CliUsage command="open" />
+
+## Options
+
+<CliOptions command="open" />
+
+## Examples
+
+Open the project linked in the current directory's `.neon` context file:
+
+```bash
+neon open
+```
+
+```text
+INFO: Opening https://console.neon.tech/app/projects/cold-grass-40154007 in your browser.
+```
+
+Open a specific project without relying on the linked context:
+
+```bash
+neon open --project-id cold-grass-40154007
+```

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1218,6 +1218,8 @@
                   slug: cli/env
                 - title: set-context
                   slug: cli/set-context
+                - title: open
+                  slug: cli/open
                 - title: me
                   slug: cli/me
                 - title: profile

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "3.1.1",
+  "neonctlVersion": "3.2.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -2717,6 +2717,25 @@
       },
       "describe": "Manage Neon Auth",
       "usage": "$0 neon-auth <sub-command> [options]"
+    },
+    "open": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "project-id": {
+          "type": "string",
+          "describe": "Project ID (defaults to the project linked in .neon)"
+        }
+      },
+      "commands": {},
+      "describe": "Open the linked project in the Neon Console",
+      "usage": "$0 open [options]",
+      "examples": [
+        {
+          "command": "$0 open",
+          "description": ""
+        }
+      ]
     },
     "operations": {
       "aliases": [

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -47,6 +47,7 @@ const GROUP_OF = {
   'api-keys': 'setup',
   profile: 'setup',
   logs: 'debugging',
+  open: 'setup',
 };
 
 // Commands documented as a section of another command's page instead of a

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -33,6 +33,10 @@ const META = {
     desc: 'Write org/project/branch context to .neon.',
     examples: ['neon set-context --project-id polished-snowflake-1234'],
   },
+  open: {
+    desc: 'Open the linked project in the Neon Console in your browser.',
+    examples: ['neon open'],
+  },
   me: { desc: 'Show the authenticated user.', examples: ['neon me'] },
   completion: { desc: 'Generate a shell completion script.' },
   projects: { desc: 'Manage projects.', examples: ['neon projects list'] },


### PR DESCRIPTION
Refreshes the CLI reference to neonctl 3.2.0, which adds `neon open` for opening the linked project in the Neon Console.

- Regenerate schema.json (3.1.1 → 3.2.0)
- New content/docs/cli/open.md page
- Wire up nav entry, group mapping, and overview index row

This pull request and its description were written by Isaac.