### PR TITLE
chore: update topbar to promote open-weight models AI Gateway post

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'You can now call LLMs directly from Neon via AI Gateway, backed by Databricks Foundation Model APIs'
+text: 'Open weight models are particularly fast in the Neon AI Gateway thanks to optimizations like prompt caching - Free to run during beta'
 link:
-  url: 'https://neon.com/blog/llms-belong-in-your-backend'
+  url: 'https://neon.com/blog/open-weight-models-are-fast-on-neon-ai-gateway'
   target: '_blank'

--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'Open weight models are particularly fast in the Neon AI Gateway thanks to optimizations like prompt caching - Free to run during beta'
+text: 'Open weight models are particularly fast in the Neon AI Gateway thanks to optimizations like prompt caching. Free to run during beta'
 link:
   url: 'https://neon.com/blog/open-weight-models-are-fast-on-neon-ai-gateway'
   target: '_blank'


### PR DESCRIPTION

- Updates the site topbar announcement to: "Open weight models are particularly fast in the Neon AI Gateway thanks to optimizations like prompt caching - Free to run during beta"
