### PR TITLE
fix: pricing-sync coverage, spending notifications rename, and llms warnings

### DIFF
--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -22,7 +22,7 @@ redirectFrom:
   - /docs/reference/billing-sample
   - /docs/introduction/legacy-plans
   - /docs/introduction/extra-usage
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-15T00:37:08.193Z'
 ---
 
 Neon offers plans to support you at every stage, from your first prototype to production at scale.
@@ -53,6 +53,7 @@ For AI agent platforms that provision thousands of databases, Neon offers an **A
 | [Public network transfer](#public-network-transfer)   | 5 GB included                              | 500 GB per project included, then $0.10/GB | 500 GB per project included, then $0.10/GB                                                        |
 | [Monitoring](#monitoring)                             | 1 day                                      | 3 days                                     | 14 days                                                                                           |
 | [Metrics/logs export](#metricslogs-export)            | —                                          | —                                          | ✅                                                                                                |
+| [Spending notifications](#spending-notifications)     | —                                          | ✅                                         | ✅                                                                                                |
 | [Instant restore](#instant-restore)                   | —                                          | $0.20/GB-month                             | $0.20/GB-month                                                                                    |
 | [History window](#history-window)                     | 6 hours, up to 1 GB-month                  | Up to 7 days                               | Up to 30 days                                                                                     |
 | [Snapshots](#snapshots)                               | 1 manual snapshot                          | 100 manual snapshots                       | 100 manual snapshots                                                                              |
@@ -265,6 +266,12 @@ See [Monitoring dashboard](/docs/introduction/monitoring-page) for details.
 
 Export metrics and Postgres logs to [Datadog](/docs/guides/datadog) or any [OTel-compatible platform](/docs/guides/opentelemetry).  
 Available only on the **Scale** plan.
+
+### Spending notifications
+
+Get email alerts when your organization's monthly Neon charges reach 80% and 100% of a threshold you set, so you can act before the bill grows. Available on the **Launch** and **Scale** plans.
+
+See [Spending notifications](/docs/introduction/spending-notifications) for how to set a threshold.
 
 ### Instant restore
 

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -38,9 +38,12 @@ Invoices under $0.50 are not collected.
 | Public network transfer (egress) | 5 GB included                              | 500 GB per project included, then $0.10/GB | 500 GB per project included, then $0.10/GB                       |
 | Private network transfer         | -                                          | -                                    | $0.01/GB                                                         |
 | Auth (MAU)                       | Up to 60k MAU                              | Up to 1M MAU                         | Up to 1M MAU                                                     |
+| Object Storage                   | No charge during beta, usage limits apply  | No charge during beta, usage limits apply | No charge during beta, usage limits apply                        |
+| Functions                        | No charge during beta, usage limits apply  | No charge during beta, usage limits apply | No charge during beta, usage limits apply                        |
+| AI Gateway                       | -                                          | Free during beta                     | Free during beta                                                 |
 | Monitoring retention             | 1 day                                      | 3 days                               | 14 days                                                          |
 | Metrics/logs export              | -                                          | -                                    | Yes                                                              |
-| Set spending limits              | -                                          | Yes                                  | Yes                                                              |
+| Spending notifications           | -                                          | Yes                                  | Yes                                                              |
 | Protected branches               | -                                          | Yes                                  | Yes                                                              |
 | IP Allow rules                   | -                                          | -                                    | Yes                                                              |
 | Private Networking               | -                                          | -                                    | Yes                                                              |
@@ -92,7 +95,7 @@ Hitting any Free monthly limit (100 CU-hours, 0.5 GB storage, 5 GB egress) suspe
 | Keep scale-to-zero on for non-prod                                                               | Idle compute = $0                       |
 | Delete unused branches, or set TTL                                                               | Saves $1.50/branch-month each           |
 | Shorten the history window                                                                         | Saves $0.20/GB-month on instant restore (History) storage |
-| Org-level [spending limits](https://neon.com/docs/introduction/spending-limit.md) (Launch/Scale) | Email alerts at 80% and 100%            |
+| Org-level [spending notifications](https://neon.com/docs/introduction/spending-notifications.md) (Launch/Scale) | Email alerts at 80% and 100%            |
 
 See [Cost optimization](https://neon.com/docs/introduction/cost-optimization.md) for the full guide and [Reduce network transfer costs](https://neon.com/docs/introduction/network-transfer.md) for egress.
 

--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -258,8 +258,8 @@ export default {
     {
       rows: '2',
       feature: {
-        title: 'Spending limits',
-        subtitle: 'Control your monthly spend',
+        title: 'Spending notifications',
+        subtitle: 'Get alerts as your spend grows',
       },
       free: false,
       launch: true,

--- a/src/scripts/check-pricing-sync.js
+++ b/src/scripts/check-pricing-sync.js
@@ -98,6 +98,35 @@ const extractNumber = (val) => {
   return match ? match[1] : normalizeValue(val);
 };
 
+// Boolean feature-presence rows (checkmarks). Each source renders the two states
+// differently: present as component `true` / docs ✅ / pricing.md "Yes", absent as
+// component `false` / docs — / pricing.md "-". Map the known tokens to 'yes'/'no';
+// any other wording falls through to its literal value so an unexpected cell (e.g.
+// "Coming soon") surfaces as a mismatch instead of silently reading as "yes".
+const yesNo = (val) => {
+  if (val === true) return 'yes';
+  if (val === false || val === undefined || val === null) return 'no';
+  const s = String(val).trim().toLowerCase();
+  if (!s || s === '--' || s === '—' || s === '-') return 'no';
+  if (['yes', '✅', 'included', 'true'].includes(s)) return 'yes';
+  return s;
+};
+
+// Beta features are free during beta, but each source words it differently
+// (component "No charges applied during beta…", docs "No charge during beta…",
+// pricing.md "Free during beta"). They share one reliable signal: the word
+// "beta". Collapse anything mentioning beta to a single concept; treat
+// false/—/blank as not-offered. Any other wording (e.g. a real GA rate) falls
+// through to its literal value, so post-beta drift surfaces as a mismatch
+// instead of silently matching.
+const betaValue = (val) => {
+  if (val === false || val === undefined || val === null) return '--';
+  const s = String(val).trim();
+  if (!s || s === '--' || s === '—' || s === '-') return '--';
+  if (/\bbeta\b/i.test(s)) return 'beta';
+  return normalizeValue(val);
+};
+
 function extractCore(pattern, replacement) {
   return (val) => {
     if (!val || val === '--') return val;
@@ -564,8 +593,8 @@ const CROSS_SOURCE_CHECKS = [
   {
     id: 'auth-free',
     label: 'Auth MAU (Free)',
-    comp: 'MAU',
-    docs: 'Auth',
+    comp: 'Managed Better Auth',
+    docs: 'Auth (Beta)',
     plan: 'free',
     norm: extractCore(/(60k|60,?000)/i, '60k'),
     agentLabel: 'Auth (MAU)',
@@ -573,8 +602,8 @@ const CROSS_SOURCE_CHECKS = [
   {
     id: 'auth-launch',
     label: 'Auth MAU (Launch)',
-    comp: 'MAU',
-    docs: 'Auth',
+    comp: 'Managed Better Auth',
+    docs: 'Auth (Beta)',
     plan: 'launch',
     norm: extractCore(/(1M|1,?000,?000)/i, '1M'),
     agentLabel: 'Auth (MAU)',
@@ -582,12 +611,46 @@ const CROSS_SOURCE_CHECKS = [
   {
     id: 'auth-scale',
     label: 'Auth MAU (Scale)',
-    comp: 'MAU',
-    docs: 'Auth',
+    comp: 'Managed Better Auth',
+    docs: 'Auth (Beta)',
     plan: 'scale',
     norm: extractCore(/(1M|1,?000,?000)/i, '1M'),
     agentLabel: 'Auth (MAU)',
   },
+
+  // --- Backend (Beta) ---
+  // These features are free during beta with no per-plan numbers to drift, so we
+  // only verify that each source agrees they're offered (betaValue collapses the
+  // differently-worded "free/no charge during beta" prose to a single concept).
+  ...['free', 'launch', 'scale'].flatMap((plan) => [
+    {
+      id: `object-storage-${plan}`,
+      label: `Object Storage (${plan})`,
+      comp: 'Object Storage',
+      docs: 'Object Storage (Beta)',
+      plan,
+      norm: betaValue,
+      agentLabel: 'Object Storage',
+    },
+    {
+      id: `functions-${plan}`,
+      label: `Functions (${plan})`,
+      comp: 'Functions',
+      docs: 'Functions (Beta)',
+      plan,
+      norm: betaValue,
+      agentLabel: 'Functions',
+    },
+    {
+      id: `ai-gateway-${plan}`,
+      label: `AI Gateway (${plan})`,
+      comp: 'AI Gateway',
+      docs: 'AI Gateway (Beta)',
+      plan,
+      norm: betaValue,
+      agentLabel: 'AI Gateway',
+    },
+  ]),
 
   // --- Monitoring & Observability ---
   {
@@ -631,6 +694,20 @@ const CROSS_SOURCE_CHECKS = [
         : 'no',
     agentLabel: 'Metrics/logs export',
   },
+
+  // --- Billing & Account ---
+  // Named "Spending notifications" across all three sources (the feature sends
+  // email alerts; a hard limit is coming soon). Free plan has no notifications,
+  // so only Launch/Scale are compared.
+  ...['launch', 'scale'].map((plan) => ({
+    id: `spending-notifications-${plan}`,
+    label: `Spending notifications (${plan})`,
+    comp: 'Spending notifications',
+    docs: 'Spending notifications',
+    plan,
+    norm: yesNo,
+    agentLabel: 'Spending notifications',
+  })),
 
   // --- Compliance & Security (component preferred — separate rows beat combined cell) ---
   {
@@ -800,10 +877,13 @@ const INTENTIONALLY_DOCS_ONLY = new Set([
 ]);
 
 // Component table rows that intentionally don't have a docs-side comparison.
-// The docs Snapshots row references scheduled backups in prose rather than
-// a dedicated table row, so the component's standalone Scheduled Backups
-// row has no docs counterpart to compare against.
-const INTENTIONALLY_COMPONENT_ONLY = new Set(['Scheduled Backups']);
+//   - Scheduled Backups: the docs Snapshots row references scheduled backups in
+//     prose rather than a dedicated table row, so there's no counterpart.
+//   - Autoscaling: a standalone yes/no checkmark in the pricing table. The
+//     substantive comparison (the CU limits) already runs via 'Compute sizes' vs
+//     the docs 'Autoscaling' row; docs folds the on/off state into that CU range,
+//     so this boolean row has no separate counterpart.
+const INTENTIONALLY_COMPONENT_ONLY = new Set(['Scheduled Backups', 'Autoscaling']);
 
 function runChecks(componentData, docsTable) {
   const results = [];

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -236,7 +236,6 @@ module.exports = {
     'auth/legacy/',
     'auth/migrate/from-auth-v0.1',
     'changelog.md',
-    'get-started/platform-private-preview.md',
     'guides/GUIDE_TEMPLATE.md',
     'introduction.md',
   ],

--- a/src/scripts/process-md-for-llms.js
+++ b/src/scripts/process-md-for-llms.js
@@ -1328,6 +1328,20 @@ const componentHandlers = {
   },
 
   /**
+   * InlineSvg -> markdown image, using the title attribute as descriptive alt text
+   * <InlineSvg src="/docs/guides/diagram.svg" title="What the diagram shows" />
+   */
+  InlineSvg(node) {
+    const src = getAttr(node, 'src');
+    if (!src) return null;
+    const title = getAttr(node, 'title') || '';
+    return {
+      type: 'paragraph',
+      children: [{ type: 'image', url: src, alt: title, title: null }],
+    };
+  },
+
+  /**
    * MegaLink -> link card with tag and description
    * <MegaLink tag="Tagline" title="Description text" url="https://..." />
    */


### PR DESCRIPTION
## Overview

Two independent fixes:

**Pricing:** Neon renamed "spending limits" to "spending notifications," but the pricing page still showed the old name and the pricing-sync check had drifted out of coverage on several renamed and newly added rows. This aligns all three pricing sources (the pricing page, the docs plans table, and the agent-facing `pricing.md`) on the new name, adds a short docs section for it, and re-wires the check so Auth, the beta backend features (Object Storage, Functions, AI Gateway), and spending notifications are compared again instead of silently skipped.

**Build warnings:** clears two warnings from the Vercel build. Removes a dead `llms.txt` exclude path for a page that was renamed away, and adds an `InlineSvg` handler to the llms markdown processor so it no longer flags the component as unknown (it now renders as an image using the SVG's descriptive title as alt text).

The pricing-sync check passes with full coverage: 63 comparisons, none skipped.

This pull request and its description were written by Isaac.
