### PR TITLE
docs: surface Lakebase Search in agent-building docs

### DIFF
--- a/content/docs/ai/ai-agents-tools.md
+++ b/content/docs/ai/ai-agents-tools.md
@@ -10,7 +10,7 @@ summary: >-
   neon@latest init`) configures OAuth, installs Agent Skills, and connects
   your editor in a single step.
 enableTableOfContents: true
-updatedOn: '2026-08-04T08:22:57.969Z'
+updatedOn: '2026-08-15T10:40:27.257Z'
 ---
 
 Neon is the backend for apps and agents. This page covers Neon's integrations with AI tools and agent frameworks, from natural language database control to autonomous agent platforms. Choose the tools that fit your workflow.
@@ -77,6 +77,8 @@ Create autonomous agents that can manage and interact with your Neon databases p
 <a href="/docs/ai/ai-database-versioning" description="How AI agents and codegen platforms use Neon snapshot APIs for database versioning" icon="openai">Database versioning</a>
 
 <a href="/docs/reference/api" description="Integrate using the Neon API" icon="transactions">Neon API</a>
+
+<a href="/docs/ai/lakebase-search" description="Add vector, keyword, and hybrid search for agent retrieval and RAG with lakebase_vector and lakebase_text" icon="openai">Lakebase Search</a>
 
 </DetailIconCards>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-07-31T16:42:49.697Z'
+updatedOn: '2026-08-15T10:47:27.123Z'
 ---
 
 ## Getting started
@@ -132,6 +132,10 @@ Browse our [framework](/docs/get-started/frameworks), [language](/docs/get-start
 <a href="/docs/guides/redwoodsdk" title="Redwood" icon="redwoodsdk"></a>
 
 </CompactCards>
+
+<Callout title="Retrieval for AI agents with Lakebase Search">
+Add vector, keyword, and hybrid search directly to your database, so agent retrieval and RAG need no separate vector store. [Explore Lakebase Search →](/docs/ai/lakebase-search)
+</Callout>
 
 ## AI tools and agents
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1169,6 +1169,8 @@
                   slug: ai/ai-database-versioning
                 - title: Neon API Reference
                   slug: reference/api
+                - title: Lakebase Search
+                  slug: ai/lakebase-search
             - section: Agent frameworks
               icon: frameworks
               items:


### PR DESCRIPTION
## What

Makes Lakebase Search discoverable as retrieval/RAG for agents, per the request to surface it in the "Build AI Agents" areas of the docs. The `ai/lakebase-search` page already existed; this PR adds it to the agent-building surfaces.

## Changes

- **`introduction.md`** — adds a "Retrieval for AI agents with Lakebase Search" callout directly above the **AI tools and agents** section, linking to the Lakebase Search overview.
- **`ai/ai-agents-tools.md`** — adds a Lakebase Search card to the **Build AI agents** section.
- **`navigation.yaml`** — adds a Lakebase Search entry to the **Build AI agents** sidebar section (intentional second nav location alongside the existing "AI & Search" home).

## Notes for reviewers

- Used the standard `<Callout>` component rather than a bespoke banner; no `src/` changes.
- The Lakebase Search callout and the agent-hub card both point to the overview page for a consistent entry point.
- The double nav placement (AI & Search + Build AI agents) is intentional for cross-discoverability.

This pull request and its description were written by Isaac.