### PR TITLE
docs: document the 5 GiB object storage max object size

### DIFF
--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   or the AWS CLI. Supports single-part and multipart uploads, range requests,
   batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-07-15T23:47:24.799Z'
+updatedOn: '2026-08-21T11:21:12.007Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -72,7 +72,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 
 ## Multipart upload
 
-For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control.
+The maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload doesn't raise the 5 GiB per-object ceiling; it makes large uploads more reliable because each part is retried independently.
 
 <CodeTabs labels={["TypeScript", "Python"]}>
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-07-15T23:52:09.670Z'
+updatedOn: '2026-08-21T11:21:12.007Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -111,6 +111,12 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 `PutBucketLifecycle` succeeds and the configuration is stored, but expiration and transition rules do not execute.
 
 **Status:** Lifecycle enforcement isn't available in beta. The API accepts and echoes the configuration so tools that read lifecycle rules will work, but the rules have no effect.
+
+### `EntityTooLarge`
+
+The object exceeds the maximum size. Neon Object Storage allows objects up to 5 GiB. A single-request `PutObject` fails immediately; a multipart upload fails at `CompleteMultipartUpload` once the assembled object would exceed the limit.
+
+**Fix:** Split the data across multiple objects, or confirm the upload isn't unexpectedly large. Multipart upload makes large uploads more reliable but doesn't raise the 5 GiB per-object ceiling.
 
 ## Connection and performance errors
 


### PR DESCRIPTION
Documents the Neon Object Storage per-object size limit, raised to 5 GiB in databricks-eng/neon-cloud#9782.

- `objects.md`: states the 5 GiB max object size and clarifies multipart doesn't raise the ceiling.
- `troubleshooting.md`: adds an `EntityTooLarge` entry.

## Live test

Verified the 5 GiB cap is live in production by uploading a 200 MiB object (double the old 100 MiB cap) via single PUT, on two accounts:
- A real external (non-Neon) account, us-east-2 project with object storage
- A Neon staff account

Both succeeded; `head-object` confirmed 209715200 bytes stored. Test buckets, objects, and credentials were cleaned up afterward.

This pull request and its description were written by Isaac.