### PR TITLE
Add cover image to Neon CLI blog post

### DIFF
--- a/content/blog/posts/just-landed-in-the-neon-cli.md
+++ b/content/blog/posts/just-landed-in-the-neon-cli.md
@@ -15,7 +15,8 @@ categories:
 authors:
   - carlota-soto
 cover:
-  image: null
+  image: >-
+    https://cdn.neonapi.io/public/images/pages/blog/just-landed-in-the-neon-cli/neon-just-landed.jpg
   alt: null
 isFeatured: false
 seo:


### PR DESCRIPTION
## Summary

Adds the cover image URL to the "Just landed in the Neon CLI" blog post.

## Pages changed

- content/blog/posts/just-landed-in-the-neon-cli.md