### PR TITLE
docs: clarify Agent vs Scale plan differences

### DIFF
--- a/content/docs/guides/ai-agent-integration.md
+++ b/content/docs/guides/ai-agent-integration.md
@@ -71,27 +71,27 @@ When a user on your platform needs a database, create a project in the appropria
 
 The two-organization structure enables you to:
 
-1. **Offer a truly free tier**: Neon sponsors all infrastructure costs for up to 30,000 free projects
+1. **Offer a truly free tier**: Neon sponsors infrastructure costs for free-tier projects (unlimited projects; we incrementally raise your limit to accommodate growing usage)
 2. **Scale sustainably**: Paid users consume from your credits ($0.106 per compute unit hour)
 3. **Upgrade users**: Transfer projects from free to paid organizations when users upgrade
 4. **Control resources**: Set different usage quotas/limits for projects to match your desired pricing model
 
 ### Project limits by organization
 
-Each organization has different limits that apply to all projects created within it. Understanding these limits helps you design your platform's features and set appropriate user expectations.
+Each organization has different limits that apply to all projects created within it. Understanding these limits helps you design your platform's features and set appropriate user expectations. For how Agent compares to Scale, see [Agent vs Scale](/docs/introduction/agent-plan#agent-vs-scale).
 
-| Limit                    | Free Organization | Paid Organization       | Notes                                                                                                            |
-| ------------------------ | ----------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Max branches**         | 10 per project    | Custom limits available | Includes all branches (production, development, snapshots)                                                       |
-| **Max manual snapshots** | 1 per project     | 100 per project         | Manual snapshots only. On paid plans, scheduled backup snapshots do not count. Critical for versioning workflows |
-| **Compute range**        | 0.25 - 2 CU       | 0.25 - 16 CU            | CU = Compute Units (~4GB RAM per CU)                                                                             |
-| **History window**       | 1 day             | Up to 7 days            | Point-in-time recovery window                                                                                    |
-| **Min auto-suspend**     | 5 minutes         | 1 minute                | Minimum time before compute suspends                                                                             |
+| Limit                    | Free Organization | Paid Organization | Notes                                                                                     |
+| ------------------------ | ----------------- | ----------------- | ----------------------------------------------------------------------------------------- |
+| **Max branches**         | 10 per project    | Up to 1,000       | Includes all branches (production, development, snapshots)                                |
+| **Max manual snapshots** | 1 per project     | 100 per project   | Manual snapshots only. Automated snapshot schedules are not available on the Agent plan.  |
+| **Compute range**        | 0.25 - 2 CU       | 0.25 - 16 CU      | CU = Compute Units (~4GB RAM per CU). Fixed sizes up to 16 CU (Scale allows up to 56 CU). |
+| **History window**       | 1 day             | Up to 7 days      | Point-in-time recovery window (Scale allows up to 30 days)                                |
+| **Min auto-suspend**     | 5 minutes         | 1 minute          | Minimum time before compute suspends                                                      |
 
 **Key constraints to consider:**
 
-- **Manual snapshot limits**: Free projects can only maintain 1 manual snapshot at a time, while paid projects can keep up to 100. On paid projects, scheduled backup snapshots do not count toward this limit. This significantly impacts versioning strategies.
-- **Branch limits**: Free projects are limited to 10 branches total, so you'll need to implement cleanup for development branches and temporary snapshots.
+- **Manual snapshot limits**: Free projects can only maintain 1 manual snapshot at a time, while paid projects can keep up to 100. Automated snapshot schedules are not available on the Agent plan. This significantly impacts versioning strategies.
+- **Branch limits**: Free projects are limited to 10 branches total, so you'll need to implement cleanup for development branches and temporary snapshots. Paid projects support up to 1,000 branches.
 - **Compute limits**: Free projects can autoscale up to 2 CU, while paid projects can scale up to 16 CU for more demanding workloads.
 
 For detailed quota examples and consumption limits, see [Configure consumption limits](/docs/guides/consumption-limits).
@@ -438,7 +438,7 @@ Development branches are:
 - **Easy to reset**: Restore development branch to match production anytime
 
 <Admonition type="note">
-**Branch limits:** Remember that Free organization projects have a **10 branch maximum** (including main branch, development branches, and snapshots), while Paid organization projects have **custom limits available** (see [Agent plan pricing](/docs/introduction/agent-plan#pricing)). Implement branch cleanup for temporary development branches to stay within limits.
+**Branch limits:** Remember that Free organization projects have a **10 branch maximum** (including main branch, development branches, and snapshots), while Paid organization projects support **up to 1,000 branches** (see [Agent plan pricing](/docs/introduction/agent-plan#pricing)). Implement branch cleanup for temporary development branches to stay within limits.
 </Admonition>
 
 Example creating a development branch using the [Create branch](/docs/reference/api/branches/create-project-branch) API:
@@ -540,7 +540,7 @@ All platform integrations use the Neon API. You can call it directly or use lang
 
 ## Cost management
 
-- **Free organization**: No charges to you for up to 30,000 free tier projects (Neon-sponsored).
+- **Free organization**: No charges to you for free-tier projects (Neon-sponsored). Project limits are unlimited; we incrementally raise your limit to accommodate growing usage.
 - **Paid organization**: Usage-based billing at $0.106 per compute unit hour, covered by your initial credits. See [Agent plan pricing](/docs/introduction/agent-plan#pricing).
 - **Monitor usage**: Track `active_time_seconds`, `compute_time_seconds`, `written_data_bytes`, `synthetic_storage_size_bytes` using [project metrics API](/docs/reference/api/consumption/get-consumption-history-per-project). Poll every 15 minutes; doesn't wake computes. See [Query consumption metrics](/docs/guides/consumption-metrics).
 - **Set quotas**: Configure usage limits during [project creation](#provisioning-projects) or update later. See [Configure consumption limits](/docs/guides/consumption-limits).

--- a/content/docs/guides/ai-agent-integration.md
+++ b/content/docs/guides/ai-agent-integration.md
@@ -83,14 +83,14 @@ Each organization has different limits that apply to all projects created within
 | Limit                    | Free Organization | Paid Organization | Notes                                                                                     |
 | ------------------------ | ----------------- | ----------------- | ----------------------------------------------------------------------------------------- |
 | **Max branches**         | 10 per project    | Up to 1,000       | Includes all branches (production, development, snapshots)                                |
-| **Max manual snapshots** | 1 per project     | 100 per project   | Manual snapshots only. Automated snapshot schedules are not available on the Agent plan.  |
+| **Max manual snapshots** | 1 per project     | 100 per project   | Manual snapshots only. Automated snapshot schedules are available upon request on the Agent plan. |
 | **Compute range**        | 0.25 - 2 CU       | 0.25 - 16 CU      | CU = Compute Units (~4GB RAM per CU). Fixed sizes up to 16 CU (Scale allows up to 56 CU). |
 | **History window**       | 1 day             | Up to 7 days      | Point-in-time recovery window (Scale allows up to 30 days)                                |
 | **Min auto-suspend**     | 5 minutes         | 1 minute          | Minimum time before compute suspends                                                      |
 
 **Key constraints to consider:**
 
-- **Manual snapshot limits**: Free projects can only maintain 1 manual snapshot at a time, while paid projects can keep up to 100. Automated snapshot schedules are not available on the Agent plan. This significantly impacts versioning strategies.
+- **Manual snapshot limits**: Free projects can only maintain 1 manual snapshot at a time, while paid projects can keep up to 100. Automated snapshot schedules are available upon request on the Agent plan.
 - **Branch limits**: Free projects are limited to 10 branches total, so you'll need to implement cleanup for development branches and temporary snapshots. Paid projects support up to 1,000 branches.
 - **Compute limits**: Free projects can autoscale up to 2 CU, while paid projects can scale up to 16 CU for more demanding workloads.
 

--- a/content/docs/guides/backup-restore.md
+++ b/content/docs/guides/backup-restore.md
@@ -16,7 +16,7 @@ updatedOn: '2026-08-05T22:15:40.109Z'
 ---
 
 <Admonition type="note" title="Snapshots">
-The **Snapshots** feature is available to all users. Manual snapshot limits: 1 on the Free plan and 100 on paid plans. On paid plans, snapshots created by backup schedules do not count toward this limit. Automated backup schedules are available on paid plans except for the Agent plan. If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
+The **Snapshots** feature is available to all users. Manual snapshot limits: 1 on the Free plan and 100 on paid plans. On paid plans, snapshots created by backup schedules do not count toward this limit. Automated backup schedules are available on paid plans; on the Agent plan, they are available upon request. If you need higher limits, please reach out to [Neon support](/docs/introduction/support).
 
 **Pricing:** Snapshot storage is billed at $0.09/GB-month.
 

--- a/content/docs/introduction/agent-plan.md
+++ b/content/docs/introduction/agent-plan.md
@@ -98,7 +98,6 @@ Agent and Scale are different plans. Enrollment starts from Scale, but after you
 | Instant restore history window | Up to 7 days | Up to 30 days |
 | Public network transfer | 100 GB per project included, then $0.10/GB | 500 GB per project included, then $0.10/GB |
 | Automated snapshot schedules | Available upon request | Available |
-| Storage and project update notifications | Not available | Available |
 
 Both plans include metrics/logs export, SOC 2 reporting, private networking, and configurable scale-to-zero. For the full Scale feature list, see [Neon plans](/docs/introduction/plans).
 

--- a/content/docs/introduction/agent-plan.md
+++ b/content/docs/introduction/agent-plan.md
@@ -97,7 +97,7 @@ Agent and Scale are different plans. Enrollment starts from Scale, but after you
 | Read replicas | Up to 3 | Unlimited |
 | Instant restore history window | Up to 7 days | Up to 30 days |
 | Public network transfer | 100 GB per project included, then $0.10/GB | 500 GB per project included, then $0.10/GB |
-| Automated snapshot schedules | Not available | Available |
+| Automated snapshot schedules | Available upon request | Available |
 | Storage and project update notifications | Not available | Available |
 
 Both plans include metrics/logs export, SOC 2 reporting, private networking, and configurable scale-to-zero. For the full Scale feature list, see [Neon plans](/docs/introduction/plans).

--- a/content/docs/introduction/agent-plan.md
+++ b/content/docs/introduction/agent-plan.md
@@ -2,15 +2,15 @@
 title: Neon Agent Plan
 subtitle: Learn about using Neon to provision and manage databases for agentic platforms
 summary: >-
-  The Neon Agent Plan is a purpose-built pricing tier for platforms that
-  provision and manage Postgres databases for end users at scale. It is
-  organized into sponsored organizations (free and paid), each supporting up to
-  30,000 projects by default. Platforms building multi-tenant SaaS or agentic
-  applications choose this plan for sponsored free-tier infrastructure and up
-  to $25,000 in paid-tier credits. Compute is billed at $0.106 per compute unit
-  hour. Enrollment requires an active Neon Scale plan and team approval. All
-  provisioning and fleet management runs through the Neon API, with
-  autoscaling, scale-to-zero, branching, and point-in-time recovery included.
+  The Neon Agent Plan is a pricing tier for platforms that provision and manage
+  Postgres databases for end users at scale. It is organized into sponsored
+  organizations (free and paid) with unlimited projects. Platforms building
+  multi-tenant SaaS or agentic applications choose this plan for sponsored
+  free-tier infrastructure and up to $25,000 in paid-tier credits. Compute is
+  billed at $0.106 per compute unit hour. Enrollment requires an active Neon
+  Scale plan and team approval. All provisioning and fleet management runs
+  through the Neon API, with autoscaling, scale-to-zero, branching, and
+  point-in-time recovery included.
 enableTableOfContents: true
 updatedOn: '2026-08-17T12:17:37.017Z'
 ---
@@ -18,7 +18,7 @@ updatedOn: '2026-08-17T12:17:37.017Z'
 <InfoBlock>
 <DocsList title="What you will learn:">
 <p>How the agent plan is organized</p>
-<p>How the agent plan works</p>
+<p>How Agent differs from Scale</p>
 <p>How to get started</p>
 </DocsList>
 <DocsList title="Related topics" theme="docs">
@@ -31,7 +31,9 @@ updatedOn: '2026-08-17T12:17:37.017Z'
 
 ## Overview
 
-The Neon agent plan provides infrastructure for platforms that deploy Postgres databases on behalf of end users. The plan uses a two-organization structure to separate free and paid user tiers, with each organization supporting up to 30,000 projects by default. You can request limit increases as your platform scales.
+The Neon agent plan provides infrastructure for platforms that deploy Postgres databases on behalf of end users. The plan uses a two-organization structure to separate free and paid user tiers, with unlimited projects in each organization. We incrementally raise your limit to accommodate growing usage.
+
+Agent plan pricing and limits differ from the [Scale plan](/docs/introduction/plans). Agent is optimized for high project volume at Launch-rate compute pricing, with some Scale features and limits adjusted for fleet-style workloads.
 
 ## Why Neon for agent platforms
 
@@ -68,28 +70,48 @@ Neon creates two organizations in your account:
 
 ### Free organization
 
-This sponsored free organization hosts databases for your free-tier users at no cost to you; Neon sponsors the infrastructure. This organization includes Neon Scale plan features, but individual projects have resource limits similar to Neon's standard free tier.
+This sponsored free organization hosts databases for your free-tier users at no cost to you; Neon sponsors the infrastructure. Individual projects have resource limits similar to Neon's standard free tier.
 
 You are not charged for usage in this organization. Use this for users who haven't upgraded to your platform's paid plans. This means your free tier is truly free, with no database infrastructure costs passed to you.
 
-For an overview of Free plan limits and Scale plan features, see [Neon plans](/docs/introduction/plans).
+For an overview of Free plan limits, see [Neon plans](/docs/introduction/plans).
 
 ### Paid organization
 
-The paid organization hosts databases for your paying users. This organization includes Scale plan features but with agent-specific pricing. Neon provides up to $25,000 in initial credits to cover usage charges.
+The paid organization hosts databases for your paying users with Agent plan pricing and limits. Neon provides up to $25,000 in initial credits to cover usage charges.
 
-Compute is billed at $0.106 per compute unit hour (lower than standard Scale pricing). You can create your own internal tier/plan structure within this organization, configuring different resource quotas for different user segments. Use this organization for users on your paid plans that need resource flexibility.
+Compute is billed at $0.106 per compute unit hour (Launch rate, lower than Scale). You can create your own internal tier/plan structure within this organization, configuring different resource quotas for different user segments. Use this organization for users on your paid plans that need resource flexibility.
+
+## Agent vs Scale
+
+Agent and Scale are different plans. Enrollment starts from Scale, but after you join Agent your organizations use Agent pricing and limits.
+
+| Feature | Agent plan | Scale plan |
+| ------- | ---------- | ---------- |
+| Projects | Unlimited. We incrementally raise your limit to accommodate growing usage. | 1,000 (can be increased on request) |
+| Compute | $0.106 per CU-hour | $0.222 per CU-hour |
+| Max fixed compute size | 16 CU | 56 CU |
+| Autoscaling | Up to 16 CU | Up to 16 CU |
+| Branches per project | Up to 1,000 | Up to 5,000 |
+| Root branches per project | 5 | 25 |
+| Read replicas | Up to 3 | Unlimited |
+| Instant restore history window | Up to 7 days | Up to 30 days |
+| Public network transfer | 100 GB per project included, then $0.10/GB | 500 GB per project included, then $0.10/GB |
+| Automated snapshot schedules | Not available | Available |
+| Storage and project update notifications | Not available | Available |
+
+Both plans include metrics/logs export, SOC 2 reporting, private networking, and configurable scale-to-zero. For the full Scale feature list, see [Neon plans](/docs/introduction/plans).
 
 ## Managing projects
 
-After initial enrollment, you have full control over both organizations as admin. Each organization supports 30,000 projects by default. All project operations are performed through the [Neon API](/docs/reference/api), enabling fleet management at scale with small engineering teams. You can:
+After initial enrollment, you have full control over both organizations as admin. Project limits are unlimited; we incrementally raise your limit to accommodate growing usage. All project operations are performed through the [Neon API](/docs/reference/api), enabling fleet management at scale with small engineering teams. You can:
 
 - Create and delete projects in either organization
 - Set per-project resource quotas and billing limits
 - Monitor compute, storage, and network usage across all projects
 - Track consumption metrics for building usage-based billing
 
-The API-first approach means you can provision and manage thousands of databases programmatically without manual intervention. When you need to scale beyond the default limits, you can request increases through your Neon contact.
+The API-first approach means you can provision and manage thousands of databases programmatically without manual intervention.
 
 ### Project transfers between organizations
 
@@ -99,15 +121,16 @@ See [transfer projects between organizations](/docs/manage/orgs-project-transfer
 
 ## Pricing
 
-The agent plan uses usage-based, agent-specific pricing with custom limits and dedicated support:
+The agent plan uses usage-based pricing with dedicated support. See [Agent vs Scale](#agent-vs-scale) for how limits compare to Scale.
 
 | Resource                        | Agent plan                                                                                            |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Projects                        | **Custom limits available** <br/> _Agents create a new project for each user application._            |
-| Branches per Project            | **Custom limits available** <br/> _Agents use branches to quickly toggle between application states._ |
-| Compute                         | **$0.106 per compute unit hour** <br/> _Usage-based pricing for agent-specific workloads_             |
-| Storage                         | **$0.35 per GB-month** <br/> _Standard storage pricing_                                               |
-| Instant Restore (PITR)          | **$0.2 per GB-month** <br/> _Point-in-time recovery storage_                                          |
+| Projects                        | **Unlimited** <br/> _We incrementally raise your limit to accommodate growing usage._                 |
+| Branches per Project            | **Up to 1,000** <br/> _Agents use branches to quickly toggle between application states._             |
+| Compute                         | **$0.106 per compute unit hour** <br/> _Same rate as Launch; lower than Scale_                        |
+| Storage                         | **$0.35 per GB-month** <br/> _Same as Launch and Scale_                                               |
+| Instant Restore (PITR)          | **$0.2 per GB-month** <br/> _Up to 7-day history window_                                              |
+| Public network transfer         | **100 GB per project included**, then $0.10/GB                                                        |
 | Management API                  | **Higher Rate Limits Available** <br/> _API for instant provisioning and management of databases_     |
 | Data API (PostgREST-compatible) | **Higher Rate Limits Available** <br/> _REST API for direct database access_                          |
 | Support                         | **Shared Slack Channel** <br/> _Direct access to the Neon team_                                       |
@@ -130,7 +153,7 @@ The agent plan includes these benefits for participating platforms:
 
 | Benefit                    | Description                                                                                                                                 |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Your Free Tier is free** | Neon sponsors up to 30,000 projects in your free tier, covering all infrastructure costs.                                                   |
+| **Your Free Tier is free** | Neon sponsors projects in your free tier, covering infrastructure costs. Project limits are unlimited; we incrementally raise your limit to accommodate growing usage. |
 | **General use credits**    | Up to $25,000 in credits for paid tier usage (for platforms not already enrolled in the [Neon Startup Program](https://neon.com/startups)). |
 | **Higher rate limits**     | Custom rate limits for Management API and Data API to support high-volume operations.                                                       |
 | **Dedicated support**      | Shared Slack channel with direct access to the Neon team for technical support.                                                             |

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -35,7 +35,7 @@ Start for free, then **pay only for what you use** as your needs grow.
 Compare Neon's **Free**, **Launch**, and **Scale** plans.
 
 <Admonition type="comingSoon" title="Building an agent platform?">
-For AI agent platforms that provision thousands of databases, Neon offers an **Agent Plan** with custom resource limits and credits for **your** free tier. [Learn more](/docs/introduction/agent-plan)
+For AI agent platforms that provision thousands of databases, Neon offers an **Agent Plan** with unlimited projects, Launch-rate compute, and credits for **your** free tier. Agent limits differ from Scale. [Learn more](/docs/introduction/agent-plan)
 </Admonition>
 
 | Plan feature                                          | **Free**                                   | **Launch**                                 | **Scale**                                                                                         |

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -315,7 +315,7 @@ Manual snapshot limits per plan:
 
 For billing, manual snapshots are charged as full snapshots. Scheduled snapshots are charged as full snapshots for the first snapshot in a schedule, then as incremental (delta) storage for subsequent snapshots in that schedule.
 
-Automated backup schedules are available on paid plans except for the Agent plan. See [Backup & restore](/docs/guides/backup-restore) for details.
+Automated backup schedules are available on paid plans. On the Agent plan, they are available upon request. See [Backup & restore](/docs/guides/backup-restore) for details.
 
 ### Auth
 

--- a/content/pages/programs/agents.md
+++ b/content/pages/programs/agents.md
@@ -60,7 +60,7 @@ Agent plan pricing and limits differ from [Scale](/docs/introduction/plans). You
 | Root branches | 5 | 25 |
 | Instant restore window | Up to 7 days | Up to 30 days |
 | Public network included | 100 GB/project | 500 GB/project |
-| Automated snapshot schedules | Not available | Available |
+| Automated snapshot schedules | Available upon request | Available |
 
 For the full comparison, see the [Agent Plan docs](/docs/introduction/agent-plan#agent-vs-scale).
 

--- a/content/pages/programs/agents.md
+++ b/content/pages/programs/agents.md
@@ -30,21 +30,39 @@ If you're building agents that generate apps from prompts, your users want to bu
 
 ## Agent Plan Pricing
 
+Agent plan pricing and limits differ from [Scale](/docs/introduction/plans). You enroll from Scale, then move to Agent for Launch-rate compute, unlimited projects, and fleet-oriented limits.
+
 |                                 | Agent Plan                                                                                            |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Projects                        | **Custom limits available** <br/> _Agents create a new project for each user application._            |
-| Branches per Project            | **Custom limits available** <br/> _Agents use branches to quickly toggle between application states._ |
-| Compute                         | from **$0.106 per CU-hour** <br/> _Same as Launch_                                                    |
+| Projects                        | **Unlimited** <br/> _We incrementally raise your limit to accommodate growing usage._                 |
+| Branches per Project            | **Up to 1,000** <br/> _Agents use branches to quickly toggle between application states._             |
+| Compute                         | from **$0.106 per CU-hour** <br/> _Same as Launch; lower than Scale_                                  |
 | Storage                         | **$0.35 per GB-month** <br/> _Same as Launch/Scale_                                                   |
-| Instant Restore (PITR)          | **$0.2 per GB-month** <br/> _Same as Launch/Scale_                                                    |
+| Instant Restore (PITR)          | **$0.2 per GB-month** <br/> _Up to 7-day history window (Scale allows up to 30 days)_                  |
+| Public network transfer         | **100 GB per project included**, then $0.10/GB <br/> _Scale includes 500 GB_                          |
 | Neon Auth                       | **Included** <br/> _All-in-one API for handling user signup and management in Neon_                   |
 | Management API                  | **Higher Rate Limits Available** <br/> _API for instant provisioning and management of databases_     |
 | Data API (PostgREST-compatible) | **Higher Rate Limits Available**                                                                      |
 | Support                         | **Shared Slack Channel**                                                                              |
 | <br/>**Agent Incentives**       |                                                                                                       |
-| **Your Free Tier is Free**      | Neon pays for up to 30,000 projects/month used in your free tier.                                     |
+| **Your Free Tier is Free**      | Neon pays for projects used in your free tier. Unlimited projects; we incrementally raise your limit to accommodate growing usage. |
 | **General Use Credits**         | Up to $25K in credits for those not eligible for the [Startup Program](/startups).                    |
 | **Co-Marketing**                | Blog and Social promotions, hackathons and more.                                                      |
+
+### How Agent differs from Scale
+
+| Feature | Agent | Scale |
+| ------- | ----- | ----- |
+| Projects | Unlimited. We incrementally raise your limit to accommodate growing usage. | 1,000 |
+| Compute | $0.106/CU-hour | $0.222/CU-hour |
+| Max fixed compute | 16 CU | 56 CU |
+| Read replicas | Up to 3 | Unlimited |
+| Root branches | 5 | 25 |
+| Instant restore window | Up to 7 days | Up to 30 days |
+| Public network included | 100 GB/project | 500 GB/project |
+| Automated snapshot schedules | Not available | Available |
+
+For the full comparison, see the [Agent Plan docs](/docs/introduction/agent-plan#agent-vs-scale).
 
 <QuoteBlock quote="Integrating Neon was a no-brainer. It gives every Databutton app a production-grade Postgres database in seconds, with zero overhead. Our AI agent can now create, manage, and debug the entire stack, not just code." author="martin-skow-røed" role="CTO and co-founder of Databutton" />
 


### PR DESCRIPTION
## Summary
- Clarifies that the Agent plan is not Scale with discounted compute: pricing and limits differ after enrollment
- Documents key Agent vs Scale differences (compute rate, restore window, fixed CU, read replicas, root branches, included egress, snapshot schedules)
- Characterizes Agent project limits as unlimited, with incremental raises to accommodate growing usage
- Updates the Agent program page, Agent plan docs, integration guide, and plans callout for consistency

## Test plan
- [ ] Preview `/programs/agents` pricing and Agent vs Scale sections
- [ ] Preview `/docs/introduction/agent-plan` (Agent vs Scale + pricing tables)
- [ ] Spot-check `/docs/guides/ai-agent-integration` for aligned project/branch limit language
- [ ] Confirm `/docs/introduction/plans` Agent plan callout links correctly