### PR TITLE
docs: update console nav for the new Branch sidebar section

### DIFF
--- a/content/blog/posts/llms-belong-in-your-backend.md
+++ b/content/blog/posts/llms-belong-in-your-backend.md
@@ -141,7 +141,7 @@ neon deploy
 
 That provisions credentials and pulls them into `.env` as `NEON_AI_GATEWAY_TOKEN` and `NEON_AI_GATEWAY_BASE_URL`.
 
-(Or create a credential in the Console under APP BACKEND → Credentials, check `ai_gateway:invoke`, and copy the snippet once.)
+(Or create a credential in the Console under Branch → Credentials, check `ai_gateway:invoke`, and copy the snippet once.)
 
 Then point the SDK you already use at Neon:
 

--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-08-06T17:43:14.909Z'
+updatedOn: '2026-08-17T23:18:55.558Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -21,7 +21,7 @@ A credential must include the `ai_gateway:invoke` scope.
 <Tabs labels={["Console", "API"]}>
 <TabItem>
 
-In the Neon Console, select your branch and click **Credentials** under **APP BACKEND** in the sidebar. Click **Create credential**, give it a name, and check **ai_gateway:invoke**.
+In the Neon Console, select your branch and click **Credentials** under **Branch** in the sidebar. Click **Create credential**, give it a name, and check **ai_gateway:invoke**.
 
 After creation, the credential is shown once. Copy the snippet or click **Download .env** before closing. The snippet includes both gateway env vars (see [Environment variables](#environment-variables) below).
 
@@ -60,7 +60,7 @@ This populates `NEON_AI_GATEWAY_TOKEN` and `NEON_AI_GATEWAY_BASE_URL` for the cu
 neon config status
 ```
 
-For production deployments, use the [API-based workflow](#creating-a-credential) to create named credentials. `expires_at` is accepted but not currently enforced during the beta -- revoke credentials explicitly instead of relying on expiry.
+For production deployments, use the [API-based workflow](#creating-a-credential) to create named credentials. `expires_at` is accepted but not currently enforced during the beta. Revoke credentials explicitly instead of relying on expiry.
 
 ## Using your credential
 

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-07-20T19:53:53.968Z'
+updatedOn: '2026-08-17T23:18:55.558Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -25,7 +25,7 @@ You need a project in the AWS us-east-2 region. Foundation model access requires
 
 ## Create a credential
 
-In the Neon Console, select your branch, click **Credentials** under **APP BACKEND**, then click **Create credential** and check **ai_gateway:invoke**. Copy the credential before closing — it's shown only once.
+In the Neon Console, select your branch, click **Credentials** under **Branch**, then click **Create credential** and check **ai_gateway:invoke**. Copy the credential before closing, it's shown only once.
 
 Or use the API:
 

--- a/content/docs/get-started/backend-beta.md
+++ b/content/docs/get-started/backend-beta.md
@@ -24,9 +24,7 @@ You declare all of it in one `neon.ts` file, and it branches together: fork a br
 
 ## Check your access
 
-To confirm access, go to [console.neon.tech](https://console.neon.tech), open a project in **US East (Ohio)**, and check the left navigation for **Storage**, **Credentials**, **AI Gateway**, and **Functions**. For what AI Gateway costs once billing begins, see [AI Gateway pricing](/docs/ai-gateway/overview#pricing).
-
-<img src="/docs/get-started/neon_app_backend.png" alt="Neon app backend navigation" width="240" />
+To confirm access, go to [console.neon.tech](https://console.neon.tech), open a project in **US East (Ohio)**, and check the left navigation for **Object storage**, **Credentials**, **AI Gateway**, and **Functions**. For what AI Gateway costs once billing begins, see [AI Gateway pricing](/docs/ai-gateway/overview#pricing).
 
 Not seeing the services? The most common reason is region: the project isn't in `us-east-2`. Create a new project in **US East (Ohio)**, or switch to an existing one there. If AI Gateway is the only thing missing, check your plan, it requires Launch or Scale. If a service is still missing after that, post in [#neon-platform-beta](https://discord.com/channels/1176467419317940276/1525919714541437058) on Discord.
 

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-07-20T20:13:30.657Z'
+updatedOn: '2026-08-17T23:18:55.558Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -23,7 +23,7 @@ An object storage credential requires at minimum one of:
 <Tabs labels={["Console", "API"]}>
 <TabItem>
 
-In the Neon Console, select your branch and click **Credentials** under **APP BACKEND** in the sidebar. Click **Create credential**, give it a name, and check the storage scopes you need.
+In the Neon Console, select your branch and click **Credentials** under **Branch** in the sidebar. Click **Create credential**, give it a name, and check the storage scopes you need.
 
 After creation, the credentials are shown once. Copy the snippet or click **Download .env** before closing:
 

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,7 +6,7 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-07-15T23:27:36.554Z'
+updatedOn: '2026-08-17T23:18:55.558Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -19,7 +19,7 @@ You can create a bucket from the Neon Console, the Neon CLI, the Neon API, or di
 
 **Neon Console**
 
-In the Neon Console, navigate to your project, select a branch, and open the **Storage** tab. Click **New bucket**, enter a name, choose an access level, and click **Create**.
+In the Neon Console, navigate to your project, select a branch, and open the **Object storage** tab. Click **New bucket**, enter a name, choose an access level, and click **Create**.
 
 <CodeTabs labels={["neon", "Neon API", "TypeScript", "Python", "AWS CLI"]}>
 
@@ -92,7 +92,7 @@ Every bucket has an access level that controls who can read objects in it.
 | `private`     | Require a valid credential            | Require a valid credential |
 | `public_read` | Open to anyone (no credential needed) | Require a valid credential |
 
-The default is `private`. Set the access level when creating a bucket via the Neon API, or change it from the **Storage** tab in the Console.
+The default is `private`. Set the access level when creating a bucket via the Neon API, or change it from the **Object storage** tab in the Console.
 
 <Admonition type="note">
 Access level is set through the Neon Console or API, not through the S3 API. S3 ACL and bucket policy mutation requests (PutBucketAcl, PutBucketPolicy) return `501 Not Implemented`. If you need to change access level on an existing bucket, use the Console or Neon API.


### PR DESCRIPTION
## Overview

The Neon Console sidebar was reorganized: the APP BACKEND section is gone, and Credentials
along with the service pages (Object storage, AI Gateway, Functions) now live under a Branch
section. Several docs still pointed at the old layout.

This updates the AI Gateway and Object Storage credential pages, the buckets and backend beta
pages, and one blog post to match the current sidebar, corrects the "Storage" nav label to
"Object storage," and removes a now-stale sidebar screenshot from the backend beta page.

This pull request and its description were written by Isaac.
