### PR TITLE
docs: reframe Electric changelog entry around the sync engine

### DIFF
--- a/content/changelog/2026-08-14.md
+++ b/content/changelog/2026-08-14.md
@@ -4,11 +4,11 @@ title: Electric joins Neon, a Vercel AI SDK provider for the AI Gateway, and age
 
 ## Electric joins Neon
 
-**Electric, the team behind PGlite and its Postgres sync engine, is joining Neon.** Together they push Postgres all the way to the client and keep it live, so you can build real-time, collaborative, local-first, and agentic apps without hand-rolling a websocket, caching, and sync layer.
+**Electric, the team behind the Electric sync engine and PGlite, is joining Neon.** The sync engine keeps data continuously synchronized between a central Postgres database and connected clients such as browser tabs, mobile apps, and agents, so you can build real-time, collaborative, and agentic apps without hand-rolling websockets, caching, and a sync layer.
 
-PGlite is a full Postgres that runs in a browser tab, a sandbox, or a serverless function, and the sync engine keeps it continuously in sync with your central Lakebase Postgres database. For AI agents, that makes real-time sync a built-in primitive, so they can add live, collaborative features without wiring up sync themselves.
+Real-time sync is hard to get right on your own: conflict resolution, partial replication, and reconnection logic are difficult to build from scratch. Electric turns it into a reusable primitive that handles the hard parts, so agents can add live, collaborative features by default instead of wiring up sync themselves.
 
-Both PGlite and the sync engine are coming to the Neon platform alongside Neon's other backend services ([Lakebase Postgres](/docs/postgres/overview), [Auth](/docs/auth/overview), [Storage](/docs/storage/overview), [Functions](/docs/compute/functions/overview), and the [AI Gateway](/docs/ai-gateway/overview)), with deeper integration already underway. To get familiar now, our [guide to Electric on Neon](/guides/electric-sql) walks through real-time sync with Shapes and a React app.
+Electric is coming to the Neon platform alongside Neon's other backend services ([Lakebase Postgres](/docs/postgres/overview), [Auth](/docs/auth/overview), [Storage](/docs/storage/overview), [Functions](/docs/compute/functions/overview), and the [AI Gateway](/docs/ai-gateway/overview)), with deeper integration already underway. To get familiar now, our [guide to Electric on Neon](/guides/electric-sql) walks through real-time sync with Shapes and a React app.
 
 Read the full announcement: [Electric is joining team Neon at Databricks](https://neon.com/blog/electric-joins-neon).
 


### PR DESCRIPTION
Reframes the "Electric joins Neon" section of the 2026-08-14 changelog
This pull request and its description were written by Isaac.