### PR TITLE
docs: route unexpected Functions pool errors to Sentry

### DIFF
--- a/content/docs/compute/functions/logs.md
+++ b/content/docs/compute/functions/logs.md
@@ -71,6 +71,19 @@ Neon sends `SIGINT`/`SIGTERM` before evicting an idle isolate, so flush buffered
 process.on('SIGINT', () => void Sentry.flush(2000));
 ```
 
+To send unexpected database pool errors to your monitoring SDK, pass `onUnexpectedError` when you call [`attachDatabasePool`](/docs/compute/functions/get-started#connect-to-postgres). Expected idle disconnects are still swallowed; only unexpected errors reach the handler:
+
+```ts
+import { attachDatabasePool } from '@neon/functions';
+import { Pool } from 'pg';
+import { Sentry } from './instrument';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+attachDatabasePool(pool, {
+  onUnexpectedError: (err) => Sentry.captureException(err),
+});
+```
+
 `neon deploy` bundles your code with esbuild, which defeats auto-instrumentation that patches modules at import time. If a library's spans are missing from a deployed function, that's the first thing to check.
 
 ## Filter, search, and retention


### PR DESCRIPTION
Adds an `onUnexpectedError` example to the Neon Functions logs page, showing how to route unexpected `pg` pool errors to a monitoring SDK such as Sentry.

Reflects neondatabase/agent-skills#88.

## Live test

Verified against the published `@neon/functions@0.8.0`:

- **API surface:** the package exports `attachDatabasePool(pool, options?: { onUnexpectedError?: (err: Error) => unknown })`, so the documented signature is accurate.
- **Behavior:** attached to a fake pool and emitted errors. Expected idle disconnects (`ECONNRESET`, `EPIPE`, Postgres `57P01`, and `Connection terminated unexpectedly`) are swallowed; only a genuinely unexpected error is routed to `onUnexpectedError`. Result: exactly one error reached the handler, matching what the doc claims.

Not tested: a live Neon Function isolate (requires a deployed function on the backend beta).

This pull request and its description were written by Isaac.