### PR TITLE
docs: refresh CLI reference for neonctl 4.1.0

### DIFF
--- a/content/docs/cli/inspect.md
+++ b/content/docs/cli/inspect.md
@@ -103,6 +103,18 @@ neon inspect db long-running-queries
 No long-running queries in any database.
 ```
 
+### neon inspect db stalled-queries (#db-stalled-queries)
+
+Active queries running longer than 30 seconds, with their parallel workers, what each one is waiting on, and any queries blocking them. It runs compute-wide. When nothing qualifies, it says so instead of printing an empty table:
+
+```bash
+neon inspect db stalled-queries
+```
+
+```text
+No active queries running longer than 30 seconds.
+```
+
 ### neon inspect db locks (#db-locks)
 
 Locks currently held, with the query that acquired each one and its age. When writes are blocked, run this to find what is holding the lock.

--- a/content/docs/cli/neon-auth.md
+++ b/content/docs/cli/neon-auth.md
@@ -280,14 +280,14 @@ neon neon-auth config email-provider update --type standard --host smtp.example.
 
 ### neon neon-auth config email-provider test (#config-email-provider-test)
 
-Sends a test email so you can verify your SMTP configuration.
+Sends a test email through your saved SMTP provider so you can verify it works. Configure the provider first with [`update`](#config-email-provider-update).
 
 <CliUsage command="neon-auth config email-provider test" />
 
 <CliOptions command="neon-auth config email-provider test" />
 
-```bash shouldWrap
-neon neon-auth config email-provider test --recipient-email user@example.com --host smtp.example.com --port 587 --username example_username --password AbC123dEf --sender-email noreply@example.com --sender-name "Example App"
+```bash
+neon neon-auth config email-provider test --recipient-email user@example.com
 ```
 
 ### neon neon-auth config organization (#config-organization)

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "3.5.1",
+  "neonctlVersion": "4.1.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -1747,6 +1747,13 @@
               "commands": {},
               "describe": "Number of sequential scans recorded against each table (pg_stat_user_tables)"
             },
+            "stalled-queries": {
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "Active queries running longer than 30 seconds with parallel workers, waits, and blockers (compute-wide)"
+            },
             "subscriptions": {
               "aliases": [],
               "positionals": [],
@@ -2226,44 +2233,14 @@
                   "aliases": [],
                   "positionals": [],
                   "options": {
-                    "host": {
-                      "type": "string",
-                      "describe": "SMTP host",
-                      "required": true
-                    },
-                    "password": {
-                      "type": "string",
-                      "describe": "SMTP password",
-                      "required": true
-                    },
-                    "port": {
-                      "type": "number",
-                      "describe": "SMTP port",
-                      "required": true
-                    },
                     "recipient-email": {
                       "type": "string",
-                      "describe": "Email address to send test email to",
-                      "required": true
-                    },
-                    "sender-email": {
-                      "type": "string",
-                      "describe": "Sender email address",
-                      "required": true
-                    },
-                    "sender-name": {
-                      "type": "string",
-                      "describe": "Sender display name",
-                      "required": true
-                    },
-                    "username": {
-                      "type": "string",
-                      "describe": "SMTP username",
+                      "describe": "Email address to deliver the test message to",
                       "required": true
                     }
                   },
                   "commands": {},
-                  "describe": "Send a test email"
+                  "describe": "Send a test message through the saved custom SMTP provider"
                 },
                 "update": {
                   "name": "update",


### PR DESCRIPTION
## Overview

Refreshes the generated CLI reference for the neonctl 4.1.0 release (bumped from 3.5.1).

- `schema.json`: regenerated for 4.1.0.
- `neon-auth.md`: `email-provider test` now sends through the saved provider and takes only `--recipient-email`; its former SMTP options live on `email-provider update` (already documented). Fixed the stale example.
- `inspect.md`: documented the new `inspect db stalled-queries` subcommand (with live-captured output), resolving the dangling `<CliSubcommands>` anchor.

All `cli-docs` coverage and example-validation checks pass. Verified `inspect db stalled-queries` live against a branch.

Note: neonctl 4.x also switched `list`/`get` human output from boxed tables to plain terminal-width columns. That's a cosmetic change across many pages' example output and is left for a separate cleanup.

This pull request and its description were written by Isaac.
