### PR TITLE
Pin the hosted neon skill to agent-skills main

### DIFF
--- a/config/skills.json
+++ b/config/skills.json
@@ -4,7 +4,7 @@
     { "name": "neon-postgres", "ref": "main" },
     { "name": "neon-postgres-egress-optimizer", "ref": "main" },
     { "name": "neon-postgres-branches", "ref": "main" },
-    { "name": "neon", "ref": "8a4200b2fdf8c4a5b301c717064d8aeb58c8eea5" },
+    { "name": "neon", "ref": "main" },
     {
       "name": "neon-postgres-agent-platforms",
       "ref": "main",


### PR DESCRIPTION
## Problem

`config/skills.json` pinned the `neon` skill to `8a4200b2fdf8c4a5b301c717064d8aeb58c8eea5`, a commit from the agent-skills branch that added the Claimable Neon reference. Every other entry in that file tracks `"main"`.

That work has since landed on `neondatabase/agent-skills` main. While the SHA pin stands, both `src/scripts/sync-skills.js` and `scripts/check-skills-sync.mjs` resolve the neon skill against a frozen commit, so later upstream edits never sync into `public/docs/ai/skills/neon/` and the drift check never reports them. The copy served from neon.com stops following its source, and nothing in CI says so.

## What changes

```json
// config/skills.json
{ "name": "neon", "ref": "main" }
```

That one field is the whole diff.

The vendored content under `public/docs/ai/skills/neon/` is untouched. agent-skills main (currently `c623f99e`) carries the same `SKILL.md` and `references/claimable-neon.md` as the pinned commit, so re-syncing produced no file changes. The next upstream change to the skill is the first one this branch will actually pull in.

## Verification

Run on this branch:

- `node src/scripts/sync-skills.js --skill neon` - fetched both files from `neondatabase/agent-skills@main`, identical to the vendored copy
- `node src/scripts/generate-skills-index.js` and `node src/scripts/generate-static-md-manifest.js` - no change to the skills index or the static markdown manifest
- `node scripts/check-skills-sync.mjs --skill neon` - passes, neon matches `neondatabase/agent-skills@main` (2 files)

## For your attention

- The drift check will now fail whenever the neon skill changes upstream and the vendored copy has not been re-synced. That is the contract the other seven skills in the file already have.