### PR TITLE
docs(cli): profile.md — drop removed --force example, add profile list storage column

### DIFF
--- a/content/docs/cli/profile.md
+++ b/content/docs/cli/profile.md
@@ -103,18 +103,18 @@ neon profile list
 
 ```text filename="Output"
 Profiles
-┌────────┬─────────┬──────────────────────────────────────┬─────────┬─────────┬──────┬──────────────────────────────────────┐
-│ Active │ Name    │ Account                              │ Auth    │ Scope   │ File │ Credentials                          │
-├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼──────────────────────────────────────┤
-│ *      │ DEFAULT │ 3f8a1c2e-5b7d-4e9a-8c1f-2d6b9e0a4c53 │ oauth   │ -       │ ok   │ ~/.config/neon/credentials.json      │
-├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼──────────────────────────────────────┤
-│        │ work    │ alex@domain.com                      │ oauth   │ -       │ ok   │ ~/.config/neon/credentials.work.json │
-├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼──────────────────────────────────────┤
-│        │ ci      │ alex@domain.com                      │ api key │ account │ ok   │ ~/.config/neon/credentials.ci.json   │
-└────────┴─────────┴──────────────────────────────────────┴─────────┴─────────┴──────┴──────────────────────────────────────┘
+┌────────┬─────────┬──────────────────────────────────────┬─────────┬─────────┬──────┬─────────┬──────────────────────────────────────┐
+│ Active │ Name    │ Account                              │ Auth    │ Scope   │ File │ Storage │ Credentials                          │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼─────────┼──────────────────────────────────────┤
+│ *      │ DEFAULT │ 3f8a1c2e-5b7d-4e9a-8c1f-2d6b9e0a4c53 │ oauth   │ -       │ ok   │ file    │ ~/.config/neon/credentials.json      │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼─────────┼──────────────────────────────────────┤
+│        │ work    │ alex@domain.com                      │ oauth   │ -       │ ok   │ file    │ ~/.config/neon/credentials.work.json │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼─────────┼──────────────────────────────────────┤
+│        │ ci      │ alex@domain.com                      │ api key │ account │ ok   │ keyring │ OS keyring                           │
+└────────┴─────────┴──────────────────────────────────────┴─────────┴─────────┴──────┴─────────┴──────────────────────────────────────┘
 ```
 
-`Account` is the recorded email label, or the user ID when there's no label, as with a `DEFAULT` profile from a plain `neon auth`. `Auth` shows how the profile authenticates (`oauth` for a browser sign-in, `api key` for a stored key), and `Scope` shows what a minted key is limited to: `account`, `org <org-id>`, or `project <project-id>`. `File` is `ok` when the credentials file is present and readable, and `missing` when it isn't.
+`Account` is the recorded email label, or the user ID when there's no label, as with a `DEFAULT` profile from a plain `neon auth`. `Auth` shows how the profile authenticates (`oauth` for a browser sign-in, `api key` for a stored key), and `Scope` shows what a minted key is limited to: `account`, `org <org-id>`, or `project <project-id>`. `File` is `ok` when the credentials file is present and readable, and `missing` when it isn't. `Storage` is `file` for a plaintext credentials file and `keyring` for the OS keyring.
 
 ## neon profile rotate-key (#rotate-key)
 
@@ -131,7 +131,7 @@ neon profile rotate-key ci
 This works for account-scoped keys, where the profile's own credential can mint the replacement. An organization- or project-scoped key can't rotate itself, since only a personal credential can mint those keys. Re-mint it with a browser sign-in instead, matching the original scope:
 
 ```bash
-neon profile create ci --mint --org-id org-example-12345678 --force
+neon profile create ci --mint --org-id org-example-12345678
 ```
 
 The `rotate-key` error names the exact command to run for the profile's scope.


### PR DESCRIPTION
LKB-16587

Doc-only fixes from the CLI docs-drift audit: 2 corrections in `content/docs/cli/profile.md`. Not auto-merged — awaiting your review.

Changes

- Before → After: `neon profile create ci --mint --org-id org-example-12345678 --force` → `neon profile create ci --mint --org-id org-example-12345678`
  Why the new text is right: `neon profile create --force` now errors because `--force` is no longer a flag; profile creation replaces an existing profile by default.
- Before → After: the `neon profile list` sample omitted `Storage` between `File` and `Credentials` → the sample now shows `Storage` in that position, with `file` and `keyring` examples, and defines both values.
  Why the new text is right: `neon profile list` prints a storage column showing whether credentials use a plaintext file or the OS keyring.

Files

| File | Change |
| --- | --- |
| `content/docs/cli/profile.md` | Remove the obsolete `--force` flag and document the emitted `storage` column. |

How this was verified

- Verified on Neon CLI `3.5.1` from the Linux release binary: `neon profile create --force` is rejected, and `neon profile list` prints a `storage` column between `file` and `credentials`.
- F4 verdict: `PASS` — the CLI returned `ERROR: --force is no longer a flag...`.
- F6 verdict: `PASS` — the CLI output included `Storage` between `File` and `Credentials`.
- The npm channel was stale during an earlier attempt (`3.2.0`); the live checks above use the `3.5.1` release binary.
- The `keyring` sample row is illustrative: the live check observed only a `file`-storage profile, and the exact `Credentials` value for keyring profiles may vary by OS.
- Text-only change; no build or deploy behavior is affected.

How to verify

1. Install or upgrade to Neon CLI `3.5.1+`. npm's `neon`/`neonctl` currently lags at `3.2.0`, so use the standalone release binary or Homebrew. Download the latest release binary for your platform from the [Neon CLI releases page](https://github.com/neondatabase/neon-pkgs/releases), for example:

   ```bash
   curl -fsSL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neon-linux-x64 -o neon
   chmod +x neon
   ./neon --version
   ```

   Expect version `3.5.1` or newer. macOS and Windows binaries are also available from the releases page, and Homebrew installation is supported.
2. Run `./neon profile create drift-test-force --force`. Expect an error that `--force` is no longer a flag.
3. Run `./neon profile list`. Expect a `Storage` column between `File` and `Credentials`.
