### PR TITLE
docs: surface 'serverless functions' in Neon Functions

### DIFF
--- a/content/changelog/2026-05-29.md
+++ b/content/changelog/2026-05-29.md
@@ -10,10 +10,10 @@ We're excited to announce that Neon is building a complete backend for apps and 
 - [Neon Auth](/docs/auth/overview) — ✅ Available
 - [Data API](/docs/data-api/overview) — ✅ Available
 - Object Storage — 🔜 Coming Soon
-- Compute — 🔜 Coming Soon
+- Functions — 🔜 Coming Soon
 - AI Gateway — 🔜 Coming Soon
 
-**Object Storage** is an S3-compatible object storage service that branches with your database, keeping data and files in sync across every branch. **Compute** is serverless compute deployed alongside your database. The **AI Gateway** is one API for frontier and open-source models, built on the same infrastructure that handles 125 trillion tokens per month on Databricks.
+**Object Storage** is an S3-compatible object storage service that branches with your database, keeping data and files in sync across every branch. **Functions** are long-running serverless functions deployed alongside your database. The **AI Gateway** is one API for frontier and open-source models, built on the same infrastructure that handles 125 trillion tokens per month on Databricks.
 
 Read the [full announcement](https://neon.com/blog/were-building-backends) and [sign up for early access](https://console.neon.tech/app/settings/early-access) to be among the first to try each service as it becomes available.
 

--- a/content/changelog/2026-06-05.md
+++ b/content/changelog/2026-06-05.md
@@ -10,7 +10,7 @@ As [announced last week](/docs/changelog/2026-05-29#neon-is-building-the-backend
 
 <a description="S3-compatible object storage that branches with your database. Every branch gets its own isolated storage state, so files and data stay in sync across dev, staging, and production." icon="data">Object Storage</a>
 
-<a description="Serverless functions that run alongside your Postgres database. Deploy code, trigger jobs asynchronously, and manage everything through the same CLI and API you already use." icon="code">Compute</a>
+<a description="Long-running serverless functions that run alongside your Postgres database. Deploy code, trigger jobs asynchronously, and manage everything through the same CLI and API you already use." icon="code">Functions</a>
 
 <a description="One API for frontier and open-source models from Anthropic, OpenAI, Google, and more, built into your Neon project. Streaming responses and per-request logging included. No extra infrastructure required." icon="sparkle">AI Gateway</a>
 

--- a/content/changelog/2026-06-12.md
+++ b/content/changelog/2026-06-12.md
@@ -7,7 +7,7 @@ title: Lakebase Search, CLI updates, and more
 Three new services are now available in beta on Neon.
 
 - **Object Storage**: S3-compatible object storage that branches with your database
-- **Compute**: Serverless functions that run alongside Postgres
+- **Functions**: Long-running serverless functions that run alongside Postgres
 - **AI Gateway**: One API for frontier and open-source models from Anthropic, OpenAI, Google, and more, built into your Neon project
 
 ## Lakebase Search (Private Preview)

--- a/content/changelog/2026-07-17.md
+++ b/content/changelog/2026-07-17.md
@@ -12,7 +12,7 @@ Declare your whole backend in one `neon.ts` file, and it branches with your data
 
 <a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data">Object Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running serverless compute that runs alongside your database." icon="code">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running serverless functions that run alongside your database." icon="code">Functions</a>
 
 <a href="/docs/ai-gateway/overview" description="One API for frontier and open-source models, built into your project." icon="sparkle">AI Gateway</a>
 

--- a/content/changelog/2026-07-24.md
+++ b/content/changelog/2026-07-24.md
@@ -66,7 +66,7 @@ See the [`neon projects` reference](/docs/cli/projects) for the full list of fla
 
 ## Query Functions and Storage logs from the Neon MCP server
 
-[Functions](/docs/compute/functions/overview) and [Object Storage](/docs/storage/overview) are core pieces of the [Neon backend](/docs/get-started/backend-overview): serverless compute and S3-compatible storage that branch with your database in the same project. You can now query logs from both services directly through the [Neon MCP server](/docs/ai/neon-mcp-server), so your AI assistant can investigate a failure without leaving your editor. Three new read-only tools make up the `observability` category:
+[Functions](/docs/compute/functions/overview) and [Object Storage](/docs/storage/overview) are core pieces of the [Neon backend](/docs/get-started/backend-overview): serverless functions and S3-compatible storage that branch with your database in the same project. You can now query logs from both services directly through the [Neon MCP server](/docs/ai/neon-mcp-server), so your AI assistant can investigate a failure without leaving your editor. Three new read-only tools make up the `observability` category:
 
 - `query_logs`: filter logs by source, service, severity, or a text match over a time window (or drop down to raw LogQL for full control).
 - `list_log_fields`: discover the fields you can filter on.

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -2,12 +2,12 @@
 title: Get started with Neon Functions
 subtitle: Deploy your first Neon Function and call it over HTTP.
 summary: >-
-  Deploy your first Neon Function with neon: initialize a project, define
-  the function in neon.ts, develop locally with neon dev, and deploy with
-  neon deploy. The function gets a public HTTPS URL with DATABASE_URL
-  injected from the branch's Postgres database.
+  Deploy your first Neon Function, a long-running serverless function that runs on your Neon
+  branch: initialize a project, define the function in neon.ts, develop locally
+  with neon dev, and deploy with neon deploy. The function gets a public HTTPS
+  URL with DATABASE_URL injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-08-03T21:34:20.270Z'
+updatedOn: '2026-08-18T17:01:39.853Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -1,17 +1,17 @@
 ---
 title: Neon Functions
-subtitle: Deploy a backend onto your Neon branch, next to your data.
+subtitle: Long-running serverless functions on your Neon branch, next to your data.
 summary: >-
-  Neon Functions are serverless compute you deploy onto a Neon branch. Host an
-  API, AI agent, real-time server, or webhook handler that runs next to your
+  Neon Functions are long-running serverless functions you deploy onto a Neon branch. Host
+  an API, AI agent, real-time server, or webhook handler that runs next to your
   Postgres data, with DATABASE_URL injected automatically.
 enableTableOfContents: true
 redirectFrom:
   - /docs/compute/functions/preview-access
-updatedOn: '2026-07-16T13:37:43.975Z'
+updatedOn: '2026-08-18T17:01:39.853Z'
 ---
 
-Neon Functions are serverless compute you deploy onto a Neon branch, so your backend code runs right next to your database. Use them to host an API, an AI agent, a real-time server, or a webhook handler without standing up separate infrastructure.
+Neon Functions are serverless functions you deploy onto a Neon branch, so your backend code runs right next to your database. Use them to host an API, an AI agent, a real-time server, or a webhook handler without standing up separate infrastructure.
 
 What makes Neon Functions different from lambda-style serverless?
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-08-15T10:47:27.123Z'
+updatedOn: '2026-08-18T16:41:42.467Z'
 ---
 
 ## Getting started
@@ -53,7 +53,7 @@ Every service is agent-ready: instant, branchable, and serverless.
 
 <a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Beta" tagTheme="orange-muted">Object Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Beta" tagTheme="orange-muted">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running serverless functions on Node.js, deployed alongside your database." icon="code" tag="Beta" tagTheme="orange-muted">Functions</a>
 
 <a href="/docs/ai-gateway/overview" description="One API for frontier and open-source models, built into your Neon project." icon="sparkle" tag="Beta" tagTheme="orange-muted">AI Gateway</a>
 

--- a/content/docs/manage/platform.md
+++ b/content/docs/manage/platform.md
@@ -9,7 +9,7 @@ summary: >-
   observability, security and compliance, and operations and maintenance.
   Use this page to find the right sub-topic when you know the management
   area but not the specific doc.
-updatedOn: '2026-07-31T15:27:48.506Z'
+updatedOn: '2026-08-18T16:41:42.467Z'
 ---
 
 ## The Neon platform, in brief
@@ -26,7 +26,7 @@ Neon is a full backend platform for apps and agents, not just a database. For an
 
 <a href="/docs/storage/overview" description="S3-compatible object storage that branches with your database." icon="data" tag="Beta" tagTheme="orange-muted">Object Storage</a>
 
-<a href="/docs/compute/functions/overview" description="Long-running Node.js compute, deployed alongside your database." icon="code" tag="Beta" tagTheme="orange-muted">Functions</a>
+<a href="/docs/compute/functions/overview" description="Long-running serverless functions on Node.js, deployed alongside your database." icon="code" tag="Beta" tagTheme="orange-muted">Functions</a>
 
 <a href="/docs/ai-gateway/overview" description="One API for frontier and open-source models, built into your Neon project." icon="sparkle" tag="Beta" tagTheme="orange-muted">AI Gateway</a>
 

--- a/content/guides/neon-functions-github-actions.md
+++ b/content/guides/neon-functions-github-actions.md
@@ -4,10 +4,10 @@ subtitle: 'Set up CI/CD for Neon Functions: deploy to production on merge and cr
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-08-06T00:00:00.000Z'
-updatedOn: '2026-08-10T23:26:27.219Z'
+updatedOn: '2026-08-18T17:01:39.853Z'
 ---
 
-[Neon Functions](/docs/compute/functions/overview) are serverless compute you deploy onto a Neon branch, so your backend runs right next to your Postgres database. Each branch runs its own function at its own URL against its own database state, with `DATABASE_URL` injected automatically. That makes them a natural fit for a workflow where every environment gets its own isolated function.
+[Neon Functions](/docs/compute/functions/overview) are long-running serverless functions you deploy onto a Neon branch, so your backend runs right next to your Postgres database. Each branch runs its own function at its own URL against its own database state, with `DATABASE_URL` injected automatically. That makes them a natural fit for a workflow where every environment gets its own isolated function.
 
 The Neon CLI (`neon deploy`) lets you deploy a function to any branch with a single command. It works well for testing locally, but as a best practice you should never deploy to the production branch by hand or push changes to it directly. Instead, every change should go through a pull request that gets exercised in isolation first. Because a PR's preview branch runs the exact same code, config, and deploy command as production, merging it becomes a simple step: if it worked in preview, it works in production.
 


### PR DESCRIPTION
Applies the agreed Neon Functions naming convention.

- `docs/compute/functions/overview.md`, `get-started.md`: add "long-running serverless functions" to subtitle/summary
- `docs/introduction.md`, `docs/manage/platform.md`: Functions card description leads with "serverless functions"
- `changelog/2026-07-17.md`, `2026-07-24.md`, `guides/neon-functions-github-actions.md`: "serverless compute" -> "(long-running) serverless functions" where it describes the product
- `changelog/2026-05-29.md`, `2026-06-05.md`, `2026-06-12.md`: old pre-launch "Compute" name -> "Functions"

This pull request and its description were written by Isaac.