### PR TITLE
docs(ai-gateway): document the new enabled field in GET /v1/models

### DIFF
--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -114,6 +114,7 @@ curl "$NEON_AI_GATEWAY_BASE_URL/v1/models" \
     {
       "id": "gpt-5-mini",
       "canonical_slug": "gpt-5-mini",
+      "enabled": true,
       "pricing": null,
       "per_request_limits": null,
       "context_length": null
@@ -123,6 +124,8 @@ curl "$NEON_AI_GATEWAY_BASE_URL/v1/models" \
 ```
 
 `canonical_slug`, `pricing`, `per_request_limits`, and `context_length` are reserved OpenRouter-compatible fields. `pricing`, `per_request_limits`, and `context_length` are currently always `null`; use the tables earlier on this page for context window and model details in the meantime.
+
+`enabled` reflects whether your account can use that model. It's currently always `true` while per-account access verification is off.
 
 ## Provider terms
 


### PR DESCRIPTION
Doc-only fix from the docs-drift audit: 1 correction in 1 file. **Not auto-merged — awaiting your review.**

The AI Gateway `GET /v1/models` response now returns an `enabled` boolean on every model entry, but the sample response and field notes on the models page didn't mention it. This adds it.

## Add the `enabled` field to the model-list example

**Before → After** (sample JSON under "List available models"):

```diff
       "id": "gpt-5-mini",
       "canonical_slug": "gpt-5-mini",
+      "enabled": true,
       "pricing": null,
```

Plus one line of prose after the reserved-fields note:

> `enabled` reflects whether your account can use that model. It's currently always `true` while per-account access verification is off.

**Why the new text is right:** a live `GET /v1/models` call against a real branch returns `enabled` on every entry, currently `true`. See How to verify.

## Files

| File | Change |
| --- | --- |
| `content/docs/ai-gateway/models.md` | Add `enabled` to the sample `/v1/models` response and a one-line note on what it reflects |

## How to verify

Create an `ai_gateway:invoke` credential for a branch (Console → **Credentials**, or the API shown on the [get-started page](/docs/ai-gateway/get-started)), then call the model list:

```bash
curl "$NEON_AI_GATEWAY_BASE_URL/v1/models" \
  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN"
```

Every object in `data[]` includes `"enabled": true`. Verified against live Neon: all 42 returned models carried `"enabled": true`.

Text-only change; no build or deploy behavior affected.

## Scope / what's intentionally untouched

Only the `enabled` field is added. The other reserved OpenRouter fields (`pricing`, `per_request_limits`, `context_length`) and their existing "always null" note are unchanged.

Tracked in LKB-14983.
