### PR TITLE
docs: redirect /docs/guides/branching to canonical branching page

### DIFF
--- a/content/docs/introduction/branching.md
+++ b/content/docs/introduction/branching.md
@@ -12,8 +12,9 @@ redirectFrom:
   - /docs/conceptual-guides/branches
   - /docs/conceptual-guides/branching
   - /docs/concepts/branching
+  - /docs/guides/branching
   - /docs/introduction/point-in-time-restore
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-25T16:32:40.555Z'
 ---
 
 With Neon, you can quickly branch your data for development, testing, and various other purposes, enabling you to improve developer productivity and optimize continuous integration and delivery (CI/CD) pipelines.


### PR DESCRIPTION
https://neon.tech/docs/guides/branching is cited in 3 published benchmark answers across 2 models and 3 runs. The URL redirects to https://neon.com/docs/guides/branching, which returns HTTP 404. The live https://neon.com/docs/introduction/branching page is already cited by 50 answers in this benchmark (68 across all benchmarks).

As per the brief in:

/dashboard/neon/actions/repair-broken-branching-guide-redirect