### PR TITLE
docs: document the neon skills command (Neon CLI 4.3.0)

### DIFF
--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,16 +6,18 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-08-17T23:18:55.558Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
 
-To set up Neon AI Gateway with an AI coding assistant, install the Neon Platform (`neon`) and Neon AI Gateway skills:
+To set up Neon AI Gateway with an AI coding assistant, install the Neon Platform (`neon`) and Neon AI Gateway skills with the [Neon CLI](/docs/cli):
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon -s neon-ai-gateway
+neon skills -s neon -s neon-ai-gateway
 ```
+
+Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s neon-ai-gateway` instead.
 
 <Steps>
 

--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -6,11 +6,11 @@ summary: >-
   assistants accurate knowledge of Neon's platform, APIs, SDKs, and best
   practices. Install them when using Cursor, Claude Code, OpenAI Codex, or any
   Agent Skills-compatible tool. Skills cover Postgres, Auth, Neon Functions,
-  Object Storage, AI Gateway, branching workflows, and more. Install all skills
-  with `npx skills add neondatabase/agent-skills -y`, a single skill with `-s`,
-  `neon init`, or editor plugins at project level or globally.
+  Object Storage, AI Gateway, branching workflows, and more. Install them
+  with `neon skills`, `npx skills add neondatabase/agent-skills -y`, `neon init`,
+  or editor plugins at project level or globally.
 enableTableOfContents: true
-updatedOn: '2026-08-20T11:15:28.658Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 redirectFrom:
   - /docs/ai/ai-rules
   - /docs/ai/ai-rules-neon-toolkit
@@ -30,6 +30,16 @@ Agent Skills provide your AI coding assistant with structured context about Neon
 
 There are several ways to install Neon skills depending on your editor and workflow.
 
+### neon skills
+
+The [Neon CLI](/docs/cli) installs skills interactively:
+
+```bash
+neon skills
+```
+
+It pre-selects your detected agents, lets you pick which skills to add, and confirms before writing. Pass `-s <skill>` and `--agent <name>` to skip the prompts, `--global` to install user-level, and run `neon skills update` to refresh installed skills. See the [`neon skills` reference](/docs/cli/skills) for all options.
+
 ### npx skills
 
 For any AI tool that supports the [Agent Skills](https://agentskills.io) format, install skills from the [Agent Skills repository](https://github.com/neondatabase/agent-skills):
@@ -41,7 +51,7 @@ npx skills add neondatabase/agent-skills -y
 This installs **all** skills in the repository. To install a specific skill instead, pass the `-s` flag:
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon-postgres -y
+npx skills add neondatabase/agent-skills -s neon -y
 ```
 
 Useful flags:
@@ -156,7 +166,7 @@ For codegen tools and multi-tenant products that provision Neon for their users,
 
 Skills can be installed at two levels:
 
-- **Project level** (default): Skills are installed in your project directory, for example via `neon init` or `npx skills add`. Your AI assistant picks them up when working in that project. This is best for team workflows since the configuration can be committed with the project.
+- **Project level** (default): Skills are installed in your project directory, for example via `neon skills`, `neon init`, or `npx skills add`. Your AI assistant picks them up when working in that project. This is best for team workflows since the configuration can be committed with the project.
 - **Global**: Skills are installed at the user or system level and available across all projects. Useful for personal development environments where you want Neon context everywhere. Pass the `-g` flag to install globally:
 
   ```bash

--- a/content/docs/ai/ai-claude-code-plugin.md
+++ b/content/docs/ai/ai-claude-code-plugin.md
@@ -12,7 +12,7 @@ summary: >-
 description: >-
   Install the Neon Claude Code plugin to give Claude access to Neon's APIs,
   Postgres workflows, and built-in Skills.
-updatedOn: '2026-08-04T08:22:57.969Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 The **Neon Claude Code plugin** is available on the official Claude plugins marketplace. It adds Neon-specific Skills and API access to Claude Code, Anthropic's AI development environment, bundling guided Skills plus an MCP (Model Context Protocol) server integration.
@@ -73,19 +73,19 @@ The plugin's MCP server integration lets Claude interact with Neon's live API en
 
 3. Start using the Skills:
    Use natural language prompts like:
-   > "Use the neon-drizzle Skill to set up Drizzle ORM with Neon."
+   > "Use the neon-postgres Skill to set up Drizzle ORM with Neon."
 
 Claude will automatically select and execute the relevant workflow.
 
 ## Use skills outside Claude Code
 
-The [Agent Skills repository](https://github.com/neondatabase/agent-skills) provides skills for other AI tools as well. You can install them with:
+The [Agent Skills repository](https://github.com/neondatabase/agent-skills) provides skills for other AI tools as well. With the [Neon CLI](/docs/cli), install them with:
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon-postgres
+neon skills -s neon -s neon-postgres
 ```
 
-See [Agent Skills](/docs/ai/agent-skills) for all installation options.
+Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s neon-postgres`. See [Agent Skills](/docs/ai/agent-skills) for all installation options.
 
 ## Learn more
 

--- a/content/docs/ai/ai-codex-plugin.md
+++ b/content/docs/ai/ai-codex-plugin.md
@@ -13,7 +13,7 @@ summary: >-
 description: >-
   Install the Neon plugin in OpenAI Codex for MCP-backed database
   management plus skills for Neon workflows and egress cost optimization.
-updatedOn: '2026-08-25T02:37:06.867Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 The **Neon** Codex plugin helps you manage Neon projects and databases. It adds Neon-specific [Agent Skills](https://developers.openai.com/codex/skills/) and Neon API access to [OpenAI Codex](https://developers.openai.com/codex/), including the **Neon MCP Server** for project and database management and skills that cover connection methods, branching, autoscaling, [Managed Better Auth](/docs/auth/overview), and more.
@@ -116,13 +116,13 @@ That flow can set up OAuth, API keys, MCP configuration, and project-level skill
 
 ## Use skills outside the Codex plugin
 
-The [Agent Skills repository](https://github.com/neondatabase/agent-skills) publishes the same skills for other AI tools. Install the main Neon skill with:
+The [Agent Skills repository](https://github.com/neondatabase/agent-skills) publishes the same skills for other AI tools. With the [Neon CLI](/docs/cli), install the core Neon skills with:
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon-postgres
+neon skills -s neon -s neon-postgres
 ```
 
-See [Agent Skills](/docs/ai/agent-skills) for global vs project install and other options.
+Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s neon-postgres`. See [Agent Skills](/docs/ai/agent-skills) for global vs project install and other options.
 
 ## Learn more
 

--- a/content/docs/ai/ai-cursor-plugin.md
+++ b/content/docs/ai/ai-cursor-plugin.md
@@ -11,7 +11,7 @@ summary: >-
 description: >-
   Install the Neon Cursor plugin to use Neon agent skills and MCP-powered
   database operations directly in Cursor.
-updatedOn: '2026-08-25T02:37:06.867Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 The **Neon Cursor plugin** adds Neon-specific Skills and MCP integration to Cursor so your assistant can both reason about best practices and take database actions.
@@ -64,7 +64,7 @@ If you want Neon to configure AI tooling automatically, run:
 npx neon@latest init
 ```
 
-This configures MCP and installs Neon agent skills for supported editors. To install just the Neon MCP server for Cursor, run [`npx neon@latest mcp --agent cursor`](/docs/cli/mcp).
+This configures MCP and installs Neon agent skills for supported editors. To install just the Neon MCP server for Cursor, run [`npx neon@latest mcp --agent cursor`](/docs/cli/mcp). To install just agent skills for Cursor, run [`npx neon@latest skills --agent cursor`](/docs/cli/skills).
 
 ## Learn more
 

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -9,7 +9,7 @@ summary: >-
   Cursor, VS Code, Claude Code, and any add-mcp client. The `--agent` flag runs
   it in agent/JSON mode.
 enableTableOfContents: true
-updatedOn: '2026-08-25T02:37:06.867Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -28,7 +28,7 @@ npx neon@latest init
 
 After running the command, restart your editor and ask your AI assistant to "Get started with Neon" to launch an interactive onboarding guide. The installed agent skills help you get started, including configuring a database connection. For Cursor and VS Code, the Neon Local Connect extension also provides database schema browsing, SQL editing, and table data management directly in your IDE.
 
-Under the hood, `init` runs `npx skills add neondatabase/agent-skills --skill neon --skill neon-postgres --agent <name>` for each selected editor. You can also run this command directly to install skills without the rest of the init flow, or use `npx skills add ... -g` to install globally. See [neon-postgres on skills.sh](https://skills.sh/neondatabase/agent-skills/neon-postgres) for more about the skills.
+Under the hood, `init` runs `npx skills add neondatabase/agent-skills --skill neon --skill neon-postgres --agent <name>` for each selected editor. To install skills on their own, without the rest of the init flow, use [`neon skills`](/docs/cli/skills) (add `--global` for a user-level install). See [neon-postgres on skills.sh](https://skills.sh/neondatabase/agent-skills/neon-postgres) for more about the skills.
 
 <Admonition type="warning">
 Skills are installed at the project level in the current working directory. Run `init` from your project root, otherwise skills will end up in the wrong location. You may want to commit project-level files so teammates get the same skills, or add them to `.gitignore` for per-developer setup.

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -15,7 +15,7 @@ The `mcp` command installs the [Neon MCP Server](/docs/ai/neon-mcp-server) into 
 Run `neon mcp` with no flags for an interactive walkthrough: it asks whether to write global or project-level config, which detected agents to install into, and whether to authenticate with a minted API key or OAuth, then shows you what it will do before writing anything. Pass flags to skip the prompts and run it non-interactively, which is what you want in scripts or a headless environment.
 
 <Callout title="mcp vs init">
-[`neon init`](/docs/cli/init) is the broader onboarding command: it sets up the MCP Server along with agent skills and editor config. Use `mcp` when you only want to install the Neon MCP Server into your agents.
+[`neon init`](/docs/cli/init) is the broader onboarding command: it sets up the MCP Server along with agent skills and editor config. Use `neon mcp` when you only want to install the Neon MCP Server into your agents, or [`neon skills`](/docs/cli/skills) when you only want to install agent skills.
 </Callout>
 
 ## Usage

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -1,0 +1,130 @@
+---
+title: 'Neon CLI command: skills'
+subtitle: 'Install and update Neon agent skills in your coding agents'
+summary: >-
+  The Neon CLI `skills` command installs [Neon agent skills](/docs/ai/agent-skills)
+  into your coding agents so they know how to work with Neon. Run it with no
+  flags for an interactive walkthrough, or pass flags to pick the skills and
+  agents and skip the prompts. Use `neon skills update` to refresh installed
+  skills to their latest versions.
+enableTableOfContents: true
+updatedOn: '2026-08-25T15:36:44.109Z'
+---
+
+The `skills` command installs [Neon agent skills](/docs/ai/agent-skills) into your coding agents, so tools like Cursor and Claude Code know how to work with Neon's Postgres, AI Gateway, Object Storage, and Functions.
+
+```bash
+neon skills
+```
+
+[Install the Neon CLI](/docs/cli/install) with `npm i -g neon@latest`, or run it once with `npx neon@latest skills`.
+
+With no flags it runs an interactive walkthrough: pick the agents, then the skills, then confirm. Pass flags to skip the prompts and script it. Without a terminal, pass `-y` or `--skill` to tell it which skills to install; `--agent` alone isn't enough.
+
+<Callout title="skills vs init">
+[`neon init`](/docs/cli/init) is the broader onboarding command: it sets up the Neon MCP Server along with agent skills and editor config. Use `neon skills` when you only want to install or update agent skills, and [`neon mcp`](/docs/cli/mcp) when you only want the [Neon MCP Server](/docs/ai/neon-mcp-server).
+</Callout>
+
+`skills` runs via `npx`, so it needs Node.js 22.20.0+; older or missing Node stops the command with an upgrade message.
+
+<CliSubcommands command="skills" />
+
+## neon skills (#skills)
+
+<CliUsage command="skills" />
+
+<CliOptions command="skills" />
+
+### Choosing agents
+
+Without `--agent`, the interactive command lists all supported agents, pre-selects the ones it detects, and lets you toggle the selection. In non-interactive mode, `-y` installs into every detected agent. Pass `--agent <name>` (repeatable) to name agents explicitly and skip the picker.
+
+The supported agents are `antigravity`, `cline`, `cline-cli`, `claude-code`, `claude-desktop`, `codex`, `cursor`, `gemini-cli`, `goose`, `github-copilot-cli`, `grok-build`, `opencode`, `vscode`, `windsurf`, and `zed`. A few also accept aliases (`claude` for `claude-code`, `copilot` for `vscode`, `gemini` for `gemini-cli`). Passing an unknown agent stops the command and prints the current supported list.
+
+An agent that can't install skills is skipped with a warning. Agents that share a target collapse into one: Claude Desktop and Claude Code both write to `claude-code`, and VS Code and the GitHub Copilot CLI both write to `github-copilot`.
+
+### Choosing skills
+
+Without `--skill`, the interactive command lets you pick from the catalog, and `-y` installs the default set. Pass `--skill <name>` (repeatable) to name skills explicitly and skip the picker.
+
+The available skills are:
+
+| Skill                            | Installed by default |
+| -------------------------------- | -------------------- |
+| `claimable-postgres`             | Yes                  |
+| `neon`                           | Yes                  |
+| `neon-ai-gateway`                | Yes                  |
+| `neon-functions`                 | Yes                  |
+| `neon-object-storage`            | Yes                  |
+| `neon-postgres`                  | Yes                  |
+| `neon-postgres-branches`         | Yes                  |
+| `neon-postgres-egress-optimizer` | Yes                  |
+| `neon-postgres-agent-platforms`  | No                   |
+
+Passing an unknown skill stops the command and prints the current supported list.
+
+The list of installable skills is built into each CLI release, so a skill that Neon publishes after the version you installed won't appear until you upgrade the CLI.
+
+### Directory vs user-level
+
+By default `skills` installs into the current directory, so the setup travels with the repository. Pass `--global` to install user-level skills instead, which apply across your projects.
+
+### Examples
+
+Run the interactive install:
+
+```bash
+neon skills
+```
+
+Install non-interactively into every detected agent, using the default skills in the current directory:
+
+```bash
+neon skills -y
+```
+
+Install named skills into a specific agent. Naming both `--skill` and `--agent` skips every prompt:
+
+```bash
+neon skills -s neon -s neon-ai-gateway --agent cursor
+```
+
+```text filename="Output"
+Skills
+Scope           Skills                 Agents  Status
+this directory  neon, neon-ai-gateway  cursor  installed
+
+INFO: Wrote skills in this directory.
+```
+
+Install user-level skills that apply across your projects:
+
+```bash
+neon skills --global
+```
+
+## neon skills update (#update)
+
+Updates every skill installed in the current directory to its latest version, or every user-level skill with `--global`. It takes neither `--agent` nor `--skill`; it updates whatever is already installed. When there's nothing to update, the status is `none` and the `Detail` column shows the reason.
+
+<CliUsage command="skills update" />
+
+<CliOptions command="skills update" />
+
+Update skills in the current directory without prompting:
+
+```bash
+neon skills update -y
+```
+
+```text filename="Output"
+Skills
+Scope           Status   Detail
+this directory  updated  ✓ Updated 1 skill(s)
+```
+
+Update user-level skills:
+
+```bash
+neon skills update --global -y
+```

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -7,7 +7,7 @@ summary: >-
   with neon dev, and deploy with neon deploy. The function gets a public HTTPS
   URL with DATABASE_URL injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-08-18T19:33:13.398Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -67,11 +67,13 @@ That's a deployed function in three commands. The rest of this guide builds a mo
 - The latest `neon`, installed and authenticated. Functions commands are new and change often, so upgrade before you start (`npm install -g neon@latest`).
 - Node.js 20 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
-`neon init --preview` is designed to be run by your AI coding assistant. It outputs structured instructions that guide the agent through setup. To install the Neon Platform (`neon`) and Neon Functions skills separately:
+`neon init --preview` is designed to be run by your AI coding assistant. It outputs structured instructions that guide the agent through setup. To install the Neon Platform (`neon`) and Neon Functions skills separately with the [Neon CLI](/docs/cli):
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon -s neon-functions
+neon skills -s neon -s neon-functions
 ```
+
+Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s neon-functions` instead.
 
 ## Set up your project
 

--- a/content/docs/get-started/backend-overview.md
+++ b/content/docs/get-started/backend-overview.md
@@ -306,7 +306,7 @@ The beta services live under `preview` while they're in beta; that key goes away
 
 Two ways to get it running:
 
-**Let your AI editor build it.** Copy the prompt at the top of this page and hand it to your assistant. It runs `neon init` to configure the MCP server and install the core skill, adds the Object Storage, Functions, and AI Gateway skills with `npx skills add neondatabase/agent-skills`, then builds against each capability's current API.
+**Let your AI editor build it.** Copy the prompt at the top of this page and hand it to your assistant. It runs `neon init` to configure the MCP server and install the core skill, adds the Object Storage, Functions, and AI Gateway skills with `neon skills`, then builds against each capability's current API.
 
 **Start from a template.** `neon bootstrap` scaffolds a ready-to-run starter, installs dependencies, and links a project:
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,7 +7,7 @@ summary: >-
   skills, and can configure the MCP server, so your agent can create a
   project and connect your app.
 enableTableOfContents: true
-updatedOn: '2026-08-25T02:37:06.867Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 Set up Neon for your project without leaving your editor. `neon init` installs the Neon CLI, signs you in, installs Neon-specific agent skills, and can set up the [Neon MCP server](/docs/ai/neon-mcp-server). Together these give your agent what it needs to create a Neon project, connect your app, and use Neon features as you build. For Cursor and VS Code, it also installs the Neon Local Connect extension for in-editor schema browsing.
@@ -61,7 +61,7 @@ npx neon@latest init
 
 The wizard asks which editor to configure, then signs you in, creates an API key, installs [agent skills](/docs/ai/agent-skills), optionally configures the [Neon MCP server](/docs/ai/neon-mcp-server), and (for Cursor and VS Code) installs the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect). Run it from your project root so the skills land in the right place. For details and manual setup, see the [`neon init` reference](/docs/cli/init).
 
-If you only want the MCP server, without the skills or extension, run [`npx neon@latest mcp`](/docs/cli/mcp) instead.
+If you only want the MCP server, without the skills or extension, run [`npx neon@latest mcp`](/docs/cli/mcp) instead. If you only want agent skills, run [`npx neon@latest skills`](/docs/cli/skills).
 
 ## Tell your agent
 

--- a/content/docs/guides/ai-agent-integration.md
+++ b/content/docs/guides/ai-agent-integration.md
@@ -11,7 +11,7 @@ summary: >-
   Project transfers require a personal API key.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-17T12:17:37.017Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 This guide covers the technical implementation of the Neon agent plan for your platform. You'll learn how to provision databases, implement versioning, manage user upgrades, and monitor usage at scale.
@@ -52,10 +52,10 @@ For details about **Agent plan** structure, pricing, and benefits, refer to the 
 </Admonition>
 
 <Admonition type="tip" title="Code samples and agent skill">
-The [neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms) repository provides runnable TypeScript samples for the patterns in this guide. Install the companion agent skill with:
+The [neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms) repository provides runnable TypeScript samples for the patterns in this guide. Install the companion agent skill with the [Neon CLI](/docs/cli):
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon-postgres-agent-platforms -y
+neon skills -s neon-postgres-agent-platforms -y
 ```
 
 </Admonition>
@@ -80,13 +80,13 @@ The two-organization structure enables you to:
 
 Each organization has different limits that apply to all projects created within it. Understanding these limits helps you design your platform's features and set appropriate user expectations. For how Agent compares to Scale, see [Agent vs Scale](/docs/introduction/agent-plan#agent-vs-scale).
 
-| Limit                    | Free Organization | Paid Organization | Notes                                                                                     |
-| ------------------------ | ----------------- | ----------------- | ----------------------------------------------------------------------------------------- |
-| **Max branches**         | 10 per project    | Up to 1,000       | Includes all branches (production, development, snapshots)                                |
+| Limit                    | Free Organization | Paid Organization | Notes                                                                                             |
+| ------------------------ | ----------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
+| **Max branches**         | 10 per project    | Up to 1,000       | Includes all branches (production, development, snapshots)                                        |
 | **Max manual snapshots** | 1 per project     | 100 per project   | Manual snapshots only. Automated snapshot schedules are available upon request on the Agent plan. |
-| **Compute range**        | 0.25 - 2 CU       | 0.25 - 16 CU      | CU = Compute Units (~4GB RAM per CU). Fixed sizes up to 16 CU (Scale allows up to 56 CU). |
-| **History window**       | 1 day             | Up to 7 days      | Point-in-time recovery window (Scale allows up to 30 days)                                |
-| **Min auto-suspend**     | 5 minutes         | 1 minute          | Minimum time before compute suspends                                                      |
+| **Compute range**        | 0.25 - 2 CU       | 0.25 - 16 CU      | CU = Compute Units (~4GB RAM per CU). Fixed sizes up to 16 CU (Scale allows up to 56 CU).         |
+| **History window**       | 1 day             | Up to 7 days      | Point-in-time recovery window (Scale allows up to 30 days)                                        |
+| **Min auto-suspend**     | 5 minutes         | 1 minute          | Minimum time before compute suspends                                                              |
 
 **Key constraints to consider:**
 

--- a/content/docs/introduction/agent-plan.md
+++ b/content/docs/introduction/agent-plan.md
@@ -12,7 +12,7 @@ summary: >-
   through the Neon API, with autoscaling, scale-to-zero, branching, and
   point-in-time recovery included.
 enableTableOfContents: true
-updatedOn: '2026-08-17T12:17:37.017Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 <InfoBlock>
@@ -86,18 +86,18 @@ Compute is billed at $0.106 per compute unit hour (Launch rate, lower than Scale
 
 Agent and Scale are different plans. Enrollment starts from Scale, but after you join Agent your organizations use Agent pricing and limits.
 
-| Feature | Agent plan | Scale plan |
-| ------- | ---------- | ---------- |
-| Projects | Unlimited. We incrementally raise your limit to accommodate growing usage. | 1,000 (can be increased on request) |
-| Compute | $0.106 per CU-hour | $0.222 per CU-hour |
-| Max fixed compute size | 16 CU | 56 CU |
-| Autoscaling | Up to 16 CU | Up to 16 CU |
-| Branches per project | Up to 1,000 | Up to 5,000 |
-| Root branches per project | 5 | 25 |
-| Read replicas | Up to 3 | Unlimited |
-| Instant restore history window | Up to 7 days | Up to 30 days |
-| Public network transfer | 100 GB per project included, then $0.10/GB | 500 GB per project included, then $0.10/GB |
-| Automated snapshot schedules | Available upon request | Available |
+| Feature                        | Agent plan                                                                 | Scale plan                                 |
+| ------------------------------ | -------------------------------------------------------------------------- | ------------------------------------------ |
+| Projects                       | Unlimited. We incrementally raise your limit to accommodate growing usage. | 1,000 (can be increased on request)        |
+| Compute                        | $0.106 per CU-hour                                                         | $0.222 per CU-hour                         |
+| Max fixed compute size         | 16 CU                                                                      | 56 CU                                      |
+| Autoscaling                    | Up to 16 CU                                                                | Up to 16 CU                                |
+| Branches per project           | Up to 1,000                                                                | Up to 5,000                                |
+| Root branches per project      | 5                                                                          | 25                                         |
+| Read replicas                  | Up to 3                                                                    | Unlimited                                  |
+| Instant restore history window | Up to 7 days                                                               | Up to 30 days                              |
+| Public network transfer        | 100 GB per project included, then $0.10/GB                                 | 500 GB per project included, then $0.10/GB |
+| Automated snapshot schedules   | Available upon request                                                     | Available                                  |
 
 Both plans include metrics/logs export, SOC 2 reporting, private networking, and configurable scale-to-zero. For the full Scale feature list, see [Neon plans](/docs/introduction/plans).
 
@@ -122,17 +122,17 @@ See [transfer projects between organizations](/docs/manage/orgs-project-transfer
 
 The agent plan uses usage-based pricing with dedicated support. See [Agent vs Scale](#agent-vs-scale) for how limits compare to Scale.
 
-| Resource                        | Agent plan                                                                                            |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Projects                        | **Unlimited** <br/> _We incrementally raise your limit to accommodate growing usage._                 |
-| Branches per Project            | **Up to 1,000** <br/> _Agents use branches to quickly toggle between application states._             |
-| Compute                         | **$0.106 per compute unit hour** <br/> _Same rate as Launch; lower than Scale_                        |
-| Storage                         | **$0.35 per GB-month** <br/> _Same as Launch and Scale_                                               |
-| Instant Restore (PITR)          | **$0.2 per GB-month** <br/> _Up to 7-day history window_                                              |
-| Public network transfer         | **100 GB per project included**, then $0.10/GB                                                        |
-| Management API                  | **Higher Rate Limits Available** <br/> _API for instant provisioning and management of databases_     |
-| Data API (PostgREST-compatible) | **Higher Rate Limits Available** <br/> _REST API for direct database access_                          |
-| Support                         | **Shared Slack Channel** <br/> _Direct access to the Neon team_                                       |
+| Resource                        | Agent plan                                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Projects                        | **Unlimited** <br/> _We incrementally raise your limit to accommodate growing usage._             |
+| Branches per Project            | **Up to 1,000** <br/> _Agents use branches to quickly toggle between application states._         |
+| Compute                         | **$0.106 per compute unit hour** <br/> _Same rate as Launch; lower than Scale_                    |
+| Storage                         | **$0.35 per GB-month** <br/> _Same as Launch and Scale_                                           |
+| Instant Restore (PITR)          | **$0.2 per GB-month** <br/> _Up to 7-day history window_                                          |
+| Public network transfer         | **100 GB per project included**, then $0.10/GB                                                    |
+| Management API                  | **Higher Rate Limits Available** <br/> _API for instant provisioning and management of databases_ |
+| Data API (PostgREST-compatible) | **Higher Rate Limits Available** <br/> _REST API for direct database access_                      |
+| Support                         | **Shared Slack Channel** <br/> _Direct access to the Neon team_                                   |
 
 > _Pricing applies to the paid organization only._
 
@@ -150,13 +150,13 @@ Track compute time, storage, and network I/O per project to monitor usage and bu
 
 The agent plan includes these benefits for participating platforms:
 
-| Benefit                    | Description                                                                                                                                 |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Benefit                    | Description                                                                                                                                                            |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Your Free Tier is free** | Neon sponsors projects in your free tier, covering infrastructure costs. Project limits are unlimited; we incrementally raise your limit to accommodate growing usage. |
-| **General use credits**    | Up to $25,000 in credits for paid tier usage (for platforms not already enrolled in the [Neon Startup Program](https://neon.com/startups)). |
-| **Higher rate limits**     | Custom rate limits for Management API and Data API to support high-volume operations.                                                       |
-| **Dedicated support**      | Shared Slack channel with direct access to the Neon team for technical support.                                                             |
-| **Co-marketing**           | Blog features, social promotions, hackathon support, and joint marketing opportunities.                                                     |
+| **General use credits**    | Up to $25,000 in credits for paid tier usage (for platforms not already enrolled in the [Neon Startup Program](https://neon.com/startups)).                            |
+| **Higher rate limits**     | Custom rate limits for Management API and Data API to support high-volume operations.                                                                                  |
+| **Dedicated support**      | Shared Slack channel with direct access to the Neon team for technical support.                                                                                        |
+| **Co-marketing**           | Blog features, social promotions, hackathon support, and joint marketing opportunities.                                                                                |
 
 ## Getting started
 
@@ -170,10 +170,10 @@ Once enrolled in the agent plan:
 For step-by-step implementation instructions, see the [AI Agent integration guide](/docs/guides/ai-agent-integration).
 
 <Admonition type="tip" title="Code samples and agent skill">
-The [neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms) repository provides TypeScript samples and a companion agent skill for building on the agent plan. Install the companion skill with:
+The [neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms) repository provides TypeScript samples and a companion agent skill for building on the agent plan. Install the companion skill with the [Neon CLI](/docs/cli):
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon-postgres-agent-platforms -y
+neon skills -s neon-postgres-agent-platforms -y
 ```
 
 </Admonition>

--- a/content/docs/introduction/network-transfer.md
+++ b/content/docs/introduction/network-transfer.md
@@ -9,7 +9,7 @@ summary: >-
   replication syncs, and to monitor usage via the Console or Consumption API.
   Reduction strategies include scoping SELECT columns, using Neon snapshots,
   adding replication filters, and routing traffic over Private Link.
-updatedOn: '2026-08-07T17:19:40.308Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 Network transfer is one of the usage metrics that affects your Neon bill. This guide explains what network transfer is, what causes it to increase, how to monitor it, and how to reduce it. For broader cost guidance, see [Cost optimization](/docs/introduction/cost-optimization). For plan allowances and pricing, see [Plans](/docs/introduction/plans).
@@ -290,11 +290,13 @@ For broader cost reduction strategies across all billing metrics, see [Cost opti
 
 ### Use the egress optimizer agent skill
 
-An [agent skill](https://github.com/neondatabase/agent-skills) is available that guides your AI assistant through diagnosing and fixing application-side query patterns that cause excessive egress. The skill walks through analyzing your codebase for anti-patterns (such as `SELECT *`, missing pagination, high-frequency queries on static data, and application-side aggregation), applying fixes, and verifying with tests. To add it to your AI assistant:
+An [agent skill](https://github.com/neondatabase/agent-skills) is available that guides your AI assistant through diagnosing and fixing application-side query patterns that cause excessive egress. The skill walks through analyzing your codebase for anti-patterns (such as `SELECT *`, missing pagination, high-frequency queries on static data, and application-side aggregation), applying fixes, and verifying with tests. To add it to your AI assistant with the [Neon CLI](/docs/cli):
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon-postgres-egress-optimizer
+neon skills -s neon-postgres-egress-optimizer
 ```
+
+Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon-postgres-egress-optimizer` instead.
 
 <Admonition type="tip">
 Building a platform on Neon? You can cap per-project network transfer with [consumption limits](/docs/guides/consumption-limits).

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1214,6 +1214,8 @@
                   slug: cli/init
                 - title: mcp
                   slug: cli/mcp
+                - title: skills
+                  slug: cli/skills
                 - title: bootstrap
                   slug: cli/bootstrap
                 - title: link

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,16 +6,18 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-07-15T23:47:24.799Z'
+updatedOn: '2026-08-25T15:36:44.109Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
 
-To set up Neon Object Storage with an AI coding assistant, install the Neon Platform (`neon`) and Neon Object Storage skills:
+To set up Neon Object Storage with an AI coding assistant, install the Neon Platform (`neon`) and Neon Object Storage skills with the [Neon CLI](/docs/cli):
 
 ```bash
-npx skills add neondatabase/agent-skills -s neon -s neon-object-storage
+neon skills -s neon -s neon-object-storage
 ```
+
+Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s neon-object-storage` instead.
 
 To follow this guide, you need:
 

--- a/scripts/docs-checks/neonctl/README.md
+++ b/scripts/docs-checks/neonctl/README.md
@@ -94,8 +94,8 @@ override deletes a stale key.
 ## Page conventions (content/docs/cli/)
 
 - Full-path headings with short custom anchors:
-  `## neonctl branches restore (#restore)`; nested leaves use prefixed
-  anchors (`### neonctl vpc endpoint list (#endpoint-list)`) matching the
+  `## neon branches restore (#restore)`; nested leaves use prefixed
+  anchors (`### neon vpc endpoint list (#endpoint-list)`) matching the
   links `<CliSubcommands anchorParts="..."/>` emits.
 - Options tables are generated; link-rich caveats live as prose below them.
 - Example outputs go in ```` ```text ```` / ```` ```json ```` fences, never
@@ -103,7 +103,7 @@ override deletes a stale key.
   outputs (18 lines or fewer) sit inline under the command; long outputs
   and JSON dumps collapse in `<details><summary>Show output</summary>`.
   Never invent output: reuse captured output or ship command-only examples.
-- The binary is `neonctl` everywhere.
+- The binary is `neon` everywhere in headings and examples.
 
 ## Files
 

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.2.1",
+  "neonctlVersion": "4.3.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -3274,6 +3274,84 @@
       "commands": {},
       "describe": "Deprecated: use `neon link`. Set the .neon context (raw write).",
       "usage": "$0 set-context [options]"
+    },
+    "skills": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "agent": {
+          "type": "array",
+          "describe": "Coding agent to install into (repeatable). Skips the agent picker",
+          "alias": "a"
+        },
+        "global": {
+          "type": "boolean",
+          "describe": "Install user-level skills (skills CLI -g). Default is this directory",
+          "default": false
+        },
+        "skill": {
+          "type": "array",
+          "describe": "Skill to install (repeatable). Skips the skill picker",
+          "alias": "s"
+        },
+        "yes": {
+          "type": "boolean",
+          "describe": "Skip prompts",
+          "default": false,
+          "alias": "y"
+        }
+      },
+      "commands": {
+        "update": {
+          "name": "update",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "global": {
+              "type": "boolean",
+              "describe": "Update user-level skills (skills CLI -g). Default is this directory",
+              "default": false
+            }
+          },
+          "commands": {},
+          "describe": "Update installed skills to the latest versions",
+          "examples": [
+            {
+              "command": "$0 skills update",
+              "description": "Interactive: confirm, then update skills in this directory"
+            },
+            {
+              "command": "$0 skills update -y",
+              "description": "Update skills in this directory without prompting"
+            },
+            {
+              "command": "$0 skills update --global -y",
+              "description": "Update user-level skills"
+            }
+          ],
+          "usage": "$0 skills update [options]"
+        }
+      },
+      "describe": "Install Neon agent skills into coding agents",
+      "usage": "$0 skills [command] [options]",
+      "examples": [
+        {
+          "command": "$0 skills",
+          "description": "Interactive: this directory, agents, skills, then confirm"
+        },
+        {
+          "command": "$0 skills -y",
+          "description": "This directory, detected agents, the default skills"
+        },
+        {
+          "command": "$0 skills -s neon -s neon-ai-gateway --agent cursor",
+          "description": "Install named skills into specific agents"
+        },
+        {
+          "command": "$0 skills --global",
+          "description": "Install user-level skills"
+        }
+      ]
     },
     "snapshots": {
       "aliases": [

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -49,6 +49,7 @@ const GROUP_OF = {
   logs: 'debugging',
   open: 'setup',
   mcp: 'setup',
+  skills: 'setup',
 };
 
 // Commands documented as a section of another command's page instead of a

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -42,6 +42,10 @@ const META = {
     desc: 'Install the Neon MCP server into your coding agents.',
     examples: ['neon mcp', 'neon mcp -y'],
   },
+  skills: {
+    desc: 'Install and update Neon agent skills in your coding agents.',
+    examples: ['neon skills', 'neon skills -y', 'neon skills update -y'],
+  },
   completion: { desc: 'Generate a shell completion script.' },
   projects: { desc: 'Manage projects.', examples: ['neon projects list'] },
   branches: {


### PR DESCRIPTION
## Overview

Neon CLI 4.3.0 adds `neon skills`, a command that installs Neon agent skills into your coding agents (Cursor, Claude Code, and others). This documents it and makes it easy to find:

- A new generated CLI reference page at `/docs/cli/skills`, added to the schema, command index, and navigation.
- Links to the command from the docs that previously showed only the raw `npx skills add ...` path: the Agent Skills hub (now leading with `neon skills`), the AI Gateway, Object Storage, and Functions quickstarts, and the Claude Code, Codex, and Cursor plugin pages.

Documents https://github.com/neondatabase/neon-pkgs/pull/473.

Examples were verified against a live `neon@4.3.0`, and the CLI docs checks pass.

This pull request and its description were written by Isaac.
