### PR TITLE
fix: patch brace-expansion for CVE-2026-14257

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13719,9 +13719,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17048,9 +17048,9 @@
       "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -19594,15 +19594,15 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/markdownlint-cli/node_modules/commander": {


### PR DESCRIPTION
## Summary

Patches all three transitive installs of `brace-expansion` to resolve **CVE-2026-14257** (GHSA-mh99-v99m-4gvg), a HIGH-severity DoS: `expand()` limits result count but not result length, so chained brace groups can trigger an uncatchable V8 out-of-memory crash.

## Changes

Lockfile-only `npm update brace-expansion`. Each install moves to the latest version **within its dependent's declared semver range**:

| Before | After | Patched in |
| ------ | ----- | ---------- |
| 1.1.13 | 1.1.18 | 1.1.17 |
| 2.0.3  | 2.1.4  | 2.1.3 |
| 5.0.6  | 5.0.9  | 5.0.8 |

No `package.json` override, so nothing is frozen and each dependent stays within range.

## Why not #5435

The contributed PR #5435 flags the same CVE but fixes it with `"overrides": { "brace-expansion": "2.1.3" }`, which forces **all** installs to an exact 2.1.3 — a cross-major downgrade for the `^5.0.5` consumer (markdownlint-cli → minimatch) and a permanent version freeze that blocks future patches. This PR takes the clean per-line approach instead and supersedes it.

## Risk

Low practical exposure: `brace-expansion` is a dev/build-time transitive dep (glob, minimatch, markdownlint-cli), and the DoS requires attacker-controlled brace patterns, which the build doesn't process. Patched anyway for clean scans. All three target versions were published 2026-07-30, past the proxy cooldown.

This pull request and its description were written by Isaac.