### PR TITLE
docs: align prisma.md summary to DATABASE_URL_UNPOOLED

### DIFF
--- a/content/docs/guides/prisma.md
+++ b/content/docs/guides/prisma.md
@@ -6,7 +6,7 @@ summary: >-
   `@prisma/adapter-neon` serverless driver adapter, which routes queries over
   WebSockets for compatibility with serverless environments. The setup requires
   two connection strings: a pooled URL (`DATABASE_URL`) for application queries
-  and a direct URL (`DIRECT_URL`) for Prisma CLI commands such as migrations and
+  and a direct URL (`DATABASE_URL_UNPOOLED`) for Prisma CLI commands such as migrations and
   `db push`. Newer Prisma versions configure the direct connection in
   `prisma.config.ts`; older versions use the `directUrl` property in
   `schema.prisma`.
@@ -16,7 +16,7 @@ redirectFrom:
   - /docs/integrations/prisma
   - /docs/guides/prisma-guide
   - /docs/guides/prisma-migrate
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-08-17T13:35:16.350Z'
 ---
 
 <CopyPrompt src="/prompts/prisma-prompt.md" 


### PR DESCRIPTION
Follow-up to #4839, which standardized the Prisma guide body on `DATABASE_URL_UNPOOLED`. The frontmatter `summary` still referenced the old `DIRECT_URL` name; this aligns it so the SEO summary matches the guide's actual instructions.

One-line change, no body/user-facing content affected.

This pull request and its description were written by Isaac.