### PR TITLE
docs: correct neon init agent skills content

### DIFF
--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -11,7 +11,7 @@ summary: >-
   files get created and where. The `--agent` flag targets a specific editor
   without the interactive prompt.
 enableTableOfContents: true
-updatedOn: '2026-08-21T13:32:28.984Z'
+updatedOn: '2026-08-21T13:36:10.536Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -30,7 +30,7 @@ npx neon@latest init
 
 After running the command, restart your editor and ask your AI assistant to "Get started with Neon" to launch an interactive onboarding guide. The installed agent skills help you get started, including configuring a database connection. For Cursor and VS Code, the Neon Local Connect extension also provides database schema browsing, SQL editing, and table data management directly in your IDE.
 
-Under the hood, `init` installs the Neon agent skills for each selected editor, running `npx skills add neondatabase/agent-skills --skill <name> --agent <name>` once per skill. You can also run these commands directly to install skills without the rest of the init flow, or use `npx skills add ... -g` to install globally. See [Agent Skills](/docs/ai/agent-skills) for the full list of skills and other ways to install them.
+`init` installs the Neon agent skills for each selected editor. To install them without running the full `init` flow, or to install them globally across all projects, see [Agent Skills](/docs/ai/agent-skills).
 
 <Admonition type="warning">
 Skills are installed at the project level in the current working directory. Run `init` from your project root, otherwise skills will end up in the wrong location. You may want to commit project-level files so teammates get the same skills, or add them to `.gitignore` for per-developer setup.

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -11,7 +11,7 @@ summary: >-
   files get created and where. The `--agent` flag targets a specific editor
   without the interactive prompt.
 enableTableOfContents: true
-updatedOn: '2026-08-21T13:36:10.536Z'
+updatedOn: '2026-08-21T13:42:46.659Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -56,8 +56,8 @@ Use `--agent` to configure a specific editor, skipping the interactive selection
 | MCP config (VS Code)                                                                                              | VS Code global `mcp.json` (written by extension) | Global  |
 | MCP config (Claude Code)                                                                                          | `~/.claude.json` (written by init)               | Global  |
 | [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect) | Cursor / VS Code                                 | Global  |
-| Agent skills                                                                                                      | `.agents/skills/`                                | Project |
-| Skills symlink (Claude Code only)                                                                                 | `.claude/skills/neon-postgres`                   | Project |
+| Agent skills (Cursor, VS Code)                                                                                    | `.agents/skills/`                                | Project |
+| Agent skills (Claude Code)                                                                                        | `.claude/skills/`                                | Project |
 | `skills-lock.json`                                                                                                | Project root                                     | Project |
 
 ## Credentials and API keys

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -11,7 +11,7 @@ summary: >-
   files get created and where. The `--agent` flag targets a specific editor
   without the interactive prompt.
 enableTableOfContents: true
-updatedOn: '2026-08-21T13:42:46.659Z'
+updatedOn: '2026-08-21T13:46:47.152Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -30,7 +30,7 @@ npx neon@latest init
 
 After running the command, restart your editor and ask your AI assistant to "Get started with Neon" to launch an interactive onboarding guide. The installed agent skills help you get started, including configuring a database connection. For Cursor and VS Code, the Neon Local Connect extension also provides database schema browsing, SQL editing, and table data management directly in your IDE.
 
-`init` installs the Neon agent skills for each selected editor. To install them without running the full `init` flow, or to install them globally across all projects, see [Agent Skills](/docs/ai/agent-skills).
+Under the hood, `init` runs `npx skills add neondatabase/agent-skills --skill neon --skill neon-postgres --agent <name>` for each selected editor. You can also run this command directly to install skills without the rest of the init flow, or use `npx skills add ... -g` to install globally. See [neon-postgres on skills.sh](https://skills.sh/neondatabase/agent-skills/neon-postgres) for more about the skills.
 
 <Admonition type="warning">
 Skills are installed at the project level in the current working directory. Run `init` from your project root, otherwise skills will end up in the wrong location. You may want to commit project-level files so teammates get the same skills, or add them to `.gitignore` for per-developer setup.

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -11,7 +11,7 @@ summary: >-
   files get created and where. The `--agent` flag targets a specific editor
   without the interactive prompt.
 enableTableOfContents: true
-updatedOn: '2026-08-20T11:33:33.461Z'
+updatedOn: '2026-08-21T13:32:28.984Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -30,7 +30,7 @@ npx neon@latest init
 
 After running the command, restart your editor and ask your AI assistant to "Get started with Neon" to launch an interactive onboarding guide. The installed agent skills help you get started, including configuring a database connection. For Cursor and VS Code, the Neon Local Connect extension also provides database schema browsing, SQL editing, and table data management directly in your IDE.
 
-Under the hood, `init` installs the `neon` and `neon-postgres` skills for each selected editor, running `npx skills add neondatabase/agent-skills --skill <name> --agent <name>` once per skill. You can also run these commands directly to install skills without the rest of the init flow, or use `npx skills add ... -g` to install globally. See [neon-postgres on skills.sh](https://skills.sh/neondatabase/agent-skills/neon-postgres) for more about the skills.
+Under the hood, `init` installs the Neon agent skills for each selected editor, running `npx skills add neondatabase/agent-skills --skill <name> --agent <name>` once per skill. You can also run these commands directly to install skills without the rest of the init flow, or use `npx skills add ... -g` to install globally. See [Agent Skills](/docs/ai/agent-skills) for the full list of skills and other ways to install them.
 
 <Admonition type="warning">
 Skills are installed at the project level in the current working directory. Run `init` from your project root, otherwise skills will end up in the wrong location. You may want to commit project-level files so teammates get the same skills, or add them to `.gitignore` for per-developer setup.

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -11,7 +11,7 @@ summary: >-
   files get created and where. The `--agent` flag targets a specific editor
   without the interactive prompt.
 enableTableOfContents: true
-updatedOn: '2026-07-01T13:41:48.668Z'
+updatedOn: '2026-08-20T11:33:33.461Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -30,7 +30,7 @@ npx neon@latest init
 
 After running the command, restart your editor and ask your AI assistant to "Get started with Neon" to launch an interactive onboarding guide. The installed agent skills help you get started, including configuring a database connection. For Cursor and VS Code, the Neon Local Connect extension also provides database schema browsing, SQL editing, and table data management directly in your IDE.
 
-Under the hood, `init` runs `npx skills add neondatabase/agent-skills --skill neon-postgres --agent <name>` for each selected editor. You can also run this command directly to install skills without the rest of the init flow, or use `npx skills add ... -g` to install globally. See [neon-postgres on skills.sh](https://skills.sh/neondatabase/agent-skills/neon-postgres) for more about the skill.
+Under the hood, `init` installs the `neon` and `neon-postgres` skills for each selected editor, running `npx skills add neondatabase/agent-skills --skill <name> --agent <name>` once per skill. You can also run these commands directly to install skills without the rest of the init flow, or use `npx skills add ... -g` to install globally. See [neon-postgres on skills.sh](https://skills.sh/neondatabase/agent-skills/neon-postgres) for more about the skills.
 
 <Admonition type="warning">
 Skills are installed at the project level in the current working directory. Run `init` from your project root, otherwise skills will end up in the wrong location. You may want to commit project-level files so teammates get the same skills, or add them to `.gitignore` for per-developer setup.


### PR DESCRIPTION
Corrects the agent-skills content on the `neon init` reference page. `init` now installs both the `neon` and `neon-postgres` agent skills (one `skills add` call per skill), reflecting neondatabase/neon-pkgs#440. The docs previously described only `neon-postgres`.

Changes:

- **Under-the-hood note:** the command now installs both skills (`--skill neon --skill neon-postgres`), the exact form the CLI's own manual-install hint prints. The rest of the note (direct-run, `-g` global, skills.sh link) was already correct and is unchanged.
- **"What gets created" table:** the skills rows were wrong. They claimed a single `.claude/skills/neon-postgres` symlink for Claude Code. Skills are actually copied per editor: `.agents/skills/` for Cursor and VS Code, `.claude/skills/` for Claude Code (both skills, real directories, not a symlink).

## Live testing

Verified against the latest CLI (the `neon`/`neonctl` package behind `npx neon@latest init`), both at the source level (reading the init installer) and by running the underlying command.

**Source of truth:** the init installer loops over `BASE_SKILLS = ["neon", "neon-postgres"]` and runs `skills add neondatabase/agent-skills --skill <skill> --agent <agent> [-g] -y` once per skill (`--preview` adds `neon-object-storage`, `neon-functions`, `neon-ai-gateway`). `init` does no symlinking of its own; the on-disk layout is whatever the `skills` CLI produces.

**Ran the exact command the doc now shows** (`npx skills add neondatabase/agent-skills --skill neon --skill neon-postgres --agent <name>`):

| Check | Result |
| --- | --- |
| Command runs and installs both skills in one call | Pass |
| Claude Code layout | Pass: `.claude/skills/neon/SKILL.md` and `.claude/skills/neon-postgres/SKILL.md` (real directories, no `.agents/skills/`) — matches the table |
| Cursor / VS Code layout | Pass: `.agents/skills/neon/SKILL.md` and `.agents/skills/neon-postgres/SKILL.md` (`vscode` maps to the `github-copilot` agent, same location) — matches the table |
| Both skills are real skill directories, not a single symlink | Pass (confirms the table correction) |
| `-g` installs globally | Verified at the source level (the installer passes `-g` through to the `skills` CLI); functional run skipped to avoid writing skills into the real home directory |

This pull request and its description were written by Isaac.
