### PR TITLE
docs: refresh CLI reference for neonctl 3.5.1

### DIFF
--- a/content/docs/cli/auth.md
+++ b/content/docs/cli/auth.md
@@ -11,7 +11,7 @@ summary: >-
   `--api-key` flag, then `NEON_API_KEY` env var, then the credentials file,
   then triggers browser auth if none are found.
 enableTableOfContents: true
-updatedOn: '2026-07-01T13:41:48.668Z'
+updatedOn: '2026-08-17T19:10:39.997Z'
 redirectFrom:
   - /docs/reference/cli-auth
   - /docs/cli/login
@@ -48,4 +48,6 @@ The Neon CLI resolves authentication in this order:
 
 ## Options
 
-Takes only the [global options](/docs/cli#global-options).
+<CliOptions command="auth" />
+
+Pass `--keyring` to store the credential in your operating system's keyring instead of the `credentials.json` file. The choice is saved per profile, so once set, `neon auth` keeps using the keyring for that profile even without the flag. Along with this option, `auth` accepts the [global options](/docs/cli#global-options).

--- a/content/docs/cli/profile.md
+++ b/content/docs/cli/profile.md
@@ -89,6 +89,8 @@ neon profile create work --api-key "$KEY"
 
 `create` ignores `NEON_API_KEY`, so exporting that variable doesn't supply the key here. Pass it explicitly with `--api-key`.
 
+By default the credential is saved to a `credentials.json` file. Pass `--keyring` to store it in your operating system's keyring instead. The choice is saved per profile and shown in the `Storage` column of `neon profile list`.
+
 ## neon profile list (#list)
 
 Lists each profile, the account it holds, and where its credentials live. `Active` marks the profile this invocation would use.
@@ -103,18 +105,24 @@ neon profile list
 
 ```text filename="Output"
 Profiles
-┌────────┬─────────┬──────────────────────────────────────┬─────────┬─────────┬──────┬──────────────────────────────────────┐
-│ Active │ Name    │ Account                              │ Auth    │ Scope   │ File │ Credentials                          │
-├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼──────────────────────────────────────┤
-│ *      │ DEFAULT │ 3f8a1c2e-5b7d-4e9a-8c1f-2d6b9e0a4c53 │ oauth   │ -       │ ok   │ ~/.config/neon/credentials.json      │
-├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼──────────────────────────────────────┤
-│        │ work    │ alex@domain.com                      │ oauth   │ -       │ ok   │ ~/.config/neon/credentials.work.json │
-├────────┼─────────┼──────────────────────────────────────┼─────────┼─────────┼──────┼──────────────────────────────────────┤
-│        │ ci      │ alex@domain.com                      │ api key │ account │ ok   │ ~/.config/neon/credentials.ci.json   │
-└────────┴─────────┴──────────────────────────────────────┴─────────┴─────────┴──────┴──────────────────────────────────────┘
+┌────────┬─────────┬──────────────────────────────────────┬─────────┬────────────────────────────────┬──────┬─────────┬──────────────────────────┐
+│ Active │ Name    │ Account                              │ Auth    │ Scope                          │ File │ Storage │ Credentials              │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼────────────────────────────────┼──────┼─────────┼──────────────────────────┤
+│ *      │ DEFAULT │ 3f8a1c2e-5b7d-4e9a-8c1f-2d6b9e0a4c53 │ oauth   │ -                              │ ok   │ file    │ credentials.json         │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼────────────────────────────────┼──────┼─────────┼──────────────────────────┤
+│        │ work    │ alex@example.com                     │ oauth   │ -                              │ ok   │ file    │ credentials.work.json    │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼────────────────────────────────┼──────┼─────────┼──────────────────────────┤
+│        │ ci      │ alex@example.com                     │ api key │ account                        │ ok   │ file    │ credentials.ci.json      │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼────────────────────────────────┼──────┼─────────┼──────────────────────────┤
+│        │ org     │ org-example-12345678                 │ api key │ org org-example-12345678       │ ok   │ file    │ credentials.org.json     │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼────────────────────────────────┼──────┼─────────┼──────────────────────────┤
+│        │ project │ org-example-12345678                 │ api key │ project cool-darkness-12345678 │ ok   │ file    │ credentials.project.json │
+├────────┼─────────┼──────────────────────────────────────┼─────────┼────────────────────────────────┼──────┼─────────┼──────────────────────────┤
+│        │ laptop  │ alex@example.com                     │ oauth   │ -                              │ ok   │ keyring │ keyring                  │
+└────────┴─────────┴──────────────────────────────────────┴─────────┴────────────────────────────────┴──────┴─────────┴──────────────────────────┘
 ```
 
-`Account` is the recorded email label, or the user ID when there's no label, as with a `DEFAULT` profile from a plain `neon auth`. `Auth` shows how the profile authenticates (`oauth` for a browser sign-in, `api key` for a stored key), and `Scope` shows what a minted key is limited to: `account`, `org <org-id>`, or `project <project-id>`. `File` is `ok` when the credentials file is present and readable, and `missing` when it isn't.
+`Account` is the recorded email label, the user ID when there's no label (as with a `DEFAULT` profile from a plain `neon auth`), or the organization identifier for an organization- or project-scoped key. `Auth` shows how the profile authenticates (`oauth` for a browser sign-in, `api key` for a stored key), and `Scope` shows what a minted key is limited to: `account`, `org <org-id>`, or `project <project-id>`. `File` reports whether the credential could be read: `ok` when it's present and readable, otherwise `missing`, `invalid`, or `unreadable`. `Storage` shows where the credential lives, `file` or `keyring`, and `Credentials` gives the file's name, or `keyring` when it's kept in the OS keyring.
 
 ## neon profile rotate-key (#rotate-key)
 
@@ -131,7 +139,7 @@ neon profile rotate-key ci
 This works for account-scoped keys, where the profile's own credential can mint the replacement. An organization- or project-scoped key can't rotate itself, since only a personal credential can mint those keys. Re-mint it with a browser sign-in instead, matching the original scope:
 
 ```bash
-neon profile create ci --mint --org-id org-example-12345678 --force
+neon profile create ci --mint --org-id org-example-12345678
 ```
 
 The `rotate-key` error names the exact command to run for the profile's scope.

--- a/scripts/docs-checks/neonctl/__tests__/generate-docs.test.js
+++ b/scripts/docs-checks/neonctl/__tests__/generate-docs.test.js
@@ -39,8 +39,10 @@ describe('generate-docs rendering', () => {
   });
 
   it('commands with no visible options render nothing', () => {
-    expect(renderOptions(resolveCommand(schema, ['auth']))).toBe('');
-    expect(renderOptionsForPath(schema, ['auth'])).toBe('');
+    // `projects` is a pure command group with no own options (its options live
+    // on the subcommands), so both renderers return empty for it.
+    expect(renderOptions(resolveCommand(schema, ['projects']))).toBe('');
+    expect(renderOptionsForPath(schema, ['projects'])).toBe('');
   });
 
   it('leaf tables include options inherited from parent commands', () => {

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "3.2.0",
+  "neonctlVersion": "3.5.1",
   "binaries": [
     "neonctl",
     "neon"
@@ -216,6 +216,10 @@
         "context-file": {
           "type": "unknown",
           "hidden": true
+        },
+        "keyring": {
+          "type": "boolean",
+          "describe": "Store the credential in the OS keyring. Per profile; later auth without the flag stays there. See `neon profile list`."
         }
       },
       "commands": {},
@@ -1664,7 +1668,7 @@
             },
             "database-name": {
               "type": "string",
-              "describe": "Database name"
+              "describe": "Database to inspect. Omit to cover every database the API lists for the branch. Ranking and row limits stay per database. One failing database fails the whole run. Compute-wide checks run once against the first listed database. Ignored with --db-url."
             },
             "db-url": {
               "type": "string",
@@ -1706,7 +1710,7 @@
               "positionals": [],
               "options": {},
               "commands": {},
-              "describe": "Local File Cache hit rate (needs neon extension)"
+              "describe": "Local File Cache hit rate (compute-wide, needs neon extension)"
             },
             "locks": {
               "aliases": [],
@@ -1734,7 +1738,7 @@
               "positionals": [],
               "options": {},
               "commands": {},
-              "describe": "Replication slots: kind, status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)"
+              "describe": "Replication slots (compute-wide): kind, status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)"
             },
             "seq-scans": {
               "aliases": [],
@@ -1776,14 +1780,14 @@
               "positionals": [],
               "options": {},
               "commands": {},
-              "describe": "Estimated working set vs LFC size (needs neon extension)"
+              "describe": "Estimated working set vs LFC size (compute-wide, needs neon extension)"
             }
           },
           "describe": "Run a diagnostic query against a branch's Postgres",
           "usage": "$0 inspect db <sub-command> [options]"
         }
       },
-      "describe": "Inspect a database's health and configuration",
+      "describe": "Inspect a branch's Postgres health and configuration",
       "usage": "$0 inspect <sub-command> [options]"
     },
     "ip-allow": {
@@ -2805,8 +2809,11 @@
             },
             "force": {
               "type": "boolean",
-              "describe": "Replace an existing profile, revoking the credential it holds now",
-              "default": false
+              "hidden": true
+            },
+            "keyring": {
+              "type": "boolean",
+              "describe": "Store the credential in the OS keyring. Per profile; later create without the flag stays there. See `neon profile list`."
             },
             "mint": {
               "type": "boolean",


### PR DESCRIPTION
## Overview

Refreshes the generated CLI reference for neonctl 3.5.1. The release adds a `--keyring`
option on `neon auth` and `neon profile create` for storing credentials in the OS keyring,
retires `--force` on `profile create` (replacing a profile is now the default, and `--force`
now errors), and adds a `Storage` column to `neon profile list`.

The schema regenerates the option tables automatically. The hand-maintained updates here are
the `--keyring` prose on both pages, the corrected `profile create` example, the refreshed
`profile list` sample output (new `Storage` column and a keyring profile), and one
option-rendering test that had used `auth` as a command with no options.

Verified against the neon@3.5.1 tag source; the full cli-docs check suite passes.

This pull request and its description were written by Isaac.