### PR TITLE
docs: document neon inspect db multi-database behavior

### DIFF
--- a/content/docs/cli/inspect.md
+++ b/content/docs/cli/inspect.md
@@ -25,6 +25,8 @@ Run a single diagnostic query against a branch's Postgres. Pick the query with a
 
 By default the command resolves the project, branch, database, and role from your [context](/docs/cli/set-context) and connects through the Neon API. Pass `--db-url` to inspect any Postgres directly from a connection string, which bypasses API resolution and lets you point `inspect` at a database outside Neon.
 
+When you omit `--database-name`, `inspect` covers every database on the branch and adds a `database` column so you can tell the rows apart. Pass `--database-name` to inspect a single database, which also scopes `locks` and `long-running-queries` to that database so lock and relation names resolve correctly. Database-scoped checks such as `table-sizes`, `locks`, and `outliers` run against each database, while compute-wide checks (`lfc-hit-rate`, `working-set`, and `replication-slots`) run once. If any database fails, the whole run fails, so pass `--database-name` to narrow to one when that happens. `--db-url` always inspects the single database in the connection string and never adds the `database` column.
+
 Some queries read from Postgres statistics extensions. `outliers` and `calls` need [`pg_stat_statements`](/docs/extensions/pg_stat_statements), and `lfc-hit-rate` and `working-set` need the [`neon`](/docs/extensions/neon) extension. If a required extension is not installed, the command reports it instead of returning rows.
 
 From an AI assistant, the same checks are available through the Neon MCP server's `inspect_database` tool. See [Database diagnostics](/docs/ai/neon-mcp-server#database-diagnostics).
@@ -98,7 +100,7 @@ neon inspect db long-running-queries
 ```
 
 ```text
-No long-running queries.
+No long-running queries in any database.
 ```
 
 ### neon inspect db locks (#db-locks)
@@ -110,7 +112,7 @@ neon inspect db locks
 ```
 
 ```text
-No locks held.
+No locks held in any database.
 ```
 
 ### neon inspect db outliers (#db-outliers)


### PR DESCRIPTION
Documents the `neon inspect db` behavior change in neondatabase/neon-pkgs#406:

- Omitting `--database-name` now inspects every database on the branch and adds a `database` column.
- Passing `--database-name` scopes `locks` and `long-running-queries` to that database so names resolve correctly.
- Compute-wide checks run once; a failure in any database fails the run.
- Updates the empty-result sample output for `long-running-queries` and `locks` to the new per-database wording.

Note: the sample-output tables still use the old box format and don't yet show the new `database` column. That belongs to a separate output-format sweep (neondatabase/neon-pkgs#446, which changed `list`/`get` rendering across the CLI docs).

## Live testing

Verified against the latest CLI (`neonctl@3.6.0`) using a throwaway project with a branch containing two databases (`neondb` + `analytics`), since deleted. All documented behavior confirmed:

| Claim | Result |
| --- | --- |
| Omit `--database-name` covers every database and adds a `database` column | Pass (`table-sizes` showed both databases with a `Database` column) |
| `--database-name` scopes to a single database, no `database` column | Pass |
| `--db-url` inspects the single database in the connection string, no `database` column | Pass |
| Empty wording `No long-running queries in any database.` | Pass (exact match) |
| Empty wording `No locks held in any database.` | Pass (exact match) |
| Compute-wide checks (`lfc-hit-rate`, `working-set`, `replication-slots`) run once | Pass (`replication-slots` returned one result with no `database` column) |
| Database-scoped checks run per database; a failure in one fails the run | Pass (`outliers` failed on `analytics` for a missing extension, failing the run) |

Note: the released behavior is in CLI 3.6.0. The `neon inspect db` invocation on CLI 2.45.0 predates this change and errors with `Multiple databases found for the branch` instead.

This pull request and its description were written by Isaac.
