### PR TITLE
docs(data-api): remove stale "not yet on npm" admonition (createClient single-URL form is shipped)

### DIFF
--- a/content/docs/data-api/access-control.md
+++ b/content/docs/data-api/access-control.md
@@ -65,10 +65,6 @@ const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL, {
 const { data, error } = await client.from('public_items').select('*');
 ```
 
-<Admonition type="warning" title="Not yet on npm">
-The single-URL form shown above, `createClient(url)`, requires a version of `@neondatabase/neon-js` that has not been published to npm as of this writing. The latest published version, `0.6.2-beta`, only accepts the two-URL object form. If `npm install @neondatabase/neon-js` installs `0.6.2-beta` or earlier for you, use the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference instead.
-</Admonition>
-
 **With a third-party provider:** Check whether your provider supports issuing anonymous or guest tokens. If it does, obtain the token using your provider's method and include it in the `Authorization: Bearer <token>` header on each request.
 
 - By default, this role has **no permissions**.

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -262,10 +262,6 @@ const { data, error } = await client
 console.log(data);
 ```
 
-<Admonition type="warning" title="Not yet on npm">
-The single-URL form shown above, `createClient(url)`, requires a version of `@neondatabase/neon-js` that has not been published to npm as of this writing. The latest published version, `0.6.2-beta`, only accepts the two-URL object form. If `npm install @neondatabase/neon-js` installs `0.6.2-beta` or earlier for you, use the [object-form alternative](/docs/reference/javascript-sdk#initializing) in the JavaScript SDK reference instead.
-</Admonition>
-
 <Admonition type="note">
 This client runs in the browser. Environment variable syntax depends on your framework: `import.meta.env.VITE_*` for Vite-based projects (Vite, SvelteKit, Astro), `process.env.NEXT_PUBLIC_*` for Next.js. The `VITE_NEON_DATABASE_URL` value is not your Postgres connection string; use the HTTPS Neon database URL shown in the example above. You can find the matching Data API URL on the **Data API** page in the Neon Console or with `neon data-api get`; to get the single database URL, remove the `.apirest` hostname label and trailing `/rest/v1` path. If you start from a Neon Auth URL instead, remove the `.neonauth` hostname label and trailing `/auth` path. The cell label (if present), region, and database path stay the same.
 </Admonition>

--- a/content/docs/reference/javascript-sdk.md
+++ b/content/docs/reference/javascript-sdk.md
@@ -105,10 +105,6 @@ const client = createClient(import.meta.env.VITE_NEON_DATABASE_URL, {
 
 </CodeTabs>
 
-<Admonition type="warning" title="Not yet on npm">
-The single-URL form shown above, `createClient(url)`, requires a version of `@neondatabase/neon-js` that has not been published to npm as of this writing. The latest published version, `0.6.2-beta`, only accepts the two-URL object form below. If `npm install @neondatabase/neon-js` installs `0.6.2-beta` or earlier for you, use the object form instead.
-</Admonition>
-
 The object form remains available for custom endpoint layouts or local development setups where the Auth and Data API URLs cannot be derived from the same Neon database URL:
 
 ```typescript


### PR DESCRIPTION
## Summary

A drift compare found a stale `warning` admonition (titled **"Not yet on npm"**) repeated across three data-api doc pages. The admonition claimed that:

- the single-URL `createClient(url)` form was **not yet published to npm**, and
- the latest published `@neondatabase/neon-js` was `0.6.2-beta`, which only accepted the two-URL object form.

Both claims are now **false**. On npm, `latest` for `@neondatabase/neon-js` is `0.7.0-beta`, and the single-URL string form is shipped and is the **default**. On `reference/javascript-sdk.md` the admonition also directly contradicted the page's own body, which already teaches the single-URL form as primary.

This PR removes the now-false admonition from all three pages. Only the admonition blocks were removed; the `createClient` code examples and the filter/method tables are untouched.

## Files changed

- `content/docs/data-api/get-started.md` — "Connect and Query → Option 1 → Managed Better Auth" tab
- `content/docs/reference/javascript-sdk.md` — "Initialize the client"
- `content/docs/data-api/access-control.md` — "API Roles → 2. The `anonymous` role"

3 admonition instances found by the drift compare; all 3 removed. A follow-up grep for `0.6.2-beta`, `has not been published to npm`, and `Not yet on npm` across `content/docs/` now returns zero matches.

Co-authored-by: omnigent <noreply@omnigent.ai>