### PR TITLE
Fix Vercel function size limit: exclude public/ from serverless traces

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,12 @@ const generateDocPagePath = require('./src/utils/generate-doc-page-path');
 const defaultConfig = {
   poweredByHeader: false,
   transpilePackages: ['geist', 'react-icons'],
+  outputFileTracingExcludes: {
+    '*': ['./public/**'],
+  },
+  outputFileTracingIncludes: {
+    '*': ['./public/**/*.svg', './public/**/*.md'],
+  },
   images: {
     formats: ['image/avif', 'image/webp'],
     qualities: [75, 85, 90, 95, 99, 100],


### PR DESCRIPTION
This PR excludes `public/` from output file tracing and re-include only what server code actually reads at runtime:

- `public/**/*.svg` (~3 MB) – read by `InlineSvg`
- `public/**/*.md` (~22 MB) – `public/md` mirrors, copyable prompts, agent skills

Static serving from the CDN is unaffected; tracing only controls what gets packed into function bundles.