### PR TITLE
perf(docs): defer mobile nav tree render to speed up static generation

### DIFF
--- a/src/components/pages/doc/mobile-nav/mobile-nav.jsx
+++ b/src/components/pages/doc/mobile-nav/mobile-nav.jsx
@@ -215,20 +215,29 @@ RecursiveList.propTypes = {
 
 const MobileMenu = ({ navigation, basePath, title = 'Neon Docs' }) => {
   const [open, setOpen] = useState(false);
+  // The drawer is a JS-only overlay that stays hidden until the user opens it,
+  // and its links are already server-rendered in the desktop Sidebar. Building
+  // and rendering the full navigation tree here is therefore wasted work at
+  // build time (it dominated static generation). Defer it until the drawer is
+  // first opened, so prerendering only emits the lightweight trigger.
+  const [hasOpened, setHasOpened] = useState(false);
   const pathname = usePathname();
 
   useEffect(() => {
     setOpen(false);
   }, [pathname]);
 
-  const onOpenChange = useCallback((next) => setOpen(next), []);
+  const onOpenChange = useCallback((next) => {
+    setOpen(next);
+    if (next) setHasOpened(true);
+  }, []);
 
   const menu = useMemo(
-    () => transformNavigation(navigation || [], basePath),
-    [navigation, basePath]
+    () => (hasOpened ? transformNavigation(navigation || [], basePath) : []),
+    [hasOpened, navigation, basePath]
   );
 
-  if (!menu.length) return null;
+  if (!navigation || !navigation.length) return null;
 
   return (
     <Drawer open={open} shouldScaleBackground={false} onOpenChange={onOpenChange}>
@@ -247,7 +256,9 @@ const MobileMenu = ({ navigation, basePath, title = 'Neon Docs' }) => {
       <DrawerContent className="bottom-12 hidden h-[70dvh]! flex-col rounded-t-2xl border-b-0 border-gray-new-80 bg-white p-0 text-black-new after:hidden dark:border-[#27272A] dark:bg-black-pure dark:text-white lg:flex">
         <DrawerTitle className="sr-only">Menu</DrawerTitle>
         <div className="flex flex-1 flex-col overflow-y-auto p-6 pt-[15px] pb-8">
-          <RecursiveList nodes={menu} currentPath={normalizeDocNavigationPath(pathname)} />
+          {menu.length > 0 && (
+            <RecursiveList nodes={menu} currentPath={normalizeDocNavigationPath(pathname)} />
+          )}
         </div>
         <div
           className="pointer-events-none absolute inset-x-0 bottom-0 h-10 w-full bg-[linear-gradient(180deg,rgba(255,255,255,0.00)_0%,#FFF_73.36%)] dark:bg-[linear-gradient(180deg,rgba(9,9,11,0.00)_0%,#09090B_73.36%)]"


### PR DESCRIPTION
This made the static generation speed go from ~59s to ~37s across 2,328 pages!

The docs mobile-nav drawer is a JS-only overlay, hidden until tapped, whose links are already server-rendered in the desktop sidebar. It rendered the full ~1,700-node navigation tree into every prerendered page which was like ~35% of static generation time.

I deferred building/rendering that tree until the drawer is first opened. No visible and SEO change as desktop sidebar still carries the links.