### PR TITLE
docs: adopt attachDatabasePool in Neon Functions examples

### DIFF
--- a/content/docs/compute/functions/agents.md
+++ b/content/docs/compute/functions/agents.md
@@ -6,7 +6,7 @@ summary: >-
   stream a response for minutes while the agent calls models and tools, with
   the Neon AI Gateway wired in automatically and Postgres next to your code.
 enableTableOfContents: true
-updatedOn: '2026-07-15T17:54:41.160Z'
+updatedOn: '2026-08-18T19:33:13.398Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -38,18 +38,22 @@ export default defineConfig({
 Install the AI SDK, the Neon provider, and `pg`:
 
 ```bash
-npm install ai @neon/ai-sdk-provider pg zod
+npm install ai@^7 @neon/ai-sdk-provider @neon/functions pg zod
 ```
+
+Pin `ai` to v7, the major `@neon/ai-sdk-provider` supports.
 
 The handler streams a tool-calling agent. The `@neon/ai-sdk-provider` reads the injected gateway credentials on its own, so `neon('<model>')` is the only model configuration you need. Tools run inside the function, right next to Postgres:
 
 ```ts filename="functions/agent.ts"
 import { neon } from '@neon/ai-sdk-provider';
+import { attachDatabasePool } from '@neon/functions';
 import { streamText, tool, stepCountIs, type ModelMessage } from 'ai';
 import { z } from 'zod';
 import { Pool } from 'pg';
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+attachDatabasePool(pool);
 
 export default {
   async fetch(request: Request) {
@@ -86,14 +90,9 @@ export default {
     });
   },
 };
-
-// Optional: drain the pool on shutdown (the platform sends SIGINT).
-process.on('SIGINT', () => {
-  pool.end().then(() => process.exit(0));
-});
 ```
 
-`tool({ inputSchema, execute })` is the AI SDK v5+ shape. Create the `pg` pool once at module scope so it's reused across requests (see [Connecting to Postgres](/docs/compute/functions/get-started#connect-to-postgres)). Pick any model from the [AI Gateway catalog](/docs/ai-gateway/models); swap `claude-sonnet-4-6` for a different one without changing anything else.
+`tool({ inputSchema, execute })` is the AI SDK v5+ shape. Create the `pg` pool once at module scope so it's reused across requests, and call `attachDatabasePool(pool)` so an idle disconnect can't crash the isolate (see [Connecting to Postgres](/docs/compute/functions/get-started#connect-to-postgres)). Pick any model from the [AI Gateway catalog](/docs/ai-gateway/models); swap `claude-sonnet-4-6` for a different one without changing anything else.
 
 Deploy and call it. `toUIMessageStreamResponse()` returns a stream the AI SDK's `useChat` hook consumes directly:
 

--- a/content/docs/compute/functions/authentication.md
+++ b/content/docs/compute/functions/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Auth JWT against the injected JWKS, check an API key, and add CORS when the
   browser calls the function directly.
 enableTableOfContents: true
-updatedOn: '2026-07-15T17:54:41.160Z'
+updatedOn: '2026-08-18T19:33:13.398Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -80,7 +80,8 @@ export default {
     if (request.method === 'OPTIONS') {
       return new Response(null, { status: 204, headers: cors(request) });
     }
-    // ... verify the JWT as above, then return responses with cors(request) headers
+    // ... verify the JWT as above, then do the work ...
+    return Response.json({ ok: true }, { headers: cors(request) });
   },
 };
 ```

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -7,7 +7,7 @@ summary: >-
   with neon dev, and deploy with neon deploy. The function gets a public HTTPS
   URL with DATABASE_URL injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-08-18T17:01:39.853Z'
+updatedOn: '2026-08-18T19:33:13.398Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -120,7 +120,7 @@ The slug is permanent: it can't be renamed after the first deploy. See the [neon
 Install dependencies:
 
 ```bash
-npm install @neon/config hono pg
+npm install @neon/config @neon/functions hono pg
 npm install --save-dev @types/pg
 ```
 
@@ -144,10 +144,12 @@ A Hono app exports the object shape, so `export default app` works directly. For
 
 ```ts filename="functions/hello.ts"
 import { Hono } from 'hono';
+import { attachDatabasePool } from '@neon/functions';
 import { Pool } from 'pg';
 
 // Create the pool once at module scope so it's reused across requests.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+attachDatabasePool(pool);
 const app = new Hono();
 
 app.get('/', async (c) => {
@@ -156,17 +158,14 @@ app.get('/', async (c) => {
 });
 
 export default app;
-
-// Optional: drain the pool on shutdown (the platform sends SIGINT).
-process.on('SIGINT', () => {
-  pool.end().then(() => process.exit(0));
-});
 ```
 
 <a id="connect-to-postgres"></a>
 
 <Admonition type="important" title="Use a connection pool, not the serverless driver">
 A function keeps running across requests, so connect to Postgres with a long-lived `pg` `Pool` created once at module scope. Don't use `@neondatabase/serverless` here: it's built for short-lived, edge-style invocations that open a connection per request, which wastes the persistent runtime a function gives you. Use the pooled `DATABASE_URL` for queries; use `DATABASE_URL_UNPOOLED` only where you need a dedicated connection (such as `LISTEN`/`NOTIFY`).
+
+Call `attachDatabasePool(pool)` once after creating the pool (requires `@neon/functions` 0.8.0 or later). When Postgres drops an idle client (scale-to-zero, pooler reclaim, a TCP reset), `pg` emits an `error` on the pool; with no listener attached, that becomes an uncaught exception and the isolate exits. `attachDatabasePool` swallows expected idle disconnects and logs anything unexpected. The pool has already discarded the dead client, so the next query opens a fresh connection. You don't need to drain the pool on shutdown: when the runtime evicts an isolate, Neon's pooler reclaims those connections for you.
 </Admonition>
 
 ## Develop locally

--- a/content/docs/compute/functions/logs.md
+++ b/content/docs/compute/functions/logs.md
@@ -5,7 +5,8 @@ summary: >-
   View a deployed function's logs in the Neon Console: standard output and
   standard error from your handler, plus a platform-emitted invoke begin /
   invoke end line around each request. Covers the console-method-to-level
-  mapping and common log entries that look like a problem but aren't.
+  mapping, common log entries that look like a problem but aren't, and
+  wiring up application instrumentation like Sentry or OpenTelemetry.
 enableTableOfContents: true
 ---
 
@@ -59,6 +60,18 @@ It's a `pg` (node-postgres) deprecation warning, not a connection problem: the i
 **Requests not showing up in your logs at all? Check the invocation URL and branch, not the logs.** A wrong branch, a typo'd slug, or a momentary control-plane hiccup returns a 404 or 503 straight to the caller and never reaches your function's log stream, because the platform hasn't resolved which function to attribute logs to yet. If you expect traffic and see nothing, the request likely never reached your function.
 
 **Function not starting after a deploy? Read the response body, not the logs.** A missing entry point, an import that throws at load time, or a default export of the wrong shape returns a `function_load_failed` error with your actual error message in the response body of the failed request, not as a log line. Check the response you got back from calling the function, not the Logs tab.
+
+## Application instrumentation
+
+A function is a long-lived Node.js process, so standard Node monitoring SDKs like [Sentry](https://sentry.io) and [OpenTelemetry](https://opentelemetry.io) work unchanged. Initialize the SDK once at module load, before your handler starts serving requests, so the whole isolate is instrumented. Gate it on an environment variable (the SDK's DSN or endpoint) so local `neon dev` runs and branches without the secret configured stay a no-op, then pass the SDK's secret at deploy time as a [user-defined variable](/docs/compute/functions/environment-variables#user-defined-variables).
+
+Neon sends `SIGINT`/`SIGTERM` before evicting an idle isolate, so flush buffered telemetry in a shutdown handler or the last events are lost:
+
+```ts
+process.on('SIGINT', () => void Sentry.flush(2000));
+```
+
+`neon deploy` bundles your code with esbuild, which defeats auto-instrumentation that patches modules at import time. If a library's spans are missing from a deployed function, that's the first thing to check.
 
 ## Filter, search, and retention
 

--- a/content/docs/compute/functions/reference/runtime-limits.md
+++ b/content/docs/compute/functions/reference/runtime-limits.md
@@ -6,7 +6,7 @@ summary: >-
   timeouts, slug constraints, and the Node.js 24 runtime. Functions are
   long-running but still serverless.
 enableTableOfContents: true
-updatedOn: '2026-07-15T11:08:18.153Z'
+updatedOn: '2026-08-18T19:33:13.398Z'
 ---
 
 Neon Functions run on Node.js 24.
@@ -15,7 +15,7 @@ Neon Functions run on Node.js 24.
 
 Neon Functions are long-running: you can host WebSocket servers, SSE endpoints, and agents that stream over HTTP without hitting a short execution timeout. They're still serverless. The platform shuts a function down when it's idle, with no open connections or pending `waitUntil` work, and can also evict and restart it for operational reasons. Treat eviction like a process restart: clients should reconnect when a connection drops.
 
-When the platform stops a function, it sends `SIGINT`. If the process is still running 5 seconds later, the platform forcibly stops the function. Handle `SIGINT` with `process.on('SIGINT', ...)` to close connections and flush in-flight work within that window. When the process exits, the OS closes its sockets, so dropped connections are usually detected without extra handling.
+When the platform stops a function, it sends `SIGINT`. If the process is still running 5 seconds later, the platform forcibly stops the function. Handle `SIGINT` with `process.on('SIGINT', ...)` to flush in-flight work within that window. You don't need to drain a `pg` pool: when the process exits, the OS closes its sockets and Neon's pooler reclaims those connections, so dropped connections are detected without extra handling.
 
 ## Timeouts
 

--- a/content/docs/compute/functions/websockets.md
+++ b/content/docs/compute/functions/websockets.md
@@ -6,7 +6,7 @@ summary: >-
   backends. Use WebSockets for two-way connections via an upgrade export, or
   server-sent events for one-way streams, and Postgres LISTEN/NOTIFY to
   broadcast across isolates.
-updatedOn: '2026-07-15T17:54:41.160Z'
+updatedOn: '2026-08-18T19:33:13.398Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -117,12 +117,16 @@ export default {
 
 WebSocket connections are local to the isolate they land on, so clients on different isolates can't communicate through shared memory.
 
-For broadcast, use Postgres `LISTEN/NOTIFY`. Each isolate maintains one `LISTEN` connection at module scope and a `Set` of its connected clients. When a message arrives via `NOTIFY`, every isolate broadcasts it to its clients, so all users receive it regardless of which isolate they landed on.
+One approach is Postgres `LISTEN/NOTIFY`. Each isolate maintains one `LISTEN` connection at module scope and a `Set` of its connected clients. When a message arrives via `NOTIFY`, every isolate broadcasts it to its clients, so all users receive it regardless of which isolate they landed on.
+
+<Admonition type="warning" title="LISTEN/NOTIFY disables scale to zero">
+The `LISTEN` client holds an idle connection open on every isolate, and an idle connection doesn't count as active traffic. [Scale to zero](/docs/introduction/scale-to-zero) suspends the compute on its normal timer and drops that connection, silently killing the feed. Only use `LISTEN`/`NOTIFY` on an always-on compute, with scale to zero disabled (a paid-plan setting). To keep scale to zero, poll Postgres on a short interval instead: each isolate re-reads new rows past a cursor and pushes them to its own clients, and polling stops when an isolate has no clients, so an idle compute still suspends.
+</Admonition>
 
 Install the additional dependencies:
 
 ```bash
-npm install pg
+npm install @neon/functions pg
 npm install --save-dev @types/pg
 ```
 
@@ -130,13 +134,18 @@ npm install --save-dev @types/pg
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { Hono } from 'hono';
+import { attachDatabasePool } from '@neon/functions';
 import { WebSocketServer, type WebSocket } from 'ws';
 import { Pool, Client } from 'pg';
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+attachDatabasePool(pool);
 
-// One dedicated LISTEN client per isolate.
+// One dedicated LISTEN client per isolate. Don't call attachDatabasePool on it:
+// that would swallow the idle drop that kills the feed. A plain error listener
+// keeps the isolate alive; the feed resumes when the isolate restarts.
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener.on('error', (err) => console.error('[listen]', err));
 listener
   .connect()
   .then(() => listener.query('LISTEN chat'))
@@ -172,11 +181,6 @@ export default {
     });
   },
 };
-
-// Optional: drain the pool and listener on shutdown (the platform sends SIGINT).
-process.on('SIGINT', () => {
-  Promise.allSettled([pool.end(), listener.end()]).then(() => process.exit(0));
-});
 ```
 
 <Admonition type="note">
@@ -283,7 +287,7 @@ For a complete example with JWT verification, Managed Better Auth integration, a
 
 ## Eviction and shutdown
 
-On shutdown the platform sends `SIGINT`, then forcibly stops the function 5 seconds later. Cleanup is optional: when the process exits, the OS closes its sockets, so dropped connections are usually detected without it. To shut down more gracefully, drain open resources in a `SIGINT` handler, as the LISTEN/NOTIFY example above does with `Promise.allSettled([pool.end(), listener.end()])`.
+On shutdown the platform sends `SIGINT`, then forcibly stops the function 5 seconds later. You don't need to drain the `pg` pool: when the process exits, the OS closes its sockets and Neon's pooler reclaims those connections. Use a `SIGINT` handler only to flush in-flight work that would otherwise be lost, such as clearing the heartbeat timer above.
 
 See [Runtime limits](/docs/compute/functions/reference/runtime-limits) for eviction and timeout behavior.
 

--- a/content/docs/get-started/full-backend-quickstart.md
+++ b/content/docs/get-started/full-backend-quickstart.md
@@ -365,13 +365,14 @@ A function keeps running across requests, so open a `pg` `Pool` once at module s
 <TwoColumnLayout.Block>
 
 ```bash filename="Terminal"
-npm install hono pg ai @neon/ai-sdk-provider zod
+npm install hono pg ai@^7 @neon/ai-sdk-provider @neon/functions zod
 npm install -D @types/pg
 ```
 
 ```typescript filename="functions/posts.ts"
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { attachDatabasePool } from '@neon/functions';
 import { Pool } from 'pg';
 import { neon } from '@neon/ai-sdk-provider';
 import { streamText, generateText, convertToModelMessages, tool, stepCountIs } from 'ai';
@@ -379,6 +380,8 @@ import { z } from 'zod';
 
 // Reused across requests. Use a pooled pg client, not the serverless driver.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+// Keep an idle disconnect from crashing the isolate.
+attachDatabasePool(pool);
 
 const app = new Hono();
 


### PR DESCRIPTION
## Overview

The Neon Functions docs examples reused a `pg.Pool` without an error listener, so an idle client dropped by Postgres (scale-to-zero, pooler reclaim, a TCP reset) surfaced as an uncaught exception and killed the isolate. This adopts `attachDatabasePool(pool)` from `@neon/functions` 0.8.0 across the pool examples, documents the concept in the Connecting to Postgres section, and drops the now-redundant SIGINT pool-drain handlers.

Auditing the examples against the updated `neon-functions` skill surfaced a few adjacent gaps, fixed here too: an Application instrumentation section (Sentry, OpenTelemetry) on the logs page, a scale-to-zero warning on the LISTEN/NOTIFY pattern, an `ai@^7` pin in the agent guides (npm's `ai@latest` currently resolves to a broken `0.0.0` snapshot), and a terminal return in the CORS example.

## Testing

Deployed all ten deployable examples to a live Neon branch and probed each; every one behaves as documented, and `attachDatabasePool` bundles and runs clean.

This pull request and its description were written by Isaac.
