### PR TITLE
docs: refresh the AI agent onboarding prompts and init reference

### DIFF
--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -1,22 +1,20 @@
 ---
 title: 'Neon CLI command: init'
-subtitle: Initialize an app project with Neon, including auth, MCP server, extensions,
-  and agent skills
+subtitle: Install the Neon CLI and set up a project with auth, agent skills, and
+  optionally the MCP server and editor extension
 summary: >-
   The `neon init` command sets up a project to use Neon with an AI coding
-  assistant by running OAuth, creating an API key, writing the Neon MCP server
-  config, and installing agent skills. It supports Cursor, VS Code, Claude
-  Code, and any editor supported by add-mcp. Use this page when starting a
-  new project with `npx neon@latest init` or when you need to know which
-  files get created and where. The `--agent` flag targets a specific editor
-  without the interactive prompt.
+  assistant: it installs or updates the Neon CLI, runs OAuth, creates an API
+  key, installs agent skills, and can configure the Neon MCP server. Works with
+  Cursor, VS Code, Claude Code, and any add-mcp client. The `--agent` flag runs
+  it in agent/JSON mode.
 enableTableOfContents: true
-updatedOn: '2026-08-21T13:46:47.152Z'
+updatedOn: '2026-08-24T21:22:07.503Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
 
-The `init` command sets up your app project to use Neon with your AI coding assistant. It authenticates via OAuth, creates a Neon API key, configures the Neon MCP server for your editor (installing the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect) for Cursor and VS Code), and installs [Neon agent skills](https://github.com/neondatabase/agent-skills). Run it once from your project root.
+The `init` command sets up your app project to use Neon with your AI coding assistant. It installs or updates the Neon CLI, authenticates via OAuth, creates a Neon API key, can configure the Neon MCP server for your editor (installing the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect) for Cursor and VS Code), and installs [Neon agent skills](https://github.com/neondatabase/agent-skills). Run it once from your project root.
 
 ## Usage
 
@@ -40,7 +38,7 @@ Skills are installed at the project level in the current working directory. Run 
 
 <CliOptions command="init" />
 
-Use `--agent` to configure a specific editor, skipping the interactive selection prompt. Without `--agent`, `init` runs an interactive wizard that detects installed tools and lets you choose which to configure; if nothing is detected, you go straight to that list.
+Use `--agent` (alias `-a`) to run `init` in agent/JSON mode, designed for when an AI coding assistant runs the command for you; the agent type is auto-detected. Without `--agent`, `init` runs an interactive wizard that detects installed tools and lets you choose which to configure; if nothing is detected, you go straight to that list.
 
 ## Coding assistant support
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -1,14 +1,16 @@
 ---
 title: Get started with your AI agent
-subtitle: Connect your AI coding assistant to Neon
+subtitle: Set up Neon in your project using your AI coding assistant
 summary: >-
-  `npx neon@latest init` connects an AI coding assistant to Neon,
-  installing agent skills and configuring the MCP server in one command.
+  `neon init` sets up Neon for your project through your AI coding
+  assistant: it installs the Neon CLI, signs you in, installs agent
+  skills, and can configure the MCP server, so your agent can create a
+  project and connect your app.
 enableTableOfContents: true
-updatedOn: '2026-07-15T17:55:02.301Z'
+updatedOn: '2026-08-24T21:22:07.503Z'
 ---
 
-`npx neon@latest init` gives your agent two things: Neon-specific context from agent skills, and tools to act on your Neon account through the MCP server. The result is an agent that can connect your app to Neon and help you use Neon features as you build. For Cursor and VS Code, it also installs the Neon Local Connect extension for in-editor schema browsing.
+Set up Neon for your project without leaving your editor. `neon init` installs the Neon CLI, signs you in, installs Neon-specific agent skills, and can set up the [Neon MCP server](/docs/ai/neon-mcp-server). Together these give your agent what it needs to create a Neon project, connect your app, and use Neon features as you build. For Cursor and VS Code, it also installs the Neon Local Connect extension for in-editor schema browsing.
 
 New to the platform? The [backend overview](/docs/get-started/backend-overview) shows how Postgres, Managed Better Auth, Object Storage, Functions, and the AI Gateway fit together. For a hands-on walkthrough, see [Build a full backend](/docs/get-started/full-backend-quickstart).
 
@@ -16,8 +18,32 @@ New to the platform? The [backend overview](/docs/get-started/backend-overview) 
 
 You'll need:
 
-- [Node.js 18+](https://nodejs.org/)
-- A supported AI coding assistant, such as Cursor, VS Code with GitHub Copilot, Claude Code, Codex, Zed, Gemini CLI, Cline, OpenCode, or another [client supported by add-mcp](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp)
+- [Node.js 20+](https://nodejs.org/)
+- A supported AI coding assistant, such as Cursor or Claude Code (see [supported clients](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp))
+
+## Let your agent set it up
+
+The fastest path is to let your agent do the whole setup, from running `init` to proving the connection works. Paste this prompt into your editor's AI chat:
+
+```text shouldWrap filename="AI assistant prompt"
+Help me get set up with Neon, based on my project:
+
+1. Run `npx neon@latest init --agent` and work through the steps it returns to install the CLI, sign in, and connect my project. If it opens a browser for sign-in, ask me to confirm before continuing.
+2. Run it through verification and show me the real query result, not just "setup complete." Give me a command to re-check it myself (e.g. `neon psql`), and never print secrets.
+3. Then suggest next steps for my project, such as a schema or migrations, branching for previews, or Neon's other services (Object Storage, Functions, Managed Better Auth, AI Gateway).
+```
+
+Your agent installs the Neon CLI and runs its setup for you, so there's no switching between the terminal and the chat. It:
+
+- Signs you in to Neon (finish the browser step if it prompts), creates an API key, optionally configures the [Neon MCP server](/docs/ai/neon-mcp-server), and installs [agent skills](/docs/ai/agent-skills)
+- Creates or connects a Neon project, writes your `DATABASE_URL` into your env file, and adds a Postgres driver for your stack
+- Uses the connection and shows you a real result so you can see it's working
+
+To confirm it yourself, run the command the agent gives you (e.g., `neon psql`), or open your project in the [Neon Console](https://console.neon.tech).
+
+## Prefer to run it yourself?
+
+You can run the setup manually and then hand off to your agent.
 
 <Steps>
 
@@ -29,19 +55,11 @@ From your project root, run:
 npx neon@latest init
 ```
 
-The wizard asks which editor to configure, then:
+<Admonition type="note">
+`neon init` installs or updates the Neon CLI and sets up your editor tooling: authentication, agent skills, and optionally the MCP server. It doesn't create a Neon project, though; your agent does that when you ask it to get started.
+</Admonition>
 
-- Signs you in to Neon (or signs you up for free)
-- Creates a Neon API key
-- Installs [agent skills](/docs/ai/agent-skills)
-- Configures the [Neon MCP server](/docs/ai/neon-mcp-server)
-- For Cursor and VS Code, installs the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect)
-
-Run this from your project root so the skills are installed in the right place. For details and manual setup, see the [`neon init` reference](/docs/cli/init).
-
-## Restart your editor
-
-Reload your editor so it picks up the new MCP configuration and skills. For Cursor and VS Code, this also activates the Neon Local Connect extension.
+The wizard asks which editor to configure, then signs you in, creates an API key, installs [agent skills](/docs/ai/agent-skills), optionally configures the [Neon MCP server](/docs/ai/neon-mcp-server), and (for Cursor and VS Code) installs the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect). Run it from your project root so the skills land in the right place. For details and manual setup, see the [`neon init` reference](/docs/cli/init).
 
 ## Tell your agent
 
@@ -51,23 +69,14 @@ In your editor's AI chat, send:
 Get started with Neon
 ```
 
-Your agent reads the installed skill and uses the MCP server to walk you through setup. It can:
-
-- Create a Neon project
-- Configure your app
-- Write your `DATABASE_URL` to `.env`
-- Suggest a Postgres driver and starter query
-
-The exact flow depends on your project. Your agent can scaffold a new connection or help with a migration.
+Your agent reads the installed skill to create or connect a Neon project, pull your `DATABASE_URL` into your env file, add a Postgres driver, and run a real query to confirm the connection. The exact flow depends on your project.
 
 </Steps>
 
 ## What's next
 
+- [How a Neon backend fits together](/docs/get-started/backend-overview)
+- [Build a full backend with Next.js and Neon](/docs/get-started/full-backend-quickstart)
 - [About branching](/docs/introduction/branching)
-- [Managed Better Auth](/docs/auth/overview)
-- [Data API](/docs/data-api/overview)
-- [Browse your schema with Neon Local Connect](/docs/local/vscode-extension)
-- [`neon init` reference](/docs/cli/init)
 
 <NeedHelp/>

--- a/public/prompts/neon-backend.md
+++ b/public/prompts/neon-backend.md
@@ -1,21 +1,27 @@
-Get this project set up on Neon and build a backend on it. If I haven't told you what to build, ask me before writing app code.
+Get this project set up on Neon so I can build a backend on it. Work through it with the Neon CLI; don't rely on interactive pickers.
 
-First, set up your tooling:
+First, ask me in one message (don't guess or pick a default): which org, an existing `aws-us-east-2` project to reuse or a name to create a new one there, and a one-line description of what I'm building. Neon's backend services (Functions, Object Storage, and the AI Gateway) are only available in `aws-us-east-2` during beta.
 
-1. Run `neon init --agent` in the terminal and help me answer its prompts (which editor, which Neon org, OAuth, and the MCP server).
-2. Install and update the Neon agent skills with `npx skills add neondatabase/agent-skills -y`. This installs all skills (including the Functions, Object Storage, and AI Gateway skills that `neon init` alone doesn't add) and updates any already present to the latest. Do this even if `neon init` ran, since it doesn't refresh existing skills.
+Then set up the tooling and connect:
 
-Then create the project (console, CLI, or MCP) in `aws-us-east-2` (required for the beta services), run `neon link` to bind this directory to it, and manage the whole backend as code in a single `neon.ts`. Neon's backend services (Functions, Object Storage, and the AI Gateway) are new and in beta, and their APIs, packages, and model IDs change often, so your training data is likely outdated or wrong. Prefer the agent skills and the docs linked below over your own memory, and if they disagree, trust the docs.
+1. Install or update the Neon CLI: `npm i -g neon@latest`. The rest uses the `neon` command.
+2. Sign in if needed: check with `neon me`, and run `neon auth` if it's not signed in (it opens a browser, so pause and ask me to confirm once I've signed in before continuing).
+3. Install the Neon agent skills: `npx skills add neondatabase/agent-skills -y` (covers Postgres plus the Functions, Object Storage, and AI Gateway skills). Optional: set up the Neon MCP server with `npx add-mcp https://mcp.neon.tech/mcp --agent <your editor> --yes`.
+4. Connect the project from the answers above:
+   - Reuse an existing one: `neon link --project-id <id>`, then `neon env pull`. Linking records the project but doesn't write env; `env pull` writes the connection variables (like `DATABASE_URL`) into `.env.local`, or `.env` if it exists.
+   - Or create a new one: `neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2`. In one step this creates the project, links this directory, pins the default branch, and writes those variables into `.env.local`.
 
-Once you know what I'm building, use only the capabilities that app needs:
+Then build the backend, using only the capabilities the app needs:
 
 - Postgres for anything relational (system of record).
 - Object Storage for files too large for a row. Store the object key on a row, not the bytes.
 - Functions for long-running or streaming work such as an AI call, a background job, or a websocket; a quick query can stay in a normal route handler.
 - AI Gateway for LLM calls through one credential. Check the model catalog for the model and modality you need (text, image, etc.).
-- Auth if the app is multi-user; scope every query to the signed-in user.
+- Managed Better Auth if the app is multi-user; scope every query to the signed-in user.
 
-Enable what you need in `neon.ts`, run `neon deploy` to provision everything, then read the injected environment variables. Create your database tables as a separate step (a migration or `run_sql`); `neon deploy` provisions services, not schema. Test changes on a branch (`neon checkout`) so the whole backend (database, buckets, functions) forks together. When done, verify each capability responds.
+Declare what you need in a single `neon.ts` (see the docs below; these beta APIs, packages, and model IDs change often, so trust the docs over your training data), run `neon deploy` to provision everything, then run `neon env pull` again to pull the new service credentials into `.env.local`. Create your database tables as a separate step (a migration, `neon psql`, or the `run_sql` MCP tool); `neon deploy` provisions services, not schema. To test in isolation, create and switch to a branch with `neon branches create --name <name>` then `neon checkout <name>` (always name the branch; bare `neon checkout` prompts interactively), so the database, buckets, and functions fork together.
+
+When done, don't just tell me it works: exercise each capability I enabled (run a query with `neon psql -- -c "..."`, store and retrieve an object, call a function endpoint, make a model request, verify a signed-in user), show me the results, and give me commands I can rerun. Never print connection strings or other secrets back to me.
 
 Read the current docs for exact package names, config syntax, injected env var names, and model IDs:
 
@@ -24,4 +30,4 @@ Read the current docs for exact package names, config syntax, injected env var n
 - Functions (deploy, connect, injected env vars): https://neon.com/docs/compute/functions/get-started.md
 - Object Storage: https://neon.com/docs/storage/get-started.md
 - AI Gateway models, endpoints, and modality: https://neon.com/docs/ai-gateway/models.md
-- Auth (sign-in flow, JWT, and verifying the caller): https://neon.com/docs/auth/authentication-flow.md
+- Managed Better Auth (sign-in flow, JWT, and verifying the caller): https://neon.com/docs/auth/authentication-flow.md


### PR DESCRIPTION
## Overview

Refreshes how we onboard developers to Neon through their AI coding assistant. The "Get started with your AI agent" page now leads with setting up Neon in your project (the agent is the tool that does it) and shows the setup prompt inline instead of behind a copy button. The backend prompt (neon-backend.md) is rewritten as an explicit, non-interactive CLI flow so agents don't stall on interactive pickers or neon init's state machine.

Also fixes the neon init CLI reference, which described the command inaccurately: it installs or updates the Neon CLI, the MCP server is optional, and --agent runs agent/JSON mode rather than targeting a specific editor.

Verified the connect commands (create-and-link, and link followed by env pull) run non-interactively against the CLI.

This pull request and its description were written by Isaac.
