### PR TITLE
docs: replace Local mcp-server-neon setup with hosted /mcp

### DIFF
--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -7,13 +7,13 @@ summary: >-
   GitHub Copilot, ChatGPT, Cline, Windsurf, Zed, Claude Desktop, and more via
   the add-mcp CLI) to the Neon MCP Server so AI assistants can query and manage
   Lakebase Postgres databases on Neon using natural language. Use this page when you need
-  per-client setup instructions for `npx neon@latest init`, OAuth, or local
-  API key authentication with `@neondatabase/mcp-server-neon`. Also covers
+  per-client setup instructions for `npx neon@latest init`, OAuth, or API
+  key authentication against `https://mcp.neon.tech/mcp`. Also covers
   troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache).
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-21T01:51:17.503Z'
+updatedOn: '2026-08-21T02:00:14.259Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -77,7 +77,7 @@ For manual configuration, Kiro reads **`~/.kiro/settings/mcp.json`** (global) or
 
 ## Cursor
 
-<Tabs labels={["Quick Setup", "OAuth", "Local"]}>
+<Tabs labels={["Quick Setup", "OAuth", "API key"]}>
 <TabItem>
 
 Run the [init](/docs/cli/init) command:
@@ -108,8 +108,11 @@ Restart Cursor (or enable the MCP server in settings). When the OAuth window ope
     {
       "mcpServers": {
         "neon": {
-          "command": "npx",
-          "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
+          "type": "http",
+          "url": "https://mcp.neon.tech/mcp",
+          "headers": {
+            "Authorization": "Bearer <YOUR_NEON_API_KEY>"
+          }
         }
       }
     }
@@ -128,7 +131,7 @@ For more, see [Get started with Cursor and Neon MCP Server](/guides/cursor-mcp-n
 
 ## Claude Code
 
-<Tabs labels={["Quick Setup", "OAuth", "Local"]}>
+<Tabs labels={["Quick Setup", "OAuth", "API key"]}>
 <TabItem>
 
 Run the [init](/docs/cli/init) command:
@@ -154,7 +157,8 @@ Restart Claude Code (or enable the MCP server in settings). When the OAuth windo
 <TabItem>
 
 ```bash
-claude mcp add neon -- npx -y @neondatabase/mcp-server-neon start "<YOUR_NEON_API_KEY>"
+claude mcp add --transport http neon https://mcp.neon.tech/mcp \
+  --header "Authorization: Bearer <YOUR_NEON_API_KEY>"
 ```
 
 Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys).
@@ -170,7 +174,7 @@ For more, see [Get started with Claude Code and Neon MCP Server](/guides/claude-
 To use MCP servers with VS Code, you need [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions installed
 </Admonition>
 
-<Tabs labels={["Quick Setup", "OAuth", "Local"]}>
+<Tabs labels={["Quick Setup", "OAuth", "API key"]}>
 <TabItem>
 
 Run the [init](/docs/cli/init) command:
@@ -202,8 +206,11 @@ Add the Neon MCP server to your [User Settings (JSON)](https://code.visualstudio
   "mcp": {
     "servers": {
       "neon": {
-        "command": "npx",
-        "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
+        "type": "http",
+        "url": "https://mcp.neon.tech/mcp",
+        "headers": {
+          "Authorization": "Bearer <YOUR_NEON_API_KEY>"
+        }
       }
     }
   }
@@ -253,7 +260,7 @@ Connect ChatGPT to Neon using custom MCP connectors. Enable Developer mode, add 
 
 ## Claude Desktop
 
-<Tabs labels={["OAuth", "Local"]}>
+<Tabs labels={["OAuth", "API key"]}>
 
 <TabItem>
 
@@ -268,7 +275,8 @@ Restart Claude Desktop. When the OAuth window opens, click **Authorize** to comp
 <TabItem>
 
 ```bash
-npx @neondatabase/mcp-server-neon init <YOUR_NEON_API_KEY>
+npx add-mcp https://mcp.neon.tech/mcp -a claude-desktop \
+  --header "Authorization: Bearer <YOUR_NEON_API_KEY>"
 ```
 
 Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys), then restart Claude Desktop.
@@ -280,7 +288,7 @@ For more, see [Get started with Neon MCP server with Claude Desktop](/guides/neo
 
 ## Cline (VS Code Extension)
 
-<Tabs labels={["OAuth", "Local"]}>
+<Tabs labels={["OAuth", "API key"]}>
 <TabItem>
 
 1. Open Cline in VS Code (Sidebar -> Cline icon).
@@ -306,20 +314,27 @@ For more, see [Get started with Neon MCP server with Claude Desktop](/guides/neo
 
 1. Open Cline in VS Code (Sidebar -> Cline icon).
 2. Click **MCP Servers** Icon -> **Installed** -> **Configure MCP Servers** to open the configuration file.
-3. Add the "Neon" server entry within the `mcpServers` object:
+3. Add the "Neon" server entry within the `mcpServers` object. Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys):
 
    ```json
    {
      "mcpServers": {
        "neon": {
          "command": "npx",
-         "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
+         "args": [
+           "-y",
+           "mcp-remote@latest",
+           "https://mcp.neon.tech/mcp",
+           "--header",
+           "Authorization:${NEON_AUTH_HEADER}"
+         ],
+         "env": {
+           "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+         }
        }
      }
    }
    ```
-
-   > Replace `<YOUR_NEON_API_KEY>` with your Neon API key.
 
 4. Save the file. Cline should reload the configuration automatically.
 
@@ -330,7 +345,7 @@ For more, see [Get started with Cline and Neon MCP Server](/guides/cline-mcp-neo
 
 ## Windsurf (Codeium)
 
-<Tabs labels={["OAuth", "Local"]}>
+<Tabs labels={["OAuth", "API key"]}>
 <TabItem>
 
 1.  Open Windsurf and navigate to the Cascade assistant sidebar.
@@ -359,20 +374,27 @@ For more, see [Get started with Cline and Neon MCP Server](/guides/cline-mcp-neo
 1.  Open Windsurf and navigate to the Cascade assistant sidebar.
 2.  Click the hammer (MCP) icon, then **Configure** which opens up the "Manage MCPs" configuration file.
 3.  Click on "View raw config" to open the raw configuration file in Windsurf.
-4.  Add the "Neon" server entry within the `mcpServers` object:
+4.  Add the "Neon" server entry within the `mcpServers` object. Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys):
 
     ```json
     {
       "mcpServers": {
         "neon": {
           "command": "npx",
-          "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
+          "args": [
+            "-y",
+            "mcp-remote@latest",
+            "https://mcp.neon.tech/mcp",
+            "--header",
+            "Authorization:${NEON_AUTH_HEADER}"
+          ],
+          "env": {
+            "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+          }
         }
       }
     }
     ```
-
-    > Replace `<YOUR_NEON_API_KEY>` with your Neon API key.
 
 5.  Save the file.
 6.  Click the **Refresh** button in the Cascade sidebar next to "available MCP servers".
@@ -388,7 +410,7 @@ For more, see [Get started with Windsurf and Neon MCP Server](/guides/windsurf-m
 MCP support in Zed is currently in **preview**. Ensure you're using the Preview version of Zed to add MCP servers (called **Context Servers** in Zed). Download the preview version from [zed.dev/releases/preview](https://zed.dev/releases/preview).
 </Admonition>
 
-<Tabs labels={["OAuth", "Local"]}>
+<Tabs labels={["OAuth", "API key"]}>
 <TabItem>
 
 ```bash
@@ -401,15 +423,27 @@ Restart Zed (or enable the MCP server in settings). When the OAuth window opens,
 
 <TabItem>
 
-1. Open the Zed Preview application.
-2. Click the Assistant (✨) icon, then **Settings** > **Context Servers** > **+ Add Context Server**.
-3. Enter **neon** as the name and this command:
+Add this to `~/.config/zed/settings.json`. Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys):
 
-   ```bash
-   npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
-   ```
-
-4. Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys) and click **Add Server**.
+```json
+"context_servers": {
+  "Neon": {
+    "source": "custom",
+    "enabled": true,
+    "command": "npx",
+    "args": [
+      "-y",
+      "mcp-remote@latest",
+      "https://mcp.neon.tech/mcp",
+      "--header",
+      "Authorization:${NEON_AUTH_HEADER}"
+    ],
+    "env": {
+      "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+    }
+  }
+}
+```
 
 </TabItem>
 </Tabs>

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -15,7 +15,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-20T23:04:25.063Z'
+updatedOn: '2026-08-20T23:11:18.470Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -487,7 +487,7 @@ npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 ```
 
 <Admonition type="important">
-The HTTP+SSE endpoints (`https://mcp.neon.tech/sse` and `/message`) are deprecated and will stop working on or after October 1, 2026. After that date they return `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication. For the stdio bridge, see [Deprecated HTTP+SSE transport](/docs/ai/neon-mcp-server#retired-sse).
+The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication. For the stdio bridge, see [Deprecated HTTP+SSE transport](/docs/ai/neon-mcp-server#retired-sse).
 </Admonition>
 
 ### OAuth Authentication Errors

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -13,7 +13,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-21T02:00:14.259Z'
+updatedOn: '2026-08-21T02:09:26.597Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -264,22 +264,46 @@ Connect ChatGPT to Neon using custom MCP connectors. Enable Developer mode, add 
 
 <TabItem>
 
-```bash
-npx add-mcp https://mcp.neon.tech/mcp -a claude-desktop
+Add this to `claude_desktop_config.json` (Claude Desktop → **Settings** → **Developer** → **Edit Config**), then restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "Neon": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp"]
+    }
+  }
+}
 ```
 
-Restart Claude Desktop. When the OAuth window opens, click **Authorize** to complete the connection.
+When the OAuth window opens, click **Authorize** to complete the connection.
 
 </TabItem>
 
 <TabItem>
 
-```bash
-npx add-mcp https://mcp.neon.tech/mcp -a claude-desktop \
-  --header "Authorization: Bearer <YOUR_NEON_API_KEY>"
-```
+Add this to `claude_desktop_config.json`. Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys), then restart Claude Desktop:
 
-Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys), then restart Claude Desktop.
+```json
+{
+  "mcpServers": {
+    "Neon": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://mcp.neon.tech/mcp",
+        "--header",
+        "Authorization:${NEON_AUTH_HEADER}"
+      ],
+      "env": {
+        "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+      }
+    }
+  }
+}
+```
 
 </TabItem>
 </Tabs>
@@ -320,16 +344,10 @@ For more, see [Get started with Neon MCP server with Claude Desktop](/guides/neo
    {
      "mcpServers": {
        "neon": {
-         "command": "npx",
-         "args": [
-           "-y",
-           "mcp-remote@latest",
-           "https://mcp.neon.tech/mcp",
-           "--header",
-           "Authorization:${NEON_AUTH_HEADER}"
-         ],
-         "env": {
-           "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+         "type": "streamableHttp",
+         "url": "https://mcp.neon.tech/mcp",
+         "headers": {
+           "Authorization": "Bearer <YOUR_NEON_API_KEY>"
          }
        }
      }
@@ -380,16 +398,9 @@ For more, see [Get started with Cline and Neon MCP Server](/guides/cline-mcp-neo
     {
       "mcpServers": {
         "neon": {
-          "command": "npx",
-          "args": [
-            "-y",
-            "mcp-remote@latest",
-            "https://mcp.neon.tech/mcp",
-            "--header",
-            "Authorization:${NEON_AUTH_HEADER}"
-          ],
-          "env": {
-            "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+          "serverUrl": "https://mcp.neon.tech/mcp",
+          "headers": {
+            "Authorization": "Bearer <YOUR_NEON_API_KEY>"
           }
         }
       }
@@ -429,17 +440,10 @@ Add this to `~/.config/zed/settings.json`. Replace `<YOUR_NEON_API_KEY>` with yo
 "context_servers": {
   "Neon": {
     "source": "custom",
-    "enabled": true,
-    "command": "npx",
-    "args": [
-      "-y",
-      "mcp-remote@latest",
-      "https://mcp.neon.tech/mcp",
-      "--header",
-      "Authorization:${NEON_AUTH_HEADER}"
-    ],
-    "env": {
-      "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+    "type": "http",
+    "url": "https://mcp.neon.tech/mcp",
+    "headers": {
+      "Authorization": "Bearer <YOUR_NEON_API_KEY>"
     }
   }
 }
@@ -493,7 +497,25 @@ This tool auto-detects supported clients and configures them. Use `-a <agent>` t
 }
 ```
 
-The local stdio package (`@neondatabase/mcp-server-neon`) is deprecated. If your client only supports stdio, use the `mcp-remote` config above. See [Deprecated local stdio](/docs/ai/neon-mcp-server#deprecated-stdio).
+**API key:**
+
+```json
+"neon": {
+  "command": "npx",
+  "args": [
+    "-y",
+    "mcp-remote@latest",
+    "https://mcp.neon.tech/mcp",
+    "--header",
+    "Authorization:${NEON_AUTH_HEADER}"
+  ],
+  "env": {
+    "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+  }
+}
+```
+
+The local stdio package (`@neondatabase/mcp-server-neon`) is deprecated. If your client only supports stdio, use one of the `mcp-remote` configs above. See [Deprecated local stdio](/docs/ai/neon-mcp-server#deprecated-stdio).
 
 For Windows-specific configurations, see [Other MCP clients](/docs/ai/connect-mcp-clients-to-neon#other-mcp-clients).
 
@@ -508,7 +530,8 @@ The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop 
 If your client doesn't support JSON config (such as older Cursor versions), use the stdio bridge. See [Deprecated local stdio](/docs/ai/neon-mcp-server#deprecated-stdio).
 
 ```bash
-npx -y mcp-remote@latest https://mcp.neon.tech/mcp
+npx -y mcp-remote@latest https://mcp.neon.tech/mcp \
+  --header "Authorization: Bearer <YOUR_NEON_API_KEY>"
 ```
 
 ### OAuth Authentication Errors

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -7,16 +7,13 @@ summary: >-
   GitHub Copilot, ChatGPT, Cline, Windsurf, Zed, Claude Desktop, and more via
   the add-mcp CLI) to the Neon MCP Server so AI assistants can query and manage
   Lakebase Postgres databases on Neon using natural language. Use this page when you need
-  per-client setup instructions for `npx neon@latest init`, OAuth, or API
-  key authentication against `https://mcp.neon.tech/mcp`. Also covers
+  per-client setup instructions for `npx neon@latest init`, OAuth, or local
+  API key authentication with `@neondatabase/mcp-server-neon`. Also covers
   troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache).
-  The HTTP+SSE `/sse` endpoint is deprecated and stops working on or after
-  October 1, 2026. The local stdio package `@neondatabase/mcp-server-neon`
-  is deprecated.
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-21T00:15:25.295Z'
+updatedOn: '2026-08-21T01:51:17.503Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -9,13 +9,13 @@ summary: >-
   Lakebase Postgres databases on Neon using natural language. Use this page when you need
   per-client setup instructions for `npx neon@latest init`, OAuth, or local
   API key authentication with `@neondatabase/mcp-server-neon`. Also covers
-  troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache)
-  and the deprecated SSE endpoint for clients that don't support Streamable
-  HTTP.
+  troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache).
+  The HTTP+SSE `/sse` endpoint is deprecated and stops working on or after
+  October 1, 2026.
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-17T11:33:55.500Z'
+updatedOn: '2026-08-20T23:04:25.063Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -486,8 +486,8 @@ npx -y mcp-remote https://mcp.neon.tech/mcp
 npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 ```
 
-<Admonition type="note">
-For clients that don't support Streamable HTTP, you can use the deprecated SSE endpoint: `https://mcp.neon.tech/sse`. SSE is not supported with API key authentication.
+<Admonition type="important">
+The HTTP+SSE endpoints (`https://mcp.neon.tech/sse` and `/message`) are deprecated and will stop working on or after October 1, 2026. After that date they return `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication. For the stdio bridge, see [Deprecated HTTP+SSE transport](/docs/ai/neon-mcp-server#retired-sse).
 </Admonition>
 
 ### OAuth Authentication Errors

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -15,7 +15,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-20T23:11:18.470Z'
+updatedOn: '2026-08-20T23:22:08.351Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -487,7 +487,7 @@ npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 ```
 
 <Admonition type="important">
-The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication. For the stdio bridge, see [Deprecated HTTP+SSE transport](/docs/ai/neon-mcp-server#retired-sse).
+The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication. For the stdio bridge, see [Other MCP clients](#other-mcp-clients).
 </Admonition>
 
 ### OAuth Authentication Errors

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -16,7 +16,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-21T00:09:53.843Z'
+updatedOn: '2026-08-21T00:15:25.295Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -470,15 +470,15 @@ For Windows-specific configurations, see [Other MCP clients](/docs/ai/connect-mc
 
 ### Configuration Issues
 
-If your client doesn't support JSON config (such as older Cursor versions), run:
+<Admonition type="important">
+The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication.
+</Admonition>
+
+If your client doesn't support JSON config (such as older Cursor versions), use the stdio bridge. See [Deprecated local stdio](/docs/ai/neon-mcp-server#deprecated-stdio).
 
 ```bash
 npx -y mcp-remote@latest https://mcp.neon.tech/mcp
 ```
-
-<Admonition type="important">
-The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication.
-</Admonition>
 
 ### OAuth Authentication Errors
 

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -7,15 +7,16 @@ summary: >-
   GitHub Copilot, ChatGPT, Cline, Windsurf, Zed, Claude Desktop, and more via
   the add-mcp CLI) to the Neon MCP Server so AI assistants can query and manage
   Lakebase Postgres databases on Neon using natural language. Use this page when you need
-  per-client setup instructions for `npx neon@latest init`, OAuth, or local
-  API key authentication with `@neondatabase/mcp-server-neon`. Also covers
+  per-client setup instructions for `npx neon@latest init`, OAuth, or API
+  key authentication against `https://mcp.neon.tech/mcp`. Also covers
   troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache).
   The HTTP+SSE `/sse` endpoint is deprecated and stops working on or after
-  October 1, 2026.
+  October 1, 2026. The local stdio package `@neondatabase/mcp-server-neon`
+  is deprecated.
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-20T23:22:08.351Z'
+updatedOn: '2026-08-21T00:09:53.843Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -450,7 +451,7 @@ Prefer **`npx neon@latest init`** for the full flow (see [Quick setup](#quick-se
 npx add-mcp https://mcp.neon.tech/mcp
 ```
 
-This tool auto-detects supported clients and configures them. Use `-a <agent>` to target a specific agent (for example, `-a cursor`). Add `-g` for global (user-level) setup instead of project-level. For more options (including global vs project-level), see the [add-mcp repository](https://github.com/neondatabase/add-mcp). For manual configuration, add one of these to your client's `mcpServers` section:
+This tool auto-detects supported clients and configures them. Use `-a <agent>` to target a specific agent (for example, `-a cursor`). Add `-g` for global (user-level) setup instead of project-level. For more options (including global vs project-level), see the [add-mcp repository](https://github.com/neondatabase/add-mcp). For manual configuration, add this to your client's `mcpServers` section:
 
 **OAuth (remote server):**
 
@@ -461,14 +462,7 @@ This tool auto-detects supported clients and configures them. Use `-a <agent>` t
 }
 ```
 
-**Local setup:**
-
-```json
-"neon": {
-  "command": "npx",
-  "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
-}
-```
+The local stdio package (`@neondatabase/mcp-server-neon`) is deprecated. If your client only supports stdio, use the `mcp-remote` config above. See [Deprecated local stdio](/docs/ai/neon-mcp-server#deprecated-stdio).
 
 For Windows-specific configurations, see [Other MCP clients](/docs/ai/connect-mcp-clients-to-neon#other-mcp-clients).
 
@@ -479,15 +473,11 @@ For Windows-specific configurations, see [Other MCP clients](/docs/ai/connect-mc
 If your client doesn't support JSON config (such as older Cursor versions), run:
 
 ```bash
-# For OAuth (remote server)
-npx -y mcp-remote https://mcp.neon.tech/mcp
-
-# For Local setup
-npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
+npx -y mcp-remote@latest https://mcp.neon.tech/mcp
 ```
 
 <Admonition type="important">
-The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication. For the stdio bridge, see [Other MCP clients](#other-mcp-clients).
+The HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. Point your client at `https://mcp.neon.tech/mcp` instead. SSE is not supported with API key authentication.
 </Admonition>
 
 ### OAuth Authentication Errors

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -117,7 +117,9 @@ For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mc
 <Admonition type="important">
 The local stdio package (`@neondatabase/mcp-server-neon`) is deprecated. Use the hosted server at `https://mcp.neon.tech/mcp`.
 
-If your client only supports local stdio servers, put this in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP:
+If your client only supports local stdio servers, put one of these in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP.
+
+**OAuth:**
 
 ```json
 {
@@ -125,6 +127,28 @@ If your client only supports local stdio servers, put this in the client config 
     "Neon": {
       "command": "npx",
       "args": ["-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp"]
+    }
+  }
+}
+```
+
+**API key:**
+
+```json
+{
+  "mcpServers": {
+    "Neon": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://mcp.neon.tech/mcp",
+        "--header",
+        "Authorization:${NEON_AUTH_HEADER}"
+      ],
+      "env": {
+        "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+      }
     }
   }
 }

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -121,7 +121,7 @@ For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mc
 ### Deprecated HTTP+SSE transport (#retired-sse)
 
 <Admonition type="important">
-The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoints (`/sse` and `/message`) are deprecated and will stop working on or after October 1, 2026. After that date they return `410 Gone`.
+The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`.
 
 If your client still points at `/sse`, change the URL to `https://mcp.neon.tech/mcp`. If your client only supports local stdio servers, put this in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP:
 

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -5,9 +5,7 @@ summary: >-
   The Neon MCP Server implements the Model Context Protocol (MCP), letting AI
   assistants interact with your Neon projects on your behalf. Set up with
   `npx neon@latest init` or use the config generator. Supports OAuth and
-  API key auth. The HTTP+SSE `/sse` endpoint is deprecated and stops working
-  on or after October 1, 2026. The local stdio package
-  `@neondatabase/mcp-server-neon` is deprecated.
+  API key auth.
 enableTableOfContents: true
 updatedOn: '2026-08-21T12:59:00.700Z'
 ---

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -37,7 +37,7 @@ Runs `neon init` via npx to configure MCP and other integrations for your editor
 
 ## Config generator
 
-Use the generator to build an MCP config for your editor, auth method, and transport, including the `Authorization` header for API key or remote agent setups.
+Use the generator to build an MCP config for your editor and auth method, including the `Authorization` header for API key or remote agent setups.
 
 <McpSetupConfigurator />
 
@@ -118,8 +118,25 @@ npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
 
 For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon).
 
-<Admonition type="note">
-For clients that don't support Streamable HTTP, you can use the deprecated SSE endpoint: `https://mcp.neon.tech/sse`. SSE is not supported with API key authentication.
+### Deprecated HTTP+SSE transport (#retired-sse)
+
+<Admonition type="important">
+The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoints (`/sse` and `/message`) are deprecated and will stop working on or after October 1, 2026. After that date they return `410 Gone`.
+
+If your client still points at `/sse`, change the URL to `https://mcp.neon.tech/mcp`. If your client only supports local stdio servers, put this in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP:
+
+```json
+{
+  "mcpServers": {
+    "Neon": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.neon.tech/mcp"]
+    }
+  }
+}
+```
+
+SSE is not supported with API key authentication.
 </Admonition>
 
 ## Resources

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -6,7 +6,8 @@ summary: >-
   assistants interact with your Neon projects on your behalf. Set up with
   `npx neon@latest init` or use the config generator. Supports OAuth and
   API key auth. The HTTP+SSE `/sse` endpoint is deprecated and stops working
-  on or after October 1, 2026.
+  on or after October 1, 2026. The local stdio package
+  `@neondatabase/mcp-server-neon` is deprecated.
 enableTableOfContents: true
 updatedOn: '2026-08-21T12:59:00.700Z'
 ---
@@ -111,20 +112,14 @@ Pick a check with the `check` parameter (for example `table-sizes` or `unused-in
 
 ## Troubleshooting
 
-If your client doesn't support JSON for MCP server configuration (such as older versions of Cursor), use this command when prompted:
-
-```bash
-npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
-```
-
 For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon).
 
-### Deprecated HTTP+SSE transport (#retired-sse)
+### Deprecated local stdio (#deprecated-stdio)
 
 <Admonition type="important">
-The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. SSE is not supported with API key authentication.
+The local stdio package (`@neondatabase/mcp-server-neon`) is deprecated. Use the hosted server at `https://mcp.neon.tech/mcp`.
 
-If your client still points at `/sse`, change the URL to `https://mcp.neon.tech/mcp`. If your client only supports local stdio servers, put this in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP:
+If your client only supports local stdio servers, put this in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP:
 
 ```json
 {
@@ -137,6 +132,14 @@ If your client still points at `/sse`, change the URL to `https://mcp.neon.tech/
 }
 ```
 
+</Admonition>
+
+### Deprecated HTTP+SSE transport (#retired-sse)
+
+<Admonition type="important">
+The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. SSE is not supported with API key authentication.
+
+If your client still points at `/sse`, change the URL to `https://mcp.neon.tech/mcp`.
 </Admonition>
 
 ## Resources

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -5,7 +5,8 @@ summary: >-
   The Neon MCP Server implements the Model Context Protocol (MCP), letting AI
   assistants interact with your Neon projects on your behalf. Set up with
   `npx neon@latest init` or use the config generator. Supports OAuth and
-  API key auth.
+  API key auth. The HTTP+SSE `/sse` endpoint is deprecated and stops working
+  on or after October 1, 2026.
 enableTableOfContents: true
 updatedOn: '2026-08-21T12:59:00.700Z'
 ---
@@ -121,7 +122,7 @@ For per-client setup instructions, see [Connect MCP clients](/docs/ai/connect-mc
 ### Deprecated HTTP+SSE transport (#retired-sse)
 
 <Admonition type="important">
-The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`.
+The hosted Neon MCP Server uses Streamable HTTP at `https://mcp.neon.tech/mcp`. The older HTTP+SSE endpoint (`https://mcp.neon.tech/sse`) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns `410 Gone`. SSE is not supported with API key authentication.
 
 If your client still points at `/sse`, change the URL to `https://mcp.neon.tech/mcp`. If your client only supports local stdio servers, put this in the client config so [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridges to Streamable HTTP:
 
@@ -130,13 +131,12 @@ If your client still points at `/sse`, change the URL to `https://mcp.neon.tech/
   "mcpServers": {
     "Neon": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.neon.tech/mcp"]
+      "args": ["-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp"]
     }
   }
 }
 ```
 
-SSE is not supported with API key authentication.
 </Admonition>
 
 ## Resources

--- a/content/guides/claude-code-mcp-neon.md
+++ b/content/guides/claude-code-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Interact with Neon APIs using Claude Code through natural language'
 author: pedro-figueiredo
 enableTableOfContents: true
 createdAt: '2025-08-27T00:00:00.000Z'
-updatedOn: '2026-07-31T19:05:29.503Z'
+updatedOn: '2026-08-21T02:00:14.259Z'
 ---
 
 This guide shows how to use [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -20,7 +20,7 @@ The Neon MCP Server grants broad database management capabilities. Always review
 Make sure you have:
 
 1. **Claude Code:** Ensure you have Claude Code installed. Visit [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code) for installation instructions.
-2. **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
+2. **Neon API Key (for API key authentication):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
 
    <Admonition type="important" title="Neon API Key Security">
    Keep your Neon API key secure, and never share it publicly. It provides access to your Neon projects.
@@ -67,22 +67,6 @@ claude mcp add --transport http neon https://mcp.neon.tech/mcp \
 Replace `<YOUR_NEON_API_KEY>` with your actual Neon API key which you obtained from the [prerequisites](#prerequisites) section.
 
 </Admonition>
-
-### Option 2: Setting up the Local Neon MCP Server
-
-This method runs the Neon MCP server locally on your machine, using a Neon API key for authentication.
-
-1. Open your terminal.
-2. Add the Neon MCP server to Claude Code with the following command, replacing `<YOUR_NEON_API_KEY>` with your actual Neon API key:
-
-   ```sh
-   claude mcp add neon -- npx -y @neondatabase/mcp-server-neon start "<YOUR_NEON_API_KEY>"
-   ```
-
-3. Start a new Claude Code session with the `claude` command and start using the Neon MCP server:
-   ```sh
-   claude
-   ```
 
 ### Verification
 

--- a/content/guides/cline-mcp-neon.md
+++ b/content/guides/cline-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Cline and Neon MCP Se
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-22T00:00:00.000Z'
-updatedOn: '2026-07-31T19:05:29.503Z'
+updatedOn: '2026-08-21T02:00:14.259Z'
 ---
 
 This guide shows how to use [Cline](https://cline.bot) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -23,7 +23,7 @@ Make sure you have:
     - Download and install the Cline VS Code extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev).
     - Set up Cline by following the [Getting Started guide](https://docs.cline.bot/getting-started/getting-started-new-coders#setting-up-openrouter-api-key) which involves obtaining an [OpenRouter API key](https://openrouter.ai) to work with Cline.
 2.  **A Neon Account and Project:** You'll need a Neon account and a project. You can create a new Neon project in the [Neon Console](https://console.neon.tech)
-3.  **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/profile). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
+3.  **Neon API Key (for API key authentication):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/profile). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
     <Admonition type="warning" title="Neon API Key Security">
     Keep your Neon API key secure, and never share it publicly. It provides access to your Neon projects.
     </Admonition>
@@ -52,9 +52,9 @@ By default, the Remote MCP Server connects to your personal Neon account. To con
    ![Neon OAuth window](/docs/guides/neon-oauth-window.png)
 8. Once authentication is complete, Cline will display a confirmation message, and **Neon** will appear under your list of available MCP servers.
 
-### Option 2: Setting up the Local Neon MCP Server
+### Option 2: API key authentication
 
-This method runs the Neon MCP server locally on your machine, using a Neon API key for authentication.
+This method uses the hosted Neon MCP Server with a Neon API key.
 
 1. Open Cline by clicking the **Cline** icon in the VS Code sidebar.
 2. In the Cline navigation bar, select the **MCP Servers** icon.
@@ -63,54 +63,31 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
    ![Cline MCP Server Configure](/docs/guides/cline-mcp-server-configure.png)
 4. This opens `cline_mcp_settings.json`.
 5. Paste the following JSON configuration into it. Replace `<YOUR_NEON_API_KEY>` with your Neon API key:
-   <CodeTabs labels={["MacOS/Linux", "Windows", "Windows (WSL)"]}>
 
    ```json
    {
      "mcpServers": {
        "neon": {
          "command": "npx",
-         "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
-       }
-     }
-   }
-   ```
-
-   ```json
-   {
-     "mcpServers": {
-       "neon": {
-         "command": "cmd",
          "args": [
-           "/c",
-           "npx",
            "-y",
-           "@neondatabase/mcp-server-neon",
-           "start",
-           "<YOUR_NEON_API_KEY>"
-         ]
+           "mcp-remote@latest",
+           "https://mcp.neon.tech/mcp",
+           "--header",
+           "Authorization:${NEON_AUTH_HEADER}"
+         ],
+         "env": {
+           "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+         }
        }
      }
    }
    ```
-
-   ```json
-   {
-     "mcpServers": {
-       "neon": {
-         "command": "wsl",
-         "args": ["npx", "-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
-       }
-     }
-   }
-   ```
-
-   </CodeTabs>
 
 6. **Save** the `cline_mcp_settings.json` file.
 7. You should see a notification in VS Code that says: "MCP servers updated".
    ![Cline MCP Server Updated](/docs/guides/cline-mcp-config-update.png)
-8. Cline is now configured to use the local Neon MCP server. You should see **neon** listed under available MCP servers.
+8. Cline is now configured to use the hosted Neon MCP Server. You should see **neon** listed under available MCP servers.
 
 ### Verifying the Integration
 

--- a/content/guides/cline-mcp-neon.md
+++ b/content/guides/cline-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Cline and Neon MCP Se
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-22T00:00:00.000Z'
-updatedOn: '2026-08-21T02:00:14.259Z'
+updatedOn: '2026-08-21T02:09:26.597Z'
 ---
 
 This guide shows how to use [Cline](https://cline.bot) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -68,16 +68,10 @@ This method uses the hosted Neon MCP Server with a Neon API key.
    {
      "mcpServers": {
        "neon": {
-         "command": "npx",
-         "args": [
-           "-y",
-           "mcp-remote@latest",
-           "https://mcp.neon.tech/mcp",
-           "--header",
-           "Authorization:${NEON_AUTH_HEADER}"
-         ],
-         "env": {
-           "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+         "type": "streamableHttp",
+         "url": "https://mcp.neon.tech/mcp",
+         "headers": {
+           "Authorization": "Bearer <YOUR_NEON_API_KEY>"
          }
        }
      }

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Cursor and Neon MCP S
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-20T00:00:00.000Z'
-updatedOn: '2026-08-21T02:00:14.259Z'
+updatedOn: '2026-08-21T02:09:26.597Z'
 ---
 
 This guide shows how to use [Cursor](https://cursor.com) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -104,8 +104,6 @@ This method uses the hosted Neon MCP Server with a Neon API key.
    ```
 
    If you have other MCP servers configured, you can copy just the `Neon` part.
-
-   ![Cursor Local MCP JSON](/docs/guides/cursor-local-mcp-server-json.png)
 
 4. Save the `mcp.json` file after pasting the configuration.
 

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Cursor and Neon MCP S
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-20T00:00:00.000Z'
-updatedOn: '2026-07-31T19:05:29.503Z'
+updatedOn: '2026-08-21T02:00:14.259Z'
 ---
 
 This guide shows how to use [Cursor](https://cursor.com) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -21,7 +21,7 @@ Make sure you have:
 
 1. **Cursor Editor:** Download and install Cursor from [cursor.com](https://cursor.com).
 2. **A Neon Account and Project:** You'll need a Neon account and a project. You can create a new Neon project in the [Neon Console](https://console.neon.tech)
-3. **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
+3. **Neon API Key (for API key authentication):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
 
    <Admonition type="important" title="Neon API Key Security">
    Keep your Neon API key secure, and never share it publicly. It provides access to your Neon projects.
@@ -81,57 +81,27 @@ By default, the Remote MCP Server connects to your personal Neon account. To con
 6. You can verify that the connection is successful by checking the **Tools & MCP** section in Cursor settings.
    ![Cursor with Neon MCP Tools](/docs/guides/cursor-with-neon-mcp-tools.png)
 
-### Option 2: Setting up the Local Neon MCP Server
+### Option 2: API key authentication
 
-This method runs the Neon MCP server locally on your machine, using a Neon API key for authentication.
+This method uses the hosted Neon MCP Server with a Neon API key.
 
 1. Open Cursor.
 2. Create a `.cursor` directory in your project's root directory. This is where Cursor will look for the MCP server configuration.
 3. Paste the following JSON configuration into a file named `mcp.json` in the `.cursor` directory. Replace `<YOUR_NEON_API_KEY>` with your actual Neon API key which you obtained from the [prerequisites](#prerequisites) section:
 
-   <CodeTabs labels={["MacOS/Linux", "Windows", "Windows (WSL)"]}>
-
    ```json
    {
      "mcpServers": {
        "Neon": {
-         "command": "npx",
-         "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
+         "type": "http",
+         "url": "https://mcp.neon.tech/mcp",
+         "headers": {
+           "Authorization": "Bearer <YOUR_NEON_API_KEY>"
+         }
        }
      }
    }
    ```
-
-   ```json
-   {
-     "mcpServers": {
-       "Neon": {
-         "command": "cmd",
-         "args": [
-           "/c",
-           "npx",
-           "-y",
-           "@neondatabase/mcp-server-neon",
-           "start",
-           "<YOUR_NEON_API_KEY>"
-         ]
-       }
-     }
-   }
-   ```
-
-   ```json
-   {
-     "mcpServers": {
-       "Neon": {
-         "command": "wsl",
-         "args": ["npx", "-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
-       }
-     }
-   }
-   ```
-
-   </CodeTabs>
 
    If you have other MCP servers configured, you can copy just the `Neon` part.
 
@@ -141,7 +111,7 @@ This method runs the Neon MCP server locally on your machine, using a Neon API k
 
 5. **Restart Cursor** or reload the window (`Developer: Reload Window` from the Command Palette).
 
-6. Check the **MCP Servers** section in Cursor settings to verify the connection.
+6. Check the **Tools & MCP** section in Cursor settings to verify the connection.
 
    ![Cursor with Neon MCP Tools](/docs/guides/cursor-with-neon-mcp-tools.png)
 
@@ -172,7 +142,7 @@ You can also set up a global MCP server in Cursor. To set this up:
 1. Open Cursor.
 2. Go to the **Settings**.
 3. In the **Tools & MCP** section, click on **+ Add Custom MCP**.
-4. Paste the same JSON configuration either for the **Remote Hosted** or **Local MCP Server** (as shown in the previous sections) into the configuration field.
+4. Paste the same JSON configuration either for OAuth or API key authentication (as shown in the previous sections) into the configuration field.
 5. Save the configuration.
 6. Restart Cursor or reload the window (`Developer: Reload Window` from the Command Palette).
 
@@ -181,7 +151,8 @@ You can also set up a global MCP server in Cursor. To set this up:
 If you are on a version of Cursor that does not support JSON configuration for MCP servers, you can use the following command when prompted:
 
 ```bash
-npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
+npx -y mcp-remote@latest https://mcp.neon.tech/mcp \
+  --header "Authorization: Bearer <YOUR_NEON_API_KEY>"
 ```
 
 For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.

--- a/content/guides/neon-mcp-server.md
+++ b/content/guides/neon-mcp-server.md
@@ -4,7 +4,7 @@ subtitle: 'Connect Claude Desktop to Neon to manage projects, run queries, and m
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-06T00:00:00.000Z'
-updatedOn: '2026-07-31T19:05:29.503Z'
+updatedOn: '2026-08-21T02:00:14.259Z'
 ---
 
 This guide shows how to connect Claude Desktop to the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) so you can manage your Neon databases.
@@ -20,7 +20,7 @@ The Neon MCP Server grants broad database management capabilities. Always review
 - **Node.js (>= v18):** Install from [nodejs.org](https://nodejs.org/).
 - **Claude Desktop:** Install Anthropic's [Claude Desktop](https://claude.ai/download).
 - **Neon Account:** Sign up for a free Neon account at [neon.tech](https://neon.tech).
-- **Neon API Key (for Local MCP server):** Get your [Neon API Key](/docs/manage/api-keys#creating-api-keys).
+- **Neon API Key (for API key authentication):** Get your [Neon API Key](/docs/manage/api-keys#creating-api-keys).
 
 ### Option 1: Setting up the remote hosted Neon MCP Server
 
@@ -74,29 +74,31 @@ Choose one of the following methods to set up the Remote Neon MCP server in Clau
 </TabItem>
 </Tabs>
 
-### Option 2: Setting up the Local Neon MCP Server
+### Option 2: API key authentication
 
-This method runs the Neon MCP server locally on your machine, using a Neon API key for authentication.
+This method uses the hosted Neon MCP Server with a Neon API key.
 
-1.  Open your terminal.
-2.  Run the following command to install the Local Neon MCP server for use with Claude Desktop:
+1.  Open `claude_desktop_config.json` (Claude Desktop → **Settings** → **Developer** → **Edit Config**).
+2.  Add the "Neon" server entry within the `mcpServers` object. Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys#creating-api-keys):
 
-    ```bash
-    npx @neondatabase/mcp-server-neon init $NEON_API_KEY
-    ```
-
-    > Make sure to replace `$NEON_API_KEY` with your actual Neon API key. You can generate one through the Neon Console by following the instructions in [Creating API keys](/docs/manage/api-keys#creating-api-keys).
-
-    You'll be prompted to install the required dependencies. Type `y` to proceed. You should see output similar to this:
-
-    ```bash
-    npx @neondatabase/mcp-server-neon init napi_xxxx
-    Need to install the following packages:
-    @neondatabase/mcp-server-neon@0.x.x
-    Ok to proceed? (y) y
-
-    Config written to: /Users/USERNAME/Library/Application Support/Claude/claude_desktop_config.json
-    The Neon MCP server will start automatically the next time you open Claude.
+    ```json
+    {
+      "mcpServers": {
+        "Neon": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "mcp-remote@latest",
+            "https://mcp.neon.tech/mcp",
+            "--header",
+            "Authorization:${NEON_AUTH_HEADER}"
+          ],
+          "env": {
+            "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+          }
+        }
+      }
+    }
     ```
 
 3.  Restart Claude Desktop.

--- a/content/guides/windsurf-mcp-neon.md
+++ b/content/guides/windsurf-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Codeium Windsurf and 
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-22T00:00:00.000Z'
-updatedOn: '2026-07-31T19:05:29.503Z'
+updatedOn: '2026-08-21T02:00:14.259Z'
 ---
 
 This guide shows how to use [Windsurf](https://codeium.com/windsurf) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -21,7 +21,7 @@ Make sure you have:
 
 1.  **Codeium Windsurf Editor:** Download and install Windsurf from [codeium.com/windsurf](https://codeium.com/windsurf).
 2.  **A Neon Account and Project:** You'll need a Neon account and a project. You can create a new Neon project in the [Neon Console](https://console.neon.tech)
-3.  **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
+3.  **Neon API Key (for API key authentication):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
 
     <Admonition type="important" title="Neon API Key Security">
     Keep your Neon API key secure, and never share it publicly. It provides access to your Neon projects.
@@ -77,10 +77,9 @@ If you encounter an error message like `{"code":"invalid_request","error":"inval
 This error commonly occurs when there are changes to the OAuth configuration or when cached credentials become invalid.
 </Admonition>
 
-### Option 2: Setting up the Local Neon MCP Server
+### Option 2: API key authentication
 
-This method runs the Neon MCP server locally on your machine, using a Neon API
-key for authentication.
+This method uses the hosted Neon MCP Server with a Neon API key.
 
 1. Open Windsurf.
 2. Open Cascade by using `⌘L` on MacOS or `Ctrl+L` on Windows/Linux.
@@ -90,49 +89,25 @@ key for authentication.
 5. Click **View raw config** to edit the JSON directly.
 6. Add the "Neon" server entry within the `mcpServers` object:
 
-   <CodeTabs labels={["MacOS/Linux", "Windows", "Windows (WSL)"]}>
-
    ```json
    {
      "mcpServers": {
        "Neon": {
          "command": "npx",
-         "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
-       }
-     }
-   }
-   ```
-
-   ```json
-   {
-     "mcpServers": {
-       "Neon": {
-         "command": "cmd",
          "args": [
-           "/c",
-           "npx",
            "-y",
-           "@neondatabase/mcp-server-neon",
-           "start",
-           "<YOUR_NEON_API_KEY>"
-         ]
+           "mcp-remote@latest",
+           "https://mcp.neon.tech/mcp",
+           "--header",
+           "Authorization:${NEON_AUTH_HEADER}"
+         ],
+         "env": {
+           "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+         }
        }
      }
    }
    ```
-
-   ```json
-   {
-     "mcpServers": {
-       "Neon": {
-         "command": "wsl",
-         "args": ["npx", "-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"]
-       }
-     }
-   }
-   ```
-
-   </CodeTabs>
 
    > Replace `<YOUR_NEON_API_KEY>` with your actual Neon API key which you obtained from the [prerequisites](#prerequisites) section:
 

--- a/content/guides/windsurf-mcp-neon.md
+++ b/content/guides/windsurf-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Codeium Windsurf and 
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-22T00:00:00.000Z'
-updatedOn: '2026-08-21T02:00:14.259Z'
+updatedOn: '2026-08-21T02:09:26.597Z'
 ---
 
 This guide shows how to use [Windsurf](https://codeium.com/windsurf) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -93,16 +93,9 @@ This method uses the hosted Neon MCP Server with a Neon API key.
    {
      "mcpServers": {
        "Neon": {
-         "command": "npx",
-         "args": [
-           "-y",
-           "mcp-remote@latest",
-           "https://mcp.neon.tech/mcp",
-           "--header",
-           "Authorization:${NEON_AUTH_HEADER}"
-         ],
-         "env": {
-           "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+         "serverUrl": "https://mcp.neon.tech/mcp",
+         "headers": {
+           "Authorization": "Bearer <YOUR_NEON_API_KEY>"
          }
        }
      }

--- a/content/guides/zed-mcp-neon.md
+++ b/content/guides/zed-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Zed and Neon MCP Serv
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-04-10T00:00:00.000Z'
-updatedOn: '2026-07-31T19:05:29.503Z'
+updatedOn: '2026-08-21T02:00:14.259Z'
 ---
 
 This guide shows how to use [Zed](https://zed.dev) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -21,7 +21,7 @@ Make sure you have:
 
 1.  **Zed editor:** Download and install Zed from [zed.dev](https://zed.dev/download).
 2.  **A Neon account and project:** You'll need a Neon account and a project. You can create a new Neon project in the [Neon Console](https://console.neon.tech)
-3.  **Neon API Key (for Local MCP server):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
+3.  **Neon API Key (for API key authentication):** After signing up, get your Neon API Key from the [Neon console](https://console.neon.tech/app/settings/api-keys). This API key is needed to authenticate your application with Neon. For instructions, see [Manage API keys](/docs/manage/api-keys).
 
     <Admonition type="warning" title="Neon API Key Security">
     Keep your Neon API key secure, and never share it publicly. It provides access to your Neon projects.
@@ -58,22 +58,30 @@ By default, the Remote MCP Server connects to your personal Neon account. To con
 7.  Check the **Model Context Protocol (MCP) Servers** section in Zed **Settings** to ensure the connection is successful. Neon should be listed as an MCP server.
     ![Zed with Neon MCP](/docs/guides/zed/with-neon-mcp.png)
 
-### Option 2: Setting up the Local Neon MCP Server
+### Option 2: API key authentication
 
-This method runs the Neon MCP server locally on your machine, using a Neon API key for authentication.
+This method uses the hosted Neon MCP Server with a Neon API key.
 
 1.  Open Zed.
 2.  Click the Assistant (✨) icon in the bottom right corner of Zed.
     ![Zed Assistant icon](/docs/guides/zed/assistant-icon.png)
 3.  Click **Add custom server** in the top right panel of the Assistant.
     ![Zed add custom server](/docs/guides/zed/add-custom-server.png)
-4.  Enter the following configuration for the Neon MCP server in the JSON input field.
+4.  Enter the following configuration for the Neon MCP server in the JSON input field. Replace `<YOUR_NEON_API_KEY>` with your [Neon API key](/docs/manage/api-keys):
     ```json
     {
       "Neon": {
         "command": "npx",
-        "args": ["-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"],
-        "env": {}
+        "args": [
+          "-y",
+          "mcp-remote@latest",
+          "https://mcp.neon.tech/mcp",
+          "--header",
+          "Authorization:${NEON_AUTH_HEADER}"
+        ],
+        "env": {
+          "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+        }
       }
     }
     ```
@@ -104,7 +112,7 @@ If you experience issues adding an MCP server from the Assistant panel, you can 
 1.  Open the `~/.config/zed/settings.json` file. You can access this file by clicking on **Settings** in the Zed menu bar.
 2.  Add the following `context_servers` section to the file.
 
-<CodeTabs labels={["Remote MCP server", "Local MCP server"]}>
+<CodeTabs labels={["OAuth", "API key"]}>
 
 ```json
 "context_servers": {
@@ -112,7 +120,7 @@ If you experience issues adding an MCP server from the Assistant panel, you can 
       "source": "custom",
       "enabled": true,
       "command": "npx",
-      "args": [ "-y", "mcp-remote", "https://mcp.neon.tech/mcp" ],
+      "args": [ "-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp" ],
       "env": {}
     }
 }
@@ -124,8 +132,16 @@ If you experience issues adding an MCP server from the Assistant panel, you can 
       "source": "custom",
       "enabled": true,
       "command": "npx",
-      "args": [ "-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>" ],
-      "env": {}
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://mcp.neon.tech/mcp",
+        "--header",
+        "Authorization:${NEON_AUTH_HEADER}"
+      ],
+      "env": {
+        "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+      }
     }
 }
 ```
@@ -134,37 +150,30 @@ If you experience issues adding an MCP server from the Assistant panel, you can 
 
 #### Troubleshooting on Windows
 
-If you are using Windows, and you encounter issues with the command line, you may need to adjust the command to use `cmd` or `wsl` to run the MCP server. For example, here's how you can set it up:
-
-<CodeTabs labels={["Windows", "Windows (WSL)"]}>
+If you are using Windows and the command line fails, run `npx` through `cmd`:
 
 ```json
 "context_servers": {
    "neon": {
       "command": {
          "path": "cmd",
-         "args": ["/c", "npx", "-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"],
-         "env": null
+         "args": [
+            "/c",
+            "npx",
+            "-y",
+            "mcp-remote@latest",
+            "https://mcp.neon.tech/mcp",
+            "--header",
+            "Authorization:${NEON_AUTH_HEADER}"
+         ],
+         "env": {
+            "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+         }
       },
       "settings": {}
    }
 }
 ```
-
-```json
-"context_servers": {
-   "neon": {
-      "command": {
-         "path": "wsl",
-         "args": ["npx", "-y", "@neondatabase/mcp-server-neon", "start", "<YOUR_NEON_API_KEY>"],
-         "env": null
-      },
-      "settings": {}
-   }
-}
-```
-
-</CodeTabs>
 
 For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.
 

--- a/content/guides/zed-mcp-neon.md
+++ b/content/guides/zed-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Zed and Neon MCP Serv
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-04-10T00:00:00.000Z'
-updatedOn: '2026-08-21T02:00:14.259Z'
+updatedOn: '2026-08-21T02:09:26.597Z'
 ---
 
 This guide shows how to use [Zed](https://zed.dev) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -45,7 +45,7 @@ By default, the Remote MCP Server connects to your personal Neon account. To con
     {
       "Neon": {
         "command": "npx",
-        "args": ["-y", "mcp-remote", "https://mcp.neon.tech/mcp"],
+        "args": ["-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp"],
         "env": {}
       }
     }
@@ -71,21 +71,15 @@ This method uses the hosted Neon MCP Server with a Neon API key.
     ```json
     {
       "Neon": {
-        "command": "npx",
-        "args": [
-          "-y",
-          "mcp-remote@latest",
-          "https://mcp.neon.tech/mcp",
-          "--header",
-          "Authorization:${NEON_AUTH_HEADER}"
-        ],
-        "env": {
-          "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+        "source": "custom",
+        "type": "http",
+        "url": "https://mcp.neon.tech/mcp",
+        "headers": {
+          "Authorization": "Bearer <YOUR_NEON_API_KEY>"
         }
       }
     }
     ```
-    ![Zed add Neon Local MCP server](/docs/guides/zed/add-neon-local-mcp-server.png)
 5.  Click **Add Server**.
 6.  Check the **Model Context Protocol (MCP) Servers** section in Zed **Settings** to ensure the connection is successful. Neon should be listed as an MCP server.
     ![Zed with Neon MCP](/docs/guides/zed/with-neon-mcp.png)
@@ -130,50 +124,16 @@ If you experience issues adding an MCP server from the Assistant panel, you can 
 "context_servers": {
     "Neon": {
       "source": "custom",
-      "enabled": true,
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote@latest",
-        "https://mcp.neon.tech/mcp",
-        "--header",
-        "Authorization:${NEON_AUTH_HEADER}"
-      ],
-      "env": {
-        "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
+      "type": "http",
+      "url": "https://mcp.neon.tech/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_NEON_API_KEY>"
       }
     }
 }
 ```
 
 </CodeTabs>
-
-#### Troubleshooting on Windows
-
-If you are using Windows and the command line fails, run `npx` through `cmd`:
-
-```json
-"context_servers": {
-   "neon": {
-      "command": {
-         "path": "cmd",
-         "args": [
-            "/c",
-            "npx",
-            "-y",
-            "mcp-remote@latest",
-            "https://mcp.neon.tech/mcp",
-            "--header",
-            "Authorization:${NEON_AUTH_HEADER}"
-         ],
-         "env": {
-            "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
-         }
-      },
-      "settings": {}
-   }
-}
-```
 
 For a full list of available tools, see [available tools](/docs/ai/neon-mcp-server#available-tools) in the Neon MCP Server overview.
 


### PR DESCRIPTION
## Problem

API key setup in the Neon MCP docs started `@neondatabase/mcp-server-neon` over stdio. That package is deprecated. The hosted server is `https://mcp.neon.tech/mcp`.

The Local tab on [Connect MCP clients](https://neon.com/docs/ai/connect-mcp-clients-to-neon) and Option 2 on the Cursor, Claude Code, VS Code, Claude Desktop, Cline, Windsurf and Zed guides all ran that install. A reader who wanted a key instead of OAuth got a local process.

The connect-page summary and troubleshooting also still offered `https://mcp.neon.tech/sse`. That URL is deprecated. On or after October 1, 2026 it returns `410 Gone`. API keys work on `/mcp`.

## Diagnosis

The hosted Streamable HTTP URL accepts `Authorization: Bearer <YOUR_NEON_API_KEY>` in the client's own config. That is how API key auth is configured.

Clients that only speak stdio still need a process. [`mcp-remote@latest`](https://www.npmjs.com/package/mcp-remote) bridges stdio to `https://mcp.neon.tech/mcp` for OAuth and for the same Bearer header.

The Local tab name is why the deprecated package stayed in the setup steps. The key is a header on the hosted URL.

`/sse` stays in the two deprecation notices that name the cutoff and the `410 Gone` response. Setup steps and page summaries do not mention it.

## The user-facing interface

Quick Setup stays `npx neon@latest init`. OAuth tabs stay `npx add-mcp https://mcp.neon.tech/mcp -a <agent>`, except Claude Desktop.

The third tab is labeled **API key**. Copy these into the client config. Replace `<YOUR_NEON_API_KEY>`.

**`.cursor/mcp.json`:**

```json
{
  "mcpServers": {
    "neon": {
      "type": "http",
      "url": "https://mcp.neon.tech/mcp",
      "headers": {
        "Authorization": "Bearer <YOUR_NEON_API_KEY>"
      }
    }
  }
}
```

**Claude Code:**

```bash
claude mcp add --transport http neon https://mcp.neon.tech/mcp \
  --header "Authorization: Bearer <YOUR_NEON_API_KEY>"
```

**VS Code User Settings (JSON):**

```json
{
  "mcp": {
    "servers": {
      "neon": {
        "type": "http",
        "url": "https://mcp.neon.tech/mcp",
        "headers": {
          "Authorization": "Bearer <YOUR_NEON_API_KEY>"
        }
      }
    }
  }
}
```

**Cline (`type: streamableHttp`):**

```json
{
  "mcpServers": {
    "neon": {
      "type": "streamableHttp",
      "url": "https://mcp.neon.tech/mcp",
      "headers": {
        "Authorization": "Bearer <YOUR_NEON_API_KEY>"
      }
    }
  }
}
```

**Windsurf (`serverUrl`):**

```json
{
  "mcpServers": {
    "neon": {
      "serverUrl": "https://mcp.neon.tech/mcp",
      "headers": {
        "Authorization": "Bearer <YOUR_NEON_API_KEY>"
      }
    }
  }
}
```

**Zed `~/.config/zed/settings.json`:**

```json
"context_servers": {
  "Neon": {
    "source": "custom",
    "type": "http",
    "url": "https://mcp.neon.tech/mcp",
    "headers": {
      "Authorization": "Bearer <YOUR_NEON_API_KEY>"
    }
  }
}
```

**`claude_desktop_config.json` (OAuth).** This tab used `npx add-mcp https://mcp.neon.tech/mcp -a claude-desktop`. It now pastes:

```json
{
  "mcpServers": {
    "Neon": {
      "command": "npx",
      "args": ["-y", "mcp-remote@latest", "https://mcp.neon.tech/mcp"]
    }
  }
}
```

**`claude_desktop_config.json` (API key).** This tab used `npx @neondatabase/mcp-server-neon init <YOUR_NEON_API_KEY>`:

```json
{
  "mcpServers": {
    "Neon": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote@latest",
        "https://mcp.neon.tech/mcp",
        "--header",
        "Authorization:${NEON_AUTH_HEADER}"
      ],
      "env": {
        "NEON_AUTH_HEADER": "Bearer <YOUR_NEON_API_KEY>"
      }
    }
  }
}
```

**Other MCP clients** use the same two `mcp-remote@latest` blocks (OAuth without the header; API key with `NEON_AUTH_HEADER`). The connect page points stdio-only clients at [Deprecated local stdio](https://neon.com/docs/ai/neon-mcp-server#deprecated-stdio).

**`#deprecated-stdio`** on `/docs/ai/neon-mcp-server` now shows both of those `mcp-remote@latest` configs.

**`#retired-sse`:**

```text
The hosted Neon MCP Server uses Streamable HTTP at https://mcp.neon.tech/mcp. The older HTTP+SSE endpoint (https://mcp.neon.tech/sse) is deprecated and will stop working on or after October 1, 2026. When it is retired it returns 410 Gone. SSE is not supported with API key authentication.

If your client still points at /sse, change the URL to https://mcp.neon.tech/mcp.
```

The same `/sse` cutoff sits at the top of Configuration Issues on the connect page.

Older Cursor versions that cannot take JSON get:

```bash
npx -y mcp-remote@latest https://mcp.neon.tech/mcp \
  --header "Authorization: Bearer <YOUR_NEON_API_KEY>"
```

## Also in here

- The Claude Code guide drops Option 2 (local package). API key is a tip on the same `claude mcp add --transport http` command.
- Windows / WSL `CodeTabs` that wrapped the stdio `npx` command are gone from Cline, Cursor, Windsurf and Zed.
- The connect-page summary no longer mentions SSE.
- The config generator sentence no longer says "and transport".
- Zed OAuth pins `mcp-remote@latest`.
- `updatedOn` on the eight pages.
- `public/docs/guides/cursor-local-mcp-server-json.png` and `public/docs/guides/zed/add-neon-local-mcp-server.png` are no longer referenced. The files stay in the tree.

## Verification

No tests in the diff. These pages are Markdown.

From the worktree vs `origin/main`:

```bash
rg '@neondatabase/mcp-server-neon|mcp\.neon\.tech/sse' content/docs/ai content/guides
```

Four hits: the package name in the `#deprecated-stdio` notice and the Other MCP clients paragraph; `https://mcp.neon.tech/sse` in the two Important admonitions.

Not verified: a live connect on each named client with a real API key. Claude Desktop and the Other clients path go through `mcp-remote`; that process was not started here. No docs preview build.

## For your attention

- Claude Desktop and Other MCP clients stay on `mcp-remote` because those pages have no URL+headers HTTP shape for those clients.
- The unused local-setup PNGs are left in `public/docs/guides/`.
- The `/sse` retirement date is unchanged: on or after October 1, 2026.