### PR TITLE
docs: document mcp inspect_database tool

### DIFF
--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -7,7 +7,7 @@ summary: >-
   `npx neon@latest init` or use the config generator. Supports OAuth and
   API key auth.
 enableTableOfContents: true
-updatedOn: '2026-08-07T16:05:20.768Z'
+updatedOn: '2026-08-13T22:11:29.293Z'
 ---
 
 The Neon MCP Server implements the Model Context Protocol (MCP), letting AI assistants interact with your Neon projects on your behalf. Your AI agent can interact with Neon via MCP tools or by running [Neon CLI](/docs/cli) commands directly.
@@ -88,6 +88,12 @@ The hosted Neon MCP Server (`mcp.neon.tech`) connects to your Neon databases fro
 - `23.22.233.166`
 
 If [IP Allow](/docs/introduction/ip-allow) is enabled on your project, add these addresses to your allowlist so the MCP server can connect.
+
+## Database diagnostics
+
+When you ask why a branch is slow, large, or behind, the MCP server can run `inspect_database` instead of inventing catalog SQL. It exposes the same 14 read-only checks as [`neon inspect db`](/docs/cli/inspect): table and index sizes, unused indexes, sequential scans, long-running queries and locks, heavy and frequent statements, cache hit rate and working set, autovacuum and bloat, and replication state.
+
+Pick a check with the `check` parameter (for example `table-sizes` or `unused-indexes`). The tool runs inside a read-only transaction, so it works with [`?readonly=true`](#read-only-mode). It belongs to the `querying` category, not `observability`. Some checks need [`pg_stat_statements`](/docs/extensions/pg_stat_statements) or the [`neon`](/docs/extensions/neon) extension; the tool reports that and asks before suggesting installation.
 
 <MCPTools />
 

--- a/content/docs/cli/inspect.md
+++ b/content/docs/cli/inspect.md
@@ -27,6 +27,8 @@ By default the command resolves the project, branch, database, and role from you
 
 Some queries read from Postgres statistics extensions. `outliers` and `calls` need [`pg_stat_statements`](/docs/extensions/pg_stat_statements), and `lfc-hit-rate` and `working-set` need the [`neon`](/docs/extensions/neon) extension. If a required extension is not installed, the command reports it instead of returning rows.
 
+From an AI assistant, the same checks are available through the Neon MCP server's `inspect_database` tool. See [Database diagnostics](/docs/ai/neon-mcp-server#database-diagnostics).
+
 <CliSubcommands command="inspect db" anchorParts="db" />
 
 ### neon inspect db table-sizes (#db-table-sizes)

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-07-30T20:15:35.210Z'
+updatedOn: '2026-08-13T22:11:29.293Z'
 ---
 
 ## Available tools
@@ -11,7 +11,7 @@ Tools are grouped into categories. Use the `?category=` URL parameter to restric
 | Project management (`projects`)   | List, create, describe, and delete projects and organizations                       |
 | Branch management (`branches`)    | Create branches, compare schemas, reset branches to parent state                    |
 | Schema (`schema`)                 | Inspect tables and columns; run schema changes via a safe temporary branch workflow |
-| SQL (`querying`)                  | Execute queries and transactions; inspect database structure                        |
+| SQL (`querying`)                  | Execute queries and transactions; run the same diagnostics as `neon inspect db`     |
 | Managed Better Auth (`neon_auth`) | Set up and configure app authentication for a branch                                |
 | Neon Data API (`data_api`)        | Enable HTTP-based Data API access for a branch                                      |
 | Observability (`observability`)   | Query logs from your serverless functions and storage                               |
@@ -21,6 +21,8 @@ Search and navigation tools (search across projects, fetch resource details by I
 
 Schema tools accept schema-qualified table names, such as `crm.contacts`. An unqualified name resolves against the database `search_path`, which defaults to the `public` schema.
 
+The `querying` category includes `inspect_database`, which runs the same 14 read-only checks as [`neon inspect db`](/docs/cli/inspect): relation and index sizes, unused indexes, sequential scans, active queries and locks, heavy and frequent statements, cache hit rate and working set, autovacuum and bloat, and replication state. Some checks need [`pg_stat_statements`](/docs/extensions/pg_stat_statements) or the [`neon`](/docs/extensions/neon) extension; the tool asks before suggesting `CREATE EXTENSION`.
+
 <Admonition type="note">
-The `observability` tools query [Neon Functions logs](/docs/compute/functions/logs) and [object storage logs](/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS `us-east-2` only. Log querying returns results only for projects in a supported region.
+The `observability` tools query [Neon Functions logs](/docs/compute/functions/logs) and [object storage logs](/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS `us-east-2` only. Log querying returns results only for projects in a supported region. Database diagnostics via `inspect_database` are under `querying`, not `observability`.
 </Admonition>

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -29,7 +29,7 @@ Tools are grouped into categories. Use the \`?category=\` URL parameter to restr
 | Project management (\`projects\`)   | List, create, describe, and delete projects and organizations                       |
 | Branch management (\`branches\`)    | Create branches, compare schemas, reset branches to parent state                    |
 | Schema (\`schema\`)                 | Inspect tables and columns; run schema changes via a safe temporary branch workflow |
-| SQL (\`querying\`)                  | Execute queries and transactions; inspect database structure                        |
+| SQL (\`querying\`)                  | Execute queries and transactions; run the same diagnostics as \`neon inspect db\`     |
 | Managed Better Auth (\`neon_auth\`) | Set up and configure app authentication for a branch                                |
 | Neon Data API (\`data_api\`)        | Enable HTTP-based Data API access for a branch                                      |
 | Observability (\`observability\`)   | Query logs from your serverless functions and storage                               |
@@ -39,7 +39,9 @@ Search and navigation tools (search across projects, fetch resource details by I
 
 Schema tools accept schema-qualified table names, such as \`crm.contacts\`. An unqualified name resolves against the database \`search_path\`, which defaults to the \`public\` schema.
 
-**Note:** The \`observability\` tools query [Neon Functions logs](https://neon.com/docs/compute/functions/logs) and [object storage logs](https://neon.com/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS \`us-east-2\` only. Log querying returns results only for projects in a supported region.
+The \`querying\` category includes \`inspect_database\`, which runs the same 14 read-only checks as [\`neon inspect db\`](https://neon.com/docs/cli/inspect): relation and index sizes, unused indexes, sequential scans, active queries and locks, heavy and frequent statements, cache hit rate and working set, autovacuum and bloat, and replication state. Some checks need [\`pg_stat_statements\`](https://neon.com/docs/extensions/pg_stat_statements) or the [\`neon\`](https://neon.com/docs/extensions/neon) extension; the tool asks before suggesting \`CREATE EXTENSION\`.
+
+**Note:** The \`observability\` tools query [Neon Functions logs](https://neon.com/docs/compute/functions/logs) and [object storage logs](https://neon.com/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS \`us-east-2\` only. Log querying returns results only for projects in a supported region. Database diagnostics via \`inspect_database\` are under \`querying\`, not \`observability\`.
 
 ### LinkAPIKey
 


### PR DESCRIPTION
## Related PR

[feat: add inspect_database tool with the 14 neon inspect db checks](https://github.com/neondatabase/mcp-server-neon/pull/316) - neondatabase/mcp-server-neon#316

## Summary

Documents the new MCP `inspect_database` tool (same 14 checks as `neon inspect db`).

## Changes

- Updated `content/docs/ai/neon-mcp-server.md`: added Database diagnostics section
- Updated `content/docs/shared-content/mcp-tools.md`: querying category + inspect note
- Updated `content/docs/cli/inspect.md`: cross-link to MCP
- Updated LLMS snapshot for shared MCP tools content

## Context

Based on deep dive of neondatabase/mcp-server-neon#316.