### PR TITLE
docs: correct neon auth credentials path

### DIFF
--- a/.polly/neon-docs-drift/live-tests/LKB-16586.md
+++ b/.polly/neon-docs-drift/live-tests/LKB-16586.md
@@ -1,0 +1,66 @@
+# LKB-16586 live test
+
+## Claim
+
+The Neon CLI stores new credentials under `~/.config/neon/credentials.json`, not
+`~/.config/neonctl/credentials.json`.
+
+## CLI version
+
+The downloaded public release binary reported:
+
+```text
+3.5.1
+```
+
+## Commands
+
+```sh
+uname -m
+curl -fsSL https://github.com/neondatabase/neon-pkgs/releases/latest/download/neon-linux-x64 -o /tmp/neon351
+chmod +x /tmp/neon351
+/tmp/neon351 --version
+rm -rf /tmp/neon-cfg-test
+HOME=/tmp/neon-cfg-test /tmp/neon351 profile list
+find /tmp/neon-cfg-test -maxdepth 5 -print | sort
+rm -rf /tmp/neon351 /tmp/neon-cfg-test
+```
+
+## Expected
+
+The binary reports version `3.5.1`, and the clean `HOME` causes the CLI to use
+or create `/tmp/neon-cfg-test/.config/neon`.
+
+## Observed verbatim
+
+```text
+ARCH=x86_64
+ASSET=neon-linux-x64
+VERSION=3.5.1
+PROFILE_LIST_BEGIN
+Profiles
+┌────────┬─────────┬─────────┬──────┬───────┬─────────┬─────────┬──────────────────┐
+│ Active │ Name    │ Account │ Auth │ Scope │ File    │ Storage │ Credentials      │
+├────────┼─────────┼─────────┼──────┼───────┼─────────┼─────────┼──────────────────┤
+│ *      │ DEFAULT │ -       │ -    │ -     │ missing │ file    │ credentials.json │
+└────────┴─────────┴─────────┴──────┴───────┴─────────┴─────────┴──────────────────┘
+PROFILE_LIST_STATUS=0
+FILES_BEGIN
+/tmp/neon-cfg-test
+/tmp/neon-cfg-test/.config
+/tmp/neon-cfg-test/.config/neon
+FILES_END
+```
+
+## Verdict
+
+PASS — the CLI created and used the current `neon` config directory under the
+clean `HOME`. The interactive browser login required to observe the exact
+credentials output file was not run.
+
+## Source evidence
+
+At commit `0188615`, `internals/cli-core/src/paths.ts` defines `CONFIG_DIR_NAME`
+as `"neon"` and `LEGACY_CONFIG_DIR_NAME` as `"neonctl"`; its path resolution
+uses the current directory for new files and reads an existing legacy file in
+place.

--- a/content/docs/cli/auth.md
+++ b/content/docs/cli/auth.md
@@ -4,7 +4,7 @@ subtitle: Authenticate to Neon via browser or API key and manage credentials
 summary: >-
   The `neon auth` command authenticates the Neon CLI to a Neon account by
   launching a browser OAuth flow that saves credentials to
-  `~/.config/neonctl/credentials.json`. Use this command when setting up
+  `~/.config/neon/credentials.json`. Use this command when setting up
   the CLI for the first time or when not using an API key. Vercel-Managed
   Integration users must authenticate via API key (`--api-key` or
   `NEON_API_KEY`) instead. The CLI resolves authentication in priority order:
@@ -26,7 +26,7 @@ The `auth` command authenticates you to Neon. `neon login` is an alias for `neon
 The command launches a browser window where you authorize the Neon CLI to access your Neon account. Your credentials are then saved locally to `credentials.json`:
 
 ```text filename="Output"
-/home/<home>/.config/neonctl/credentials.json
+/home/<home>/.config/neon/credentials.json
 ```
 
 <Admonition type="note">


### PR DESCRIPTION
LKB-16586
Doc-only fix from the CLI docs-drift audit: corrected the credentials file path in `content/docs/cli/auth.md`. Not auto-merged — awaiting your review.

## Before → After

- Before: `~/.config/neonctl/credentials.json`
- After: `~/.config/neon/credentials.json`

## Why the new text is right

A fresh CLI install stores credentials under `~/.config/neon/`, not `~/.config/neonctl/`.

## Files

| File | Change |
| --- | --- |
| `content/docs/cli/auth.md` | Correct the credentials file path in the summary and `Output` example. |

## How this was verified

The public 3.5.1 release binary reported version `3.5.1`; with `HOME=/tmp/neon-cfg-test`, `neon profile list` created `/tmp/neon-cfg-test/.config/neon`. The exact output is recorded in `.polly/neon-docs-drift/live-tests/LKB-16586.md`.

`content/docs/cli/profile.md` already documents `~/.config/neon`, consistent with the CLI's current config directory. The exact credentials output from `neon auth` was not exercised because it requires an interactive browser login.

## How to verify

Use the public release binary or the Homebrew installation, not `npx neonctl@3.5.1` — npm currently serves `3.2.0`. Run `neon profile list` with a clean `HOME` and inspect that `<HOME>/.config/neon/` is used or created; a browser login can then confirm the credentials file output interactively.
