### PR TITLE
docs: update Postgres compatibility table to latest minor versions

### DIFF
--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -13,7 +13,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/conceptual-guides/compatibility
-updatedOn: '2026-08-07T13:46:01.605Z'
+updatedOn: '2026-08-19T21:46:19.502Z'
 ---
 
 **Neon is Postgres**. However, as a managed Postgres service, there are some differences you should be aware of.
@@ -26,11 +26,11 @@ The table below lists the latest minor version available on Neon for each suppor
 
 | Major version | Latest minor version on Neon | Upstream release date |
 | ------------- | ---------------------------- | --------------------- |
-| 14            | PostgreSQL 14.23             | 2026-05-14            |
-| 15            | PostgreSQL 15.18             | 2026-05-14            |
-| 16            | PostgreSQL 16.14             | 2026-05-14            |
-| 17            | PostgreSQL 17.10             | 2026-05-14            |
-| 18            | PostgreSQL 18.4              | 2026-05-14            |
+| 14            | PostgreSQL 14.24             | 2026-08-13            |
+| 15            | PostgreSQL 15.19             | 2026-08-13            |
+| 16            | PostgreSQL 16.15             | 2026-08-13            |
+| 17            | PostgreSQL 17.11             | 2026-08-13            |
+| 18            | PostgreSQL 18.6              | 2026-08-13            |
 
 ## Postgres extensions
 


### PR DESCRIPTION
## What

Updates the Postgres version table on the [compatibility reference page](/docs/reference/compatibility) to the latest minor releases.

| Major | Was | Now |
| ----- | --- | --- |
| 14 | 14.23 | **14.24** |
| 15 | 15.18 | **15.19** |
| 16 | 16.14 | **16.15** |
| 17 | 17.10 | **17.11** |
| 18 | 18.4 | **18.6** |

Upstream release date updated from `2026-05-14` to `2026-08-13`.

## How I verified

Provisioned one Neon project per supported major version (14 through 18) and read the running `server_version` directly from each:

```
14 -> 14.24    15 -> 15.19    16 -> 16.15    17 -> 17.11    18 -> 18.6
```

Cross-checked against the upstream PostgreSQL release announcement (18.6, 17.11, 16.15, 15.19, 14.24 released August 13, 2026).

The temporary verification projects have been / will be cleaned up.

This pull request and its description were written by Isaac.
