### PR TITLE
docs: add fx as an MCP client

### DIFF
--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -13,7 +13,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-21T02:09:26.597Z'
+updatedOn: '2026-08-23T13:30:00.000Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -57,6 +57,7 @@ This adds the MCP config to your editor's configuration files. Add `-g` for glob
 | Claude Desktop            | `claude-desktop`     |
 | Codex                     | `codex`              |
 | Cursor                    | `cursor`             |
+| fx                        | `fx`                 |
 | Gemini CLI                | `gemini-cli`         |
 | GitHub Copilot CLI        | `github-copilot-cli` |
 | Goose                     | `goose`              |
@@ -453,6 +454,73 @@ Add this to `~/.config/zed/settings.json`. Replace `<YOUR_NEON_API_KEY>` with yo
 </Tabs>
 
 For more details, including workflow examples and troubleshooting, see [Get started with Zed and Neon MCP Server](/guides/zed-mcp-neon).
+
+## fx
+
+[fx](https://fx.sh) reads MCP servers only from **`~/.fx/mcp.json`**. A project file cannot add a server. add-mcp always writes that global file; `-g` is not required.
+
+<Admonition type="note">
+fx rejects a literal `Authorization` header. Do not pass `--header "Authorization: Bearer $NEON_API_KEY"` when installing to fx. Use `bearer_token_env` (API key tab) or `/mcp auth` (OAuth tab).
+</Admonition>
+
+<Tabs labels={["OAuth", "API key"]}>
+<TabItem>
+
+```bash
+npx add-mcp https://mcp.neon.tech/mcp -a fx
+```
+
+This writes `~/.fx/mcp.json`:
+
+```json
+{
+  "mcp": {
+    "neon": {
+      "type": "http",
+      "url": "https://mcp.neon.tech/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+A running session applies the change with `/mcp reload`. Then authorize from the fx shell:
+
+```text
+/mcp auth neon --open
+```
+
+</TabItem>
+
+<TabItem>
+
+1. Create a [Neon API key](/docs/manage/api-keys#creating-api-keys) and export it in the environment fx will inherit:
+
+   ```bash
+   export NEON_API_KEY=<YOUR_NEON_API_KEY>
+   ```
+
+2. Write `~/.fx/mcp.json`:
+
+   ```json
+   {
+     "mcp": {
+       "neon": {
+         "type": "http",
+         "url": "https://mcp.neon.tech/mcp",
+         "enabled": true,
+         "bearer_token_env": "NEON_API_KEY"
+       }
+     }
+   }
+   ```
+
+3. Apply the file with `/mcp reload`, or start a new `fx` / `fx ask` session.
+
+</TabItem>
+</Tabs>
+
+See [fx MCP](https://fx.sh/docs/capabilities/mcp) for `/mcp reload`, `/mcp auth`, and `bearer_token_env`.
 
 ## Jules
 

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -470,6 +470,8 @@ fx rejects a literal `Authorization` header. Do not pass `--header "Authorizatio
 npx add-mcp https://mcp.neon.tech/mcp -a fx
 ```
 
+Requires add-mcp 2.2.0 or later (`npx add-mcp list-agents` should list `fx`). If it does not, write the file below yourself.
+
 This writes `~/.fx/mcp.json`:
 
 ```json

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -492,6 +492,8 @@ A running session applies the change with `/mcp reload`. Then authorize from the
 /mcp auth neon --open
 ```
 
+Confirm with `/mcp list`.
+
 </TabItem>
 
 <TabItem>
@@ -517,12 +519,12 @@ A running session applies the change with `/mcp reload`. Then authorize from the
    }
    ```
 
-3. Apply the file with `/mcp reload`, or start a new `fx` / `fx ask` session.
+3. Start a new `fx` or `fx ask` session from this shell. Confirm with `/mcp list`. `/mcp reload` applies a later file change only in a session that already has `NEON_API_KEY`.
 
 </TabItem>
 </Tabs>
 
-See [fx MCP](https://fx.sh/docs/capabilities/mcp) for `/mcp reload`, `/mcp auth`, and `bearer_token_env`.
+See [fx MCP](https://fx.sh/docs/capabilities/mcp) for `/mcp reload`, `/mcp auth`, `/mcp list`, and `bearer_token_env`.
 
 ## Jules
 

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -470,8 +470,6 @@ fx rejects a literal `Authorization` header. Do not pass `--header "Authorizatio
 npx add-mcp https://mcp.neon.tech/mcp -a fx
 ```
 
-Requires add-mcp 2.2.0 or later (`npx add-mcp list-agents` should list `fx`). If it does not, write the file below yourself.
-
 This writes `~/.fx/mcp.json`:
 
 ```json


### PR DESCRIPTION
## Problem

The Connect MCP clients page has a `--agent` table for `npx add-mcp` and a per-client section for every tool with anything specific to say. fx was in neither, so a reader on fx fell back to the generic instructions at the top of the page. Those instructions offer `-g` for a global install and `--header "Authorization: Bearer $NEON_API_KEY"` for API key auth. Both are wrong for fx.

fx reads MCP servers only from `~/.fx/mcp.json`. A project-level file adds no server, so the global/project choice the generic instructions describe does not exist here.

fx also rejects a literal `Authorization` header. add-mcp 2.2.0 throws before writing anything when that header is passed, so a reader following the generic API key path ends up with an error and no config file. The field fx reads for a bearer token is `bearer_token_env`, which takes the name of an environment variable that fx resolves when the session starts.

## The page

`fx` is now a row in the supported-agents table:

| Assistant | `--agent` |
| :-------- | :-------- |
| fx        | `fx`      |

And there is an `## fx` section between Zed and Jules, opening with the global-only behavior and an admonition about the header, then two tabs.

### OAuth tab

```bash
npx add-mcp https://mcp.neon.tech/mcp -a fx
```

The page shows the file that command writes:

```json
{
  "mcp": {
    "neon": {
      "type": "http",
      "url": "https://mcp.neon.tech/mcp",
      "enabled": true
    }
  }
}
```

A session that is already running picks the change up with `/mcp reload`. Authorization is then explicit:

```text
/mcp auth neon --open
```

The tab ends with `/mcp list` to confirm.

### API key tab

The API key path is written by hand, because add-mcp cannot pass the token to fx:

```bash
export NEON_API_KEY=<YOUR_NEON_API_KEY>
```

```json
{
  "mcp": {
    "neon": {
      "type": "http",
      "url": "https://mcp.neon.tech/mcp",
      "enabled": true,
      "bearer_token_env": "NEON_API_KEY"
    }
  }
}
```

The third step starts a new `fx` or `fx ask` session from the shell that ran the export, and confirms with `/mcp list`. The page states the reason a restart is required rather than a reload: `/mcp reload` re-reads the file, and a session that started before the export has no `NEON_API_KEY` to resolve.

The section closes with a link to [fx MCP](https://fx.sh/docs/capabilities/mcp) for `/mcp reload`, `/mcp auth`, `/mcp list` and `bearer_token_env`.

## Also in here

- `updatedOn` in the frontmatter is bumped, which the docs site expects on every content edit.

Nothing else on the page changes. The generic `add-mcp` instructions at the top, the other client sections and the OAuth troubleshooting section are untouched.

## Verification

The section uses the `Tabs`, `TabItem` and `Admonition` components already used by the Cursor, Zed and Claude Code sections on this page, with the same tab labels ("OAuth", "API key") as the other two-tab clients.

The JSON in the OAuth tab is the file add-mcp writes for `-a fx`. The JSON in the API key tab is that file plus `bearer_token_env`.

Not verified in this branch: the OAuth authorization round trip from an fx session against `mcp.neon.tech`. For that reason the page says to run `/mcp auth neon --open` and does not describe what appears on screen afterwards.

## For your attention

- **The `fx` agent needs add-mcp 2.2.0, and npm may not resolve that version yet.** The page tells the reader to run `npx add-mcp ... -a fx` with no version pin. On an older resolved version the flag is rejected. This is a release-timing question rather than a page question, so nothing in the docs mentions a version.
- **The API key path is manual by design.** add-mcp can write the fx config, but it has no flag that produces `bearer_token_env`, so the tab hands the reader the JSON instead of a command.
