### PR TITLE
fix: add skip link and raise footer compliance label contrast

### DIFF
--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -131,7 +131,7 @@ const Footer = ({ hasThemesSupport = false }) => (
                       {description && (
                         <span
                           className={cn(
-                            'ml-1.5 py-px text-gray-new-70 dark:text-gray-new-40',
+                            'ml-1.5 py-px text-gray-new-45 dark:text-gray-new-50',
                             to &&
                               'transition-colors duration-200 group-hover/link:text-gray-new-10 group-hover/link:dark:text-gray-new-90'
                           )}

--- a/src/components/shared/layout/layout.jsx
+++ b/src/components/shared/layout/layout.jsx
@@ -22,6 +22,18 @@ const Layout = ({
   isClient = false,
 }) => (
   <>
+    <a
+      className={cn(
+        'fixed top-0 left-4 z-100 -translate-y-full rounded-b-sm px-4 py-2.5',
+        'text-sm leading-none font-medium tracking-extra-tight',
+        'border border-t-0 border-gray-new-90 bg-white text-black-pure',
+        'dark:border-gray-new-20 dark:bg-black-pure dark:text-white',
+        'focus:translate-y-0'
+      )}
+      href="#main-content"
+    >
+      Skip to main content
+    </a>
     {!isClient && <Topbar />}
     <div
       className={cn(
@@ -44,6 +56,8 @@ const Layout = ({
       />
       <main
         className={cn(withOverflowHidden && 'overflow-hidden', 'flex flex-1 flex-col', className)}
+        id="main-content"
+        tabIndex={-1}
       >
         {children}
       </main>


### PR DESCRIPTION
## Summary
- Adds a sitewide “Skip to main content” link (WCAG SC 2.4.1) so keyboard users can bypass the header/nav instead of tabbing through ~59 focus stops on every visit.
- Raises footer compliance badge contrast (`Compliant` / `Certified`) from failing greys to tokens that meet 4.5:1 in light and dark (WCAG SC 1.4.3). Scoped to the footer only so shared palette tokens are unchanged.
- Leaves focus order alone: the reported backwards jumps were not reproducible (no positive `tabindex`, no visual reordering in live homepage content; footer-column wrapping and the HIPAA submenu explain the apparent jumps).

## Test plan
- [ ] Tab once on `/`, `/security`, `/docs/introduction`, and `/pricing`: first stop is “Skip to main content”; Enter moves focus into `#main-content`.
- [ ] Confirm the skip link is off-screen until focused, then visible with the green focus ring.
- [ ] Check footer Compliance labels (`Compliant` / `Certified`) in light and dark: readable against white/black, still visually secondary to the link text.
- [ ] Spot-check that unrelated `gray-new-70` / `gray-new-40` usages elsewhere are unchanged.