### PR TITLE
chore: gitignore .isaac/ local tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ package-lock.json
 .vercel
 .neon
 
+# Isaac Review local tooling state
+.isaac/
+
 # Evals directory (test validation for documentation)
 .evals/
 


### PR DESCRIPTION
The `isaac` CLI (Isaac Review) writes local bookkeeping to `.isaac/` (e.g. reminder-throttle timestamps like `sync_reminder_last_shown`). It's machine-local state, read by no repo script, so it shouldn't be tracked. This ignores `.isaac/` alongside the other local tool-state dirs (`.vercel`, `.neon`).

This pull request and its description were written by Isaac.