### PR TITLE
Point the Sentry Functions guide canonical at Sentry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ Official Neon documentation written and maintained by the Neon docs team. All pa
 
 Community and third-party contributed guides showing how to use Neon with other technologies, frameworks, and services. These go through a lighter review process than core docs. Guides do **not** require a `navigation.yaml` entry — they are surfaced through their own index. Follow the same frontmatter and style conventions as `content/docs/` unless a guide contributor has a specific format.
 
+Optional guide-only field: `canonical` — an absolute `http://` or `https://` URL. When set, `<link rel="canonical">` points there instead of the Neon guide URL. Use it when a partner published the same guide and should receive the search ranking. Invalid values fail the build.
+
 ### Updating components
 
 1. Find the component in `src/components/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Official Neon documentation written and maintained by the Neon docs team. All pa
 
 Community and third-party contributed guides showing how to use Neon with other technologies, frameworks, and services. These go through a lighter review process than core docs. Guides do **not** require a `navigation.yaml` entry — they are surfaced through their own index. Follow the same frontmatter and style conventions as `content/docs/` unless a guide contributor has a specific format.
 
-Optional guide-only field: `canonical` — an absolute `http://` or `https://` URL. When set, `<link rel="canonical">` points there instead of the Neon guide URL. Use it when a partner published the same guide and should receive the search ranking. Invalid values fail the build.
+Optional guide-only field: `canonical` — an absolute `http://` or `https://` URL. When set, `<link rel="canonical">` points there instead of the Neon guide URL, and the guide is omitted from the sitemap. Use it when a partner published the same guide and should receive the search ranking. Invalid values fail the build.
 
 ### Updating components
 

--- a/content/guides/README.md
+++ b/content/guides/README.md
@@ -26,6 +26,7 @@ Right now Markdown files accept the following fields:
 6. `enableTableOfContents`: flag that turns on the display of the outline for the page. The outline gets built out of second and third-level headings ([`h2`, `h3`]), thus appears as two-level nested max.
 7. `ogImage` - the social preview image of the page.
 8. `excludeFromBlog`: flag that hides the guide from the blog's guides listing and the "All posts" feed. The guide page itself is still published at its `/guides/...` URL — use this for guides that should remain accessible but not be surfaced alongside blog content.
+9. `canonical`: an absolute `http://` or `https://` URL. When set, `<link rel="canonical">` points there instead of the Neon guide URL, and the guide is omitted from the sitemap. Use it when a partner published the same guide and should receive the search ranking. Invalid values fail the build.
 
 > ⚠️ Please note that the project won't build if at least one of the Markdown files is missing a required field.
 

--- a/content/guides/sentry-neon-functions.md
+++ b/content/guides/sentry-neon-functions.md
@@ -5,6 +5,7 @@ author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-08-05T00:00:00.000Z'
 updatedOn: '2026-08-13T14:46:11.074Z'
+canonical: 'https://sentry.io/cookbook/monitor-neon-functions-sentry/'
 ---
 
 [Neon Functions](/docs/compute/functions/overview) let you ship server-side code next to your Postgres. They also come with basic visibility out of the box: every deployed function streams its standard output and error to the [Monitoring page in the Neon Console](/docs/compute/functions/logs), with a platform-emitted `invoke begin` / `invoke end` line around each request. That's great for raw logs and spot checks.

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,5 +1,21 @@
+const { guideHasExternalCanonical } = require('./src/utils/guide-has-external-canonical');
+
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.com',
+  transform: async (config, routePath) => {
+    if (guideHasExternalCanonical(routePath)) {
+      return null;
+    }
+
+    return {
+      loc: routePath,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      changefreq: config.changefreq,
+      priority: config.priority,
+      alternateRefs: config.alternateRefs ?? [],
+      trailingSlash: config.trailingSlash,
+    };
+  },
   exclude: [
     // API routes
     '/api/*',

--- a/src/app/(docs)/guides/[slug]/page.jsx
+++ b/src/app/(docs)/guides/[slug]/page.jsx
@@ -32,7 +32,7 @@ export async function generateMetadata(props) {
   if (!post) return notFound();
 
   const {
-    data: { title, subtitle },
+    data: { title, subtitle, canonical },
   } = post;
 
   const authorID = post.data.author;
@@ -49,6 +49,7 @@ export async function generateMetadata(props) {
     type: 'article',
     category: 'Guides',
     authors: [author.name],
+    canonical,
   });
 }
 

--- a/src/utils/get-metadata.js
+++ b/src/utils/get-metadata.js
@@ -3,6 +3,19 @@ import SEO_DATA, { DEFAULT_IMAGE_PATH } from 'constants/seo-data';
 const DEFAULT_TITLE = SEO_DATA.index.title;
 const DEFAULT_DESCRIPTION = SEO_DATA.index.description;
 
+const assertAbsoluteHttpUrl = (value, fieldName) => {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${fieldName} must be an absolute HTTP(S) URL, got ${JSON.stringify(value)}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`${fieldName} must be an absolute HTTP(S) URL, got ${JSON.stringify(value)}`);
+  }
+};
+
 export default function getMetadata({
   title,
   description,
@@ -18,6 +31,7 @@ export default function getMetadata({
   isPostgres = false,
   currentSlug = null,
   markdownPath = null,
+  canonical,
 }) {
   const SITE_URL =
     process.env.VERCEL_ENV === 'preview'
@@ -33,14 +47,21 @@ export default function getMetadata({
   const siteName = 'Neon';
   const robots = robotsNoindex === 'noindex' ? { index: false } : null;
 
+  let alternateCanonical = isPostgres
+    ? `https://www.postgresql.org/docs/16/${currentSlug}.html`
+    : canonicalUrl;
+
+  if (canonical !== undefined && canonical !== null) {
+    assertAbsoluteHttpUrl(canonical, 'canonical');
+    alternateCanonical = canonical;
+  }
+
   return {
     metadataBase: new URL(SITE_URL),
     title: metaTitle,
     description: metaDescription,
     alternates: {
-      canonical: isPostgres
-        ? `https://www.postgresql.org/docs/16/${currentSlug}.html`
-        : canonicalUrl,
+      canonical: alternateCanonical,
       types: {
         'application/rss+xml': rssPathname ? `${SITE_URL}${rssPathname}` : null,
         'text/markdown': markdownPath ? `${SITE_URL}${markdownPath}` : null,

--- a/src/utils/get-metadata.test.js
+++ b/src/utils/get-metadata.test.js
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { GUIDES_DIR_PATH } from 'constants/content';
+
+import { getPostBySlug } from './api-content';
+import getMetadata from './get-metadata';
+
+describe('getMetadata', () => {
+  const originalSiteUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_DEFAULT_SITE_URL = 'https://neon.com';
+    delete process.env.VERCEL_ENV;
+  });
+
+  afterEach(() => {
+    if (originalSiteUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_DEFAULT_SITE_URL = originalSiteUrl;
+    }
+
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnv;
+    }
+  });
+
+  it('defaults canonical to the Neon page URL', () => {
+    const metadata = getMetadata({ pathname: '/guides/sentry-neon-mcp' });
+
+    expect(metadata.alternates.canonical).toBe('https://neon.com/guides/sentry-neon-mcp');
+    expect(metadata.openGraph.url).toBe('https://neon.com/guides/sentry-neon-mcp');
+  });
+
+  it('uses an absolute external canonical and keeps og:url on Neon', () => {
+    const metadata = getMetadata({
+      pathname: '/guides/sentry-neon-functions',
+      canonical: 'https://sentry.io/cookbook/monitor-neon-functions-sentry/',
+    });
+
+    expect(metadata.alternates.canonical).toBe(
+      'https://sentry.io/cookbook/monitor-neon-functions-sentry/'
+    );
+    expect(metadata.openGraph.url).toBe('https://neon.com/guides/sentry-neon-functions');
+  });
+
+  it('rejects a relative canonical', () => {
+    expect(() =>
+      getMetadata({ pathname: '/guides/sentry-neon-functions', canonical: '/elsewhere' })
+    ).toThrow('canonical must be an absolute HTTP(S) URL, got "/elsewhere"');
+  });
+
+  it('rejects an empty canonical', () => {
+    expect(() => getMetadata({ pathname: '/guides/sentry-neon-functions', canonical: '' })).toThrow(
+      'canonical must be an absolute HTTP(S) URL, got ""'
+    );
+  });
+
+  it('rejects a non-HTTP canonical', () => {
+    expect(() =>
+      getMetadata({
+        pathname: '/guides/sentry-neon-functions',
+        canonical: 'ftp://example.com/guide',
+      })
+    ).toThrow('canonical must be an absolute HTTP(S) URL, got "ftp://example.com/guide"');
+  });
+
+  it('still points postgres pages at postgresql.org when isPostgres is set', () => {
+    const metadata = getMetadata({
+      pathname: '/postgresql/tutorial',
+      isPostgres: true,
+      currentSlug: 'tutorial',
+    });
+
+    expect(metadata.alternates.canonical).toBe('https://www.postgresql.org/docs/16/tutorial.html');
+    expect(metadata.openGraph.url).toBe('https://neon.com/postgresql/tutorial');
+  });
+});
+
+describe('guide canonical frontmatter', () => {
+  const originalSiteUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_DEFAULT_SITE_URL = 'https://neon.com';
+    delete process.env.VERCEL_ENV;
+  });
+
+  afterEach(() => {
+    if (originalSiteUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_DEFAULT_SITE_URL = originalSiteUrl;
+    }
+
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnv;
+    }
+  });
+
+  it('reads the Sentry Functions guide canonical and emits it', () => {
+    const post = getPostBySlug('sentry-neon-functions', GUIDES_DIR_PATH);
+
+    expect(post.data.canonical).toBe('https://sentry.io/cookbook/monitor-neon-functions-sentry/');
+
+    const metadata = getMetadata({
+      pathname: '/guides/sentry-neon-functions',
+      canonical: post.data.canonical,
+    });
+
+    expect(metadata.alternates.canonical).toBe(post.data.canonical);
+    expect(metadata.openGraph.url).toBe('https://neon.com/guides/sentry-neon-functions');
+  });
+
+  it('leaves a guide without canonical on the Neon URL', () => {
+    const post = getPostBySlug('sentry-neon-mcp', GUIDES_DIR_PATH);
+
+    expect(post.data.canonical).toBeUndefined();
+
+    const metadata = getMetadata({
+      pathname: '/guides/sentry-neon-mcp',
+      canonical: post.data.canonical,
+    });
+
+    expect(metadata.alternates.canonical).toBe('https://neon.com/guides/sentry-neon-mcp');
+  });
+});

--- a/src/utils/guide-has-external-canonical.js
+++ b/src/utils/guide-has-external-canonical.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const matter = require('gray-matter');
+
+const guideHasExternalCanonical = (routePath) => {
+  const pathname = /^https?:\/\//.test(routePath) ? new URL(routePath).pathname : routePath;
+  const match = /^\/guides\/([^/]+)\/?$/.exec(pathname);
+
+  if (!match) return false;
+
+  const filePath = path.join(process.cwd(), 'content/guides', `${match[1]}.md`);
+  if (!fs.existsSync(filePath)) return false;
+
+  const { data } = matter(fs.readFileSync(filePath, 'utf8'));
+  return typeof data.canonical === 'string' && data.canonical.length > 0;
+};
+
+module.exports = { guideHasExternalCanonical };

--- a/src/utils/guide-has-external-canonical.test.js
+++ b/src/utils/guide-has-external-canonical.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { guideHasExternalCanonical } from './guide-has-external-canonical';
+
+describe('guideHasExternalCanonical', () => {
+  it('is true for the Sentry Functions guide', () => {
+    expect(guideHasExternalCanonical('/guides/sentry-neon-functions')).toBe(true);
+  });
+
+  it('is false for a guide without canonical', () => {
+    expect(guideHasExternalCanonical('/guides/sentry-neon-mcp')).toBe(false);
+  });
+
+  it('is false for non-guide paths', () => {
+    expect(guideHasExternalCanonical('/docs/introduction')).toBe(false);
+    expect(guideHasExternalCanonical('/guides')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Neon and Sentry published the same Neon Functions monitoring guide. The Neon page self-canonicals, so search treats `neon.com/guides/sentry-neon-functions` as the original instead of Sentry's cookbook.

## Diagnosis

Guides have no way to set an external canonical. `getMetadata` always emits `SITE_URL + pathname` for `<link rel="canonical">`. The sitemap also lists every guide URL as a `<loc>`, which would contradict an off-site canonical.

## The user-facing interface

A guide can set an absolute HTTP(S) `canonical` in frontmatter:

```yaml
---
title: 'Monitor Neon Functions with Sentry'
canonical: 'https://sentry.io/cookbook/monitor-neon-functions-sentry/'
---
```

That page then emits:

```html
<link rel="canonical" href="https://sentry.io/cookbook/monitor-neon-functions-sentry/"/>
```

The guide is omitted from `sitemap-0.xml`. `og:url` stays on the Neon URL. Guides without the field are unchanged. A relative, empty, or non-HTTP value fails the build.

First use: `content/guides/sentry-neon-functions.md` → https://sentry.io/cookbook/monitor-neon-functions-sentry/

## Also in here

- `content/guides/README.md` and `CLAUDE.md` document the field on the guides path only.
- `next-sitemap.config.js` now has a `transform` that runs for every sitemap URL. It returns `null` for a guide with `canonical` and otherwise reproduces next-sitemap's default entry (`loc`, `lastmod`, `changefreq`, `priority`, `alternateRefs`, `trailingSlash`). It copies that default instead of calling `defaultSitemapTransformer` because `next-sitemap` is ESM-only and cannot be `require`d from this CJS config.

## Verification

Preview: https://neon-next-git-guides-sentry-functions-canonical-neondatabase.vercel.app

- `/guides/sentry-neon-functions` → `<link rel="canonical" href="https://sentry.io/cookbook/monitor-neon-functions-sentry/"/>`; `og:url` stays on the Neon URL
- `/guides/sentry-neon-mcp` → self-canonical
- Preview `sitemap-0.xml`: 1397 `<loc>` entries; Sentry Functions guide absent; control guide present; `changefreq` / `priority` / `lastmod` unchanged on other entries
- `npm run test:unit:run -- src/utils/get-metadata.test.js src/utils/guide-has-external-canonical.test.js` — 11 passed
- Sentry's cookbook returns 200, self-canonicals, and is `index,follow`. No canonical loop

Not verified: production HTML after merge. Blog `seo.canonical` is still unused.

## For your attention

- Blog posts are out of scope. `turning-off-fpw-for-faster-writes` already has `seo.canonical` pointing at Databricks, but the blog loader never passes it to `getMetadata`. The blog field is nested (`seo.canonical`); guides use top-level `canonical`.
- This does not noindex or redirect the Neon guide. The page stays up; ranking consolidates to Sentry.