### PR TITLE
docs(ai): document snapshot per-hour scheduling limit (blocked on neon-cloud#9065)

### DIFF
--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -11,7 +11,7 @@ summary: >-
   connection string stable, or when you need temporary preview branches from any
   saved version. Snapshot limits and storage pricing vary by plan.
 enableTableOfContents: true
-updatedOn: '2026-08-17T13:43:13.000Z'
+updatedOn: '2026-08-17T14:20:06.000Z'
 ---
 
 <Admonition type="note">
@@ -384,7 +384,11 @@ If you create scheduled snapshots programmatically at high volume (for example, 
 
 Each account can schedule up to 5,000 snapshots per hour by default, so concentrating too many in a single hour can reach this limit.
 
-A scheduled snapshot's `hour` (`0`–`23`) determines when it's created. Spread the `hour` across branches: hash the branch ID to an hour, cycle through hours as you create schedules, or pick a random hour per branch and keep it.
+A scheduled snapshot's `hour` (`0`–`23`) determines when it's created. Spread the `hour` across branches using one of these approaches:
+
+- **Hash the branch ID**: map each branch to a fixed hour (`0`–`23`) so it always schedules to the same hour.
+- **Cycle through hours**: assign each new schedule the next hour in sequence.
+- **Pick a random hour**: choose one per branch and keep it.
 
 ## FAQ
 

--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -11,7 +11,7 @@ summary: >-
   connection string stable, or when you need temporary preview branches from any
   saved version. Snapshot limits and storage pricing vary by plan.
 enableTableOfContents: true
-updatedOn: '2026-08-17T13:35:12.000Z'
+updatedOn: '2026-08-17T13:43:13.000Z'
 ---
 
 <Admonition type="note">
@@ -380,9 +380,11 @@ Proper cleanup reduces costs and keeps your project manageable:
 
 ## Scheduling snapshots at scale
 
-If you create scheduled snapshots programmatically at high volume, say an agent platform that schedules across many branches, watch the per-account limit: each account can schedule up to 5,000 snapshots per hour by default. Scheduling manually or for a handful of branches won't come close.
+If you create scheduled snapshots programmatically at high volume (for example, an agent platform that schedules across many branches), we recommend distributing snapshot creation across several hours rather than concentrating it in one. For example, avoid scheduling every branch at the same hour, such as midnight.
 
-A scheduled snapshot's `hour` (`0` to `23`) sets when it's created, so putting thousands of branches on the same hour can hit that limit. Spread the `hour` across branches instead: hash the branch ID to an hour, cycle through hours as you create schedules, or pick a random hour per branch and keep it.
+Each account can schedule up to 5,000 snapshots per hour by default, so concentrating too many in a single hour can reach this limit.
+
+A scheduled snapshot's `hour` (`0`–`23`) determines when it's created. Spread the `hour` across branches: hash the branch ID to an hour, cycle through hours as you create schedules, or pick a random hour per branch and keep it.
 
 ## FAQ
 

--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -11,7 +11,7 @@ summary: >-
   connection string stable, or when you need temporary preview branches from any
   saved version. Snapshot limits and storage pricing vary by plan.
 enableTableOfContents: true
-updatedOn: '2026-08-07T17:19:40.308Z'
+updatedOn: '2026-08-17T13:01:54.000Z'
 ---
 
 <Admonition type="note">
@@ -377,6 +377,24 @@ Proper cleanup reduces costs and keeps your project manageable:
 - **Keep backup branches briefly**: After restore, keep the automatically-created backup branch (for example, `prod (old)`) for sanity checks before deletion, or assign a [time to live](/docs/guides/branch-expiration) for automatic cleanup.
 - **Cleanup strategy**: Set `expires_at` on temporary snapshots and preview branches. Delete orphaned branches (for example, `production (old)`) created during restores.
 - **Version metadata**: Keep version metadata separate to preserve audit trail across restores.
+
+## Scheduling snapshots at scale
+
+<Admonition type="note">
+This applies only if you're creating scheduled snapshots programmatically at high volume—for example, an agent platform or automation layer that schedules snapshots across many branches. If you're scheduling snapshots manually or for a handful of branches, you won't hit this limit and can skip this section.
+</Admonition>
+
+Each account can schedule up to **5,000 snapshots per hour** (the default limit). If you exceed this in the same hour, snapshot creation returns an error:
+
+> You have reached the maximum of 5,000 scheduled snapshots per hour for your account. Schedule this snapshot for a different hour.
+
+Because a scheduled snapshot's hour (`0`–`23`) determines when it's created, concentrating thousands of branches on the same hour can reach this limit. When you generate snapshot schedules programmatically, distribute the `hour` value across branches to stay well under it:
+
+- **Hash the branch name or ID**: map it to a consistent hour (`0`–`23`) so each branch always schedules to the same, evenly distributed hour.
+- **Cycle through hours**: assign hours sequentially as you create new schedules.
+- **Pick a random hour**: choose one per branch and keep it.
+
+Spreading scheduled snapshots across hours keeps you under the per-hour limit as your branch count grows.
 
 ## FAQ
 

--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -11,7 +11,7 @@ summary: >-
   connection string stable, or when you need temporary preview branches from any
   saved version. Snapshot limits and storage pricing vary by plan.
 enableTableOfContents: true
-updatedOn: '2026-08-17T14:20:06.000Z'
+updatedOn: '2026-08-18T12:50:47.000Z'
 ---
 
 <Admonition type="note">
@@ -380,11 +380,9 @@ Proper cleanup reduces costs and keeps your project manageable:
 
 ## Scheduling snapshots at scale
 
-If you create scheduled snapshots programmatically at high volume (for example, an agent platform that schedules across many branches), we recommend distributing snapshot creation across several hours rather than concentrating it in one. For example, avoid scheduling every branch at the same hour, such as midnight.
+If you create scheduled snapshots programmatically at high volume (for example, an agent platform that schedules across many branches), it's good practice to distribute snapshot creation across different hours of the day rather than concentrating it in one, such as scheduling every branch at midnight.
 
-Each account can schedule up to 5,000 snapshots per hour by default, so concentrating too many in a single hour can reach this limit.
-
-A scheduled snapshot's `hour` (`0`–`23`) determines when it's created. Spread the `hour` across branches using one of these approaches:
+A scheduled snapshot's `hour` (`0`–`23`) sets when it's created. Spread the `hour` across branches:
 
 - **Hash the branch ID**: map each branch to a fixed hour (`0`–`23`) so it always schedules to the same hour.
 - **Cycle through hours**: assign each new schedule the next hour in sequence.

--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -11,7 +11,7 @@ summary: >-
   connection string stable, or when you need temporary preview branches from any
   saved version. Snapshot limits and storage pricing vary by plan.
 enableTableOfContents: true
-updatedOn: '2026-08-17T13:01:54.000Z'
+updatedOn: '2026-08-17T13:35:12.000Z'
 ---
 
 <Admonition type="note">
@@ -380,21 +380,9 @@ Proper cleanup reduces costs and keeps your project manageable:
 
 ## Scheduling snapshots at scale
 
-<Admonition type="note">
-This applies only if you're creating scheduled snapshots programmatically at high volume—for example, an agent platform or automation layer that schedules snapshots across many branches. If you're scheduling snapshots manually or for a handful of branches, you won't hit this limit and can skip this section.
-</Admonition>
+If you create scheduled snapshots programmatically at high volume, say an agent platform that schedules across many branches, watch the per-account limit: each account can schedule up to 5,000 snapshots per hour by default. Scheduling manually or for a handful of branches won't come close.
 
-Each account can schedule up to **5,000 snapshots per hour** (the default limit). If you exceed this in the same hour, snapshot creation returns an error:
-
-> You have reached the maximum of 5,000 scheduled snapshots per hour for your account. Schedule this snapshot for a different hour.
-
-Because a scheduled snapshot's hour (`0`–`23`) determines when it's created, concentrating thousands of branches on the same hour can reach this limit. When you generate snapshot schedules programmatically, distribute the `hour` value across branches to stay well under it:
-
-- **Hash the branch name or ID**: map it to a consistent hour (`0`–`23`) so each branch always schedules to the same, evenly distributed hour.
-- **Cycle through hours**: assign hours sequentially as you create new schedules.
-- **Pick a random hour**: choose one per branch and keep it.
-
-Spreading scheduled snapshots across hours keeps you under the per-hour limit as your branch count grows.
+A scheduled snapshot's `hour` (`0` to `23`) sets when it's created, so putting thousands of branches on the same hour can hit that limit. Spread the `hour` across branches instead: hash the branch ID to an hour, cycle through hours as you create schedules, or pick a random hour per branch and keep it.
 
 ## FAQ
 

--- a/content/docs/ai/ai-database-versioning.md
+++ b/content/docs/ai/ai-database-versioning.md
@@ -11,7 +11,7 @@ summary: >-
   connection string stable, or when you need temporary preview branches from any
   saved version. Snapshot limits and storage pricing vary by plan.
 enableTableOfContents: true
-updatedOn: '2026-08-18T12:50:47.000Z'
+updatedOn: '2026-08-18T13:12:58.000Z'
 ---
 
 <Admonition type="note">
@@ -380,7 +380,7 @@ Proper cleanup reduces costs and keeps your project manageable:
 
 ## Scheduling snapshots at scale
 
-If you create scheduled snapshots programmatically at high volume (for example, an agent platform that schedules across many branches), it's good practice to distribute snapshot creation across different hours of the day rather than concentrating it in one, such as scheduling every branch at midnight.
+If you create scheduled snapshots programmatically at high volume (for example, an agent platform that schedules across many branches), it's good practice to distribute snapshot creation across different hours of the day rather than concentrating it in one. For example, avoid scheduling every branch at midnight.
 
 A scheduled snapshot's `hour` (`0`–`23`) sets when it's created. Spread the `hour` across branches:
 


### PR DESCRIPTION
Adds a "Scheduling snapshots at scale" section to the AI database-versioning guide, documenting the per-account 5,000-scheduled-snapshots-per-hour limit and how high-volume/agent-platform builders should distribute the schedule `hour` to stay under it.

Eng PR: https://github.com/databricks-eng/neon-cloud/pull/9065 (`[cplane/public_api] feat: Hard limit snapshot schedules per account per hour`) is currently OPEN / not merged. The limit value (5,000, a live-config default), the error string, and whether it ships at all can still change in review. Hold this docs PR as a draft until #9065 merges, then reconcile the number/error text against the merged code before marking ready.

Tracking: DOC-25882.
