### PR TITLE
docs: frame object storage 5 GiB max as a beta limit

### DIFF
--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   or the AWS CLI. Supports single-part and multipart uploads, range requests,
   batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-08-21T11:21:12.007Z'
+updatedOn: '2026-08-21T15:53:18.662Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -72,7 +72,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 
 ## Multipart upload
 
-The maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload doesn't raise the 5 GiB per-object ceiling; it makes large uploads more reliable because each part is retried independently.
+During beta, the maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. This is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects. For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload makes large uploads more reliable because each part is retried independently, though it doesn't raise the per-object limit during beta.
 
 <CodeTabs labels={["TypeScript", "Python"]}>
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-08-21T11:21:12.007Z'
+updatedOn: '2026-08-21T15:53:18.662Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -114,9 +114,9 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 
 ### `EntityTooLarge`
 
-The object exceeds the maximum size. Neon Object Storage allows objects up to 5 GiB. A single-request `PutObject` fails immediately; a multipart upload fails at `CompleteMultipartUpload` once the assembled object would exceed the limit.
+The object exceeds the maximum size. During beta, Neon Object Storage allows objects up to 5 GiB. A single-request `PutObject` fails immediately; a multipart upload fails at `CompleteMultipartUpload` once the assembled object would exceed the limit.
 
-**Fix:** Split the data across multiple objects, or confirm the upload isn't unexpectedly large. Multipart upload makes large uploads more reliable but doesn't raise the 5 GiB per-object ceiling.
+**Fix:** Split the data across multiple objects, or confirm the upload isn't unexpectedly large. Multipart upload makes large uploads more reliable but doesn't raise the per-object limit. The 5 GiB limit is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects.
 
 ## Connection and performance errors
 


### PR DESCRIPTION
Reframes the object storage 5 GiB max object size as a beta limit rather than a permanent cap, and points to support for larger objects.

- `content/docs/storage/objects.md` — Multipart upload section
- `content/docs/storage/troubleshooting.md` — `EntityTooLarge` entry

This pull request and its description were written by Isaac.