### PR TITLE
docs: document the neon mcp command (neonctl 4.2.1)

### DIFF
--- a/content/docs/ai/ai-codex-plugin.md
+++ b/content/docs/ai/ai-codex-plugin.md
@@ -13,7 +13,7 @@ summary: >-
 description: >-
   Install the Neon plugin in OpenAI Codex for MCP-backed database
   management plus skills for Neon workflows and egress cost optimization.
-updatedOn: '2026-08-04T08:23:34.817Z'
+updatedOn: '2026-08-25T02:37:06.867Z'
 ---
 
 The **Neon** Codex plugin helps you manage Neon projects and databases. It adds Neon-specific [Agent Skills](https://developers.openai.com/codex/skills/) and Neon API access to [OpenAI Codex](https://developers.openai.com/codex/), including the **Neon MCP Server** for project and database management and skills that cover connection methods, branching, autoscaling, [Managed Better Auth](/docs/auth/overview), and more.
@@ -112,7 +112,7 @@ To configure Neon MCP and agent skills across supported tools from the command l
 npx neon@latest init
 ```
 
-That flow can set up OAuth, API keys, MCP configuration, and project-level skills where applicable. See the [`neon init` reference](/docs/cli/init) for details.
+That flow can set up OAuth, API keys, MCP configuration, and project-level skills where applicable. See the [`neon init` reference](/docs/cli/init) for details. To install just the Neon MCP server for Codex, run [`npx neon@latest mcp --agent codex`](/docs/cli/mcp).
 
 ## Use skills outside the Codex plugin
 

--- a/content/docs/ai/ai-cursor-plugin.md
+++ b/content/docs/ai/ai-cursor-plugin.md
@@ -11,7 +11,7 @@ summary: >-
 description: >-
   Install the Neon Cursor plugin to use Neon agent skills and MCP-powered
   database operations directly in Cursor.
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-08-25T02:37:06.867Z'
 ---
 
 The **Neon Cursor plugin** adds Neon-specific Skills and MCP integration to Cursor so your assistant can both reason about best practices and take database actions.
@@ -64,7 +64,7 @@ If you want Neon to configure AI tooling automatically, run:
 npx neon@latest init
 ```
 
-This configures MCP and installs Neon agent skills for supported editors.
+This configures MCP and installs Neon agent skills for supported editors. To install just the Neon MCP server for Cursor, run [`npx neon@latest mcp --agent cursor`](/docs/cli/mcp).
 
 ## Learn more
 

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -1,19 +1,16 @@
 ---
 title: Connect MCP clients to Neon
-subtitle: Learn how to connect MCP clients such as Cursor, Claude Code, VS Code,
-  ChatGPT, and other tools to your Lakebase Postgres database on Neon.
+subtitle: Connect MCP clients like Cursor, Claude Code, VS Code, and ChatGPT to
+  your Lakebase Postgres database on Neon.
 summary: >-
-  Connection guide for wiring MCP clients (Cursor, Claude Code, VS Code with
-  GitHub Copilot, ChatGPT, Cline, Windsurf, Zed, Claude Desktop, and more via
-  the add-mcp CLI) to the Neon MCP Server so AI assistants can query and manage
-  Lakebase Postgres databases on Neon using natural language. Use this page when you need
-  per-client setup instructions for `npx neon@latest init`, OAuth, or API
-  key authentication against `https://mcp.neon.tech/mcp`. Also covers
-  troubleshooting OAuth errors (invalid redirect URI, stale ~/.mcp-auth cache).
+  Connect MCP clients (Cursor, Claude Code, VS Code, ChatGPT, and more) to the
+  Neon MCP Server so AI assistants can query and manage your Lakebase Postgres
+  databases on Neon in natural language. Covers per-client setup, OAuth and API
+  key auth, and OAuth troubleshooting.
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-23T13:30:00.000Z'
+updatedOn: '2026-08-25T02:37:06.867Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -36,13 +33,21 @@ npx neon@latest init
 Each run of `npx neon@latest init` creates a new Neon API key. If you run it multiple times, review your [API keys](https://console.neon.tech/app/settings/api-keys) and revoke any you no longer need.
 </Admonition>
 
-If you only want the MCP server and nothing else, use:
+If you only want the MCP server and nothing else, run [`neon mcp`](/docs/cli/mcp):
+
+```bash
+neon mcp
+```
+
+It prompts for config location, agents, and auth, then writes the config. Pass `-y` to run non-interactively, or `--oauth` to skip minting a key. See the [`neon mcp` reference](/docs/cli/mcp) for all flags and supported agents.
+
+To use the lower-level `add-mcp` tool directly instead:
 
 ```bash
 npx add-mcp https://mcp.neon.tech/mcp
 ```
 
-This adds the MCP config to your editor's configuration files. Add `-g` for global (user-level) setup instead of project-level. Restart your editor (or enable the MCP server in your editor's settings); when you use the connection, an OAuth window will open to authorize. For API key authentication, add `--header "Authorization: Bearer $NEON_API_KEY"`. For more options, see the [add-mcp repository](https://github.com/neondatabase/add-mcp).
+This writes the MCP config to your editor. Add `-g` for global (user-level) instead of project-level, then restart your editor. On first use, an OAuth window opens to authorize; for API key auth, add `--header "Authorization: Bearer $NEON_API_KEY"`. See the [add-mcp repository](https://github.com/neondatabase/add-mcp) for more.
 
 ## Supported agents (add-mcp)
 

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -4,10 +4,9 @@ subtitle: Connect your AI assistant to Neon to manage projects, run queries, and
 summary: >-
   The Neon MCP Server implements the Model Context Protocol (MCP), letting AI
   assistants interact with your Neon projects on your behalf. Set up with
-  `npx neon@latest init` or use the config generator. Supports OAuth and
-  API key auth.
+  `npx neon@latest mcp` or use the config generator. Supports OAuth and API key auth.
 enableTableOfContents: true
-updatedOn: '2026-08-21T12:59:00.700Z'
+updatedOn: '2026-08-25T02:37:06.867Z'
 ---
 
 The Neon MCP Server implements the Model Context Protocol (MCP), letting AI assistants interact with your Neon projects on your behalf. Your AI agent can interact with Neon via MCP tools or by running [Neon CLI](/docs/cli) commands directly.
@@ -15,6 +14,28 @@ The Neon MCP Server implements the Model Context Protocol (MCP), letting AI assi
 <Admonition type="important" title="Security">
 The Neon MCP Server grants broad database management capabilities. **Always review and authorize actions requested by the LLM before execution.** Restrict access to trusted users only. See [MCP security guidance](#mcp-security-guidance).
 </Admonition>
+
+## Quick setup
+
+Install the Neon MCP server into your coding agents with [`neon mcp`](/docs/cli/mcp):
+
+```bash
+npx neon@latest mcp
+```
+
+It prompts for where to write the config, which agents to install into, and how to authenticate, then writes it for you.
+
+To set up the MCP server together with agent skills and editor tooling, run [`neon init`](/docs/cli/init):
+
+```bash
+npx neon@latest init
+```
+
+## Config generator
+
+Use the generator to build an MCP config for your editor and auth method, including the `Authorization` header for API key or remote agent setups.
+
+<McpSetupConfigurator />
 
 ## Claude connector
 
@@ -25,21 +46,7 @@ The Neon MCP server is an official Claude connector, so you don't need a custom 
 3. Click **Browse connectors** (top-right of that page), find **Neon**, and add it.
 4. Authorize access to your Neon account.
 
-For other clients, use Quick setup or the config generator below.
-
-## Quick setup
-
-```bash
-npx neon@latest init
-```
-
-Runs `neon init` via npx to configure MCP and other integrations for your editor. If you only want the MCP server, use the config generator below.
-
-## Config generator
-
-Use the generator to build an MCP config for your editor and auth method, including the `Authorization` header for API key or remote agent setups.
-
-<McpSetupConfigurator />
+For other clients, use Quick setup or the config generator above.
 
 ## Access control
 

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -9,7 +9,7 @@ summary: >-
   Cursor, VS Code, Claude Code, and any add-mcp client. The `--agent` flag runs
   it in agent/JSON mode.
 enableTableOfContents: true
-updatedOn: '2026-08-24T21:22:07.503Z'
+updatedOn: '2026-08-25T02:37:06.867Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -42,7 +42,7 @@ Use `--agent` (alias `-a`) to run `init` in agent/JSON mode, designed for when a
 
 ## Coding assistant support
 
-`init` is backed by the `neon-init` package bundled with `neon`. Besides Cursor, VS Code, and Claude Code, the interactive flow can configure any client that [add-mcp supports](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp). To register only the Neon MCP server in a client config (no `init`, no agent skills, no extension install), run `npx add-mcp https://mcp.neon.tech/mcp`. See [Connect MCP clients to Neon](/docs/ai/connect-mcp-clients-to-neon).
+`init` is backed by the `neon-init` package bundled with `neon`. Besides Cursor, VS Code, and Claude Code, the interactive flow can configure any client that [add-mcp supports](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp). To register only the Neon MCP server in a client config (no `init`, no agent skills, no extension install), run [`neon mcp`](/docs/cli/mcp), or `npx add-mcp https://mcp.neon.tech/mcp` for the lower-level tool directly. See [Connect MCP clients to Neon](/docs/ai/connect-mcp-clients-to-neon).
 
 ## What gets created
 

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -1,0 +1,116 @@
+---
+title: 'Neon CLI command: mcp'
+subtitle: 'Install the Neon MCP Server into your coding agents'
+summary: >-
+  The Neon CLI `mcp` command installs the [Neon MCP Server](/docs/ai/neon-mcp-server)
+  into your coding agents by writing their MCP config for you. Run it with no flags
+  for an interactive walkthrough, or pass flags to skip the prompts and script the
+  install. It handles the server URL, authentication, and which tools each agent
+  gets.
+enableTableOfContents: true
+---
+
+The `mcp` command installs the [Neon MCP Server](/docs/ai/neon-mcp-server) into your coding agents by writing their MCP config for you. It points each agent at the hosted server (`https://mcp.neon.tech/mcp`), sets up authentication, and can narrow which tools the agent sees.
+
+Run `neon mcp` with no flags for an interactive walkthrough: it asks whether to write global or project-level config, which detected agents to install into, and whether to authenticate with a minted API key or OAuth, then shows you what it will do before writing anything. Pass flags to skip the prompts and run it non-interactively, which is what you want in scripts or a headless environment.
+
+<Callout title="mcp vs init">
+[`neon init`](/docs/cli/init) is the broader onboarding command: it sets up the MCP Server along with agent skills and editor config. Use `mcp` when you only want to install the Neon MCP Server into your agents.
+</Callout>
+
+## Usage
+
+<CliUsage command="mcp" />
+
+## Options
+
+<CliOptions command="mcp" />
+
+### Authentication
+
+By default, `mcp` mints a new Neon API key and writes it into each agent's config. Minting requires you to already be signed in, so run [`neon auth`](/docs/cli/auth) first or pass `--api-key`. If you aren't authenticated, the command stops and tells you to sign in, pass `--api-key`, or use `--oauth`.
+
+<Admonition type="warning" title="Minted keys are account-wide">
+A minted API key reaches everything your account can access, in every organization. The command prints the key's id when it mints one. Revoke it with [`neon api-keys revoke <id>`](/docs/cli/api-keys).
+</Admonition>
+
+To install without minting a key, pass `--oauth`. This writes the server URL only, and the agent prompts you to sign in to Neon on first use. When `mcp` finds a Neon API key already configured for an agent, it reuses that key instead of minting a new one.
+
+### Choosing agents
+
+Without `--agent`, the interactive command detects installed agents and lets you pick from them. In non-interactive mode, `-y` installs into every detected agent. Pass `--agent <name>` (repeatable) to name agents explicitly and skip the picker.
+
+The supported agents are `antigravity`, `cline`, `cline-cli`, `claude-code`, `codex`, `cursor`, `gemini-cli`, `goose`, `github-copilot-cli`, `grok-build`, `mcporter`, `opencode`, `vscode`, `windsurf`, and `zed`. A few names also accept aliases (`claude` for `claude-code`, `copilot` for `vscode`, `gemini` for `gemini-cli`). Passing an unknown agent stops the command and prints the current supported list. A supported agent that can't take the chosen config (for example, one with no project-level config file when you pass `--project`) is reported and skipped.
+
+### Scoping the tools
+
+By default the server exposes every MCP tool. Use these flags to narrow what an agent can do:
+
+- `--read-only` hides the write tools by adding `?readonly=true` to the server URL.
+- `--category <name>` limits tools to one or more categories (repeatable, or comma-separated). Categories are `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, and `docs`.
+- `--project-id <id>` pins the tools to a single Neon project with `?projectId=`.
+
+These flags shape the server URL only. They don't change the scope of a minted API key.
+
+### Global vs project config
+
+By default `mcp` writes global (per-user) agent config. Pass `--project` to write project-level config in the current directory instead, so the setup travels with the repository. If a project-level config file is tracked by git, the command refuses to write an API key into it. Use `--oauth` in that case, or untrack the file first.
+
+## Examples
+
+Run the interactive install. It walks you through config location, agents, and authentication, then asks you to confirm:
+
+```bash
+neon mcp
+```
+
+Install non-interactively into every detected agent, using global config and a freshly minted API key. You need to be signed in already for the mint to succeed:
+
+```bash
+neon mcp -y
+```
+
+Install without minting a key. Each agent prompts you to sign in to Neon on first use:
+
+```bash
+neon mcp --oauth
+```
+
+Install into specific agents only:
+
+```bash
+neon mcp --agent cursor --agent claude-code
+```
+
+Write project-level config that travels with the repository. Here, `--oauth` skips minting a key and `--agent` names the target directly, so the command runs without prompts:
+
+```bash
+neon mcp --oauth --project --agent cursor
+```
+
+```text
+INFO: Wrote /home/user/my-app/.cursor/mcp.json
+INFO: URL: https://mcp.neon.tech/mcp
+MCP
+Agent   Status
+cursor  installed
+INFO: The agent will prompt for Neon sign-in on first use.
+```
+
+Give the agent read-only access:
+
+```bash
+neon mcp --read-only
+```
+
+Limit the agent to schema and querying tools:
+
+```bash
+neon mcp --category querying --category schema
+```
+
+Pin the MCP tools to a single project:
+
+```bash
+neon mcp --project-id cold-grass-40154007
+```

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,7 +7,7 @@ summary: >-
   skills, and can configure the MCP server, so your agent can create a
   project and connect your app.
 enableTableOfContents: true
-updatedOn: '2026-08-24T21:22:07.503Z'
+updatedOn: '2026-08-25T02:37:06.867Z'
 ---
 
 Set up Neon for your project without leaving your editor. `neon init` installs the Neon CLI, signs you in, installs Neon-specific agent skills, and can set up the [Neon MCP server](/docs/ai/neon-mcp-server). Together these give your agent what it needs to create a Neon project, connect your app, and use Neon features as you build. For Cursor and VS Code, it also installs the Neon Local Connect extension for in-editor schema browsing.
@@ -60,6 +60,8 @@ npx neon@latest init
 </Admonition>
 
 The wizard asks which editor to configure, then signs you in, creates an API key, installs [agent skills](/docs/ai/agent-skills), optionally configures the [Neon MCP server](/docs/ai/neon-mcp-server), and (for Cursor and VS Code) installs the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect). Run it from your project root so the skills land in the right place. For details and manual setup, see the [`neon init` reference](/docs/cli/init).
+
+If you only want the MCP server, without the skills or extension, run [`npx neon@latest mcp`](/docs/cli/mcp) instead.
 
 ## Tell your agent
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1212,6 +1212,8 @@
                   slug: cli/auth
                 - title: init
                   slug: cli/init
+                - title: mcp
+                  slug: cli/mcp
                 - title: bootstrap
                   slug: cli/bootstrap
                 - title: link

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.1.0",
+  "neonctlVersion": "4.2.1",
   "binaries": [
     "neonctl",
     "neon"
@@ -2126,6 +2126,84 @@
       },
       "describe": "Query branch logs",
       "usage": "$0 logs <sub-command> [options]"
+    },
+    "mcp": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "agent": {
+          "type": "array",
+          "describe": "Coding agent to install into (repeatable). Skips the agent picker",
+          "alias": "a"
+        },
+        "category": {
+          "type": "array",
+          "describe": "MCP tool category (repeatable or comma-separated). Default: all"
+        },
+        "oauth": {
+          "type": "boolean",
+          "describe": "Write the server URL only. The agent prompts for Neon sign-in on first use. No CLI login, no API key minted. Skips the auth question",
+          "default": false
+        },
+        "project": {
+          "type": "boolean",
+          "describe": "Write project-level MCP config. Skips the config-location question. Does not change the minted key",
+          "default": false
+        },
+        "project-id": {
+          "type": "string",
+          "describe": "Pin MCP tools to one Neon project (?projectId=). Does not change the minted key. Interactive asks only for a linked project-folder install"
+        },
+        "read-only": {
+          "type": "boolean",
+          "describe": "Restrict MCP tools to read-only (?readonly=true). Not prompted. Does not change the minted key",
+          "default": false,
+          "alias": "readonly"
+        },
+        "yes": {
+          "type": "boolean",
+          "describe": "Skip prompts. Defaults to global config, every detected agent and a minted account-wide API key. --project, --oauth, --agent, --read-only, --project-id and --category still apply",
+          "default": false,
+          "alias": "y"
+        }
+      },
+      "commands": {},
+      "describe": "Install the Neon MCP server into coding agents",
+      "usage": "$0 mcp [options]",
+      "examples": [
+        {
+          "command": "$0 mcp",
+          "description": "Interactive: config location, agents, auth, then confirm"
+        },
+        {
+          "command": "$0 mcp -y",
+          "description": "Global config, detected agents, minted API key"
+        },
+        {
+          "command": "$0 mcp --oauth",
+          "description": "Install with OAuth; the agent signs in on first use"
+        },
+        {
+          "command": "$0 mcp --project",
+          "description": "Write project-level config"
+        },
+        {
+          "command": "$0 mcp --agent cursor --agent claude-code",
+          "description": "Install into specific agents"
+        },
+        {
+          "command": "$0 mcp --read-only",
+          "description": "Hide write tools via ?readonly=true"
+        },
+        {
+          "command": "$0 mcp --project-id <id>",
+          "description": "Pin tools to one project via ?projectId="
+        },
+        {
+          "command": "$0 mcp --category querying --category schema",
+          "description": "Limit tools to those categories"
+        }
+      ]
     },
     "me": {
       "aliases": [],

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -48,6 +48,7 @@ const GROUP_OF = {
   profile: 'setup',
   logs: 'debugging',
   open: 'setup',
+  mcp: 'setup',
 };
 
 // Commands documented as a section of another command's page instead of a

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -38,6 +38,10 @@ const META = {
     examples: ['neon open'],
   },
   me: { desc: 'Show the authenticated user.', examples: ['neon me'] },
+  mcp: {
+    desc: 'Install the Neon MCP server into your coding agents.',
+    examples: ['neon mcp', 'neon mcp -y'],
+  },
   completion: { desc: 'Generate a shell completion script.' },
   projects: { desc: 'Manage projects.', examples: ['neon projects list'] },
   branches: {


### PR DESCRIPTION
## Overview

neonctl 4.2.1 adds a top-level `neon mcp` command that installs the Neon MCP Server into coding agents. This documents the command and threads it through the existing MCP setup docs.

- New CLI reference page for `neon mcp`, wired into the schema, command group, navigation, and the overview index.
- The Neon MCP Server overview now leads its quick setup with `neon mcp`, and its Claude connector section moved below the setup methods.
- The connect-clients, `neon init`, get-started, and Cursor/Codex plugin pages point to `neon mcp` as the MCP-only install path.

Verified `neon mcp` against the CLI source and a live install (OAuth, project scope, and the read-only/category/project-id URL flags).

This pull request and its description were written by Isaac.
