### PR TITLE
docs: document the neon plugins command (Neon CLI 4.4.0)

### DIFF
--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -10,7 +10,7 @@ summary: >-
   with `neon skills`, `npx skills add neondatabase/agent-skills -y`, `neon init`,
   or editor plugins at project level or globally.
 enableTableOfContents: true
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-25T21:56:50.915Z'
 redirectFrom:
   - /docs/ai/ai-rules
   - /docs/ai/ai-rules-neon-toolkit
@@ -39,6 +39,16 @@ neon skills
 ```
 
 It pre-selects your detected agents, lets you pick which skills to add, and confirms before writing. Pass `-s <skill>` and `--agent <name>` to skip the prompts, `--global` to install user-level, and run `neon skills update` to refresh installed skills. See the [`neon skills` reference](/docs/cli/skills) for all options.
+
+### neon plugins
+
+For agents that support plugin marketplaces (Claude Code, Cursor, Codex, and more), the Neon CLI can install the plugin, which bundles the skills and the Neon MCP Server:
+
+```bash
+neon plugins
+```
+
+It pre-selects your detected agents and confirms before writing. Pass `--agent <name>` to name agents, `-y` to install into detected agents without prompts, and `--global` to install user-level. See the [`neon plugins` reference](/docs/cli/plugins) for all options.
 
 ### npx skills
 
@@ -70,7 +80,7 @@ In Cursor chat, run:
 /add-plugin neon-postgres
 ```
 
-Or install from [cursor.com/marketplace/neon](https://cursor.com/marketplace/neon). See [Cursor plugin for Neon](/docs/ai/ai-cursor-plugin) for details.
+Or install from [cursor.com/marketplace/neon](https://cursor.com/marketplace/neon). To install from the command line, run [`npx neon@latest plugins --agent cursor`](/docs/cli/plugins). See [Cursor plugin for Neon](/docs/ai/ai-cursor-plugin) for details.
 
 <Admonition type="note">
 Editor plugins currently bundle the core Postgres skill set and MCP integration. To give your assistant context for **Neon Functions**, **Object Storage**, and **AI Gateway**, run `npx skills add neondatabase/agent-skills -y` or install the platform skills individually (see [Available skills](#available-skills)).
@@ -85,13 +95,13 @@ If you're using Claude Code, install the Neon plugin for skills and MCP integrat
 /plugin install neon-postgres@neon
 ```
 
-See [Claude Code plugin for Neon](/docs/ai/ai-claude-code-plugin) for details.
+Or install it from the command line with [`npx neon@latest plugins --agent claude-code`](/docs/cli/plugins). See [Claude Code plugin for Neon](/docs/ai/ai-claude-code-plugin) for details.
 
 ### Codex plugin
 
 If you're using OpenAI Codex, install the **Neon** plugin from the [Codex plugin directory](https://developers.openai.com/codex/plugins/) (in the Codex app under **Plugins**, or in the Codex CLI with `/plugins`). It includes the Neon app (MCP), the main Neon skill, and the egress optimizer skill.
 
-See [Codex plugin for Neon](/docs/ai/ai-codex-plugin) for details.
+To install from the command line instead, run [`npx neon@latest plugins --agent codex`](/docs/cli/plugins). See [Codex plugin for Neon](/docs/ai/ai-codex-plugin) for details.
 
 ### Kimi Code plugin
 

--- a/content/docs/ai/ai-claude-code-plugin.md
+++ b/content/docs/ai/ai-claude-code-plugin.md
@@ -12,7 +12,7 @@ summary: >-
 description: >-
   Install the Neon Claude Code plugin to give Claude access to Neon's APIs,
   Postgres workflows, and built-in Skills.
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-25T21:56:50.915Z'
 ---
 
 The **Neon Claude Code plugin** is available on the official Claude plugins marketplace. It adds Neon-specific Skills and API access to Claude Code, Anthropic's AI development environment, bundling guided Skills plus an MCP (Model Context Protocol) server integration.
@@ -60,6 +60,12 @@ The plugin's MCP server integration lets Claude interact with Neon's live API en
 
    ```text
    /plugin install neon@claude-plugins-official
+   ```
+
+   Or install it from the [Neon CLI](/docs/cli), which can target several agents in one command:
+
+   ```bash
+   neon plugins --agent claude-code
    ```
 
 2. Verify the installation:

--- a/content/docs/ai/ai-codex-plugin.md
+++ b/content/docs/ai/ai-codex-plugin.md
@@ -13,7 +13,7 @@ summary: >-
 description: >-
   Install the Neon plugin in OpenAI Codex for MCP-backed database
   management plus skills for Neon workflows and egress cost optimization.
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-25T21:56:50.915Z'
 ---
 
 The **Neon** Codex plugin helps you manage Neon projects and databases. It adds Neon-specific [Agent Skills](https://developers.openai.com/codex/skills/) and Neon API access to [OpenAI Codex](https://developers.openai.com/codex/), including the **Neon MCP Server** for project and database management and skills that cover connection methods, branching, autoscaling, [Managed Better Auth](/docs/auth/overview), and more.
@@ -112,7 +112,7 @@ To configure Neon MCP and agent skills across supported tools from the command l
 npx neon@latest init
 ```
 
-That flow can set up OAuth, API keys, MCP configuration, and project-level skills where applicable. See the [`neon init` reference](/docs/cli/init) for details. To install just the Neon MCP server for Codex, run [`npx neon@latest mcp --agent codex`](/docs/cli/mcp).
+That flow can set up OAuth, API keys, MCP configuration, and project-level skills where applicable. See the [`neon init` reference](/docs/cli/init) for details. To install just the Neon MCP server for Codex, run [`npx neon@latest mcp --agent codex`](/docs/cli/mcp). To install the plugin (skills plus MCP) for Codex, run [`npx neon@latest plugins --agent codex`](/docs/cli/plugins).
 
 ## Use skills outside the Codex plugin
 

--- a/content/docs/ai/ai-cursor-plugin.md
+++ b/content/docs/ai/ai-cursor-plugin.md
@@ -11,7 +11,7 @@ summary: >-
 description: >-
   Install the Neon Cursor plugin to use Neon agent skills and MCP-powered
   database operations directly in Cursor.
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-25T21:56:50.915Z'
 ---
 
 The **Neon Cursor plugin** adds Neon-specific Skills and MCP integration to Cursor so your assistant can both reason about best practices and take database actions.
@@ -64,7 +64,7 @@ If you want Neon to configure AI tooling automatically, run:
 npx neon@latest init
 ```
 
-This configures MCP and installs Neon agent skills for supported editors. To install just the Neon MCP server for Cursor, run [`npx neon@latest mcp --agent cursor`](/docs/cli/mcp). To install just agent skills for Cursor, run [`npx neon@latest skills --agent cursor`](/docs/cli/skills).
+This configures MCP and installs Neon agent skills for supported editors. To install just the Neon MCP server for Cursor, run [`npx neon@latest mcp --agent cursor`](/docs/cli/mcp). To install just agent skills for Cursor, run [`npx neon@latest skills --agent cursor`](/docs/cli/skills). To install the plugin (skills plus MCP) for Cursor, run [`npx neon@latest plugins --agent cursor`](/docs/cli/plugins).
 
 ## Learn more
 

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -30,8 +30,8 @@ Run `neon mcp` with no flags for an interactive walkthrough: it asks whether to 
 
 By default, `mcp` mints a new Neon API key and writes it into each agent's config. Minting requires you to already be signed in, so run [`neon auth`](/docs/cli/auth) first or pass `--api-key`. If you aren't authenticated, the command stops and tells you to sign in, pass `--api-key`, or use `--oauth`.
 
-<Admonition type="warning" title="Minted keys are account-wide">
-A minted API key reaches everything your account can access, in every organization. The command prints the key's id when it mints one. Revoke it with [`neon api-keys revoke <id>`](/docs/cli/api-keys).
+<Admonition type="warning" title="Minted keys are account-wide by default">
+By default a minted API key reaches everything your account can access, in every organization. Pass `--project-id` to limit a newly minted key to a single project instead (see [Scoping the tools](#scoping-the-tools)). The command prints the key's id when it mints one. Revoke it with [`neon api-keys revoke <id>`](/docs/cli/api-keys).
 </Admonition>
 
 To install without minting a key, pass `--oauth`. This writes the server URL only, and the agent prompts you to sign in to Neon on first use. When `mcp` finds a Neon API key already configured for an agent, it reuses that key instead of minting a new one.
@@ -48,9 +48,9 @@ By default the server exposes every MCP tool. Use these flags to narrow what an 
 
 - `--read-only` hides the write tools by adding `?readonly=true` to the server URL.
 - `--category <name>` limits tools to one or more categories (repeatable, or comma-separated). Categories are `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, and `docs`.
-- `--project-id <id>` pins the tools to a single Neon project with `?projectId=`.
+- `--project-id <id>` pins the tools to a single Neon project with `?projectId=`, and limits a newly minted key to that project.
 
-These flags shape the server URL only. They don't change the scope of a minted API key.
+`--read-only` and `--category` shape the server URL only; they don't change a key's scope, and neither does reusing an already-configured key.
 
 ### Global vs project config
 
@@ -109,7 +109,7 @@ Limit the agent to schema and querying tools:
 neon mcp --category querying --category schema
 ```
 
-Pin the MCP tools to a single project:
+Pin the tools to one project and limit the minted key to it:
 
 ```bash
 neon mcp --project-id cold-grass-40154007

--- a/content/docs/cli/plugins.md
+++ b/content/docs/cli/plugins.md
@@ -1,0 +1,89 @@
+---
+title: 'Neon CLI command: plugins'
+subtitle: 'Install the Neon plugin into coding agents that support plugin marketplaces'
+summary: >-
+  The Neon CLI `plugins` command installs the `neon-postgres` plugin into
+  coding agents that support plugin marketplaces, such as Claude Code, Cursor,
+  and Codex. The plugin bundles Neon's agent skills and MCP access. Run it with
+  no flags for an interactive walkthrough, or pass `--agent` and `-y` to pick
+  the agents and skip the prompts.
+enableTableOfContents: true
+---
+
+The `plugins` command installs the `neon-postgres` plugin into coding agents that support plugin marketplaces, so tools like Claude Code, Cursor, and Codex know how to work with Neon. The plugin bundles [Neon's agent skills](/docs/ai/agent-skills) and the [Neon MCP Server](/docs/ai/neon-mcp-server) in one package.
+
+```bash
+neon plugins
+```
+
+[Install the Neon CLI](/docs/cli/install) with `npm i -g neon@latest`, or run it once with `npx neon@latest plugins`.
+
+With no flags it runs an interactive walkthrough: pick the agents, then confirm. Pass flags to skip the prompts and script it. Without a terminal, pass `-y` to install into detected agents, or name agents with `--agent`.
+
+<Callout title="plugins vs skills vs mcp">
+Use `neon plugins` for agents that support plugin marketplaces, where the plugin bundles skills and MCP access together. Use [`neon skills`](/docs/cli/skills) to install [agent skills](/docs/ai/agent-skills) on their own, and [`neon mcp`](/docs/cli/mcp) to set up just the [Neon MCP Server](/docs/ai/neon-mcp-server). [`neon init`](/docs/cli/init) is the broader onboarding command that sets these up together.
+</Callout>
+
+`plugins` runs via `npx`, so it needs Node.js; without it the command stops with a message to install Node.js and retry.
+
+## Usage
+
+<CliUsage command="plugins" />
+
+## Options
+
+<CliOptions command="plugins" />
+
+### Choosing agents
+
+Without `--agent`, the interactive command lists the supported agents, pre-selects the ones it detects, and lets you toggle the selection. In non-interactive mode, `-y` installs into every detected agent. Pass `--agent <name>` (repeatable) to name agents explicitly and skip the picker.
+
+The agents that support plugins are `claude-code`, `claude-desktop`, `codex`, `cursor`, `github-copilot-cli`, `grok-build`, and `vscode`. Several also accept aliases: `claude` for `claude-code`, `grok` for `grok-build`, and `copilot`, `github-copilot`, or `vs-code` for `vscode`. Passing an unknown agent stops the command and prints the supported list. An agent with no plugin support is skipped when others can install, or stops the command when it's the only one selected.
+
+Agents that share a target collapse into one: Claude Desktop and Claude Code both write to `claude-code`, and VS Code and the GitHub Copilot CLI both write to `github-copilot`.
+
+### Directory vs user-level
+
+By default `plugins` installs into the current project, so the setup travels with the repository. Pass `--global` to install user-level instead, which applies across your projects.
+
+Some agents only support user-level plugins. In a project install, `github-copilot-cli`, `grok-build`, and `vscode` need `--global`; without it, the command tells you to pass it.
+
+## Examples
+
+Run the interactive install:
+
+```bash
+neon plugins
+```
+
+Install into a specific agent, skipping every prompt:
+
+```bash
+neon plugins --agent claude-code -y
+```
+
+```text filename="Output"
+Plugins
+Scope    Plugin         Agent        Status
+project  neon-postgres  claude-code  installed
+
+INFO: Installed the Neon plugin (project).
+```
+
+Install into several agents at once:
+
+```bash
+neon plugins --agent cursor --agent claude-code
+```
+
+Install non-interactively into every detected agent:
+
+```bash
+neon plugins -y
+```
+
+Install user-level so the plugin applies across your projects, including agents that only support user-level plugins:
+
+```bash
+neon plugins --global
+```

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1216,6 +1216,8 @@
                   slug: cli/mcp
                 - title: skills
                   slug: cli/skills
+                - title: plugins
+                  slug: cli/plugins
                 - title: bootstrap
                   slug: cli/bootstrap
                 - title: link

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.3.0",
+  "neonctlVersion": "4.4.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -2147,12 +2147,12 @@
         },
         "project": {
           "type": "boolean",
-          "describe": "Write project-level MCP config. Skips the config-location question. Does not change the minted key",
+          "describe": "Write project-level MCP config. Skips the config-location question. A linked project-folder install may still pin a project and scope a newly minted key",
           "default": false
         },
         "project-id": {
           "type": "string",
-          "describe": "Pin MCP tools to one Neon project (?projectId=). Does not change the minted key. Interactive asks only for a linked project-folder install"
+          "describe": "Pin MCP tools to one Neon project (?projectId=). A newly minted API key is limited to that project. A linked project-folder install asks the same when you pick API-key auth"
         },
         "read-only": {
           "type": "boolean",
@@ -2838,6 +2838,49 @@
       },
       "describe": "Manage organizations",
       "usage": "$0 orgs <sub-command> [options]"
+    },
+    "plugins": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "agent": {
+          "type": "array",
+          "describe": "Coding agent to install into (repeatable). Skips the agent picker",
+          "alias": "a"
+        },
+        "global": {
+          "type": "boolean",
+          "describe": "Install user-level. Default is project",
+          "default": false
+        },
+        "yes": {
+          "type": "boolean",
+          "describe": "Skip prompts",
+          "default": false,
+          "alias": "y"
+        }
+      },
+      "commands": {},
+      "describe": "Install the Neon plugin into coding agents",
+      "usage": "$0 plugins [options]",
+      "examples": [
+        {
+          "command": "$0 plugins",
+          "description": "Interactive: agents, then confirm"
+        },
+        {
+          "command": "$0 plugins -y",
+          "description": "Detected agents, skip prompts"
+        },
+        {
+          "command": "$0 plugins --agent cursor --agent claude-code",
+          "description": "Install into specific agents"
+        },
+        {
+          "command": "$0 plugins --global",
+          "description": "Install user-level"
+        }
+      ]
     },
     "profile": {
       "aliases": [

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -50,6 +50,7 @@ const GROUP_OF = {
   open: 'setup',
   mcp: 'setup',
   skills: 'setup',
+  plugins: 'setup',
 };
 
 // Commands documented as a section of another command's page instead of a

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -46,6 +46,10 @@ const META = {
     desc: 'Install and update Neon agent skills in your coding agents.',
     examples: ['neon skills', 'neon skills -y', 'neon skills update -y'],
   },
+  plugins: {
+    desc: 'Install the Neon plugin (skills plus MCP) into your coding agents.',
+    examples: ['neon plugins', 'neon plugins -y', 'neon plugins --global'],
+  },
   completion: { desc: 'Generate a shell completion script.' },
   projects: { desc: 'Manage projects.', examples: ['neon projects list'] },
   branches: {


### PR DESCRIPTION
## Overview

Refreshes the Neon CLI reference to version 4.4.0. The release introduces
`neon plugins`, which installs the `neon-postgres` plugin (Neon's agent skills
plus the Neon MCP Server) into coding agents that support plugin marketplaces,
targeting several agents in one command.

Changes:
- New reference page `content/docs/cli/plugins.md`, with the regenerated
  `schema.json`, nav entry, group mapping, and command-index copy.
- Links to `neon plugins` from the agent skills page and the Cursor, Claude
  Code, and Codex plugin pages, alongside their existing install steps.
- Updates `mcp.md` for the 4.4.0 behavior change: `--project-id` now limits a
  newly minted API key to that project.

Verified each documented invocation against the installed 4.4.0 binary and the
CLI source, and the CLI docs coverage suite passes.

This pull request and its description were written by Isaac.
