### PR TITLE
docs: update console UI instructions for Postgres database sidebar restructure

### DIFF
--- a/content/docs/auth/migrate/from-supabase.md
+++ b/content/docs/auth/migrate/from-supabase.md
@@ -11,7 +11,7 @@ summary: >-
   OAuth-only apps. Managed Better Auth does not support phone authentication (SMS/WhatsApp),
   SAML SSO, or Web3 wallet sign-in.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
@@ -26,7 +26,7 @@ Existing password-based users cannot migrate due to different hashing algorithms
 
 - A Neon project ([create one here](https://console.neon.tech))
 - Data API enabled (Managed Better Auth is enabled by default when you enable Data API):
-  - Go to **Data API** in the Neon Console and enable it
+  - Go to **Postgres database** > **Data API** in the Neon Console and enable it
   - In **Data API → Configuration**, verify it's configured with **Managed Better Auth**
   - Copy your Neon connection host and database name from **Connect** in the Console. The SDK derives both the Auth and Data API URLs from this single base URL. See [Initialize the client](/docs/reference/javascript-sdk#initializing) for the derivation rules, or use the separate Auth and Data API base URLs instead if you'd rather configure them explicitly
 

--- a/content/docs/data-api/demo.md
+++ b/content/docs/data-api/demo.md
@@ -10,7 +10,7 @@ summary: >-
   for a working end-to-end example of Data API query patterns, RLS setup, and
   ON DELETE CASCADE.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 This tutorial uses a note-taking app to show how Neon's Data API works with the `@neondatabase/neon-js` client library to write queries from your frontend code, with authentication and Row-Level Security (RLS) policies keeping your data secure. The Data API is compatible with PostgREST, so you can use any PostgREST client library.
@@ -41,7 +41,7 @@ Before you begin, ensure you have:
 ### Create a Neon project with Auth and Data API
 
 1. Go to the [Neon Console](https://console.neon.tech) to create a new Neon project
-2. In the Neon Console, navigate to your project and go to the **Data API** page in the left sidebar
+2. In the Neon Console, navigate to your project and go to **Postgres database** > **Data API**
 3. Select **Managed Better Auth** as your authentication option (the default), then click **Enable**
 
 This enables both the Data API and Managed Better Auth in one step. For detailed instructions, see [Getting started with Data API](/docs/data-api/get-started).

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -10,7 +10,7 @@ summary: >-
   branch for a single database and does not support projects with IP Allow or
   Private Networking configured.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 This guide walks you through enabling the Data API, creating a table with RLS, and running your first query.
@@ -30,7 +30,7 @@ You can also enable the Data API using the [Neon API](/docs/data-api/manage#mana
 
 ### 1. Navigate to the Data API page
 
-In the Neon Console, select your project and go to the **Data API** page in the sidebar.
+In the Neon Console, select your project and select **Postgres database** > **Data API**.
 
 ![Data API page with enable button](/docs/data-api/data_api_sidebar.png)
 
@@ -207,7 +207,7 @@ The Data API caches your database schema for performance. When you modify your s
 
 **Option 1: Neon Console**
 
-Go to the **Data API** page in the Neon Console and click **Refresh schema cache**.
+Go to **Postgres database** > **Data API** in the Neon Console and click **Refresh schema cache**.
 
 ![Data API refresh schema cache button](/docs/data-api/data_api_schema_refresh.png)
 

--- a/content/docs/data-api/manage.md
+++ b/content/docs/data-api/manage.md
@@ -8,7 +8,7 @@ summary: >-
   page to switch auth providers, tighten security, or manage the API lifecycle
   programmatically via the Neon REST API.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Data API" />
@@ -32,7 +32,7 @@ You can configure which authentication provider validates JWT tokens for your Da
 
 <TabItem>
 
-Navigate to the **Data API** page in your project sidebar and select the **Settings** tab. The **Authentication** section shows the current provider.
+Navigate to **Postgres database** > **Data API** and select the **Settings** tab. The **Authentication** section shows the current provider.
 
 ![Data API settings](/docs/data-api/data_api_advanced_settings.png)
 

--- a/content/docs/data-api/troubleshooting.md
+++ b/content/docs/data-api/troubleshooting.md
@@ -9,7 +9,7 @@ summary: >-
   rows, stale schema cache hiding new tables, and OpenAPI spec "Entry not
   found" errors.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <InfoBlock>
@@ -136,7 +136,7 @@ If authenticated users can see all rows in a table regardless of ownership, Row-
 
 ### Check RLS status
 
-In the Neon Console, go to the **Data API** page. If a table has RLS disabled, you'll see a warning:
+In the Neon Console, go to **Postgres database** > **Data API**. If a table has RLS disabled, you'll see a warning:
 
 > "table_name has RLS disabled. All authenticated users can view all rows in this table(s)."
 
@@ -195,7 +195,7 @@ The OpenAPI schema feature is disabled in your Data API configuration.
 
 ### Fix
 
-1. Go to the **Data API** page in the Neon Console
+1. Go to **Postgres database** > **Data API** in the Neon Console
 2. Open the **Settings** tab
 3. Enable the **OpenAPI schema** toggle
 4. Try your request again
@@ -225,7 +225,7 @@ The Data API caches your database schema for performance. When you create or mod
 
 ### Fix
 
-1. Go to the **Data API** page in the Neon Console
+1. Go to **Postgres database** > **Data API** in the Neon Console
 2. Click the **Refresh schema cache** button
 3. Retry your request
 

--- a/content/docs/get-started/full-backend-quickstart.md
+++ b/content/docs/get-started/full-backend-quickstart.md
@@ -190,7 +190,7 @@ Then seed three sample posts in the [Neon Console SQL Editor](https://console.ne
 npx drizzle-kit push
 ```
 
-Open your project in the Neon Console, go to **SQL Editor**, and run:
+Open your project in the Neon Console, go to **Postgres database** > **SQL Editor**, and run:
 
 ```sql
 INSERT INTO posts (author, content, is_published) VALUES

--- a/content/docs/get-started/query-with-neon-sql-editor.md
+++ b/content/docs/get-started/query-with-neon-sql-editor.md
@@ -11,7 +11,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/get-started/tutorials
-updatedOn: '2026-06-18T20:46:14.637Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 The Neon SQL Editor allows you to run queries on your Neon databases directly from the Neon Console. In addition, the editor keeps a query history, permits saving queries, and provides [**Explain**](https://www.postgresql.org/docs/current/sql-explain.html) and [**Analyze**](https://www.postgresql.org/docs/current/using-explain.html#USING-EXPLAIN-ANALYZE) features.
@@ -22,7 +22,7 @@ To use the SQL Editor:
 
 1. Navigate to the [Neon Console](https://console.neon.tech/).
 2. Select your project.
-3. Select **SQL Editor**.
+3. Select **Postgres database** > **SQL Editor**.
 4. Select a branch and database.
 5. Enter a query into the editor and click **Run** to view the results.
 

--- a/content/docs/get-started/signing-up.md
+++ b/content/docs/get-started/signing-up.md
@@ -14,7 +14,7 @@ redirectFrom:
   - /docs/cloud/getting-started/
   - /docs/cloud/getting_started/
   - /docs/get-started-with-neon/signing-up
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <InfoBlock>
@@ -94,7 +94,7 @@ Your organization is now set up. You can start inviting teammates immediately. S
 
 Let's get familiar with the **SQL Editor**, where you can run queries against your databases directly from the Neon Console, as well as access more advanced features like [Time Travel](/docs/guides/time-travel-assist) and [Explain and Analyze](/docs/get-started/query-with-neon-sql-editor#explain-and-analyze).
 
-From the Neon Console, use the sidebar navigation to open the **SQL Editor** page. Notice that your default branch `production` is already selected, along with the database created during onboarding, `neondb`.
+From the Neon Console, use the sidebar navigation to open **Postgres database** > **SQL Editor**. Notice that your default branch `production` is already selected, along with the database created during onboarding, `neondb`.
 
 ![Neon SQL Editor](/docs/get-started/sql_editor.png)
 
@@ -168,7 +168,7 @@ Let's create a `development` branch and learn how to use the Neon CLI to manage 
 
 1. **Create a development branch**
 
-   From the Neon Console, navigate to the **Branches** page and click **Create branch**. Name it `development`, select `production` as the parent branch, and click **Create new branch**. This creates an isolated copy of your production data that you can safely modify.
+   From the Neon Console, navigate to the **Branches** page (under **Project**) and click **Create branch**. Name it `development`, select `production` as the parent branch, and click **Create new branch**. This creates an isolated copy of your production data that you can safely modify.
 
 2. **Install CLI with Brew or NPM**
 

--- a/content/docs/guides/autoscaling-guide.md
+++ b/content/docs/guides/autoscaling-guide.md
@@ -9,7 +9,7 @@ summary: >-
   neon_utils extension exposes a num_cpus() function for observing live CPU
   allocation.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <InfoBlock>
@@ -36,9 +36,9 @@ You can edit an individual compute to alter the compute configuration, which inc
 
 To edit a compute:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. On the **Computes** tab, identify the compute you want to configure and click **Edit**.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Identify the compute you want to configure and click **Edit**.
    ![Edit compute menu](/docs/guides/autoscaling_edit.png)
 1. On the **Edit compute** drawer, select **Autoscale** and use the slider to specify a minimum and maximum compute size.
 

--- a/content/docs/guides/aws-lambda.md
+++ b/content/docs/guides/aws-lambda.md
@@ -8,7 +8,7 @@ summary: >-
   Neon database using the pg library, the Serverless Framework CLI, and
   DATABASE_URL with SSL enabled via sslmode=require.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 AWS Lambda is a serverless, event-driven compute service that allows you to run code without provisioning or managing servers. It is a convenient and cost-effective solution for running various types of workloads, including those that require a database.
@@ -35,7 +35,7 @@ If you do not have one already, create a Neon project:
 
 ## Create a table in Neon
 
-To create a table, navigate to the **SQL Editor** in the [Neon Console](https://console.neon.tech/):
+To create a table, navigate to **Postgres database** > **SQL Editor** in the [Neon Console](https://console.neon.tech/):
 
 In the SQL Editor, run the following queries to create a `users` table and insert some data:
 

--- a/content/docs/guides/branch-expiration.md
+++ b/content/docs/guides/branch-expiration.md
@@ -12,7 +12,7 @@ summary: >-
   default, or parent branches, and deletion is permanent and also removes
   associated compute endpoints.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 ## Overview
@@ -141,7 +141,7 @@ When a branch expires and is deleted, all associated compute endpoints are also 
 
 <TabItem>
 
-1. Navigate to the **Branches** page in the Console
+1. Navigate to the **Branches** page (under **Project**) in the Console
 2. Click **New branch**
 3. Enter branch name and select parent branch
 4. By default, **Automatically delete branch after** is checked with 1 day selected. You can choose 1 hour, 1 day, or 7 days, or uncheck to disable.
@@ -214,7 +214,7 @@ curl --request POST \
 
 <TabItem>
 
-1. Navigate to the **Branches** page in the Console
+1. Navigate to the **Branches** page (under **Project**) in the Console
 2. Choose the **Update expiration** option for your branch
 
 ![Update branch expiration](/docs/guides/branch-update-set-expiration.png)
@@ -291,7 +291,7 @@ Check expiration status of your branches:
 
 <TabItem>
 
-1. Navigate to the **Branches** page in the Console
+1. Navigate to the **Branches** page (under **Project**) in the Console
 2. Click on the desired branch to open the **Branch Overview**
 3. See information similar to the following if branch expiration is set:
 

--- a/content/docs/guides/branching-schema-only.md
+++ b/content/docs/guides/branching-schema-only.md
@@ -11,7 +11,7 @@ summary: >-
   independent root branches with plan-specific storage limits; reset-from-parent
   is not supported.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <FeatureBeta />
@@ -29,7 +29,7 @@ You can create schema-only branches in the Neon Console or using the Neon API, i
 To create a schema-only branch from the Neon Console:
 
 1. Select your project.
-2. Select **Branches**.
+2. Select **Branches** under **Project**.
 3. Click **New branch** to open the branch creation dialog.
    ![Create branch dialog](/docs/guides/create_schema_only_branch.png)
 4. Select a **Parent branch**. The schema from this branch will be copied to your new schema-only branch. By default, your project's default branch is selected, but you can choose any existing branch in your project.

--- a/content/docs/guides/branching-test-queries.md
+++ b/content/docs/guides/branching-test-queries.md
@@ -11,7 +11,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/tutorial/test-queries
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Complex queries that modify data or alter schemas have the potential to be destructive. It is advisable to test these types of queries before running them in production. On other database systems, testing potentially destructive queries can be time and resource intensive. For example, testing may involve setting up a separate database instance and replicating data. With Neon, you can instantly create a database branch with a full copy-on-write clone of your production data in just a few clicks. When you finish testing, you can remove the branch just as easily.
@@ -51,7 +51,7 @@ VALUES
 ## Create a test branch
 
 1. In the Neon Console, select your project.
-2. Select **Branches**.
+2. Select **Branches** under **Project**.
 3. Click **Create branch** to open the branch creation dialog.
    ![Create branch dialog](/docs/manage/create_branch.png)
 4. Enter a name for the branch. This guide uses the name `my_test_branch`.
@@ -88,7 +88,7 @@ curl --request POST \
 
 ## Test your query
 
-Navigate to the **SQL Editor**, select the test branch, and run your query. For example, perhaps you are deleting blog posts from your database for a certain author published before a certain date, and you want to make sure the query only removes the intended records.
+Navigate to **Postgres database** > **SQL Editor**, select the test branch, and run your query. For example, perhaps you are deleting blog posts from your database for a certain author published before a certain date, and you want to make sure the query only removes the intended records.
 
 ```sql
 DELETE FROM Post
@@ -108,7 +108,7 @@ Before the `DELETE` query, there were 5 records. If the query ran correctly, thi
 When you finish testing your query, you can delete the test branch:
 
 1. In the Neon Console, select a project.
-2. Select **Branches**.
+2. Select **Branches** under **Project**.
 3. Select the test branch from the table.
 4. From the **Actions** menu on the branch overview page, select **Delete**.
 

--- a/content/docs/guides/cloudflare-hyperdrive.md
+++ b/content/docs/guides/cloudflare-hyperdrive.md
@@ -12,7 +12,7 @@ summary: >-
   behavior in Hyperdrive local connection strings and how to test with
   wrangler dev --remote.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) is a serverless application that proxies queries to your database and accelerates them. It works by maintaining a globally distributed pool of database connections, and routing queries to the closest available connection.
@@ -41,7 +41,7 @@ To follow along with this guide, you require:
 
 2. Click the **New Project** button to create a new project.
 
-3. From your project dashboard, navigate to the **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
+3. From your project dashboard, navigate to **Postgres database** > **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
 
    ```sql
    CREATE TABLE books_to_read (

--- a/content/docs/guides/cloudflare-pages.md
+++ b/content/docs/guides/cloudflare-pages.md
@@ -11,7 +11,7 @@ summary: >-
   Wrangler, and adding DATABASE_URL as a Cloudflare environment variable for
   production deployment.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 `Cloudflare Pages` is a modern web application hosting platform that allows you to build, deploy, and scale your web applications. While it is typically used to host static websites, you can also use it to host interactive web applications by leveraging `functions` to run server-side code. Internally, Cloudflare functions are powered by `Cloudflare Workers`, a serverless platform that allows you to run JavaScript code on Cloudflare's edge network.
@@ -36,7 +36,7 @@ To follow along with this guide, you will need:
 
 2. Click the **New Project** button to create a new project.
 
-3. From your project dashboard, navigate to the **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
+3. From your project dashboard, navigate to **Postgres database** > **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
 
    ```sql
    CREATE TABLE books_to_read (

--- a/content/docs/guides/cloudflare-workers.md
+++ b/content/docs/guides/cloudflare-workers.md
@@ -10,7 +10,7 @@ summary: >-
   Worker that queries Postgres and needs to choose between Hyperdrive's
   connection pooling and the serverless driver's lightweight setup.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Cloudflare Workers](https://workers.cloudflare.com/) is a serverless platform allowing you to deploy your applications globally across Cloudflare's network. It supports running JavaScript, TypeScript, and WebAssembly, making it a great choice for high-performance, low-latency web applications.
@@ -40,7 +40,7 @@ Log in to the Neon Console and navigate to the [Projects](https://console.neon.t
 
 1. Click the **New Project** button to create a new project.
 
-2. From the Neon **Dashboard**, navigate to the **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
+2. From the Neon **Dashboard**, navigate to **Postgres database** > **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
 
    ```sql
    CREATE TABLE books_to_read (
@@ -72,8 +72,8 @@ Log in to the Neon Console and navigate to the [Projects](https://console.neon.t
 To use Hyperdrive with Neon, you'll need to create a dedicated database role for Hyperdrive to use:
 
 1. In the Neon Console, navigate to your project.
-2. Select **Branches** from the sidebar, then select the branch you want to use.
-3. Navigate to the **Roles & Databases** section.
+2. In the sidebar, select your branch from the **BRANCH** selector.
+3. Under **Postgres database**, select **Roles**.
 4. Click **New Role** and enter `hyperdrive-user` as the name (or your preferred name).
 5. **Copy the password** that is generated. You'll use this password in the connection string in the next step.
 

--- a/content/docs/guides/elixir-ecto.md
+++ b/content/docs/guides/elixir-ecto.md
@@ -9,7 +9,7 @@ summary: >-
   Postgrex idle_interval defaults that can prevent Neon's scale-to-zero
   autosuspend from triggering.
 enableTableOfContents: true
-updatedOn: '2026-07-14T19:04:57.024Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <CopyPrompt src="/prompts/elixir-ecto-prompt.md" 
@@ -31,7 +31,7 @@ To create the database:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 1. Select a project.
-1. Select **Databases**.
+1. Select **Postgres database** > **Databases**.
 1. Select the branch where you want to create the database.
 1. Click **New Database**.
 1. Enter a database name (`friends`), and select a database owner.
@@ -188,7 +188,7 @@ You can use the **Tables** feature in the Neon Console to view the table that wa
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 1. Select a project.
-1. Select **Tables** from the sidebar.
+1. Select **Postgres database** > **Tables** from the sidebar.
 1. Select the Branch, Database (`friends`), and the schema (`public`). You should see the `people` table along with a `schema_migration` table that was created by the migration.
 
 </Steps>

--- a/content/docs/guides/flyway-multiple-environments.md
+++ b/content/docs/guides/flyway-multiple-environments.md
@@ -11,7 +11,7 @@ summary: >-
   environments and want to integrate Neon branch creation with Flyway migration
   ordering.
 enableTableOfContents: true
-updatedOn: '2026-08-07T18:39:13.799Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 With Flyway, you can manage and track changes to your database schema, ensuring that the database evolves consistently across different environments.
@@ -49,7 +49,7 @@ Perform these steps twice, once for your _development_ branch and once for your 
 
 <TabItem>
 1. In the Neon Console, select your project.
-2. Select **Branches**.
+2. Select **Branches** under **Project**.
 3. Click **New Branch** to open the branch creation dialog.
 4. Enter a name for the branch. For example, name the branch for the environment (_development_ or _staging_).
 5. Select a parent branch. This should be the branch where you created the `person` table.
@@ -210,7 +210,7 @@ Successfully applied 1 migration to schema "public", now at version v2 (executio
 A Flyway report has been generated here: /home/alex/flyway-x.y.z/report.html
 ```
 
-After you run the migration commands, your database should be consistent across all three environments. You can verify that the data was added to each database by viewing the branch and table on the **Tables** page in the Neon Console. Select **Tables** from the sidebar and select your database.
+After you run the migration commands, your database should be consistent across all three environments. You can verify that the data was added to each database by viewing the branch and table on the **Tables** page in the Neon Console. Select **Postgres database** > **Tables** from the sidebar and select your database.
 
 ## Conclusion
 

--- a/content/docs/guides/flyway.md
+++ b/content/docs/guides/flyway.md
@@ -10,7 +10,7 @@ summary: >-
   migration workflow across multiple Neon branches or environments, see the
   companion guide on multiple database environments.
 enableTableOfContents: true
-updatedOn: '2026-08-07T18:39:13.799Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Flyway is a database migration tool that provides version control for databases. It allows developers to manage and track changes to the database schema, ensuring that the database evolves consistently across different environments.
@@ -119,7 +119,7 @@ Migrating schema "PUBLIC" to version 1 - Create person table
 Successfully applied 1 migration to schema "PUBLIC" (execution time 00:00.033s)
 ```
 
-To verify that the `person` table was created, you can view it on the **Tables** page in the Neon Console. Select **Tables** from the sidebar and select your database.
+To verify that the `person` table was created, you can view it on the **Tables** page in the Neon Console. Select **Postgres database** > **Tables** from the sidebar and select your database.
 
 ## Add a second migration
 
@@ -148,7 +148,7 @@ Successfully applied 1 migration to schema "public", now at version v2 (executio
 A Flyway report has been generated here: /home/alex/flyway-x.y.z/sql/report.html
 ```
 
-You can verify that the data was added by viewing the table on the **Tables** page in the Neon Console. Select **Tables** from the sidebar and select your database.
+You can verify that the data was added by viewing the table on the **Tables** page in the Neon Console. Select **Postgres database** > **Tables** from the sidebar and select your database.
 
 ## View your schema migration history
 
@@ -167,7 +167,7 @@ Schema version: 2
 A Flyway report has been generated here: /home/alex/flyway-x.y.z/sql/report.html
 ```
 
-You can also view the table on the **Tables** page in the Neon Console. Select **Tables** from the sidebar and select your database.
+You can also view the table on the **Tables** page in the Neon Console. Select **Postgres database** > **Tables** from the sidebar and select your database.
 
 ## Next steps
 

--- a/content/docs/guides/grafbase.md
+++ b/content/docs/guides/grafbase.md
@@ -12,7 +12,7 @@ summary: >-
   environment variable configuration, and local testing with the Grafbase CLI.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 _This guide was contributed by Josep Vidal from Grafbase_
@@ -53,7 +53,7 @@ The example project in this guide simulates a marketplace of products, where the
 ## Create the schema in Neon
 
 1. Navigate to the Neon Console and select your project.
-2. Open the Neon **SQL Editor** and run the following `CREATE TABLE` statement:
+2. In the Neon Console, open **Postgres database** > **SQL Editor** and run the following `CREATE TABLE` statement:
 
    ```sql
    CREATE TABLE product_visits(id SERIAL PRIMARY KEY, product_id TEXT NOT NULL);

--- a/content/docs/guides/heroku.md
+++ b/content/docs/guides/heroku.md
@@ -9,7 +9,7 @@ summary: >-
   Useful when migrating from Heroku Postgres or hosting a new Node app on
   Heroku with Neon.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Heroku](https://heroku.com) is a popular platform as a service (PaaS) that enables developers to build, run, and operate applications entirely in the cloud. It simplifies the deployment process, making it a favorite among developers for its ease of use and integration capabilities.
@@ -33,7 +33,7 @@ To follow along with this guide, you will need:
 
 2. Click **New Project** to create a new project.
 
-3. In your project dashboard, go to the **SQL Editor** and run the following SQL command to create a new table:
+3. In your project dashboard, go to **Postgres database** > **SQL Editor** and run the following SQL command to create a new table:
 
    ```sql
    CREATE TABLE music_albums (

--- a/content/docs/guides/liquibase-workflow.md
+++ b/content/docs/guides/liquibase-workflow.md
@@ -9,7 +9,7 @@ summary: >-
   setup. Neon's copy-on-write branching keeps development changes isolated
   until explicitly promoted.
 enableTableOfContents: true
-updatedOn: '2026-08-07T18:39:13.799Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Liquibase is an open-source database-independent library for tracking, managing, and applying database schema changes. To learn more about Liquibase, refer to the [Liquibase documentation](https://docs.liquibase.com/home.html).
@@ -41,7 +41,7 @@ For demonstration purposes, create a `blog` database in Neon with two tables, `p
 
 1. Open the [Neon Console](https://console.neon.tech/app/projects).
 1. Select your project.
-1. Select **Databases** from the sidebar and create a database named `blog`. For instructions, see [Create a database](/docs/manage/databases#create-a-database).
+1. Select **Postgres database** > **Databases** from the sidebar and create a database named `blog`. For instructions, see [Create a database](/docs/manage/databases#create-a-database).
 1. Using the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor), add the following tables:
 
    ```sql
@@ -70,7 +70,7 @@ Now, let's prepare a development database in Neon by creating a development bran
 
 To create a branch:
 
-1. In the Neon Console, select **Branches**. You will see your `production` branch, where you just created your `blog` database and tables.
+1. In the Neon Console, select **Branches** under **Project**. You will see your `production` branch, where you just created your `blog` database and tables.
 2. Click **New Branch** to open the branch creation dialog.
 3. Enter a name for the branch. Let's call it `feature/blog-schema`.
 4. Leave `production` selected as the parent branch. This is where you created the `blog` database.
@@ -268,7 +268,7 @@ When you run a changeset for the first time, Liquibase automatically creates two
 - [databasechangelog](https://docs.liquibase.com/concepts/tracking-tables/databasechangelog-table.html): Tracks which changesets have been run.
 - [databasechangeloglock](https://docs.liquibase.com/concepts/tracking-tables/databasechangeloglock-table.html): Ensures only one instance of Liquibase runs at a time.
 
-You can verify these tables were created by viewing the `blog` database on your `feature/blog-schema` branch on the **Tables** page in the Neon Console. Select **Tables** from the sidebar.
+You can verify these tables were created by viewing the `blog` database on your `feature/blog-schema` branch on the **Tables** page in the Neon Console. Select **Postgres database** > **Tables** from the sidebar.
 </Admonition>
 
 At this point, you can continue to iterate, applying schema changes to your database, until you are satisfied with the modified schema.

--- a/content/docs/guides/liquibase.md
+++ b/content/docs/guides/liquibase.md
@@ -9,7 +9,7 @@ summary: >-
   JDBC URL format for Neon and demonstrates the update and rollbackCount
   commands.
 enableTableOfContents: true
-updatedOn: '2026-08-07T18:39:13.799Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Liquibase is an open-source library for tracking, managing, and applying database schema changes. To learn more about Liquibase, refer to the [Liquibase documentation](https://docs.liquibase.com/home.html).
@@ -84,7 +84,7 @@ For demonstration purposes, create a `blog` database in Neon with two tables, `p
 
 1. Open the [Neon Console](https://console.neon.tech/app/projects).
 1. Select your project.
-1. Select **Databases** from the sidebar and create a database named `blog`. For instructions, see [Create a database](/docs/manage/databases#create-a-database).
+1. Select **Postgres database** > **Databases** from the sidebar and create a database named `blog`. For instructions, see [Create a database](/docs/manage/databases#create-a-database).
 1. Using the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor), add the following tables:
 
    ```sql
@@ -268,7 +268,7 @@ When you run a changeset for the first time, Liquibase automatically creates two
 - [databasechangelog](https://docs.liquibase.com/concepts/tracking-tables/databasechangelog-table.html): Tracks which changesets have been run.
 - [databasechangeloglock](https://docs.liquibase.com/concepts/tracking-tables/databasechangeloglock-table.html): Ensures only one instance of Liquibase runs at a time.
 
-You can verify these tables were created by viewing the `blog` database on the **Tables** page in the Neon Console. Select **Tables** from the sidebar.
+You can verify these tables were created by viewing the `blog` database on the **Tables** page in the Neon Console. Select **Postgres database** > **Tables** from the sidebar.
 </Admonition>
 
 ## Rollback a change
@@ -294,7 +294,7 @@ Liquibase command 'rollbackCount' was executed successfully.
 
 </details>
 
-You can verify that creation of the `comments` table was rolled back viewing the `blog` database on the **Tables** page in the Neon Console. Select **Tables** from the sidebar.
+You can verify that creation of the `comments` table was rolled back viewing the `blog` database on the **Tables** page in the Neon Console. Select **Postgres database** > **Tables** from the sidebar.
 
 ## Next steps
 

--- a/content/docs/guides/logical-replication-airbyte-snowflake.md
+++ b/content/docs/guides/logical-replication-airbyte-snowflake.md
@@ -9,7 +9,7 @@ summary: >-
   wal_level to logical for all databases in the Neon project.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-07T18:39:13.799Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations. In this guide, you will learn how to define your Lakebase Postgres database as a data source in Airbyte so that you can stream data to Snowflake.
@@ -84,12 +84,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-airbyte.md
+++ b/content/docs/guides/logical-replication-airbyte.md
@@ -9,7 +9,7 @@ summary: >-
   sets wal_level to logical for all databases in the project.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -76,12 +76,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-clickhouse.md
+++ b/content/docs/guides/logical-replication-clickhouse.md
@@ -10,7 +10,7 @@ summary: >-
   wal_level=logical for the entire Neon project.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -101,12 +101,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name (`replication_user`).
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name (`replication_user`).
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-databricks.md
+++ b/content/docs/guides/logical-replication-databricks.md
@@ -12,7 +12,7 @@ summary: >-
   supported.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-07T18:39:13.799Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature lets you stream changes from your Lakebase Postgres database into external systems. This guide shows how to use Databricks Lakeflow Connect's PostgreSQL connector to replicate data from Lakebase Postgres into Databricks Lakehouse using PostgreSQL logical replication.
@@ -82,8 +82,8 @@ Databricks recommends a dedicated database user for ingestion. Create a role in 
 
 <TabItem>
 
-1. In the [Neon Console](https://console.neon.tech), select your project and **Branches**.
-2. Select the branch, then the **Roles & Databases** tab.
+1. In the [Neon Console](https://console.neon.tech), select your project.
+2. In the sidebar, select your branch from the **BRANCH** selector, then under **Postgres database** select **Roles**.
 3. Click **Add Role**, enter the role name (e.g. `databricks_replication`), and click **Create**. Save the password.
 
 </TabItem>

--- a/content/docs/guides/logical-replication-decodable.md
+++ b/content/docs/guides/logical-replication-decodable.md
@@ -12,7 +12,7 @@ summary: >-
   table. Connect Decodable using a direct non-pooled connection string.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -76,12 +76,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-estuary-flow.md
+++ b/content/docs/guides/logical-replication-estuary-flow.md
@@ -11,7 +11,7 @@ summary: >-
   allowlisting for Estuary's egress addresses.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-07T16:05:20.768Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -74,12 +74,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name (for example, `cdc_role`).
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name (for example, `cdc_role`).
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-fivetran.md
+++ b/content/docs/guides/logical-replication-fivetran.md
@@ -10,7 +10,7 @@ summary: >-
   irreversible change, and Fivetran IPs must be added to Neon's IP Allow list.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -73,12 +73,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-kafka-confluent.md
+++ b/content/docs/guides/logical-replication-kafka-confluent.md
@@ -12,7 +12,7 @@ summary: >-
   prevent scale-to-zero and may increase billing.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -101,12 +101,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-materialize.md
+++ b/content/docs/guides/logical-replication-materialize.md
@@ -11,7 +11,7 @@ summary: >-
   scale-to-zero and increases compute billing.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-04T05:18:26.469Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -99,12 +99,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-postgres.md
+++ b/content/docs/guides/logical-replication-postgres.md
@@ -12,7 +12,7 @@ summary: >-
   connected.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from Neon to external subscribers. This guide shows you how to stream data from a Lakebase Postgres database to an external Postgres database (a Postgres destination other than Neon). If you're looking to replicate data from one Lakebase Postgres instance to another, see [Replicate data from one Neon project to another](/docs/guides/logical-replication-neon-to-neon).
@@ -87,12 +87,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/logical-replication-stacksync.md
+++ b/content/docs/guides/logical-replication-stacksync.md
@@ -11,7 +11,7 @@ summary: >-
   connection pooler) when configuring the Postgres source.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's logical replication feature allows you to replicate data from your Lakebase Postgres database to external destinations.
@@ -74,12 +74,11 @@ To create a role in the Neon Console:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. Select the **Roles & Databases** tab.
-6. Click **Add Role**.
-7. In the role creation dialog, specify a role name, such as `replication_user`.
-8. Click **Create**. The role is created, and you are provided with the password for the role.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add Role**.
+6. In the role creation dialog, specify a role name, such as `replication_user`.
+7. Click **Create**. The role is created, and you are provided with the password for the role.
 
 </TabItem>
 

--- a/content/docs/guides/medusajs.md
+++ b/content/docs/guides/medusajs.md
@@ -11,7 +11,7 @@ summary: >-
   and self-hosted environments such as DigitalOcean, AWS EC2, Render, and
   Fly.io.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Medusa](https://medusajs.com/) is an open-source headless e-commerce platform that provides a flexible backend for building modern e-commerce applications. It uses Postgres as its primary database to store all product, order, and customer data.
@@ -113,7 +113,7 @@ Following successful registration, you will be redirected to the Medusa Admin da
 After the installation is complete, you can optionally verify the tables in the Neon Console:
 
 1.  Navigate to your Neon Project dashboard.
-2.  Click the **Tables** tab.
+2.  In the sidebar, select **Postgres database** > **Tables**.
 3.  You should see all the Medusa tables created in your database.
 
 ![Medusa Tables in Neon](/docs/guides/medusa-neon-tables.png)

--- a/content/docs/guides/netlify-functions.md
+++ b/content/docs/guides/netlify-functions.md
@@ -10,7 +10,7 @@ summary: >-
   page when the goal is serverless backend database access inside a Netlify
   Function, not edge middleware or static site build steps.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Netlify Functions](https://www.netlify.com/products/functions/) provide a serverless execution environment for building and deploying backend functionality without managing server infrastructure. It's integrated with Netlify's ecosystem, making it ideal for augmenting web applications with server-side logic, API integrations, and data processing tasks in a scalable way.
@@ -33,7 +33,7 @@ After logging into the Neon Console, proceed to the [Projects](https://console.n
 
 1. Click `New Project` to start a new one.
 
-2. In the Neon **Dashboard**, use the `SQL Editor` from the sidebar to execute the SQL command below, creating a new table for coffee blends:
+2. In the Neon **Dashboard**, use **Postgres database** > **SQL Editor** from the sidebar to execute the SQL command below, creating a new table for coffee blends:
 
    ```sql
    CREATE TABLE favorite_coffee_blends (

--- a/content/docs/guides/protected-branches.md
+++ b/content/docs/guides/protected-branches.md
@@ -10,7 +10,7 @@ summary: >-
   can be combined with the IP Allow feature to restrict network access to
   protected branches only. Available on paid plans.
 enableTableOfContents: true
-updatedOn: '2026-08-11T18:35:41.335Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's protected branches feature implements a series of protections:
@@ -35,7 +35,7 @@ This example sets a branch as protected.
 To set a branch as protected:
 
 1. In the Neon Console, select a project.
-2. Select **Branches** to view the branches for the project.
+2. Select **Branches** under **Project** to view the branches for the project.
 
    ![Branch page](/docs/guides/ip_allow_branch_page.png)
 

--- a/content/docs/guides/railway.md
+++ b/content/docs/guides/railway.md
@@ -11,7 +11,7 @@ summary: >-
   Postgres, which provisions a database instantly without signup and stays
   claimable for 72 hours.
 enableTableOfContents: true
-updatedOn: '2026-08-04T04:41:00.271Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Railway](https://railway.com?utm_medium=integration&utm_source=button&utm_campaign=neon) is a cloud deployment platform that allows users to deploy anything, anywhere, seamlessly. On Railway, develop locally, connect to a repository or image, and have infrastructure provisioned automatically. Railway integrates with GitHub for continuous deployment and supports a variety of programming languages and frameworks.
@@ -41,7 +41,7 @@ To follow along with this guide, you will need:
 
 2. Click the `New Project` button to create a new project.
 
-3. From your project dashboard, navigate to the `SQL Editor` from the sidebar, and run the following SQL command to create a new table in your database:
+3. From your project dashboard, navigate to **Postgres database** > **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
 
    ```sql
    CREATE TABLE plant_care_log (

--- a/content/docs/guides/read-replica-adhoc-queries.md
+++ b/content/docs/guides/read-replica-adhoc-queries.md
@@ -9,7 +9,7 @@ summary: >-
   running them against production. Replicas share primary storage at no extra
   cost and automatically suspend after 5 minutes of inactivity.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 In many situations, you may need to run quick, one-time queries to retrieve specific data or test an idea. These are known as **ad-hoc queries**. Ad-hoc queries work well for tasks like analytics, troubleshooting, or exploring your data without setting up complex reports. However, running resource-intensive queries on your production database can degrade performance, especially if they target heavily used tables.
@@ -48,8 +48,8 @@ The Free plan is limited to a maximum of 3 read replica computes per project.
 
 You can add a read replica compute to any branch in your Neon project by following these steps:
 
-1. In the Neon Console, select **Branches**.
-2. Select the branch where your database resides.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+2. Under **Postgres database**, select **Computes**.
 3. Click **Add Read Replica**.
 4. On the **Add new compute** dialog, select **Read replica** as the **Compute type**.
 5. Specify the **Compute size settings**. You can configure a fixed-size compute with a specific amount of RAM (the default) or enable autoscaling by configuring a minimum and maximum compute size using the slider. On paid plans, you can adjust the **Scale to zero time** setting, which controls whether a compute suspends due to inactivity after 5 minutes.
@@ -58,7 +58,7 @@ You can add a read replica compute to any branch in your Neon project by followi
    </Admonition>
 6. When you finish making your selections, click **Create**.
 
-Your read replica is provisioned and appears on the **Computes** tab of the **Branches** page. The following section describes how to connect to your read replica.
+Your read replica is provisioned and appears on the **Computes** tab under **Postgres database**. The following section describes how to connect to your read replica.
 
 Alternatively, you can create read replicas using the [Neon CLI](/docs/cli/branches#create) or [Neon API](/docs/reference/api/endpoints/create-project-endpoint).
 

--- a/content/docs/guides/read-replica-data-analysis.md
+++ b/content/docs/guides/read-replica-data-analysis.md
@@ -10,7 +10,7 @@ summary: >-
   seconds via the Console, CLI, or API, and scales to zero automatically after
   5 minutes of inactivity.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 With Neon's read replica feature, you can instantly create a dedicated read replica for running data-intensive analytics or reporting queries. This allows you to avoid disruption or performance degradation on your production database.
@@ -62,8 +62,8 @@ The Free plan is limited to a maximum of 3 read replica computes per project.
 
 You can add a read replica compute to any branch in your Neon project by following these steps:
 
-1. In the Neon Console, select **Branches**.
-2. Select the branch where your database resides.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+2. Under **Postgres database**, select **Computes**.
 3. Click **Add Read Replica**.
 4. On the **Add new compute** dialog, select **Read replica** as the **Compute type**.
 5. Specify the **Compute size settings**. You can configure a fixed size compute with a specific amount of RAM (the default) or enable autoscaling by configuring a minimum and maximum compute size using the slider. You can also configure a **Scale to zero** setting, which determines whether a compute suspends due to inactivity after 5 minutes.
@@ -72,7 +72,7 @@ You can add a read replica compute to any branch in your Neon project by followi
    </Admonition>
 6. When you finish making your selections, click **Create**.
 
-Your read replica is provisioned and appears on the **Computes** tab of the **Branches** page. The following section describes how to connect to your read replica.
+Your read replica is provisioned and appears on the **Computes** tab under **Postgres database**. The following section describes how to connect to your read replica.
 
 Alternatively, you can create read replicas using the [Neon CLI](/docs/cli/branches#create) or [Neon API](/docs/reference/api/endpoints/create-project-endpoint), providing the flexibility required to integrate read replicas into your workflows or CI/CD processes.
 
@@ -154,9 +154,9 @@ Alternatively, you can let the read replica scale to zero so that it's readily a
 
 To delete a read replica:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. On the **Computes** tab, find the read replica you want to delete.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Find the read replica you want to delete.
 1. Click **Edit** &#8594; **Delete compute**.
 
 <NeedHelp/>

--- a/content/docs/guides/read-replica-guide.md
+++ b/content/docs/guides/read-replica-guide.md
@@ -11,7 +11,7 @@ summary: >-
   automatic synchronization of max_connections and related Postgres parameters
   between primary and replica computes.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Read replicas](/docs/introduction/read-replicas) are supported with all Neon plans. The Free plan is limited to a maximum of 3 read replica computes per project. This guide steps you through the process of creating and managing read replicas.
@@ -42,8 +42,8 @@ The Free plan is limited to a maximum of 3 read replica computes per project.
 <TabItem>
 To create a read replica from the Neon Console:
 
-1. In the Neon Console, select **Branches**.
-2. Select the branch where your database resides.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+2. Under **Postgres database**, select **Computes**.
 3. Click **Add Read Replica**.
 4. On the **Add new compute** dialog, select **Read replica** as the **Compute type**.
 5. Specify the **Compute size settings**. You can configure a **Fixed Size** compute with a specific amount of RAM (the default) or enable autoscaling by configuring a minimum and maximum compute size. You can also configure the **Suspend compute after inactivity** setting, which is the amount of idle time after which your compute is automatically suspended. The default setting is 5 minutes.
@@ -52,7 +52,7 @@ To create a read replica from the Neon Console:
    </Admonition>
 6. When you finish making your selections, click **Create**.
 
-In a few seconds, your read replica is provisioned and appears on the **Computes** tab on the **Branches** page. The following section describes how to connect to your read replica.
+In a few seconds, your read replica is provisioned and appears on the **Computes** tab under **Postgres database**. The following section describes how to connect to your read replica.
 </TabItem>
 
 <TabItem>
@@ -116,7 +116,7 @@ You can view read replicas using the Neon Console or [Neon API](/docs/reference/
 <Tabs labels={["Console", "API"]}>
 
 <TabItem>
-To view read replicas for a branch, select **Branches** in the Neon Console, and select a branch. Read replicas are listed on the **Computes** tab.
+To view read replicas for a branch, in the Neon Console select your branch from the **BRANCH** selector, then select **Postgres database** > **Computes**. Read replicas are listed on the **Computes** tab.
 
 ![View read replicas](/docs/guides/view_read_replica.png)
 </TabItem>
@@ -147,9 +147,9 @@ You can edit a read replica using the Neon Console or [Neon API](/docs/reference
 <TabItem>
 To edit a read replica compute using the Neon Console:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. Under **Computes**, identify the read replica compute you want to modify, and click **Edit**.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Identify the read replica compute you want to modify, and click **Edit**.
 1. Make the changes to your compute settings, and click **Save**.
 
 </TabItem>
@@ -190,9 +190,9 @@ You can delete a read replica using the Neon Console or [Neon API](/docs/referen
 <TabItem>
 To delete a read replica using the Neon Console:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. On the **Computes** tab, find the read replica you want to delete.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Find the read replica you want to delete.
 1. Click **Edit** &#8594; **Delete**.
 
 </TabItem>

--- a/content/docs/guides/read-replica-prisma.md
+++ b/content/docs/guides/read-replica-prisma.md
@@ -10,7 +10,7 @@ summary: >-
   to be a separate PrismaClient instance with a PrismaNeon adapter. Multiple
   replicas are selected randomly per query.
 enableTableOfContents: true
-updatedOn: '2026-08-07T18:39:13.799Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 A Neon read replica is an independent read-only compute that performs read operations on the same data as your primary read-write compute, which means adding a read replica to a Neon project requires no additional storage.
@@ -35,8 +35,8 @@ The Free plan is limited to a maximum of 3 read replica computes per project.
 
 You can add a read replica by following these steps:
 
-1. In the Neon Console, select **Branches**.
-2. Select the branch where your database resides.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+2. Under **Postgres database**, select **Computes**.
 3. Click **Add Read Replica**.
 4. On the **Add new compute** dialog, select **Read replica** as the **Compute type**.
 5. Specify the **Compute size settings** options. You can configure a **Fixed Size** compute with a specific amount of RAM (the default) or enable autoscaling by configuring a minimum and maximum compute size. You can also configure the **Scale to zero** setting, which controls whether your read replica compute is automatically suspended due to inactivity after 5 minutes.
@@ -45,7 +45,7 @@ You can add a read replica by following these steps:
    </Admonition>
 6. When you finish making selections, click **Create**.
 
-   Your read replica compute is provisioned and appears on the **Computes** tab of the **Branches** page.
+   Your read replica compute is provisioned and appears on the **Computes** tab under **Postgres database**.
 
 Alternatively, you can create read replicas using the [Neon API](/docs/reference/api/endpoints/create-project-endpoint) or [Neon CLI](/docs/cli/branches#create).
 

--- a/content/docs/guides/render.md
+++ b/content/docs/guides/render.md
@@ -9,7 +9,7 @@ summary: >-
   using Render's native database. The guide uses Node.js with the pg library and
   Render's Git-based continuous deployment.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 [Render](https://render.com) is a comprehensive cloud service that provides hosting for web applications and static sites, with PR previews, zero-downtime deployments, and more. Render supports full-stack applications, offering both web services and background workers.
@@ -33,7 +33,7 @@ Log in to the Neon Console and navigate to the [Projects](https://console.neon.t
 
 - Click the `New Project` button to create a new project.
 
-- From your project dashboard, navigate to the `SQL Editor` from the sidebar, and run the following SQL command to create a new table in your database:
+- From your project dashboard, navigate to **Postgres database** > **SQL Editor** from the sidebar, and run the following SQL command to create a new table in your database:
 
   ```sql
   CREATE TABLE books_to_read (

--- a/content/docs/guides/reset-from-parent.md
+++ b/content/docs/guides/reset-from-parent.md
@@ -10,7 +10,7 @@ summary: >-
   cannot be reset, and branches with their own children must have those children
   deleted first.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's **Reset from parent** feature lets you instantly reset all databases on a branch to the latest schema and data from its parent branch, helping you recover from issues, start on new feature development, or keep the different branches in your environment in sync.
@@ -49,7 +49,7 @@ You can reset any branch to its parent using any of our tools.
 <Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
-On the **Branches** page in the Neon Console, select the branch that you want to reset.
+On the **Branches** page (under **Project**) in the Neon Console, select the branch that you want to reset.
 
 The console opens to the details page for your branch, giving you key information about the branch and its child status: its parent, the last time it was reset, and other relevant detail.
 

--- a/content/docs/guides/scale-to-zero-guide.md
+++ b/content/docs/guides/scale-to-zero-guide.md
@@ -13,7 +13,7 @@ summary: >-
 redirectFrom:
   - /docs/guides/auto-suspend-guide
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Neon's [Scale to Zero](/docs/introduction/scale-to-zero) feature controls whether a Neon compute transitions to an idle state due to inactivity. For example, if scale to zero is enabled, your compute will transition to an idle state after it's been inactive for 5 minutes. Neon's paid plans allow you to disable scale to zero to keep your compute active. On the Scale plan, you can configure the scale to zero threshold.
@@ -42,9 +42,9 @@ Scale to zero is only available for computes up to 16 CU in size. Computes large
 
 To enable or disable scale to zero:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. On the **Computes** tab, click **Edit**.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Click **Edit**.
 1. Enable or disable the scale to zero setting, and save your selection.
 
 > Disabling scale to zero is only supported on paid plans.

--- a/content/docs/guides/schema-diff-tutorial.md
+++ b/content/docs/guides/schema-diff-tutorial.md
@@ -11,7 +11,7 @@ summary: >-
   Schema Diff to see exactly which tables, sequences, and constraints differ
   before merging or restoring.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 In this guide we will create an initial schema on a new database called `people` on our `production` branch. We'll then create a development branch called `feature/address`, following one possible convention for naming feature branches. After making schema changes on `feature/address`, we'll use the **Schema Diff** tool on the **Branches** page to get a side-by-side, GitHub-style visual comparison between the `feature/address` development branch and `production`.
@@ -37,11 +37,11 @@ First, create a new database called `people` on the `production` branch and add 
 
 1. Create the database.
 
-   In the **Neon Console**, go to **Databases** &#8594; **New Database**. Make sure your `production` branch is selected, then create the new database called `people`.
+   In the **Neon Console**, go to **Postgres database** > **Databases** &#8594; **New Database**. Make sure your `production` branch is selected, then create the new database called `people`.
 
 2. Add the schema.
 
-   Go to the **SQL Editor**, enter the following SQL statement and click **Run** to apply.
+   Go to **Postgres database** > **SQL Editor**, enter the following SQL statement and click **Run** to apply.
 
    ```sql
    CREATE TABLE person (
@@ -165,7 +165,7 @@ For the purposes of this tutorial, name the branch `feature/address`, which coul
 
 1. Create the development branch
 
-   On the **Branches** page, click **Create Branch**, making sure of the following:
+   On the **Branches** page (under **Project**), click **Create Branch**, making sure of the following:
    - Select `production` as the parent branch.
    - Name the branch `feature/address`.
 

--- a/content/docs/guides/time-travel-assist.md
+++ b/content/docs/guides/time-travel-assist.md
@@ -11,7 +11,7 @@ summary: >-
   & Restore page, or the Neon CLI using RFC 3339 timestamps or Log Sequence
   Numbers (LSN).
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 To help review your data's history, Time Travel lets you connect to any selected point in time still covered by your project's **history window** (the retention configured for **instant restore**) and then run queries against that connection. Time Travel is part of Neon's **instant restore** feature, which maintains a history of changes through Write-Ahead Log (WAL) records.
@@ -82,7 +82,7 @@ Here is how to use Time Travel from the **SQL Editor**, from **Backup & Restore*
 
 <TabItem>
 
-1. In the Neon Console, open the **SQL Editor**.
+1. In the Neon Console, select your branch, then open **Postgres database** > **SQL Editor**.
 1. Use the **Time Travel** (🕣) icon to enable querying against an earlier point in time.
 
    ![Time Travel toggle](/docs/get-started/time_travel_sql_editor.png)
@@ -94,7 +94,7 @@ Here is how to use Time Travel from the **SQL Editor**, from **Backup & Restore*
 
 <TabItem>
 
-1. In the Neon Console, open the branch's **Backup & Restore** page and go to **Restore from history**.
+1. In the Neon Console, select your branch, then open **Postgres database** > **Backup & Restore** and go to **Restore from history**.
 1. Select the branch you want to query against, then select a timestamp, the same as you would to [Restore a branch](#restore-a-branch-to-an-earlier-state).
 
    ![time travel selection](/docs/guides/time_travel_restore_select.png)

--- a/content/docs/guides/trigger-serverless-functions.md
+++ b/content/docs/guides/trigger-serverless-functions.md
@@ -10,7 +10,7 @@ summary: >-
   installing the Inngest client, writing TypeScript Inngest functions, and
   syncing with the Inngest platform across all three serverless runtimes.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Combining your serverless Neon database with [Inngest](https://www.inngest.com/?utm_source=neon&utm_medium=trigger-serverless-functions-guide) enables you to **trigger serverless functions** running on Vercel, AWS, and Cloudflare Worker **based on database changes.**
@@ -40,7 +40,7 @@ If you do not have one already, create a Neon project:
 
 ## Create a table in Neon
 
-To create a table, navigate to the **SQL Editor** in the [Neon Console](https://console.neon.tech/):
+To create a table, navigate to **Postgres database** > **SQL Editor** in the [Neon Console](https://console.neon.tech/):
 
 In the SQL Editor, run the following queries to create a `users` table and insert some data:
 

--- a/content/docs/guides/vercel-branch-cleanup.md
+++ b/content/docs/guides/vercel-branch-cleanup.md
@@ -12,7 +12,7 @@ summary: >-
   Stale branches count toward plan branch limits and incur storage costs even
   after being auto-archived.
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <InfoBlock>
@@ -160,7 +160,7 @@ This shows all branches with their names, states, and creation dates. Look for b
 
 To remove stale branches:
 
-- **Neon Console**: Go to the **Branches** page and delete branches individually
+- **Neon Console**: Go to the **Branches** page (under **Project**) and delete branches individually
 - **Neon CLI**: Use `neon branches delete <branch-id-or-name>` to remove specific branches. See [CLI branches reference](/docs/cli/branches#delete).
 - **Neon API**: Use `DELETE /projects/{project_id}/branches/{branch_id}`. See [Delete a branch with the API](/docs/manage/branches#delete-a-branch-with-the-api).
 

--- a/content/docs/guides/wundergraph.md
+++ b/content/docs/guides/wundergraph.md
@@ -11,7 +11,7 @@ summary: >-
   full-stack app without a dedicated CI/CD pipeline or DevOps setup.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 _This guide was contributed by the team at WunderGraph_
@@ -46,7 +46,7 @@ The deployment will take a few moments.
 
 While the project is deploying, add some sample data to your database.
 
-1. Navigate to the Console and select **SQL Editor** from the sidebar.
+1. Navigate to the Console and select **Postgres database** > **SQL Editor** from the sidebar.
 2. Run the following SQL statements to add the sample data.
 
 ```sql

--- a/content/docs/import/migrate-aws-dms.md
+++ b/content/docs/import/migrate-aws-dms.md
@@ -10,7 +10,7 @@ summary: >-
   endpoint setup, migration task configuration, table mapping, and post-migration
   verification in the Neon Console.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 This guide outlines the steps for using the AWS Database Migration Service (DMS) to migrate data to Neon from another hosted database server. AWS DMS supports a variety of database migration sources including PostgreSQL, MySQL, Oracle, and Microsoft SQL Server. For a complete list of data migration sources supported by AWS DMS, see [Source endpoints for data migration](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.Sources.html#CHAP_Introduction.Sources.DataMigration).
@@ -109,7 +109,7 @@ Configure the table mapping:
 To verify that data was migrated to your Neon database:
 
 1. In the Neon Console, select your Neon project.
-2. Select **Tables** from the side bar.
+2. Select **Postgres database** > **Tables** from the sidebar.
 3. Select the **Branch**, **Database**, and **Schema** where you imported the data.
    ![Neon Tables view showing imported data](/docs/import/dms_neon_table_data.png).
 

--- a/content/docs/import/migrate-from-firebase.md
+++ b/content/docs/import/migrate-from-firebase.md
@@ -13,7 +13,7 @@ summary: >-
 redirectFrom:
   - /docs/import/import-from-firebase
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 This guide describes how to migrate data from Firebase Firestore to Lakebase Postgres.
@@ -191,7 +191,7 @@ This section describes how to prepare your destination Lakebase Postgres databas
 ### Create the Neon database
 
 1. In the Neon Console, go to your project dashboard.
-2. In the sidebar, click on **Databases**.
+2. In the sidebar, select **Postgres database** > **Databases**.
 3. Click the **New Database** button.
 4. Enter a name for your database and click **Create**.
 

--- a/content/docs/import/migrate-from-heroku.md
+++ b/content/docs/import/migrate-from-heroku.md
@@ -10,7 +10,7 @@ redirectFrom:
   - /docs/how-to-guides/hasura-heroku-migration
   - /docs/how-to-guides/import-from-heroku
   - /docs/import/import-from-heroku
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 This guide describes how to import your data from Heroku Postgres to Neon.
@@ -155,7 +155,7 @@ heroku-cli: Pulling complete.
 
 1. Log in to the [Neon Console](https://console.neon.tech/app/projects).
 2. Select the Neon project that you transferred data to.
-3. Select the **Tables** tab.
+3. In the sidebar, select **Postgres database** > **Tables**.
 4. In the sidebar, verify that your database tables appear under the **Tables** heading.
 
 </Steps>

--- a/content/docs/introduction/branch-restore.md
+++ b/content/docs/introduction/branch-restore.md
@@ -19,7 +19,7 @@ redirectFrom:
   - /docs/guides/branch-promote
   - /docs/guides/branch-restore
   - /docs/guides/instant-restore
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <InfoBlock>
@@ -39,7 +39,7 @@ With Neon's instant restore capability, also known as point-in-time restore or P
 
 ### Restore from history
 
-In the Neon Console, open a branch's **Backup & Restore** page and use **Restore from history** to start this flow.
+In the Neon Console, select your branch, then open **Postgres database** > **Backup & Restore** and use **Restore from history** to start this flow.
 
 Instant restore is only supported for root branches. You can revert a root branch to an earlier point in time in its own or another root branch's history, using time and date or Log Sequence Number (LSN). For example, you can revert to a state just before a data loss occurred.
 
@@ -282,7 +282,7 @@ Backup branches are deletable except in two cases:
 
 To delete a backup branch:
 
-1. Navigate to the **Branches** page.
+1. Navigate to the **Branches** page (under **Project**).
 2. Find the backup branch you want to delete. It will have a name with the following format:
 
    ```

--- a/content/docs/manage/branches.md
+++ b/content/docs/manage/branches.md
@@ -11,7 +11,7 @@ enableTableOfContents: true
 isDraft: false
 redirectFrom:
   - /docs/get-started/get-started-branching
-updatedOn: '2026-08-11T18:35:41.335Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 Data resides in a branch. Each Neon project is created with a [root branch](#root-branch), which is also designated as your [default branch](#default-branch). Projects created in the Neon Console have a root branch named `production`, while projects created via the API or CLI have a root branch named `main`. You can create child branches from your root branch or from previously created branches. A branch can contain multiple databases and roles. Neon's [plan allowances](/docs/introduction/plans) define the number of branches you can create.
@@ -41,7 +41,7 @@ If you do specify a custom branch name when creating or renaming a branch, it mu
 To create a branch:
 
 1. In the Neon Console, select a project.
-2. Select **Branches**.
+2. Select **Branches** under **Project**.
 3. Click **New branch** to open the branch creation dialog.
    ![Create branch dialog](/docs/manage/create_branch.png)
 4. Select a **Parent branch**. This determines the origin of the schema and data for your new branch. By default, your project's default branch (named `main` if the project was created with the CLI or API, or `production` if created in the Console) is selected, but you can choose any existing branch in your project.
@@ -68,7 +68,7 @@ You are presented with the connection details for your new branch and directed t
 To view the branches in a Neon project:
 
 1. In the Neon Console, select a project.
-1. Select **Branches** to view all current branches in the project.
+1. Select **Branches** under **Project** to view all current branches in the project.
 
    ![all branches](/docs/manage/branches_all_list.png)
 
@@ -91,7 +91,7 @@ To view the branches in a Neon project:
    - **Data size**: The logical data size of the branch. Data size does not include history.
    - **Parent branch**: The branch from which this branch was created (only applicable to child branches).
 
-   The branch details page also includes details about the **Computes**, **Roles & Databases**, and **Child branches** that belong to the branch. All of these objects are associated with a particular branch. For information about these objects, see:
+   The branch details page also includes details about the **Computes**, **Roles**, **Databases**, and **Child branches** that belong to the branch. All of these objects are associated with a particular branch. For information about these objects, see:
    - [Manage computes](/docs/manage/computes#view-a-compute).
    - [Manage roles](/docs/manage/roles)
    - [Manage databases](/docs/manage/databases)
@@ -110,7 +110,7 @@ For branches with predictable lifespans, you can set an expiration date when cre
 Neon permits renaming a branch, including your project's default branch. To rename a branch:
 
 1. In the Neon Console, select a project.
-2. Select **Branches** to view the branches for the project.
+2. Select **Branches** under **Project** to view the branches for the project.
 3. Select a branch from the table.
 4. On the branch overview page, click the **More** drop-down menu and select **Rename**.
 5. Specify a new name for the branch and click **Save**.
@@ -124,7 +124,7 @@ For more information, see [Default branch](#default-branch).
 To set a branch as the default branch:
 
 1. In the Neon Console, select a project.
-2. Select **Branches** to view the branches for the project.
+2. Select **Branches** under **Project** to view the branches for the project.
 3. Select a branch from the table.
 4. On the branch overview page, click the **More** drop-down menu and select **Set as default**.
 5. In the **Set as default** confirmation dialog, click **Set as default** to confirm your selection.
@@ -136,7 +136,7 @@ This feature is available on all Neon's paid plans, which supports up to five pr
 To set a branch as protected:
 
 1. In the Neon Console, select a project.
-2. Select **Branches** to view the branches for the project.
+2. Select **Branches** under **Project** to view the branches for the project.
 3. Select a branch from the table.
 4. On the branch overview page, click the **More** drop-down menu and select **Set as protected**.
 5. In the **Set as protected** confirmation dialog, click **Set as protected** to confirm your selection.
@@ -148,7 +148,7 @@ For details and configuration instructions, refer to our [Protected branches gui
 To set or update a branch's expiration (auto-deletion TTL):
 
 1. In the Neon Console, select a project.
-2. Select **Branches** to view the branches for the project.
+2. Select **Branches** under **Project** to view the branches for the project.
 3. Select a branch from the table.
 4. On the branch overview page, click the **Actions** drop-down menu and select **Edit expiration**.
 5. Set a new expiration date and time, or toggle off "Automatically delete branch after" to remove expiration.
@@ -203,7 +203,7 @@ Deleting a branch is a permanent action. Deleting a branch also deletes the data
 To delete a branch:
 
 1. In the Neon Console, select a project.
-2. Select **Branches**.
+2. Select **Branches** under **Project**.
 3. Select a branch from the table.
 4. On the branch overview page, click the **More** drop-down menu and select **Delete**.
 5. On the confirmation dialog, click **Delete**.

--- a/content/docs/manage/computes.md
+++ b/content/docs/manage/computes.md
@@ -8,7 +8,7 @@ summary: >-
   compute endpoints via the Neon Console or API.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-07T13:46:01.605Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 A compute is a virtualized service that runs applications. In Neon, a compute runs Postgres.
@@ -32,7 +32,7 @@ Your Neon plan determines the resources available to a compute. The Neon Free pl
 
 ## View a compute
 
-A compute is associated with a branch. To view a compute, select **Branches** in the Neon Console, and select a branch. If the branch has a compute, it is shown on the **Computes** tab on the branch page.
+A compute is associated with a branch. To view a compute, in the Neon Console select your branch from the **BRANCH** selector, then select **Postgres database** > **Computes**. If the branch has a compute, it is shown on the **Computes** tab of the branch overview.
 
 Compute details shown on the **Computes** tab include:
 
@@ -50,9 +50,9 @@ You can only create a single primary read-write compute for a branch that does n
 
 To create an endpoint:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. On the **Computes** tab, click **Add a compute** or **Add Read Replica** if you already have a primary read-write compute.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Click **Add a compute** or **Add Read Replica** if you already have a primary read-write compute.
 1. On the **Add new compute** drawer or **Add read replica** drawer, specify your compute settings, and click **Add**. Selecting the **Read replica** compute type creates a [read replica](/docs/introduction/read-replicas).
 
 ## Edit a compute
@@ -61,9 +61,9 @@ You can edit a compute to change the [compute size](#compute-size-and-autoscalin
 
 To edit a compute:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. From the **Computes** tab, select **Edit** for the compute you want to edit.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Select **Edit** for the compute you want to edit.
 
    The **Edit** drawer opens, letting you modify settings such as compute size, the autoscaling configuration, and your scale to zero setting.
 
@@ -241,7 +241,7 @@ Restarting a compute interrupts any connections currently using the compute. To 
 
 You can restart a compute using these methods:
 
-- Use the **Restart compute** option in the Neon console. Navigate to the **Branches** page from your project dashboard, and select a branch. On the Computes tab, select **Restart compute** from the menu.
+- Use the **Restart compute** option in the Neon console. Select your branch from the **BRANCH** selector, then select **Postgres database** > **Computes** and choose **Restart compute** from the compute's menu.
   ![Restart a compute in the console](/docs/manage/restart_compute.png)
 - Issue a [Restart compute endpoint](/docs/reference/api/endpoints/restart-project-endpoint) call using the Neon API. You can do this directly from the Neon API Reference using the **Try It!** feature or via the command line with a cURL command similar to the one shown below. You'll need your [project ID](/docs/reference/glossary#project-id), compute [endpoint ID](/docs/reference/glossary#endpoint-id), and an [API key](/docs/manage/api-keys#create-an-api-key).
 
@@ -264,9 +264,9 @@ A branch can have a single read-write compute and multiple read replica computes
 
 To delete a compute:
 
-1. In the Neon Console, select **Branches**.
-1. Select a branch.
-1. On the **Computes** tab, click **Edit** for the compute you want to delete.
+1. In the Neon Console, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Computes**.
+1. Click **Edit** for the compute you want to delete.
 1. At the bottom of the **Edit compute** drawer, click **Delete compute**.
 
 ## Manage computes with the Neon API

--- a/content/docs/manage/databases.md
+++ b/content/docs/manage/databases.md
@@ -9,7 +9,7 @@ summary: >-
   ALTER TABLE ... OWNER TO or REASSIGN OWNED.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 A database is a container for SQL objects such as schemas, tables, views, functions, and indexes. In the [Neon object hierarchy](/docs/manage/overview), a database exists within a branch of a project. There is a limit of 500 databases per branch.
@@ -43,9 +43,8 @@ To create a database:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 1. Select a project.
-1. Select **Branches** from the sidebar.
-1. Select the branch where you want to create the database.
-1. Select the **Roles** & **Databases** tab.
+1. In the sidebar, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Databases**.
 1. Click **Add database**.
 1. Enter a database name, and select a database owner.
 1. Click **Create**.
@@ -60,9 +59,8 @@ To view databases:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 1. Select a project.
-1. Select **Branches** from the sidebar.
-1. Select the branch where you want to view databases.
-1. Select the **Roles** & **Databases** tab.
+1. In the sidebar, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Databases**.
 
 ### Delete a database
 
@@ -72,8 +70,8 @@ To delete a database:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 1. Select a project.
-1. Select **Databases** from the sidebar.
-1. Select a branch to view the databases in the branch.
+1. In the sidebar, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Databases**.
 1. For the database you want to delete, click the delete icon.
 1. In the confirmation dialog, click **Delete**.
 

--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -11,7 +11,7 @@ enableTableOfContents: true
 isDraft: false
 redirectFrom:
   - /docs/manage/users
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 In Neon, roles are Postgres roles. Each Neon project is created with a Postgres role that is named for your database. For example, if your database is named `neondb`, the project is created with a role named `neondb_owner`. This role owns the database that is created in your Neon project's default branch.
@@ -68,9 +68,9 @@ To create a role:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to create the role.
-5. On the **Roles & Databases** tab, click **Add role**.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Click **Add role**.
 6. In the role creation modal, specify a role name. The branch is pre-selected.
 7. Click **Create**. The role is created and you are provided with the password for the role.
 
@@ -86,9 +86,9 @@ To delete a role:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the branch where you want to delete a role.
-5. On the **Roles & Databases** tab, select **Delete role** from the role menu.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Select **Delete role** from the role menu.
 6. On the confirmation modal, click **Delete**.
 
 ### Reset a password
@@ -97,9 +97,9 @@ To reset a role's password:
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
-3. Select **Branches**.
-4. Select the role's branch.
-5. On the **Roles & Databases** tab, select **Reset password** from the role menu.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Select **Reset password** from the role menu.
 6. On the **Reset password** modal, click **Reset**. A reset password modal is displayed with your new password.
 
 <Admonition type="note">

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/conceptual-guides/glossary
   - /docs/cloud/concepts/
-updatedOn: '2026-08-07T13:46:01.605Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 ## access token
@@ -245,7 +245,7 @@ A Neon Control Plane operation that deletes stored data when a Neon project is d
 
 ## Endpoint ID
 
-A string that identifies a Neon compute endpoint. Neon Endpoint IDs are generated Heroku-like memorable random names, similar to `ep-calm-flower-a5b75h79`. These names are always prefixed by `ep` for "endpoint". You can find your Endpoint ID by navigating to your project in the Neon Console, selecting **Branches** from the sidebar, and clicking on a branch. The **Endpoint ID** is shown in the table under the **Computes** heading.
+A string that identifies a Neon compute endpoint. Neon Endpoint IDs are generated Heroku-like memorable random names, similar to `ep-calm-flower-a5b75h79`. These names are always prefixed by `ep` for "endpoint". You can find your Endpoint ID by navigating to your project in the Neon Console, selecting **Branches** under **Project** in the sidebar, and clicking on a branch. The **Endpoint ID** is shown in the table under the **Computes** heading.
 
 ## Egress
 

--- a/content/docs/workflows/data-anonymization.md
+++ b/content/docs/workflows/data-anonymization.md
@@ -14,7 +14,7 @@ redirectFrom:
 tag: new
 tagTheme: green
 enableTableOfContents: true
-updatedOn: '2026-08-11T18:35:41.335Z'
+updatedOn: '2026-08-18T10:29:02.410Z'
 ---
 
 <FeatureBeta />
@@ -42,7 +42,7 @@ This feature uses **static masking**, which permanently transforms data in the b
 To create a branch with anonymized data from the Neon Console:
 
 1. Select your project.
-2. Select **Branches**.
+2. Select **Branches** under **Project**.
 3. Click **New branch** to open the branch creation dialog.
    ![Neon Console 'Create new branch' dialog with 'Anonymized data' selected](/docs/workflows/anon-create-a-new-branch.png)
 4. Select a **Parent branch**. This determines the origin of the schema and data for your new branch. By default, your project's default branch (named `main` if the project was created with the CLI or API, or `production` if created in the Console) is selected, but you can choose any existing branch in your project.


### PR DESCRIPTION
## What

The Neon console sidebar has been restructured. Database features are now grouped under a **Postgres database** service, alongside **Auth**, **Object storage**, **Functions**, and **AI Gateway**. The branch you're working on is set via the **BRANCH** selector, and the project branch list lives under **Project > Branches**.

This PR updates the affected UI navigation instructions across the docs to match.

## Changes

- **Sidebar nav routed through Postgres database** — Tables, SQL Editor, Data API, Backup & Restore, and Databases instructions now read `Postgres database > [item]`.
- **"Roles & Databases" combined tab split** — that tab no longer exists; references now point to the separate **Roles** and **Databases** tabs.
- **Branch-scoped flows rewritten** — creating/deleting/editing roles, databases, computes, and read replicas now follow: select the branch in the **BRANCH** selector, then **Postgres database > [item]**.
- **Project branch list** — "view branches" / "Branches page" instructions now specify **Project > Branches**.

60 files changed (documentation only).

## Not included (needs follow-up)

12 screenshots still show the old sidebar and need re-capture. Referenced by: `data-api/get-started.md`, `guides/tables.md`, `auth/guides/plugins/admin.md`, `guides/logical-replication-clickhouse.md`, `guides/logical-replication-inngest.md`, `guides/trigger-serverless-functions.md`, `guides/branching-github-actions.md`, `manage/projects.md`, `reference/terraform.md`, `workflows/data-anonymization.md`, `import/migrate-aws-dms.md`.

This pull request and its description were written by Isaac.