### PR TITLE
docs: add real-time sync to roadmap and Electric-joins-Neon notice

### DIFF
--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /docs/cloud/roadmap
   - /docs/conceptual-guides/roadmap
   - /docs/reference/roadmap
-updatedOn: '2026-08-08T09:32:54.609Z'
+updatedOn: '2026-08-24T12:09:13.878Z'
 ---
 
 This roadmap describes what's in flight, what we delivered recently, and what's on the horizon.
@@ -29,6 +29,10 @@ We're expanding the platform with [a branchable stack of backend primitives](/bl
 ## Core Postgres database features and improvements
 
 We're accelerating work on improving and scaling the core database on Neon as well. Here is what is on the roadmap.
+
+### Real-time sync
+
+- Real-time Postgres sync powered by the Electric sync engine, keeping your database and connected clients (browser tabs, mobile apps, and agents) continuously in sync so you can build real-time, collaborative, and agentic apps without hand-rolling a sync layer. [Read the announcement](/blog/electric-joins-neon).
 
 ### Backups & restore
 

--- a/content/guides/electric-sql.md
+++ b/content/guides/electric-sql.md
@@ -4,10 +4,14 @@ subtitle: A step-by-step guide to integrating Electric with Lakebase Postgres
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-05-28T00:00:00.000Z'
-updatedOn: '2026-08-14T09:39:45.068Z'
+updatedOn: '2026-08-24T12:09:13.878Z'
 ---
 
 This guide demonstrates how to integrate [Electric](https://electric.ax/) with Lakebase Postgres. Electric is a Postgres sync engine designed to handle partial replication, fan-out, and data delivery, making apps faster and more collaborative. It can scale to millions of users while maintaining low, stable, and predictable compute and memory usage.
+
+<Admonition type="info" title="Electric has joined Neon">
+Electric, the team behind the Electric sync engine, is [joining Neon at Databricks](/blog/electric-joins-neon). Real-time sync is coming to Neon Postgres, with deeper integration already underway. In the meantime, this guide shows how to use Electric with Neon today.
+</Admonition>
 
 Electric acts as a read-path sync engine, efficiently replicating partial subsets of your Postgres data to client applications. These data subsets are defined using [Shapes](https://electric.ax/docs/guides/shapes), which are similar to live queries. Writes are handled by your application's existing API and backend logic, ensuring Electric integrates smoothly with your current stack.
 


### PR DESCRIPTION
- Add a **Real-time sync** entry under Core Postgres database features on the roadmap, framing sync as a Postgres database feature powered by the Electric sync engine.
- Add an **Electric has joined Neon** admonition to the Electric guide, linking the announcement.

Naming follows the public announcement (Electric / sync)

This pull request and its description were written by Isaac.