### PR TITLE
docs: surface the Neon CLI and API across feature docs with tabs

### DIFF
--- a/content/docs/auth/guides/configure-domains.md
+++ b/content/docs/auth/guides/configure-domains.md
@@ -8,7 +8,7 @@ summary: >-
   (https://*.preview.vercel.app) in Console > Auth > Configuration > Domains.
   Localhost ports are pre-approved and need no entry.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
@@ -23,11 +23,46 @@ Without adding your production domain, OAuth sign-in and verification links will
 
 ## Add a domain
 
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
 1. Go to **Console → Auth → Configuration → Domains**
 2. Enter your domain with protocol: `https://myapp.com`
 3. Click **Add domain**
 
 Repeat for each domain where your app runs.
+
+</TabItem>
+
+<TabItem>
+
+Add a domain with [`neon neon-auth domain add`](/docs/cli/neon-auth#domain-add):
+
+```bash
+neon neon-auth domain add https://myapp.com
+```
+
+Use `neon neon-auth domain list` and `neon neon-auth domain delete` to view and remove entries.
+
+</TabItem>
+
+<TabItem>
+
+Send a `POST` request to the [add trusted domain](/docs/reference/api/auth/add-branch-neon-auth-trusted-domain) endpoint. Replace `{project_id}` and `{branch_id}` with your project and branch IDs.
+
+```bash shouldWrap
+curl -X POST 'https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/domains' \
+  -H 'Authorization: Bearer $NEON_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"domain": "https://myapp.com", "auth_provider": "better_auth"}'
+```
+
+Use [`GET`](/docs/reference/api/auth/list-branch-neon-auth-trusted-domains) on the same path to list domains, and [`DELETE`](/docs/reference/api/auth/delete-branch-neon-auth-trusted-domain) to remove them. See [Manage Managed Better Auth via the API](/docs/auth/guides/manage-auth-api#related-auth-endpoints) for the full set of auth endpoints.
+
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note">
 Include the protocol (`https://`) and omit trailing slashes. For example: `https://myapp.com` not `https://myapp.com/`

--- a/content/docs/auth/guides/email-verification.md
+++ b/content/docs/auth/guides/email-verification.md
@@ -9,7 +9,7 @@ summary: >-
   resent; verification can be configured as required or optional in the Neon
   Console, controlling whether unverified users can sign in.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
@@ -27,9 +27,43 @@ Verification links require a [custom email provider](/docs/auth/production-check
 
 ## Enable email verification
 
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
 In your project's **Settings** → **Auth** page, enable **Sign-up with Email** and **Verify at Sign-up**. Choose your verification method.
 
 ![Email verification settings in Neon Console](/docs/auth/email-verification-settings.png)
+
+</TabItem>
+
+<TabItem>
+
+Enable email and password authentication with verification required using [`neon neon-auth config email-password update`](/docs/cli/neon-auth#config-email-password-update):
+
+```bash
+neon neon-auth config email-password update --enabled --require-email-verification
+```
+
+</TabItem>
+
+<TabItem>
+
+Update the configuration with the [Update email and password configuration](/docs/reference/api/auth/update-neon-auth-email-and-password-config) endpoint. Replace `{project_id}` and `{branch_id}` with your project and branch IDs:
+
+```bash
+curl -X PATCH 'https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/email_and_password' \
+  -H 'Authorization: Bearer $NEON_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "enabled": true,
+  "require_email_verification": true
+}'
+```
+
+</TabItem>
+
+</Tabs>
 
 ## Verification links
 

--- a/content/docs/auth/guides/manage-auth-api.md
+++ b/content/docs/auth/guides/manage-auth-api.md
@@ -15,12 +15,12 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/neon-auth/api
   - /docs/guides/neon-auth-api
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
 
-You can manage Managed Better Auth programmatically using the [Neon API](/docs/reference/api). You can also enable and configure Managed Better Auth from an AI editor using the [Neon MCP server](/docs/ai/neon-mcp-server#supported-actions-tools) (`provision_neon_auth`, `configure_neon_auth`, `get_neon_auth_config`). See [Set up with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor).
+You can manage Managed Better Auth programmatically using the [Neon API](/docs/reference/api), or from the terminal with the [Neon CLI](/docs/cli/neon-auth) (`neon neon-auth`), which wraps these same operations. You can also enable and configure Managed Better Auth from an AI editor using the [Neon MCP server](/docs/ai/neon-mcp-server#supported-actions-tools) (`provision_neon_auth`, `configure_neon_auth`, `get_neon_auth_config`). See [Set up with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor).
 
 <Admonition type="note">
 Managed Better Auth operates at the **branch level**. Each branch can have its own independent auth configuration, which means preview and development branches can have separate auth state from your production branch.

--- a/content/docs/auth/guides/plugins.md
+++ b/content/docs/auth/guides/plugins.md
@@ -9,7 +9,7 @@ summary: >-
   them via the Neon Console or Neon API. The Organization plugin has partial
   support.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
@@ -19,7 +19,7 @@ Managed Better Auth is built on [Better Auth](https://www.better-auth.com/), whi
 <Admonition type="info" title="Plugins are managed by Managed Better Auth">
 Managed Better Auth is a **managed** Better Auth service. You **don’t install or configure Better Auth plugins directly** - instead, Managed Better Auth exposes a supported subset of plugins through the Neon SDK.
 
-For plugins that have Console settings (for example [Organization](/docs/auth/guides/plugins/organization)), open **Auth** > **Plugins** (beta) in the Neon Console, or use the Neon API. Additional plugin options may still arrive over time; see the [Managed Better Auth roadmap](/docs/auth/roadmap).
+For plugins that have Console settings (for example [Organization](/docs/auth/guides/plugins/organization)), open **Auth** > **Plugins** (beta) in the Neon Console, or use the Neon API. From the terminal, [`neon neon-auth config organization update`](/docs/cli/neon-auth#config-organization-update) configures the Organization plugin, and [`neon neon-auth plugins list`](/docs/cli/neon-auth#plugins-list) shows the current plugin configurations. Additional plugin options may still arrive over time; see the [Managed Better Auth roadmap](/docs/auth/roadmap).
 </Admonition>
 
 The following Better Auth plugins are currently supported in Managed Better Auth:

--- a/content/docs/auth/guides/setup-oauth.md
+++ b/content/docs/auth/guides/setup-oauth.md
@@ -12,7 +12,7 @@ summary: >-
   credentials and redirect URIs must be configured per branch; preview
   deployments can use wildcard trusted domain patterns to cover multiple hosts.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
@@ -162,11 +162,46 @@ Before testing production OAuth, add every origin you pass as **`callbackURL`** 
 
 ### 3. Create OAuth apps and paste credentials into Neon
 
-1. Create OAuth apps with your providers:
-   - [Google OAuth setup](https://developers.google.com/identity/protocols/oauth2/web-server) (see [Google OAuth branding](#google-oauth-branding) below before going live)
-   - [GitHub OAuth setup](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
-   - [Vercel OAuth setup](https://vercel.com/docs/sign-in-with-vercel/manage-from-dashboard#create-an-app)
-2. In the Neon Console, open your **project**, select the **branch**, open **Auth**, then enter the **Client ID** and **Client Secret** for each provider.
+Create OAuth apps with your providers:
+
+- [Google OAuth setup](https://developers.google.com/identity/protocols/oauth2/web-server) (see [Google OAuth branding](#google-oauth-branding) below before going live)
+- [GitHub OAuth setup](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
+- [Vercel OAuth setup](https://vercel.com/docs/sign-in-with-vercel/manage-from-dashboard#create-an-app)
+
+Then give the **Client ID** and **Client Secret** to Managed Better Auth for that branch:
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+In the Neon Console, open your **project**, select the **branch**, open **Auth**, then enter the **Client ID** and **Client Secret** for each provider.
+
+</TabItem>
+
+<TabItem>
+
+Add a provider with [`neon neon-auth oauth-provider add`](/docs/cli/neon-auth#oauth-provider-add):
+
+```bash shouldWrap
+neon neon-auth oauth-provider add --provider-id google --oauth-client-id <client-id> --oauth-client-secret <client-secret>
+```
+
+</TabItem>
+
+<TabItem>
+
+Send a `POST` request to the [add OAuth provider](/docs/reference/api/auth/add-branch-neon-auth-oauth-provider) endpoint. Replace `{project_id}` and `{branch_id}` with your project and branch IDs.
+
+```bash shouldWrap
+curl -X POST 'https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/oauth_providers' \
+  -H 'Authorization: Bearer $NEON_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"id": "google", "client_id": "<client-id>", "client_secret": "<client-secret>"}'
+```
+
+</TabItem>
+
+</Tabs>
 
 Managed Better Auth will use your configured credentials for that branch.
 

--- a/content/docs/auth/guides/webhooks.md
+++ b/content/docs/auth/guides/webhooks.md
@@ -13,7 +13,7 @@ summary: >-
   phone_number.verified, use EdDSA Ed25519 detached JWS signatures for
   verification, and retry blocking events within a global timeout.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
@@ -44,7 +44,7 @@ When you subscribe to `send.otp` or `send.magic_link`, Managed Better Auth skips
 
 ## Configure webhooks
 
-Configure webhooks per project and branch using the Neon API. Your webhook URL must use HTTPS protocol. See the API reference for [Get webhook configuration](/docs/reference/api/auth/get-neon-auth-webhook-config) and [Update webhook configuration](/docs/reference/api/auth/update-neon-auth-webhook-config).
+Configure webhooks per project and branch using the Neon Console, CLI, or API. Your webhook URL must use HTTPS protocol. See the API reference for [Get webhook configuration](/docs/reference/api/auth/get-neon-auth-webhook-config) and [Update webhook configuration](/docs/reference/api/auth/update-neon-auth-webhook-config).
 
 ```bash
 PUT /projects/{project_id}/branches/{branch_id}/auth/webhooks
@@ -78,6 +78,24 @@ Webhook endpoints that point at private networks, localhost, cloud metadata serv
 
 ### Set or update configuration
 
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+In the Neon Console, go to **Auth → Configuration → Webhooks** to enable webhook delivery, set the **Webhook URL** (an HTTPS endpoint; see [Webhook URL requirements](#webhook-url-requirements)), choose which events to send, and set the per-attempt timeout in seconds (1-10, default 5). Save to apply.
+
+</TabItem>
+
+<TabItem>
+
+```bash shouldWrap
+neon neon-auth config webhook update --enabled --url https://your-app.com/webhooks/neon-auth --enabled-events user.created --timeout 5
+```
+
+</TabItem>
+
+<TabItem>
+
 ```bash
 curl -X PUT "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/webhooks" \
   -H "Content-Type: application/json" \
@@ -90,12 +108,38 @@ curl -X PUT "https://console.neon.tech/api/v2/projects/{project_id}/branches/{br
   }'
 ```
 
+</TabItem>
+
+</Tabs>
+
 ### Get current configuration
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+View the current webhook configuration under **Auth → Configuration → Webhooks** in the Neon Console.
+
+</TabItem>
+
+<TabItem>
+
+```bash
+neon neon-auth config webhook get
+```
+
+</TabItem>
+
+<TabItem>
 
 ```bash
 curl "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/webhooks" \
   -H "Authorization: Bearer $NEON_API_KEY"
 ```
+
+</TabItem>
+
+</Tabs>
 
 Both endpoints return the configuration in the same format:
 

--- a/content/docs/auth/overview.md
+++ b/content/docs/auth/overview.md
@@ -8,7 +8,7 @@ summary: >-
   gets its own isolated auth environment, so you can test sign-up, login, and
   OAuth flows in preview or CI branches without touching production.
 enableTableOfContents: true
-updatedOn: '2026-07-31T15:49:10.111Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 redirectFrom:
   - /docs/neon-auth/quick-start/nextjs
   - /docs/auth/migrate/from-stack-auth
@@ -83,7 +83,7 @@ As Managed Better Auth evolves, more Better Auth integrations and features will 
 
 ## Basic usage
 
-Enable Auth in the Neon Console or [with your AI editor](#set-up-with-your-ai-editor), then add authentication to your app.
+Enable Auth in the Neon Console, from the terminal with [`neon neon-auth enable`](/docs/cli/neon-auth#enable), or [with your AI editor](#set-up-with-your-ai-editor), then add authentication to your app.
 
 **For Next.js (server-side):**
 

--- a/content/docs/auth/production-checklist.md
+++ b/content/docs/auth/production-checklist.md
@@ -10,7 +10,7 @@ summary: >-
   rate-limited and does not support verification links. A custom SMTP provider
   is required for both.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
@@ -53,6 +53,10 @@ A custom SMTP provider uses your sender address but still sends Neon's default e
 
 ### Configure custom SMTP
 
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
 In your project's **Settings** → **Auth** page, configure your email provider:
 
 1. Select **Custom SMTP provider**
@@ -64,6 +68,33 @@ In your project's **Settings** → **Auth** page, configure your email provider:
    - **Sender email**: Email address to send from
    - **Sender name**: Display name for sent emails
 3. Click **Save**
+
+</TabItem>
+
+<TabItem>
+
+Configure a standard SMTP provider with [`neon neon-auth config email-provider update`](/docs/cli/neon-auth#config-email-provider-update):
+
+```bash shouldWrap
+neon neon-auth config email-provider update --type standard --host smtp.example.com --port 587 --username example_username --password AbC123dEf --sender-email noreply@example.com --sender-name "Example App"
+```
+
+</TabItem>
+
+<TabItem>
+
+Update the provider with the [Update email provider configuration](/docs/reference/api/auth/update-neon-auth-email-provider) endpoint. Replace `{project_id}` and `{branch_id}` with your project and branch IDs:
+
+```bash shouldWrap
+curl -X PATCH 'https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/auth/email_provider' \
+  -H 'Authorization: Bearer $NEON_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"type": "standard", "host": "smtp.example.com", "port": 587, "username": "example_username", "password": "AbC123dEf", "sender_email": "noreply@example.com", "sender_name": "Example App"}'
+```
+
+</TabItem>
+
+</Tabs>
 
 ### Email provider requirements
 

--- a/content/docs/cli/logs.md
+++ b/content/docs/cli/logs.md
@@ -9,7 +9,7 @@ summary: >-
   LogQL, and list which fields and values a branch reports. Logs are in beta
   and available only in AWS US East (Ohio) (aws-us-east-2).
 enableTableOfContents: true
-updatedOn: '2026-08-19T00:03:14.837Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 <FeatureBeta />
@@ -32,7 +32,7 @@ Query log records over a time window. By default it returns the last hour of log
 
 Bound the window with `--since` (a duration like `30m` or `1h`, ending at `--end-time` or now) or with an explicit `--start-time`/`--end-time` pair. `--since` and `--start-time` are mutually exclusive, and the maximum window is 7 days.
 
-The structured content filters (`--source`, `--service-name`, `--scope-name`, `--minimum-severity`, `--severity-text`, `--body-contains`, and `--trace-id`) combine with each other. Passing `--logql` replaces all of them with a raw [LogQL](https://grafana.com/docs/loki/latest/query/) expression (stream selectors and line filters only); the window, `--limit`, `--sort-order`, and `--cursor` still apply.
+The structured content filters (`--source`, `--service-name`, `--scope-name`, `--severity-text`, `--body-contains`, and `--trace-id`) combine with each other. Passing `--logql` replaces all of them with a raw [LogQL](https://grafana.com/docs/loki/latest/query/) expression (stream selectors and line filters only); the window, `--limit`, `--sort-order`, and `--cursor` still apply.
 
 `--source` accepts `function`, `storage`, and `pg_endpoint`. Only `function` and `storage` return records today; `pg_endpoint` (Postgres compute) is accepted but comes back empty until Postgres logs ship.
 
@@ -45,7 +45,7 @@ neon logs query --since 30m
 Filter function errors on a specific branch:
 
 ```bash
-neon logs query --branch main --source function --minimum-severity error
+neon logs query --branch main --source function --severity-text ERROR
 ```
 
 Use a raw LogQL selection instead of the structured filters:

--- a/content/docs/compute/functions/logs.md
+++ b/content/docs/compute/functions/logs.md
@@ -90,4 +90,10 @@ attachDatabasePool(pool, {
 
 For details on filtering by level or service name, searching log bodies, live tail, downloading logs, and the 3-day retention window, see [Monitor logs](/docs/introduction/monitor-logs).
 
+You can also read function logs from the terminal with [`neon logs query`](/docs/cli/logs), scoped with `--source function`:
+
+```bash
+neon logs query --source function --since 1h
+```
+
 <NeedHelp/>

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -10,7 +10,7 @@ summary: >-
   branch for a single database and does not support projects with IP Allow or
   Private Networking configured.
 enableTableOfContents: true
-updatedOn: '2026-08-18T10:29:02.410Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 This guide walks you through enabling the Data API, creating a table with RLS, and running your first query.
@@ -25,7 +25,7 @@ This guide walks you through enabling the Data API, creating a table with RLS, a
 ## Enable the Data API
 
 <Admonition type="tip" title="Enable programmatically">
-You can also enable the Data API using the [Neon API](/docs/data-api/manage#manage-via-the-neon-api) or the [Neon MCP Server](/docs/ai/neon-mcp-server#supported-actions-tools) (`provision_neon_data_api` tool).
+You can also enable the Data API from the terminal with [`neon data-api create`](/docs/cli/data-api#create), using the [Neon API](/docs/data-api/manage#manage-via-the-neon-api), or with the [Neon MCP Server](/docs/ai/neon-mcp-server#supported-actions-tools) (`provision_neon_data_api` tool).
 </Admonition>
 
 ### 1. Navigate to the Data API page

--- a/content/docs/introduction/monitor-logs.md
+++ b/content/docs/introduction/monitor-logs.md
@@ -53,6 +53,16 @@ If no logs match the current filters, the empty state offers a **Widen time rang
 
 **Download** saves the log lines currently loaded in the view, exactly as filtered, to a plain-text `.log` file, newest first. Downloading doesn't re-run the query against the full retention window: it's a snapshot of what's on screen, so narrow your search, levels, and time range first if you want a smaller or more targeted file.
 
+## Query logs from the CLI
+
+The same branch logs are available from the terminal with [`neon logs query`](/docs/cli/logs), so you can filter and script against them without opening the Console:
+
+```bash
+neon logs query --since 30m
+```
+
+Combine filters like `--source`, `--service-name`, and `--severity-text`, or pass a raw `--logql` expression.
+
 ## Retention
 
 Logs are retained for **3 days**. Once a log line falls outside that window, it's no longer queryable in the Console.

--- a/content/docs/introduction/read-replicas.md
+++ b/content/docs/introduction/read-replicas.md
@@ -11,7 +11,7 @@ summary: >-
   Autoscaling and Scale to Zero. Cross-region replicas require logical
   replication to a separate Neon project.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 Neon read replicas are independent computes designed to perform read operations on the same data as your primary read-write compute. Neon's read replicas do not replicate or duplicate data. Instead, read requests are served from the same storage, as shown in the diagram below. While your read-write queries are directed through your primary compute, read queries can be offloaded to one or more read replicas.
@@ -31,21 +31,33 @@ You can instantly create read replicas for any branch in your Neon project and c
 
 You can create read replicas using the Neon Console, [Neon CLI](/docs/cli), or [Neon API](/docs/reference/api), providing the flexibility required to integrate read replicas into your workflow or CI/CD processes.
 
-From the Neon Console, it's a simple **Add Read Replica** action on a branch.
-
 <Admonition type="note">
 You can add read replicas to a branch as needed to accommodate your workload. The Free plan is limited to a maximum of 3 read replica computes per project.
 </Admonition>
 
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+From the Neon Console, it's a simple **Add Read Replica** action on a branch.
+
 ![Create a read replica](/docs/introduction/create_read_replica.png)
 
-From the CLI or API:
+</TabItem>
 
-<CodeTabs labels={["CLI", "API"]}>
+<TabItem>
+
+Add a read-only compute to a branch with [`neon branches add-compute`](/docs/cli/branches#add-compute):
 
 ```bash
-neon branches add-compute mybranch --type read_only
+neon branches add-compute br-young-fire-15282225 --type read_only
 ```
+
+</TabItem>
+
+<TabItem>
+
+Create a read-only compute with the [Create compute](/docs/reference/api/endpoints/create-project-endpoint) endpoint:
 
 ```bash
 curl --request POST \
@@ -63,7 +75,9 @@ curl --request POST \
 ' | jq
 ```
 
-</CodeTabs>
+</TabItem>
+
+</Tabs>
 
 For more details and how to connect to a read replica, see [Create and manage Read Replicas](/docs/guides/read-replica-guide).
 

--- a/content/docs/manage/api-keys.md
+++ b/content/docs/manage/api-keys.md
@@ -10,7 +10,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/get-started/using-api-keys
   - /docs/get-started/api-keys
-updatedOn: '2026-08-04T19:37:07.626Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 Most actions performed in the Neon Console can also be performed using the [Neon API](/docs/reference/api). You'll need an API key to validate your requests. Each key is a randomly-generated 64-bit token that you must include when calling Neon API methods. All keys remain valid until deliberately revoked.
@@ -306,10 +306,22 @@ Refer to the [Neon API Reference](/docs/reference/api) for other supported Neon 
 
 ## List API keys
 
-<Tabs labels={["Console", "API"]}>
+<Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
 Navigate to **Account settings** > **API keys** to view your personal API keys, or your organization's **Settings** > **API keys** to view organization API keys.
+</TabItem>
+
+<TabItem>
+
+List your account keys with [`neon api-keys list`](/docs/cli/api-keys#list). It shows key metadata, never the keys themselves:
+
+```bash
+neon api-keys list
+```
+
+Organization keys aren't visible to your account, so pass `--org-id` to list them.
+
 </TabItem>
 
 <TabItem>
@@ -347,12 +359,24 @@ You should revoke API keys that are no longer needed or if you suspect a key may
 - Organization API keys can be revoked by organization admins
 - Project-scoped keys can be revoked by organization admins
 
-<Tabs labels={["Console", "API"]}>
+<Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
 In the Neon Console, navigate to **Account settings** > **API keys** and click **Revoke** next to the key you want to revoke. The key will be immediately revoked. Any request that uses this key will now fail.
 
 ![Revoking an API key in the Neon Console](/docs/manage/revoke_api_key.png)
+</TabItem>
+
+<TabItem>
+
+Revoke a key with [`neon api-keys revoke`](/docs/cli/api-keys#revoke), passing the numeric key ID (not the name). The action is immediate and permanent, so confirm the ID with `neon api-keys list` first:
+
+```bash
+neon api-keys revoke 177630
+```
+
+Organization and project-scoped keys need admin permissions and `--org-id`.
+
 </TabItem>
 
 <TabItem>

--- a/content/docs/manage/branches.md
+++ b/content/docs/manage/branches.md
@@ -11,7 +11,7 @@ enableTableOfContents: true
 isDraft: false
 redirectFrom:
   - /docs/get-started/get-started-branching
-updatedOn: '2026-08-18T10:29:02.410Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 Data resides in a branch. Each Neon project is created with a [root branch](#root-branch), which is also designated as your [default branch](#default-branch). Projects created in the Neon Console have a root branch named `production`, while projects created via the API or CLI have a root branch named `main`. You can create child branches from your root branch or from previously created branches. A branch can contain multiple databases and roles. Neon's [plan allowances](/docs/introduction/plans) define the number of branches you can create.
@@ -38,6 +38,10 @@ If you do specify a custom branch name when creating or renaming a branch, it mu
 
 ## Create a branch
 
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
 To create a branch:
 
 1. In the Neon Console, select a project.
@@ -63,265 +67,21 @@ You are presented with the connection details for your new branch and directed t
    When creating a new branch, the branch will have the same Postgres roles and passwords as the parent branch. If you want your branch created with new role passwords, you can enable [branch protection](/docs/guides/protected-branches).
    </Admonition>
 
-## View branches
+</TabItem>
 
-To view the branches in a Neon project:
+<TabItem>
 
-1. In the Neon Console, select a project.
-1. Select **Branches** under **Project** to view all current branches in the project.
+Create a branch with [`neon branches create`](/docs/cli/branches#create). By default it branches from your project's default branch; pass `--name` to name it:
 
-   ![all branches](/docs/manage/branches_all_list.png)
-
-   Branch details in this table view include:
-   - **Branch**: The branch name, which is a generated name if no name was specified when created.
-   - **Parent**: Indicates the parent from which this branch was created, helping you track your branch hierarchy.
-   - **Compute hours**: Number of hours the branch's compute was active so far in the current billing period.
-   - **Primary compute**: Shows the current compute size and status for the branch's compute.
-   - **Data size**: Indicates the logical data size of the branch, helping you monitor your plan's storage limit. Data size does not include history.
-   - **Created by**: The account or integration that created the branch.
-   - **Last active**: Shows when the branch's compute was last active.
-
-1. Select a branch from the table to view details about the branch.
-
-   Branch details shown on the branch page may include:
-   - **Archive status**: This only appears if the branch was archived. For more, see [Branch archiving](/docs/guides/branch-archiving).
-   - **ID**: The branch ID. Branch IDs have a `br-` prefix.
-   - **Created on**: The date and time the branch was created.
-   - **Compute hours**: The compute hours used by the default branch in the current billing period.
-   - **Data size**: The logical data size of the branch. Data size does not include history.
-   - **Parent branch**: The branch from which this branch was created (only applicable to child branches).
-
-   The branch details page also includes details about the **Computes**, **Roles**, **Databases**, and **Child branches** that belong to the branch. All of these objects are associated with a particular branch. For information about these objects, see:
-   - [Manage computes](/docs/manage/computes#view-a-compute).
-   - [Manage roles](/docs/manage/roles)
-   - [Manage databases](/docs/manage/databases)
-   - [View branches](#view-branches)
-
-## Branch archiving
-
-On the Free plan, Neon automatically archives inactive branches to cost-efficient archive storage after a defined threshold. For more, see [Branch archiving](/docs/guides/branch-archiving).
-
-<Admonition type="note">
-For branches with predictable lifespans, you can set an expiration date when creating branches to automatically delete them at a specified time. This offers an alternative to archiving for temporary development and testing environments, ensuring cleanup happens exactly when needed.
-</Admonition>
-
-## Rename a branch
-
-Neon permits renaming a branch, including your project's default branch. To rename a branch:
-
-1. In the Neon Console, select a project.
-2. Select **Branches** under **Project** to view the branches for the project.
-3. Select a branch from the table.
-4. On the branch overview page, click the **More** drop-down menu and select **Rename**.
-5. Specify a new name for the branch and click **Save**.
-
-## Set a branch as default
-
-Each Neon project is created with a default branch (named `main` if the project was created with the CLI or API, or `production` if created in the Console), but you can designate any branch as your project's default branch. When creating a new branch without specifying the parent, a new branch is created from your project's default branch. Default branch is automatically selected in the UI when creating the new branch, and it's used in the [create branch API call](/docs/reference/api/branches/create-project-branch). The [Neon-Managed Vercel integration](/docs/guides/neon-managed-vercel-integration) also creates preview deployment branches from your project's default branch.
-
-For more information, see [Default branch](#default-branch).
-
-To set a branch as the default branch:
-
-1. In the Neon Console, select a project.
-2. Select **Branches** under **Project** to view the branches for the project.
-3. Select a branch from the table.
-4. On the branch overview page, click the **More** drop-down menu and select **Set as default**.
-5. In the **Set as default** confirmation dialog, click **Set as default** to confirm your selection.
-
-## Set a branch as protected
-
-This feature is available on all Neon's paid plans, which supports up to five protected branches.
-
-To set a branch as protected:
-
-1. In the Neon Console, select a project.
-2. Select **Branches** under **Project** to view the branches for the project.
-3. Select a branch from the table.
-4. On the branch overview page, click the **More** drop-down menu and select **Set as protected**.
-5. In the **Set as protected** confirmation dialog, click **Set as protected** to confirm your selection.
-
-For details and configuration instructions, refer to our [Protected branches guide](/docs/guides/protected-branches).
-
-## Set a branch expiration
-
-To set or update a branch's expiration (auto-deletion TTL):
-
-1. In the Neon Console, select a project.
-2. Select **Branches** under **Project** to view the branches for the project.
-3. Select a branch from the table.
-4. On the branch overview page, click the **Actions** drop-down menu and select **Edit expiration**.
-5. Set a new expiration date and time, or toggle off "Automatically delete branch after" to remove expiration.
-6. Click **Save**.
-
-For details and configuration instructions, refer to our [Branch expiration guide](/docs/guides/branch-expiration).
-
-## Connect to a branch
-
-Connecting to a database in a branch requires connecting via a compute associated with the branch. The following steps describe how to connect using `psql` and a connection string obtained from the Neon Console.
-
-<Admonition type="tip">
-You can also query the databases in a branch from the Neon SQL Editor. For instructions, see [Query with Neon's SQL Editor](/docs/get-started/query-with-neon-sql-editor).
-</Admonition>
-
-1. In the Neon Console, select a project.
-2. Find the connection string for your database by clicking the **Connect** button on your **Project Dashboard**. Select the branch, the database, and the role you want to connect with.
-   ![Connection details modal](/docs/connect/connection_details.png)
-3. Copy the connection string. A connection string includes your role name, the compute hostname, and database name.
-4. Connect with `psql` as shown below.
-
-   ```bash shouldWrap
-   psql postgresql://[user]:[password]@[neon_hostname]/[dbname]
-   ```
-
-   <Admonition type="tip">
-   A compute hostname starts with an `ep-` prefix. You can also find a compute hostname on the **Branches** page in the Neon Console. See [View branches](#view-branches).
-   </Admonition>
-
-   If you want to connect from an application, the **Connect to your database modal**, accessed by clicking **Connect** on the project **Dashboard**, and the [Frameworks](/docs/get-started/frameworks) and [Languages](/docs/get-started/languages) sections in the documentation provide various connection examples.
-
-## Reset a branch from parent
-
-You can use Neon's **Reset from parent** feature to instantly update a branch with the latest schema and data from its parent. This feature can be an integral part of your CI/CD automation.
-
-You can use the Neon Console, CLI, or API. For details, see [Reset from parent](/docs/guides/reset-from-parent).
-
-## Restore a branch to its own or another branch's history
-
-There are several restore operations available using Neon's instant restore feature:
-
-- Restore a branch to its own history
-- Restore a branch to the head of another branch
-- Restore a branch to the history of another branch
-
-You can use the Neon Console, CLI, or API. For more details, see [Instant restore](/docs/guides/branch-restore).
-
-## Delete a branch
-
-Deleting a branch is a permanent action. Deleting a branch also deletes the databases and roles that belong to the branch as well as the compute associated with the branch. You cannot delete a branch that has child branches. The child branches must be deleted first.
-
-To delete a branch:
-
-1. In the Neon Console, select a project.
-2. Select **Branches** under **Project**.
-3. Select a branch from the table.
-4. On the branch overview page, click the **More** drop-down menu and select **Delete**.
-5. On the confirmation dialog, click **Delete**.
-
-<Admonition type="tip">
-For temporary branches, consider setting an expiration date when creating them to automate cleanup and reduce manual deletion overhead.
-</Admonition>
-
-## Check the data size
-
-You can check the logical data size for the databases on a branch by viewing the **Data size** value on the **Branches** page or page in the Neon Console. Alternatively, you can run the following query on your branch from the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or any SQL client connected to your database:
-
-```sql
-SELECT pg_size_pretty(sum(pg_database_size(datname)))
-FROM pg_database;
+```bash
+neon branches create --name mybranch
 ```
 
-The query value may differ slightly from the **Data size** reported in the Neon Console.
+</TabItem>
 
-Data size is your logical data size.
+<TabItem>
 
-<Admonition type="note">
-Paid plans support a logical data size of up to **16 TB per branch**. When a branch reaches this limit, write performance drops, but you can still drop or delete data to reclaim space. To increase this limit, [request a storage increase in the feedback form in console](https://console.neon.tech/app/settings?modal=feedback&modalparams=%22Storage%20limit%20increase%22).
-</Admonition>
-
-## Branch types
-
-Neon has different branch types with different characteristics.
-
-### Root branch
-
-A root branch is a branch without a parent branch. Each Neon project starts with a root branch (named `production` in the Console, `main` via API/CLI), which cannot be deleted and is set as the [default branch](#default-branch) for the project.
-
-Neon also supports two other types of root branches that have no parent but _can_ be deleted:
-
-- [Backup branches](#backup-branch), created by instant restore operations on other root branches.
-- [Schema-only branches](#schema-only-branch).
-
-The number of root branches allowed in a project depends on your Neon plan.
-
-| Plan   | Root branch allowance per project |
-| :----- | :-------------------------------- |
-| Free   | 3                                 |
-| Launch | 5                                 |
-| Scale  | 25                                |
-
-### Default branch
-
-Each Neon project has a default branch. In the Neon Console, your default branch is identified by a `DEFAULT` tag. You can designate any branch as the default branch for your project.
-
-When creating a new branch without specifying the parent, a new branch is created from your project's default branch. The [Neon-Managed Vercel integration](/docs/guides/neon-managed-vercel-integration) also creates preview deployment branches from your project's default branch.
-
-### Non-default branch
-
-Any branch not designated as the default branch is considered a non-default branch. You can rename or delete non-default branches.
-
-### Protected branch
-
-Neon's protected branches feature implements a series of protections:
-
-- Protected branches cannot be deleted.
-- Protected branches cannot be [reset](/docs/manage/branches#reset-a-branch-from-parent).
-- Projects with protected branches cannot be deleted.
-- Computes associated with a protected branch cannot be deleted.
-- New passwords are automatically generated for Postgres roles on branches created from protected branches. [See below](#new-passwords-generated-for-postgres-roles-on-child-branches).
-- With additional configuration steps, you can apply IP Allow restrictions to protected branches only. See [below](#how-to-apply-ip-restrictions-to-protected-branches).
-- Protected branches are not [archived](/docs/guides/branch-archiving) due to inactivity.
-
-Typically, a protected status is given to a branch or branches that hold production data or sensitive data. The protected branch feature is only supported on Neon's paid plans. See [Set a branch as protected](#set-a-branch-as-protected).
-
-### Schema-only branch
-
-A branch that replicates only the database schema from a source branch, without copying any of the actual data. This feature is particularly valuable when working with sensitive information. Rather than creating branches that include confidential data, you can duplicate just the database structure and then populate it with your own data.
-
-Schema-only branches are [root branches](#root-branch), meaning they have no parent. As a root branch, each schema-only branch starts an independent line of data in a Neon project.
-
-See [Schema-only branches](/docs/guides/branching-schema-only).
-
-### Backup branch
-
-A branch created by an [instant restore](#branch-restore) operation. When you restore a branch from a particular point in time, the current branch is saved as a backup branch. Performing a restore operation on a root branch, creates a backup branch without a parent branch (a root branch). See [Instant restore](/docs/guides/branch-restore).
-
-### Branch with expiration
-
-A branch with an expiration timestamp is automatically deleted when the expiration time is reached. Any branch can have an expiration timestamp added or removed at any time. Use it for temporary development and testing environments.
-
-## Branching with the Neon CLI
-
-The Neon CLI supports creating and managing branches. For instructions, see [Neon CLI commands — branches](/docs/cli/branches). For a Neon CLI branching guide, see [Branching with the Neon CLI](/docs/cli/branches).
-
-## Branching with the Neon API
-
-Branch actions performed in the Neon Console can also be performed using the Neon API. The following examples demonstrate how to create, view, and delete branches using the Neon API. For other branch-related API methods, refer to the [Neon API Reference](/docs/reference/api).
-
-<Admonition type="note">
-The API examples that follow may not show all of the user-configurable request body attributes that are available to you. To view all of the attributes for a particular method, refer to the method's request body schema in the [Neon API Reference](/docs/reference/api).
-</Admonition>
-
-The `jq` option specified in each example is an optional third-party tool that formats the `JSON` response, making it easier to read. For information about this utility, see [jq](https://stedolan.github.io/jq/).
-
-### Prerequisites
-
-A Neon API request requires an API key. For information about obtaining an API key, see [Create an API key](/docs/manage/api-keys#create-an-api-key). In the examples shown below, `$NEON_API_KEY` is specified in place of an actual API key, which you must provide when making a Neon API request.
-
-<LinkAPIKey />
-### Create a branch with the API
-
-The following Neon API method creates a branch. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/create-project-branch).
-
-```http
-POST /projects/{project_id}/branches
-```
-
-The API method appears as follows when specified in a cURL command. The `endpoints` attribute creates a compute, which is required to connect to the branch. A branch can be created with or without a compute. The `branch` attribute specifies the parent branch.
-
-<Admonition type="note">
-This method does not require a request body. Without a request body, the method creates a branch from the project's default branch, and a compute is not created.
-</Admonition>
+Create a branch with the [Create branch](/docs/reference/api/branches/create-project-branch) endpoint. The `branch` attribute specifies the parent; the `endpoints` attribute creates a compute, which is required to connect:
 
 ```bash
 curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches' \
@@ -337,13 +97,8 @@ curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches' \
   "branch": {
     "parent_id": "br-wispy-dew-591433"
   }
-}' | jq
+}'
 ```
-
-- The `project_id` for a Neon project is found on the **Settings** page in the Neon Console, or you can find it by listing the projects for your Neon account using the Neon API.
-- The `parent_id` can be obtained by listing the branches for your project. See [List branches](#list-branches-with-the-api). The `<parent_id>` is the `id` of the branch you are branching from. A branch `id` has a `br-` prefix. You can branch from your Neon project's default branch or a previously created branch.
-
-The response body includes information about the branch, the branch's compute, and the `create_branch` and `start_compute` operations that were initiated.
 
 <details>
 <summary>Response body</summary>
@@ -464,25 +219,79 @@ For attribute definitions, find the [Create branch](/docs/reference/api/branches
 
 </details>
 
-### List branches with the API
+</TabItem>
 
-The following Neon API method lists branches for the specified project. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/list-project-branches).
+</Tabs>
 
-```http
-GET /projects/{project_id}/branches
+## View branches
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+To view the branches in a Neon project:
+
+1. In the Neon Console, select a project.
+1. Select **Branches** under **Project** to view all current branches in the project.
+
+   ![all branches](/docs/manage/branches_all_list.png)
+
+   Branch details in this table view include:
+   - **Branch**: The branch name, which is a generated name if no name was specified when created.
+   - **Parent**: Indicates the parent from which this branch was created, helping you track your branch hierarchy.
+   - **Compute hours**: Number of hours the branch's compute was active so far in the current billing period.
+   - **Primary compute**: Shows the current compute size and status for the branch's compute.
+   - **Data size**: Indicates the logical data size of the branch, helping you monitor your plan's storage limit. Data size does not include history.
+   - **Created by**: The account or integration that created the branch.
+   - **Last active**: Shows when the branch's compute was last active.
+
+1. Select a branch from the table to view details about the branch.
+
+   Branch details shown on the branch page may include:
+   - **Archive status**: This only appears if the branch was archived. For more, see [Branch archiving](/docs/guides/branch-archiving).
+   - **ID**: The branch ID. Branch IDs have a `br-` prefix.
+   - **Created on**: The date and time the branch was created.
+   - **Compute hours**: The compute hours used by the default branch in the current billing period.
+   - **Data size**: The logical data size of the branch. Data size does not include history.
+   - **Parent branch**: The branch from which this branch was created (only applicable to child branches).
+
+   The branch details page also includes details about the **Computes**, **Roles**, **Databases**, and **Child branches** that belong to the branch. All of these objects are associated with a particular branch. For information about these objects, see:
+   - [Manage computes](/docs/manage/computes#view-a-compute).
+   - [Manage roles](/docs/manage/roles)
+   - [Manage databases](/docs/manage/databases)
+   - [View branches](#view-branches)
+
+</TabItem>
+
+<TabItem>
+
+List the branches in a project with [`neon branches list`](/docs/cli/branches#list):
+
+```bash
+neon branches list --project-id dry-heart-13671059
 ```
 
-The API method appears as follows when specified in a cURL command:
+```text filename="Output"
+┌────────────────────────────┬────────────────────────┬──────────────────────┬──────────────────────┐
+│ Id                         │ Name                   │ Created At           │ Updated At           │
+├────────────────────────────┼────────────────────────┼──────────────────────┼──────────────────────┤
+│ br-morning-meadow-afu2s1jl │ main [default]         │ 2025-08-04T07:07:55Z │ 2025-08-04T07:13:11Z │
+├────────────────────────────┼────────────────────────┼──────────────────────┼──────────────────────┤
+│ br-curly-wave-af4i4oeu     │ br-curly-wave-af4i4oeu │ 2025-08-04T07:13:09Z │ 2025-08-04T07:18:15Z │
+└────────────────────────────┴────────────────────────┴──────────────────────┴──────────────────────┘
+```
+
+</TabItem>
+
+<TabItem>
+
+List the branches in a project with the [List branches](/docs/reference/api/branches/list-project-branches) endpoint:
 
 ```bash
 curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches' \
   -H 'accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY" | jq
+  -H "Authorization: Bearer $NEON_API_KEY"
 ```
-
-The `project_id` for a Neon project is found on the **Settings** page in the Neon Console, or you can find it by listing the projects for your Neon account using the Neon API.
-
-The response body lists the project's default branch and any child branches. The name of the default branch in this example is `main`.
 
 <details>
 <summary>Response body</summary>
@@ -553,27 +362,303 @@ For attribute definitions, find the [List branches](/docs/reference/api/branches
 
 </details>
 
-### Delete a branch with the API
+</TabItem>
 
-The following Neon API method deletes the specified branch. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/delete-project-branch).
+</Tabs>
 
-```http
-DELETE /projects/{project_id}/branches/{branch_id}
+## Branch archiving
+
+On the Free plan, Neon automatically archives inactive branches to cost-efficient archive storage after a defined threshold. For more, see [Branch archiving](/docs/guides/branch-archiving).
+
+<Admonition type="note">
+For branches with predictable lifespans, you can set an expiration date when creating branches to automatically delete them at a specified time. This offers an alternative to archiving for temporary development and testing environments, ensuring cleanup happens exactly when needed.
+</Admonition>
+
+## Rename a branch
+
+Neon permits renaming a branch, including your project's default branch.
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+To rename a branch:
+
+1. In the Neon Console, select a project.
+2. Select **Branches** under **Project** to view the branches for the project.
+3. Select a branch from the table.
+4. On the branch overview page, click the **More** drop-down menu and select **Rename**.
+5. Specify a new name for the branch and click **Save**.
+
+</TabItem>
+
+<TabItem>
+
+Rename a branch with [`neon branches rename`](/docs/cli/branches#rename), passing the current name or ID and the new name:
+
+```bash
+neon branches rename br-rough-sky-158193 teambranch
 ```
 
-The API method appears as follows when specified in a cURL command:
+</TabItem>
+
+<TabItem>
+
+Rename a branch with the [Update branch](/docs/reference/api/branches/update-project-branch) endpoint:
+
+```bash
+curl -X 'PATCH' \
+  'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-rough-sky-158193' \
+  -H 'accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"branch": {"name": "teambranch"}}'
+```
+
+</TabItem>
+
+</Tabs>
+
+## Set a branch as default
+
+Each Neon project is created with a default branch (named `main` if the project was created with the CLI or API, or `production` if created in the Console), but you can designate any branch as your project's default branch. When creating a new branch without specifying the parent, a new branch is created from your project's default branch. Default branch is automatically selected in the UI when creating the new branch, and it's used in the [create branch API call](/docs/reference/api/branches/create-project-branch). The [Neon-Managed Vercel integration](/docs/guides/neon-managed-vercel-integration) also creates preview deployment branches from your project's default branch.
+
+For more information, see [Default branch](#default-branch).
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+To set a branch as the default branch:
+
+1. In the Neon Console, select a project.
+2. Select **Branches** under **Project** to view the branches for the project.
+3. Select a branch from the table.
+4. On the branch overview page, click the **More** drop-down menu and select **Set as default**.
+5. In the **Set as default** confirmation dialog, click **Set as default** to confirm your selection.
+
+</TabItem>
+
+<TabItem>
+
+Set the default branch with [`neon branches set-default`](/docs/cli/branches#set-default):
+
+```bash
+neon branches set-default br-curly-wave-af4i4oeu
+```
+
+</TabItem>
+
+<TabItem>
+
+Set the default branch with the [Set default branch](/docs/reference/api/branches/set-default-project-branch) endpoint:
+
+```bash
+curl -X POST 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-curly-wave-af4i4oeu/set_as_default' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+</TabItem>
+
+</Tabs>
+
+## Set a branch as protected
+
+This feature is available on all Neon's paid plans, which supports up to five protected branches.
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+To set a branch as protected:
+
+1. In the Neon Console, select a project.
+2. Select **Branches** under **Project** to view the branches for the project.
+3. Select a branch from the table.
+4. On the branch overview page, click the **More** drop-down menu and select **Set as protected**.
+5. In the **Set as protected** confirmation dialog, click **Set as protected** to confirm your selection.
+
+</TabItem>
+
+<TabItem>
+
+No dedicated command sets protection, so use the [`neon api`](/docs/cli/api) passthrough, which sends the request with your CLI credentials:
+
+```bash
+neon api /projects/dry-heart-13671059/branches/br-curly-wave-af4i4oeu -X PATCH -F branch.protected=true
+```
+
+</TabItem>
+
+<TabItem>
+
+Mark a branch as protected with the [Update branch](/docs/reference/api/branches/update-project-branch) endpoint:
+
+```bash
+curl -X PATCH 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-curly-wave-af4i4oeu' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"branch": {"protected": true}}'
+```
+
+</TabItem>
+
+</Tabs>
+
+For details and configuration instructions, refer to our [Protected branches guide](/docs/guides/protected-branches).
+
+## Set a branch expiration
+
+To set or update a branch's expiration (auto-deletion TTL):
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+1. In the Neon Console, select a project.
+2. Select **Branches** under **Project** to view the branches for the project.
+3. Select a branch from the table.
+4. On the branch overview page, click the **Actions** drop-down menu and select **Edit expiration**.
+5. Set a new expiration date and time, or toggle off "Automatically delete branch after" to remove expiration.
+6. Click **Save**.
+
+</TabItem>
+
+<TabItem>
+
+Set an expiration with [`neon branches set-expiration`](/docs/cli/branches#set-expiration). Omit `--expires-at` to remove it:
+
+```bash
+neon branches set-expiration br-curly-wave-af4i4oeu --expires-at 2025-08-15T18:00:00Z
+```
+
+</TabItem>
+
+<TabItem>
+
+Set an expiration with the [Update branch](/docs/reference/api/branches/update-project-branch) endpoint:
+
+```bash
+curl -X PATCH 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-curly-wave-af4i4oeu' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"branch": {"expires_at": "2025-08-15T18:00:00Z"}}'
+```
+
+</TabItem>
+
+</Tabs>
+
+For details and configuration instructions, refer to our [Branch expiration guide](/docs/guides/branch-expiration).
+
+## Connect to a branch
+
+You connect to a branch through a compute associated with it, using a Postgres connection string that carries your role, the compute hostname (it starts with `ep-`), and the database name. Get the string from the Console, CLI, or API, then connect with any Postgres client. To run queries without a client, use the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor).
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+On the **Project Dashboard**, click **Connect**, then select the branch, database, and role. Copy the connection string.
+
+![Connection details modal](/docs/connect/connection_details.png)
+
+</TabItem>
+
+<TabItem>
+
+Connect directly with [`neon psql`](/docs/cli/psql):
+
+```bash
+neon psql br-curly-wave-af4i4oeu
+```
+
+Or print the connection string to use elsewhere with [`neon connection-string`](/docs/cli/connection-string) (add `--pooled` or `--prisma` as needed):
+
+```bash
+neon connection-string br-curly-wave-af4i4oeu --database-name neondb --role-name alex
+```
+
+</TabItem>
+
+<TabItem>
+
+Retrieve the connection string with the [Get connection URI](/docs/reference/api/projects/get-connection-uri) endpoint (`database_name` and `role_name` are required):
+
+```bash shouldWrap
+curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/connection_uri?branch_id=br-curly-wave-af4i4oeu&database_name=neondb&role_name=alex' \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+</TabItem>
+
+</Tabs>
+
+Then connect with any client, for example `psql`:
+
+```bash shouldWrap
+psql postgresql://[user]:[password]@[neon_hostname]/[dbname]
+```
+
+For application connection examples, see [Frameworks](/docs/get-started/frameworks) and [Languages](/docs/get-started/languages).
+
+## Reset a branch from parent
+
+You can use Neon's **Reset from parent** feature to instantly update a branch with the latest schema and data from its parent. This feature can be an integral part of your CI/CD automation.
+
+You can use the Neon Console, CLI, or API. For details, see [Reset from parent](/docs/guides/reset-from-parent).
+
+## Restore a branch to its own or another branch's history
+
+There are several restore operations available using Neon's instant restore feature:
+
+- Restore a branch to its own history
+- Restore a branch to the head of another branch
+- Restore a branch to the history of another branch
+
+You can use the Neon Console, CLI, or API. For more details, see [Instant restore](/docs/guides/branch-restore).
+
+## Delete a branch
+
+Deleting a branch is a permanent action. Deleting a branch also deletes the databases and roles that belong to the branch as well as the compute associated with the branch. You cannot delete a branch that has child branches. The child branches must be deleted first.
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+To delete a branch:
+
+1. In the Neon Console, select a project.
+2. Select **Branches** under **Project**.
+3. Select a branch from the table.
+4. On the branch overview page, click the **More** drop-down menu and select **Delete**.
+5. On the confirmation dialog, click **Delete**.
+
+</TabItem>
+
+<TabItem>
+
+Delete a branch with [`neon branches delete`](/docs/cli/branches#delete), passing the branch name or ID:
+
+```bash
+neon branches delete br-curly-wave-af4i4oeu
+```
+
+</TabItem>
+
+<TabItem>
+
+Delete a branch with the [Delete branch](/docs/reference/api/branches/delete-project-branch) endpoint:
 
 ```bash
 curl -X 'DELETE' \
   'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-curly-wave-af4i4oeu' \
   -H 'accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY" | jq
+  -H "Authorization: Bearer $NEON_API_KEY"
 ```
-
-- The `project_id` for a Neon project is found on the **Settings** page in the Neon Console, or you can find it by listing the projects for your Neon account using the Neon API.
-- The `branch_id` can be found by listing the branches for your project. The `<branch_id>` is the `id` of a branch. A branch `id` has a `br-` prefix. See [List branches](#list-branches-with-the-api).
-
-The response body shows information about the branch being deleted and the `suspend_compute` and `delete_timeline` operations that were initiated.
 
 <details>
 <summary>Response body</summary>
@@ -640,6 +725,110 @@ For attribute definitions, find the [Delete branches](/docs/reference/api/branch
 
 </details>
 
-You can verify that a branch is deleted by listing the branches for your project. See [List branches](#list-branches-with-the-api). The deleted branch should no longer be listed.
+</TabItem>
+
+</Tabs>
+
+<Admonition type="tip">
+For temporary branches, consider setting an expiration date when creating them to automate cleanup and reduce manual deletion overhead.
+</Admonition>
+
+## Check the data size
+
+You can check the logical data size for the databases on a branch by viewing the **Data size** value on the **Branches** page or page in the Neon Console. Alternatively, you can run the following query on your branch from the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or any SQL client connected to your database:
+
+```sql
+SELECT pg_size_pretty(sum(pg_database_size(datname)))
+FROM pg_database;
+```
+
+The query value may differ slightly from the **Data size** reported in the Neon Console.
+
+Data size is your logical data size.
+
+<Admonition type="note">
+Paid plans support a logical data size of up to **16 TB per branch**. When a branch reaches this limit, write performance drops, but you can still drop or delete data to reclaim space. To increase this limit, [request a storage increase in the feedback form in console](https://console.neon.tech/app/settings?modal=feedback&modalparams=%22Storage%20limit%20increase%22).
+</Admonition>
+
+## Branch types
+
+Neon has different branch types with different characteristics.
+
+### Root branch
+
+A root branch is a branch without a parent branch. Each Neon project starts with a root branch (named `production` in the Console, `main` via API/CLI), which cannot be deleted and is set as the [default branch](#default-branch) for the project.
+
+Neon also supports two other types of root branches that have no parent but _can_ be deleted:
+
+- [Backup branches](#backup-branch), created by instant restore operations on other root branches.
+- [Schema-only branches](#schema-only-branch).
+
+The number of root branches allowed in a project depends on your Neon plan.
+
+| Plan   | Root branch allowance per project |
+| :----- | :-------------------------------- |
+| Free   | 3                                 |
+| Launch | 5                                 |
+| Scale  | 25                                |
+
+### Default branch
+
+Each Neon project has a default branch. In the Neon Console, your default branch is identified by a `DEFAULT` tag. You can designate any branch as the default branch for your project.
+
+When creating a new branch without specifying the parent, a new branch is created from your project's default branch. The [Neon-Managed Vercel integration](/docs/guides/neon-managed-vercel-integration) also creates preview deployment branches from your project's default branch.
+
+### Non-default branch
+
+Any branch not designated as the default branch is considered a non-default branch. You can rename or delete non-default branches.
+
+### Protected branch
+
+Neon's protected branches feature implements a series of protections:
+
+- Protected branches cannot be deleted.
+- Protected branches cannot be [reset](/docs/manage/branches#reset-a-branch-from-parent).
+- Projects with protected branches cannot be deleted.
+- Computes associated with a protected branch cannot be deleted.
+- New passwords are automatically generated for Postgres roles on branches created from protected branches. [Learn more](/docs/guides/protected-branches#new-passwords-generated-for-postgres-roles-on-child-branches).
+- With additional configuration steps, you can apply IP Allow restrictions to protected branches only. See [How to apply IP restrictions to protected branches](/docs/guides/protected-branches#how-to-apply-ip-restrictions-to-protected-branches).
+- Protected branches are not [archived](/docs/guides/branch-archiving) due to inactivity.
+
+Typically, a protected status is given to a branch or branches that hold production data or sensitive data. The protected branch feature is only supported on Neon's paid plans. See [Set a branch as protected](#set-a-branch-as-protected).
+
+### Schema-only branch
+
+A branch that replicates only the database schema from a source branch, without copying any of the actual data. This feature is particularly valuable when working with sensitive information. Rather than creating branches that include confidential data, you can duplicate just the database structure and then populate it with your own data.
+
+Schema-only branches are [root branches](#root-branch), meaning they have no parent. As a root branch, each schema-only branch starts an independent line of data in a Neon project.
+
+See [Schema-only branches](/docs/guides/branching-schema-only).
+
+### Backup branch
+
+A branch created by an [instant restore](/docs/introduction/branch-restore) operation. When you restore a branch from a particular point in time, the current branch is saved as a backup branch. Performing a restore operation on a root branch, creates a backup branch without a parent branch (a root branch). See [Instant restore](/docs/guides/branch-restore).
+
+### Branch with expiration
+
+A branch with an expiration timestamp is automatically deleted when the expiration time is reached. Any branch can have an expiration timestamp added or removed at any time. Use it for temporary development and testing environments.
+
+## Branching with the Neon CLI
+
+The Neon CLI supports creating and managing branches. See [Neon CLI commands — branches](/docs/cli/branches).
+
+## Branching with the Neon API
+
+Branch actions performed in the Neon Console can also be performed using the [Neon API](/docs/reference/api). Each operation above includes an example in its **API** tab; see the [Neon API Reference](/docs/reference/api) for complete request and response schemas. A request requires an API key: see [Create an API key](/docs/manage/api-keys#create-an-api-key), where `$NEON_API_KEY` stands in for your key.
+
+### Create a branch with the API
+
+See [Create a branch](#create-a-branch) for the Console, CLI, and API options.
+
+### List branches with the API
+
+See [View branches](#view-branches) for the Console, CLI, and API options.
+
+### Delete a branch with the API
+
+See [Delete a branch](#delete-a-branch) for the Console, CLI, and API options.
 
 <NeedHelp/>

--- a/content/docs/manage/computes.md
+++ b/content/docs/manage/computes.md
@@ -8,7 +8,7 @@ summary: >-
   compute endpoints via the Neon Console or API.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-18T10:29:02.410Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 A compute is a virtualized service that runs applications. In Neon, a compute runs Postgres.
@@ -32,7 +32,13 @@ Your Neon plan determines the resources available to a compute. The Neon Free pl
 
 ## View a compute
 
-A compute is associated with a branch. To view a compute, in the Neon Console select your branch from the **BRANCH** selector, then select **Postgres database** > **Computes**. If the branch has a compute, it is shown on the **Computes** tab of the branch overview.
+A compute is associated with a branch.
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+In the Neon Console, select your branch from the **BRANCH** selector, then select **Postgres database** > **Computes**. If the branch has a compute, it is shown on the **Computes** tab of the branch overview.
 
 Compute details shown on the **Computes** tab include:
 
@@ -44,22 +50,230 @@ Compute details shown on the **Computes** tab include:
 
 **Edit**, **Monitor**, and **Connect** actions for a compute can be accessed from the **Computes** tab.
 
+</TabItem>
+
+<TabItem>
+
+The CLI has no separate compute object; a branch's compute state (`current_state`, `compute_time_seconds`) is shown by [`neon branches list`](/docs/cli/branches#list):
+
+```bash
+neon branches list --output json
+```
+
+<details>
+<summary>Show output</summary>
+
+```json
+[
+  {
+    "id": "br-dry-glitter-a1rh0x6q",
+    "project_id": "autumn-lake-30024670",
+    "name": "br-dry-glitter-a1rh0x6q",
+    "current_state": "ready",
+    "logical_size": 29515776,
+    "creation_source": "console",
+    "default": true,
+    "cpu_used_sec": 78,
+    "compute_time_seconds": 78,
+    "active_time_seconds": 312,
+    "written_data_bytes": 107816,
+    "data_transfer_bytes": 0,
+    "created_at": "2023-07-09T17:01:34Z",
+    "updated_at": "2023-07-09T17:15:13Z"
+  }
+]
+```
+
+</details>
+
+Or list the project's computes directly through the [`neon api`](/docs/cli/api) passthrough:
+
+```bash
+neon api /projects/autumn-lake-30024670/endpoints
+```
+
+</TabItem>
+
+<TabItem>
+
+List the computes for a project with the [List computes](/docs/reference/api/endpoints/list-project-endpoints) endpoint:
+
+```bash
+curl -X 'GET' \
+  'https://console.neon.tech/api/v2/projects/autumn-lake-30024670/endpoints' \
+  -H 'accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+<details>
+<summary>Response body</summary>
+
+For attribute definitions, find the [List computes](/docs/reference/api/endpoints/list-project-endpoints) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
+
+```json
+{
+  "endpoints": [
+    {
+      "host": "ep-misty-morning-a1pfa4ez.ap-southeast-1.aws.neon.tech",
+      "id": "ep-misty-morning-a1pfa4ez",
+      "project_id": "autumn-lake-30024670",
+      "branch_id": "br-dry-glitter-a1rh0x6q",
+      "autoscaling_limit_min_cu": 1,
+      "autoscaling_limit_max_cu": 2,
+      "region_id": "aws-ap-southeast-1",
+      "type": "read_write",
+      "current_state": "idle",
+      "settings": {},
+      "pooler_enabled": false,
+      "pooler_mode": "transaction",
+      "disabled": false,
+      "passwordless_access": true,
+      "last_active": "2025-08-03T17:40:20Z",
+      "creation_source": "console",
+      "created_at": "2025-08-03T17:40:19Z",
+      "updated_at": "2025-08-03T17:45:24Z",
+      "suspended_at": "2025-08-03T17:45:24Z",
+      "proxy_host": "ap-southeast-1.aws.neon.tech",
+      "suspend_timeout_seconds": 0,
+      "provisioner": "k8s-neonvm"
+    },
+    {
+      "host": "ep-autumn-frost-a1wlmval.ap-southeast-1.aws.neon.tech",
+      "id": "ep-autumn-frost-a1wlmval",
+      "project_id": "autumn-lake-30024670",
+      "branch_id": "br-dark-bar-a11jneqm",
+      "autoscaling_limit_min_cu": 1,
+      "autoscaling_limit_max_cu": 2,
+      "region_id": "aws-ap-southeast-1",
+      "type": "read_write",
+      "current_state": "idle",
+      "settings": {},
+      "pooler_enabled": false,
+      "pooler_mode": "transaction",
+      "disabled": false,
+      "passwordless_access": true,
+      "last_active": "2025-08-03T17:34:40Z",
+      "creation_source": "console",
+      "created_at": "2025-08-03T11:27:50Z",
+      "updated_at": "2025-08-03T17:41:11Z",
+      "suspended_at": "2025-08-03T17:41:11Z",
+      "proxy_host": "ap-southeast-1.aws.neon.tech",
+      "suspend_timeout_seconds": 0,
+      "provisioner": "k8s-neonvm"
+    }
+  ]
+}
+```
+
+</details>
+
+</TabItem>
+
+</Tabs>
+
 ## Create a compute
 
 You can only create a single primary read-write compute for a branch that does not have a compute, but a branch can have multiple read replica computes.
 
-To create an endpoint:
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
 
 1. In the Neon Console, select your branch from the **BRANCH** selector.
 1. Under **Postgres database**, select **Computes**.
 1. Click **Add a compute** or **Add Read Replica** if you already have a primary read-write compute.
 1. On the **Add new compute** drawer or **Add read replica** drawer, specify your compute settings, and click **Add**. Selecting the **Read replica** compute type creates a [read replica](/docs/introduction/read-replicas).
 
+</TabItem>
+
+<TabItem>
+
+Add a compute to a branch with [`neon branches add-compute`](/docs/cli/branches#add-compute), passing `--type read_write` for the branch's primary compute. Add `--cu` to set a fixed size or an autoscaling range:
+
+```bash
+neon branches add-compute br-dry-glitter-a1rh0x6q --type read_write
+```
+
+</TabItem>
+
+<TabItem>
+
+Create a compute with the [Create compute](/docs/reference/api/endpoints/create-project-endpoint) endpoint. The branch you specify cannot already have a read-write compute:
+
+```bash
+curl -X 'POST' \
+  'https://console.neon.tech/api/v2/projects/autumn-lake-30024670/endpoints' \
+  -H 'accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "endpoint": {
+    "branch_id": "br-dry-glitter-a1rh0x6q",
+    "type": "read_write"
+  }
+}'
+```
+
+<details>
+<summary>Response body</summary>
+
+For attribute definitions, find the [Create compute](/docs/reference/api/endpoints/create-project-endpoint) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
+
+```json
+{
+  "endpoint": {
+    "host": "ep-misty-morning-a1pfa4ez.ap-southeast-1.aws.neon.tech",
+    "id": "ep-misty-morning-a1pfa4ez",
+    "project_id": "autumn-lake-30024670",
+    "branch_id": "br-dry-glitter-a1rh0x6q",
+    "autoscaling_limit_min_cu": 1,
+    "autoscaling_limit_max_cu": 2,
+    "region_id": "aws-ap-southeast-1",
+    "type": "read_write",
+    "current_state": "init",
+    "pending_state": "active",
+    "settings": {},
+    "pooler_enabled": false,
+    "pooler_mode": "transaction",
+    "disabled": false,
+    "passwordless_access": true,
+    "creation_source": "console",
+    "created_at": "2025-08-03T17:40:19Z",
+    "updated_at": "2025-08-03T17:40:19Z",
+    "proxy_host": "ap-southeast-1.aws.neon.tech",
+    "suspend_timeout_seconds": 0,
+    "provisioner": "k8s-neonvm"
+  },
+  "operations": [
+    {
+      "id": "d6ef3cc2-663b-440a-88e7-ea6a59ea2c6a",
+      "project_id": "autumn-lake-30024670",
+      "branch_id": "br-dry-glitter-a1rh0x6q",
+      "endpoint_id": "ep-misty-morning-a1pfa4ez",
+      "action": "start_compute",
+      "status": "running",
+      "failures_count": 0,
+      "created_at": "2025-08-03T17:40:19Z",
+      "updated_at": "2025-08-03T17:40:19Z",
+      "total_duration_ms": 0
+    }
+  ]
+}
+```
+
+</details>
+
+</TabItem>
+
+</Tabs>
+
 ## Edit a compute
 
 You can edit a compute to change the [compute size](#compute-size-and-autoscaling-configuration) or [scale to zero](#scale-to-zero-configuration) configuration.
 
-To edit a compute:
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
 
 1. In the Neon Console, select your branch from the **BRANCH** selector.
 1. Under **Postgres database**, select **Computes**.
@@ -68,6 +282,77 @@ To edit a compute:
    The **Edit** drawer opens, letting you modify settings such as compute size, the autoscaling configuration, and your scale to zero setting.
 
 1. Once you've made your changes, click **Save**. All changes take immediate effect.
+
+</TabItem>
+
+<TabItem>
+
+No dedicated command edits a compute, so reach for the [`neon api`](/docs/cli/api) passthrough, which sends the request with your CLI credentials. For example, change the autoscaling range:
+
+```bash shouldWrap
+neon api /projects/autumn-lake-30024670/endpoints/ep-misty-morning-a1pfa4ez -X PATCH -F endpoint.autoscaling_limit_min_cu=0.5 -F endpoint.autoscaling_limit_max_cu=3
+```
+
+</TabItem>
+
+<TabItem>
+
+Update a compute with the [Update compute](/docs/reference/api/endpoints/update-project-endpoint) endpoint. For example, change the autoscaling range:
+
+```bash
+curl -X 'PATCH' \
+  'https://console.neon.tech/api/v2/projects/autumn-lake-30024670/endpoints/ep-misty-morning-a1pfa4ez' \
+  -H 'accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "endpoint": {
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 3
+  }
+}'
+```
+
+<details>
+<summary>Response body</summary>
+
+For attribute definitions, find the [Update compute](/docs/reference/api/endpoints/update-project-endpoint) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
+
+```json
+{
+  "endpoint": {
+    "host": "ep-misty-morning-a1pfa4ez.ap-southeast-1.aws.neon.tech",
+    "id": "ep-misty-morning-a1pfa4ez",
+    "project_id": "autumn-lake-30024670",
+    "branch_id": "br-dry-glitter-a1rh0x6q",
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 3,
+    "region_id": "aws-ap-southeast-1",
+    "type": "read_write",
+    "current_state": "idle",
+    "settings": {},
+    "pooler_enabled": false,
+    "pooler_mode": "transaction",
+    "disabled": false,
+    "passwordless_access": true,
+    "last_active": "2025-08-03T17:40:20Z",
+    "creation_source": "console",
+    "created_at": "2025-08-03T17:40:19Z",
+    "updated_at": "2025-08-03T17:49:01Z",
+    "suspended_at": "2025-08-03T17:45:24Z",
+    "proxy_host": "ap-southeast-1.aws.neon.tech",
+    "suspend_timeout_seconds": 0,
+    "provisioner": "k8s-neonvm"
+  },
+  "operations": []
+}
+```
+
+</details>
+
+</TabItem>
+
+</Tabs>
 
 For information about selecting an appropriate compute size or autoscaling configuration, see [How to size your compute](#how-to-size-your-compute).
 
@@ -239,272 +524,75 @@ Restarting ensures your compute is running with the latest configurations and im
 Restarting a compute interrupts any connections currently using the compute. To avoid prolonged interruptions resulting from compute restarts, we recommend configuring your clients and applications to reconnect automatically in case of a dropped connection.
 </Admonition>
 
-You can restart a compute using these methods:
+<Tabs labels={["Console", "CLI", "API"]}>
 
-- Use the **Restart compute** option in the Neon console. Select your branch from the **BRANCH** selector, then select **Postgres database** > **Computes** and choose **Restart compute** from the compute's menu.
-  ![Restart a compute in the console](/docs/manage/restart_compute.png)
-- Issue a [Restart compute endpoint](/docs/reference/api/endpoints/restart-project-endpoint) call using the Neon API. You can do this directly from the Neon API Reference using the **Try It!** feature or via the command line with a cURL command similar to the one shown below. You'll need your [project ID](/docs/reference/glossary#project-id), compute [endpoint ID](/docs/reference/glossary#endpoint-id), and an [API key](/docs/manage/api-keys#create-an-api-key).
+<TabItem>
 
-  ```bash
-  curl --request POST \
-     --url https://console.neon.tech/api/v2/projects/cool-forest-86753099/endpoints/ep-calm-flower-a5b75h79/restart \
-     --header 'accept: application/json' \
-     --header 'authorization: Bearer $NEON_API_KEY'
-  ```
+Use the **Restart compute** option in the Neon Console. Select your branch from the **BRANCH** selector, then select **Postgres database** > **Computes** and choose **Restart compute** from the compute's menu.
 
-  <Admonition type="note">
-  The [Restart compute endpoint](/docs/reference/api/endpoints/restart-project-endpoint) API only works on an active compute. If you're compute is idle, you can wake it up with a query or the [Start compute endpoint](/docs/reference/api/endpoints/start-project-endpoint) API. 
-  </Admonition>
+![Restart a compute in the console](/docs/manage/restart_compute.png)
 
-- Stop activity on your compute (stop running queries) and wait for your compute to suspend due to inactivity. By default, Neon suspends a compute after 5 minutes of inactivity. You can watch the status of your compute on the **Branches** page in the Neon Console. Select your branch and monitor your compute's **Status** field. Wait for it to report an `Idle` status. The compute will restart the next time it's accessed, and the status will change to `Active`.
+You can also restart a compute by letting it suspend: stop activity (stop running queries) and wait for the compute to suspend due to inactivity, which happens after 5 minutes by default. Watch the compute's **Status** field on the **Branches** page until it reports `Idle`. The compute restarts the next time it's accessed, and the status changes to `Active`.
+
+</TabItem>
+
+<TabItem>
+
+Restart the compute through the [`neon api`](/docs/cli/api) passthrough:
+
+```bash
+neon api /projects/autumn-lake-30024670/endpoints/ep-misty-morning-a1pfa4ez/restart -X POST
+```
+
+</TabItem>
+
+<TabItem>
+
+Issue a [Restart compute endpoint](/docs/reference/api/endpoints/restart-project-endpoint) call. You'll need your [project ID](/docs/reference/glossary#project-id), compute [endpoint ID](/docs/reference/glossary#endpoint-id), and an [API key](/docs/manage/api-keys#create-an-api-key):
+
+```bash
+curl --request POST \
+   --url https://console.neon.tech/api/v2/projects/autumn-lake-30024670/endpoints/ep-misty-morning-a1pfa4ez/restart \
+   --header 'accept: application/json' \
+   --header 'authorization: Bearer $NEON_API_KEY'
+```
+
+<Admonition type="note">
+The [Restart compute endpoint](/docs/reference/api/endpoints/restart-project-endpoint) API only works on an active compute. If your compute is idle, you can wake it up with a query or the [Start compute endpoint](/docs/reference/api/endpoints/start-project-endpoint) API.
+</Admonition>
+
+</TabItem>
+
+</Tabs>
 
 ## Delete a compute
 
 A branch can have a single read-write compute and multiple read replica computes. You can delete any of these computes from a branch. However, be aware that a compute is required to connect to a branch and access its data. If you delete a compute and add it back later, the new compute will have different connection details.
 
-To delete a compute:
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
 
 1. In the Neon Console, select your branch from the **BRANCH** selector.
 1. Under **Postgres database**, select **Computes**.
 1. Click **Edit** for the compute you want to delete.
 1. At the bottom of the **Edit compute** drawer, click **Delete compute**.
 
-## Manage computes with the Neon API
+</TabItem>
 
-Compute actions performed in the Neon Console can also be performed using the [Neon API](/docs/reference/api). The following examples demonstrate how to create, view, update, and delete computes using the Neon API. For other compute-related API methods, refer to the [Neon API Reference](/docs/reference/api).
+<TabItem>
 
-<Admonition type="note">
-The API examples that follow may not show all of the user-configurable request body attributes that are available to you. To view all attributes for a particular method, refer to method's request body schema in the [Neon API Reference](/docs/reference/api).
-</Admonition>
-
-The `jq` option specified in each example is an optional third-party tool that formats the `JSON` response, making it easier to read. For information about this utility, see [jq](https://stedolan.github.io/jq/).
-
-### Prerequisites
-
-A Neon API request requires an API key. For information about obtaining an API key, see [Create an API key](/docs/manage/api-keys#create-an-api-key). In the cURL examples below, `$NEON_API_KEY` is specified in place of an actual API key, which you must provide when making a Neon API request.
-
-<LinkAPIKey />
-### Create a compute with the API
-
-The following Neon API method creates a compute.
-
-```http
-POST /projects/{project_id}/endpoints
-```
-
-The API method appears as follows when specified in a cURL command. The branch you specify cannot have an existing compute. A compute must be associated with a branch. Neon supports read-write and read replica compute. A branch can have a single primary read-write compute but supports multiple read replica computes.
+Delete the compute through the [`neon api`](/docs/cli/api) passthrough:
 
 ```bash
-curl -X 'POST' \
-  'https://console.neon.tech/api/v2/projects/autumn-lake-30024670/endpoints' \
-  -H 'accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY" \
-  -H 'Content-Type: application/json' \
-  -d '{
-  "endpoint": {
-    "branch_id": "br-dry-glitter-a1rh0x6q",
-    "type": "read_write"
-  }
-}'
+neon api /projects/autumn-lake-30024670/endpoints/ep-misty-morning-a1pfa4ez -X DELETE
 ```
 
-<details>
-<summary>Response body</summary>
+</TabItem>
 
-For attribute definitions, find the [Create compute](/docs/reference/api/endpoints/create-project-endpoint) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
+<TabItem>
 
-```json
-{
-  "endpoint": {
-    "host": "ep-misty-morning-a1pfa4ez.ap-southeast-1.aws.neon.tech",
-    "id": "ep-misty-morning-a1pfa4ez",
-    "project_id": "autumn-lake-30024670",
-    "branch_id": "br-dry-glitter-a1rh0x6q",
-    "autoscaling_limit_min_cu": 1,
-    "autoscaling_limit_max_cu": 2,
-    "region_id": "aws-ap-southeast-1",
-    "type": "read_write",
-    "current_state": "init",
-    "pending_state": "active",
-    "settings": {},
-    "pooler_enabled": false,
-    "pooler_mode": "transaction",
-    "disabled": false,
-    "passwordless_access": true,
-    "creation_source": "console",
-    "created_at": "2025-08-03T17:40:19Z",
-    "updated_at": "2025-08-03T17:40:19Z",
-    "proxy_host": "ap-southeast-1.aws.neon.tech",
-    "suspend_timeout_seconds": 0,
-    "provisioner": "k8s-neonvm"
-  },
-  "operations": [
-    {
-      "id": "d6ef3cc2-663b-440a-88e7-ea6a59ea2c6a",
-      "project_id": "autumn-lake-30024670",
-      "branch_id": "br-dry-glitter-a1rh0x6q",
-      "endpoint_id": "ep-misty-morning-a1pfa4ez",
-      "action": "start_compute",
-      "status": "running",
-      "failures_count": 0,
-      "created_at": "2025-08-03T17:40:19Z",
-      "updated_at": "2025-08-03T17:40:19Z",
-      "total_duration_ms": 0
-    }
-  ]
-}
-```
-
-</details>
-
-### List computes with the API
-
-The following Neon API method lists computes for the specified project. A compute belongs to a Neon project. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/endpoints/list-project-endpoints).
-
-```http
-GET /projects/{project_id}/endpoints
-```
-
-The API method appears as follows when specified in a cURL command:
-
-```bash
-curl -X 'GET' \
-  'https://console.neon.tech/api/v2/projects/autumn-lake-30024670/endpoints' \
-  -H 'accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY"
-```
-
-<details>
-<summary>Response body</summary>
-
-For attribute definitions, find the [List computes](/docs/reference/api/endpoints/list-project-endpoints) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
-
-```json
-{
-  "endpoints": [
-    {
-      "host": "ep-misty-morning-a1pfa4ez.ap-southeast-1.aws.neon.tech",
-      "id": "ep-misty-morning-a1pfa4ez",
-      "project_id": "autumn-lake-30024670",
-      "branch_id": "br-dry-glitter-a1rh0x6q",
-      "autoscaling_limit_min_cu": 1,
-      "autoscaling_limit_max_cu": 2,
-      "region_id": "aws-ap-southeast-1",
-      "type": "read_write",
-      "current_state": "idle",
-      "settings": {},
-      "pooler_enabled": false,
-      "pooler_mode": "transaction",
-      "disabled": false,
-      "passwordless_access": true,
-      "last_active": "2025-08-03T17:40:20Z",
-      "creation_source": "console",
-      "created_at": "2025-08-03T17:40:19Z",
-      "updated_at": "2025-08-03T17:45:24Z",
-      "suspended_at": "2025-08-03T17:45:24Z",
-      "proxy_host": "ap-southeast-1.aws.neon.tech",
-      "suspend_timeout_seconds": 0,
-      "provisioner": "k8s-neonvm"
-    },
-    {
-      "host": "ep-autumn-frost-a1wlmval.ap-southeast-1.aws.neon.tech",
-      "id": "ep-autumn-frost-a1wlmval",
-      "project_id": "autumn-lake-30024670",
-      "branch_id": "br-dark-bar-a11jneqm",
-      "autoscaling_limit_min_cu": 1,
-      "autoscaling_limit_max_cu": 2,
-      "region_id": "aws-ap-southeast-1",
-      "type": "read_write",
-      "current_state": "idle",
-      "settings": {},
-      "pooler_enabled": false,
-      "pooler_mode": "transaction",
-      "disabled": false,
-      "passwordless_access": true,
-      "last_active": "2025-08-03T17:34:40Z",
-      "creation_source": "console",
-      "created_at": "2025-08-03T11:27:50Z",
-      "updated_at": "2025-08-03T17:41:11Z",
-      "suspended_at": "2025-08-03T17:41:11Z",
-      "proxy_host": "ap-southeast-1.aws.neon.tech",
-      "suspend_timeout_seconds": 0,
-      "provisioner": "k8s-neonvm"
-    }
-  ]
-}
-```
-
-</details>
-
-### Update a compute with the API
-
-The following Neon API method updates the specified compute. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/endpoints/update-project-endpoint).
-
-```http
-PATCH /projects/{project_id}/endpoints/{endpoint_id}
-```
-
-The API method appears as follows when specified in a cURL command. The example reassigns the compute to another branch by changing the `branch_id`. The branch that you specify cannot have an existing compute. A compute must be associated with a branch, and a branch can have only one primary read-write compute. Multiple read-replica computes are allowed.
-
-```bash
-curl -X 'PATCH' \
-  'https://console.neon.tech/api/v2/projects/autumn-lake-30024670/endpoints/ep-misty-morning-a1pfa4ez' \
-  -H 'accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY" \
-  -H 'Content-Type: application/json' \
-  -d '{
-  "endpoint": {
-    "branch_id": "br-raspy-pine-a1hspnzv"
-  }
-}'
-```
-
-<details>
-<summary>Response body</summary>
-
-For attribute definitions, find the [Update compute](/docs/reference/api/endpoints/update-project-endpoint) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
-
-```json
-{
-  "endpoint": {
-    "host": "ep-misty-morning-a1pfa4ez.ap-southeast-1.aws.neon.tech",
-    "id": "ep-misty-morning-a1pfa4ez",
-    "project_id": "autumn-lake-30024670",
-    "branch_id": "br-raspy-pine-a1hspnzv",
-    "autoscaling_limit_min_cu": 1,
-    "autoscaling_limit_max_cu": 2,
-    "region_id": "aws-ap-southeast-1",
-    "type": "read_write",
-    "current_state": "idle",
-    "settings": {},
-    "pooler_enabled": false,
-    "pooler_mode": "transaction",
-    "disabled": false,
-    "passwordless_access": true,
-    "last_active": "2025-08-03T17:40:20Z",
-    "creation_source": "console",
-    "created_at": "2025-08-03T17:40:19Z",
-    "updated_at": "2025-08-03T17:49:01Z",
-    "suspended_at": "2025-08-03T17:45:24Z",
-    "proxy_host": "ap-southeast-1.aws.neon.tech",
-    "suspend_timeout_seconds": 0,
-    "provisioner": "k8s-neonvm"
-  },
-  "operations": []
-}
-```
-
-</details>
-
-### Delete a compute with the API
-
-The following Neon API method deletes the specified compute. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/endpoints/delete-project-endpoint).
-
-```http
-DELETE /projects/{project_id}/endpoints/{endpoint_id}
-```
-
-The API method appears as follows when specified in a cURL command.
+Delete a compute with the [Delete compute](/docs/reference/api/endpoints/delete-project-endpoint) endpoint:
 
 ```bash
 curl -X 'DELETE' \
@@ -524,9 +612,9 @@ For attribute definitions, find the [Delete compute](/docs/reference/api/endpoin
     "host": "ep-misty-morning-a1pfa4ez.ap-southeast-1.aws.neon.tech",
     "id": "ep-misty-morning-a1pfa4ez",
     "project_id": "autumn-lake-30024670",
-    "branch_id": "br-raspy-pine-a1hspnzv",
-    "autoscaling_limit_min_cu": 1,
-    "autoscaling_limit_max_cu": 2,
+    "branch_id": "br-dry-glitter-a1rh0x6q",
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 3,
     "region_id": "aws-ap-southeast-1",
     "type": "read_write",
     "current_state": "idle",
@@ -549,6 +637,10 @@ For attribute definitions, find the [Delete compute](/docs/reference/api/endpoin
 ```
 
 </details>
+
+</TabItem>
+
+</Tabs>
 
 ## Compute-related issues
 

--- a/content/docs/manage/databases.md
+++ b/content/docs/manage/databases.md
@@ -9,7 +9,7 @@ summary: >-
   ALTER TABLE ... OWNER TO or REASSIGN OWNED.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-18T10:29:02.410Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 A database is a container for SQL objects such as schemas, tables, views, functions, and indexes. In the [Neon object hierarchy](/docs/manage/overview), a database exists within a branch of a project. There is a limit of 500 databases per branch.
@@ -24,22 +24,15 @@ As of Postgres 15, only a database owner has the `CREATE` privilege on a databas
 
 Databases belong to a branch. If you create a child branch, databases from the parent branch are copied to the child branch. For example, if database `mydb` exists in the parent branch, it will be copied to the child branch. The only time this does not occur is when you create a branch that includes data up to a particular point in time. If a database was created in the parent branch after that point in time, it is not duplicated in the child branch.
 
-Neon supports creating and managing databases from the following interfaces:
-
-- [Neon Console](#manage-databases-in-the-neon-console)
-- [Neon CLI](#manage-databases-with-the-neon-cli)
-- [Neon API](#manage-databases-with-the-neon-api)
-- [SQL](#manage-databases-with-sql)
-
-## Manage databases in the Neon Console
-
-This section describes how to create, view, and delete databases in the Neon Console.
+Neon supports creating and managing databases from the Neon Console, CLI, and API, and directly with [SQL](#manage-databases-with-sql).
 
 The role that creates a database is automatically made the owner of that database. The `neon_superuser` role is also granted all privileges on databases created in the Neon Console. For information about this role, see [The neon_superuser role](/docs/manage/roles#the-neonsuperuser-role).
 
-### Create a database
+## Create a database
 
-To create a database:
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 1. Select a project.
@@ -49,68 +42,21 @@ To create a database:
 1. Enter a database name, and select a database owner.
 1. Click **Create**.
 
-<Admonition type="note">
-Some names are not permitted. See [Reserved database names](#reserved-database-names).
-</Admonition>
+</TabItem>
 
-### View databases
+<TabItem>
 
-To view databases:
+Create a database with [`neon databases create`](/docs/cli/databases#create). If you omit `--branch`, the CLI uses the project's default branch:
 
-1. Navigate to the [Neon Console](https://console.neon.tech).
-1. Select a project.
-1. In the sidebar, select your branch from the **BRANCH** selector.
-1. Under **Postgres database**, select **Databases**.
-
-### Delete a database
-
-Deleting a database is a permanent action. All database objects belonging to the database such as schemas, tables, and roles are also deleted.
-
-To delete a database:
-
-1. Navigate to the [Neon Console](https://console.neon.tech).
-1. Select a project.
-1. In the sidebar, select your branch from the **BRANCH** selector.
-1. Under **Postgres database**, select **Databases**.
-1. For the database you want to delete, click the delete icon.
-1. In the confirmation dialog, click **Delete**.
-
-## Manage databases with the Neon CLI
-
-The Neon CLI supports creating and deleting databases with `neon databases create --name <database_name>` and `neon databases delete <database_name>`. If you omit `--branch`, the CLI uses the project's default branch. For full instructions and options, see [Neon CLI commands — databases](/docs/cli/databases).
-
-## Manage databases with the Neon API
-
-Database actions performed in the Neon Console can also be also performed using the Neon API. The following examples demonstrate how to create, view, update, and delete databases using the Neon API. For other database-related methods, refer to the [Neon API Reference](/docs/reference/api).
-
-In Neon, a database belongs to a branch, which means that when you create a database, it is created in a branch. Database-related requests are therefore performed using branch API methods.
-
-<Admonition type="note">
-The API examples that follow may not show all user-configurable request body attributes that are available to you. To view all  attributes for a particular method, refer to the method's request body schema in the [Neon API Reference](/docs/reference/api).
-</Admonition>
-
-The `jq` option specified in each example is an optional third-party tool that formats the `JSON` response, making it easier to read. For information about this utility, see [jq](https://stedolan.github.io/jq/).
-
-### Prerequisites
-
-A Neon API request requires an API key. For information about obtaining an API key, see [Create an API key](/docs/manage/api-keys#create-an-api-key). In the cURL examples below, `$NEON_API_KEY` is specified in place of an actual API key, which you must provide when making a Neon API request.
-
-<LinkAPIKey />
-### Create a database with the API
-
-The following Neon API method creates a database. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/create-project-branch-database).
-
-The role specified by `owner_name` is the owner of that database.
-
-```http
-POST /projects/{project_id}/branches/{branch_id}/databases
+```bash
+neon databases create --name mydb --owner-name casey
 ```
 
-<Admonition type="note">
-Some names are not permitted for databases. See [Reserved database names](#reserved-database-names).
-</Admonition>
+</TabItem>
 
-The API method appears as follows when specified in a cURL command. The `project_id` and `branch_id` are required parameters, and a database `name` and `owner` are required attributes.
+<TabItem>
+
+Create a database with the [Create database](/docs/reference/api/branches/create-project-branch-database) endpoint. A database `name` and `owner_name` are required:
 
 ```bash
 curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/databases' \
@@ -122,7 +68,7 @@ curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-m
     "name": "mydb",
     "owner_name": "casey"
   }
-}' | jq
+}'
 ```
 
 <details>
@@ -159,20 +105,55 @@ For attribute definitions, find the [Create database](/docs/reference/api/branch
 
 </details>
 
-### List databases with the API
+</TabItem>
 
-The following Neon API method lists databases for the specified branch. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/list-project-branch-databases).
+</Tabs>
 
-```http
-GET /projects/{project_id}/branches/{branch_id}/databases
-```
+<Admonition type="note">
+Some names are not permitted. See [Reserved database names](#reserved-database-names).
+</Admonition>
 
-The API method appears as follows when specified in a cURL command. The `project_id` and `branch_id` are required parameters.
+## View databases
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+1. Navigate to the [Neon Console](https://console.neon.tech).
+1. Select a project.
+1. In the sidebar, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Databases**.
+
+</TabItem>
+
+<TabItem>
+
+List databases with [`neon databases list`](/docs/cli/databases#list). If you omit `--branch`, the CLI uses the project's default branch:
 
 ```bash
-curl 'https://console.neon.tech/api/v2/projects/hidden-cell-763301/branches/br-blue-tooth-671580/databases' \
+neon databases list
+```
+
+```text filename="Output"
+┌────────┬────────────┬──────────────────────┐
+│ Name   │ Owner Name │ Created At           │
+├────────┼────────────┼──────────────────────┤
+│ neondb │ casey      │ 2023-06-19T18:27:19Z │
+├────────┼────────────┼──────────────────────┤
+│ mydb   │ casey      │ 2023-06-19T18:27:19Z │
+└────────┴────────────┴──────────────────────┘
+```
+
+</TabItem>
+
+<TabItem>
+
+List databases for a branch with the [List databases](/docs/reference/api/branches/list-project-branch-databases) endpoint:
+
+```bash
+curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/databases' \
   -H 'Accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY" | jq
+  -H "Authorization: Bearer $NEON_API_KEY"
 ```
 
 <details>
@@ -185,7 +166,7 @@ For attribute definitions, find the [List databases](/docs/reference/api/branche
   "databases": [
     {
       "id": 1139149,
-      "branch_id": "br-blue-tooth-671580",
+      "branch_id": "br-morning-meadow-afu2s1jl",
       "name": "neondb",
       "owner_name": "casey",
       "created_at": "2023-01-04T18:38:23Z",
@@ -193,7 +174,7 @@ For attribute definitions, find the [List databases](/docs/reference/api/branche
     },
     {
       "id": 1140822,
-      "branch_id": "br-blue-tooth-671580",
+      "branch_id": "br-morning-meadow-afu2s1jl",
       "name": "mydb",
       "owner_name": "casey",
       "created_at": "2023-01-04T21:17:17Z",
@@ -205,15 +186,13 @@ For attribute definitions, find the [List databases](/docs/reference/api/branche
 
 </details>
 
-### Update a database with the API
+</TabItem>
 
-The following Neon API method updates the specified database. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/update-project-branch-database).
+</Tabs>
 
-```http
-PATCH /projects/{project_id}/branches/{branch_id}/databases/{database_name}
-```
+## Update a database
 
-The API method appears as follows when specified in a cURL command. The `project_id` and `branch_id` are required parameters. This example updates the database `name` value to `database1`.
+Rename a database with the [Update database](/docs/reference/api/branches/update-project-branch-database) endpoint, or with [SQL](#rename-a-database-with-sql). This example renames `mydb` to `database1`:
 
 ```bash
 curl -X PATCH 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/databases/mydb' \
@@ -224,7 +203,7 @@ curl -X PATCH 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/bran
   "database": {
     "name": "database1"
   }
-}' | jq
+}'
 ```
 
 <details>
@@ -261,21 +240,42 @@ For attribute definitions, find the [Update database](/docs/reference/api/branch
 
 </details>
 
-### Delete a database with the API
+## Delete a database
 
-The following Neon API method deletes the specified database. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/delete-project-branch-database).
+Deleting a database is a permanent action. All database objects belonging to the database such as schemas, tables, and roles are also deleted.
 
-```http
-DELETE /projects/{project_id}/branches/{branch_id}/databases/{database_name}
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+1. Navigate to the [Neon Console](https://console.neon.tech).
+1. Select a project.
+1. In the sidebar, select your branch from the **BRANCH** selector.
+1. Under **Postgres database**, select **Databases**.
+1. For the database you want to delete, click the delete icon.
+1. In the confirmation dialog, click **Delete**.
+
+</TabItem>
+
+<TabItem>
+
+Delete a database with [`neon databases delete`](/docs/cli/databases#delete):
+
+```bash
+neon databases delete database1
 ```
 
-The API method appears as follows when specified in a cURL command. The `project_id`, `branch_id`, and `database_name` are required parameters.
+</TabItem>
+
+<TabItem>
+
+Delete a database with the [Delete database](/docs/reference/api/branches/delete-project-branch-database) endpoint:
 
 ```bash
 curl -X 'DELETE' \
   'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/databases/database1' \
   -H 'Accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY" | jq
+  -H "Authorization: Bearer $NEON_API_KEY"
 ```
 
 <details>
@@ -312,6 +312,9 @@ For attribute definitions, find the [Delete database](/docs/reference/api/branch
 
 </details>
 
+</TabItem>
+
+</Tabs>
 ## Manage databases with SQL
 
 You can create and manage databases in Neon with SQL, as you can with any standalone Postgres installation. To create a database, issue a `CREATE DATABASE` statement from a client such as [psql](/docs/connect/query-with-psql-editor) or from the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor).
@@ -347,7 +350,7 @@ WHERE datname = 'old_db_name'
   AND pid <> pg_backend_pid();
 ```
 
-The rename is instant, and data, schemas, tables, roles, and grants are unaffected. The database name is part of every connection string for the database, so update any application, script, or stored secret that references the old name. You can also rename a database with the [Neon API](#update-a-database-with-the-api).
+The rename is instant, and data, schemas, tables, roles, and grants are unaffected. The database name is part of every connection string for the database, so update any application, script, or stored secret that references the old name. You can also rename a database with the [Neon API](#update-a-database).
 
 ### Delete a database with SQL
 
@@ -357,7 +360,7 @@ To delete a database, use `DROP DATABASE`. As with renaming, connect to a differ
 DROP DATABASE old_db_name;
 ```
 
-Deletion is permanent. All schemas, tables, indexes, and other objects in the database are dropped along with it. You can also delete a database from the [Neon Console](#delete-a-database), the [Neon CLI](#manage-databases-with-the-neon-cli), or the [Neon API](#delete-a-database-with-the-api).
+Deletion is permanent. All schemas, tables, indexes, and other objects in the database are dropped along with it. You can also delete a database from the [Neon Console, CLI, or API](#delete-a-database).
 
 ## Transfer database table ownership between roles
 

--- a/content/docs/manage/projects.md
+++ b/content/docs/manage/projects.md
@@ -13,7 +13,7 @@ summary: >-
   window using the CLI or API.
 redirectFrom:
   - /docs/get-started/projects
-updatedOn: '2026-08-04T15:25:12.468Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 In Neon, the project is your main workspace. Within a project, you create branches for different workflows, like environments, features, or previews. Each branch contains its own databases, roles, computes, and replicas. Your [Neon Plan](/docs/introduction/plans) determines how many projects you can create and the resource limits within those projects.
@@ -383,7 +383,7 @@ Logical replication lets you replicate data changes from Neon to external data s
 Enabling logical replication changes the PostgreSQL `wal_level` setting from `replica` to `logical` for all databases in your Neon project. This allows Postgres to record the row-level WAL detail required for logical decoding. Once changed, it cannot be reverted. Enabling logical replication also restarts all computes, so active connections will be dropped and have to reconnect.
 </Admonition>
 
-<Tabs labels={["Console", "API"]}>
+<Tabs labels={["Console", "CLI", "API"]}>
 
 <TabItem>
 
@@ -391,6 +391,16 @@ Enabling logical replication changes the PostgreSQL `wal_level` setting from `re
 2. On the **Project Dashboard**, select **Settings**.
 3. Select **Logical replication**.
 4. Click **Enable** to enable logical replication.
+
+</TabItem>
+
+<TabItem>
+
+Use [`neon projects update`](/docs/cli/projects#update) with the `--enable-logical-replication` flag. Because this can't be undone, add `--yes` to skip the confirmation prompt. Replace `$PROJECT_ID` with your project ID.
+
+```bash
+neon projects update $PROJECT_ID --enable-logical-replication --yes
+```
 
 </TabItem>
 

--- a/content/docs/manage/roles.md
+++ b/content/docs/manage/roles.md
@@ -11,7 +11,7 @@ enableTableOfContents: true
 isDraft: false
 redirectFrom:
   - /docs/manage/users
-updatedOn: '2026-08-18T10:29:02.410Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 In Neon, roles are Postgres roles. Each Neon project is created with a Postgres role that is named for your database. For example, if your database is named `neondb`, the project is created with a role named `neondb_owner`. This role owns the database that is created in your Neon project's default branch.
@@ -28,10 +28,8 @@ In Neon, roles belong to a branch, which could be your production branch or a ch
 
 Neon supports creating and managing roles from the following interfaces:
 
-- [Neon Console](#manage-roles-in-the-neon-console)
-- [Neon CLI](#manage-roles-with-the-neon-cli)
-- [Neon API](#manage-roles-with-the-neon-api)
-- [SQL](#manage-roles-with-sql)
+- [Manage roles](#manage-roles) using the Neon Console, CLI, or API
+- [Manage roles with SQL](#manage-roles-with-sql)
 
 ## The neon_superuser role
 
@@ -58,13 +56,15 @@ You can think of roles with `neon_superuser` privileges as administrator roles. 
 Creating a database with the `neon_superuser` role, altering a database to have owner `neon_superuser`, and altering the `neon_superuser role` itself are _not_ permitted. This `NOLOGIN` role is not intended to be used directly or modified.
 </Admonition>
 
-## Manage roles in the Neon Console
+## Manage roles
 
-This section describes how to create, view, and delete roles in the Neon Console. All roles created in the Neon Console are granted membership in the [neon_superuser](#the-neonsuperuser-role) role.
+You can create, list, delete, and reset passwords for roles using the Neon Console, CLI, or API. Roles created through any of these interfaces are granted membership in the [neon_superuser](#the-neonsuperuser-role) role. To create roles with limited privileges, use [SQL](#manage-roles-with-sql).
 
 ### Create a role
 
-To create a role:
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
 
 1. Navigate to the [Neon Console](https://console.neon.tech).
 2. Select a project.
@@ -74,85 +74,21 @@ To create a role:
 6. In the role creation modal, specify a role name. The branch is pre-selected.
 7. Click **Create**. The role is created and you are provided with the password for the role.
 
-<Admonition type="note">
-Role names cannot exceed 63 characters, and some names are not permitted. See [Reserved role names](#reserved-role-names).
-</Admonition>
+</TabItem>
 
-### Delete a role
+<TabItem>
 
-Deleting a role is a permanent action that cannot be undone, and you cannot delete a role that owns a database. The database must be deleted before deleting the role that owns the database.
+Create a role with [`neon roles create`](/docs/cli/roles#create). Pass `--no-login` to create a `NOLOGIN` role:
 
-To delete a role:
-
-1. Navigate to the [Neon Console](https://console.neon.tech).
-2. Select a project.
-3. In the sidebar, select your branch from the **BRANCH** selector.
-4. Under **Postgres database**, select **Roles**.
-5. Select **Delete role** from the role menu.
-6. On the confirmation modal, click **Delete**.
-
-### Reset a password
-
-To reset a role's password:
-
-1. Navigate to the [Neon Console](https://console.neon.tech).
-2. Select a project.
-3. In the sidebar, select your branch from the **BRANCH** selector.
-4. Under **Postgres database**, select **Roles**.
-5. Select **Reset password** from the role menu.
-6. On the **Reset password** modal, click **Reset**. A reset password modal is displayed with your new password.
-
-<Admonition type="note">
-Resetting a password in the Neon Console resets the password to a generated value. To set your own password value, you can reset the password using the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or an SQL client like [psql](/docs/connect/query-with-psql-editor) with the following syntax:
-
-```sql
-ALTER USER user_name WITH PASSWORD 'new_password';
+```bash
+neon roles create --name alex
 ```
 
-For password requirements, see [Manage roles with SQL](/docs/manage/roles#manage-roles-with-sql).
-</Admonition>
+</TabItem>
 
-A password reset takes effect immediately. The old password stops working on the next connection, so copy the new connection string from the **Connect** modal and update it wherever it is stored (deployment environment variables, secret managers, and `.env` files). Resets are branch-scoped, so reset the role on each branch where it is used.
+<TabItem>
 
-Resetting a password is also how you rotate the credential behind a connection string. To rotate after a leak or as routine security practice, see [Rotate credentials](/docs/security/security-overview#rotate-credentials).
-
-## Manage roles with the Neon CLI
-
-The Neon CLI supports creating and deleting roles. For instructions, see [Neon CLI commands — roles](/docs/cli/roles). Roles created with the Neon CLI are granted membership in the [neon_superuser](#the-neonsuperuser-role) role.
-
-## Manage roles with the Neon API
-
-Role actions performed in the Neon Console can also be performed using Neon API role methods. The following examples demonstrate how to create, view, reset passwords for, and delete roles using the Neon API. For other role-related methods, refer to the [Neon API Reference](/docs/reference/api).
-
-Roles created with the Neon API are granted membership in the [neon_superuser](#the-neonsuperuser-role) role.
-
-In Neon, roles belong to branches, which means that when you create a role, it is created in a branch. Role-related requests are therefore performed using branch API methods.
-
-<Admonition type="note">
-The API examples that follow may not show all user-configurable request body attributes that are available to you. To view all  attributes for a particular method, refer to method's request body schema in the [Neon API Reference](/docs/reference/api).
-</Admonition>
-
-The `jq` option specified in each example is an optional third-party tool that formats the `JSON` response, making it easier to read. For information about this utility, see [jq](https://stedolan.github.io/jq/).
-
-### Prerequisites
-
-A Neon API request requires an API key. For information about obtaining an API key, see [Create an API key](/docs/manage/api-keys#create-an-api-key). In the cURL examples shown below, `$NEON_API_KEY` is specified in place of an actual API key, which you must provide when making a Neon API request.
-
-<LinkAPIKey />
-
-### Create a role with the API
-
-The following Neon API method creates a role. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/create-project-branch-role).
-
-```http
-POST /projects/{project_id}/branches/{branch_id}/roles
-```
-
-<Admonition type="note">
-Role names cannot exceed 63 characters, and some role names are not permitted. See [Reserved role names](#reserved-role-names).
-</Admonition>
-
-The API method appears as follows when specified in a cURL command. The `project_id` and `branch_id` are required parameters, and the role `name` is a required attribute. The length of a role name is limited to 63 bytes.
+Create a role with the [Create role](/docs/reference/api/branches/create-project-branch-role) endpoint. The role `name` is required and limited to 63 bytes:
 
 ```bash
 curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/roles' \
@@ -200,18 +136,50 @@ For attribute definitions, find the [Create role](/docs/reference/api/branches/c
 
 </details>
 
-### List roles with the API
+</TabItem>
 
-The following Neon API method lists roles for the specified branch. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/list-project-branch-roles).
+</Tabs>
 
-```http
-GET /projects/{project_id}/branches/{branch_id}/roles
-```
+<Admonition type="note">
+Role names cannot exceed 63 characters, and some names are not permitted. See [Reserved role names](#reserved-role-names).
+</Admonition>
 
-The API method appears as follows when specified in a cURL command. The `project_id` and `branch_id` are required parameters.
+### List roles
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+In the Neon Console, select your branch from the **BRANCH** selector, then under **Postgres database** select **Roles** to see the roles on the branch.
+
+</TabItem>
+
+<TabItem>
+
+List the roles on a branch with [`neon roles list`](/docs/cli/roles#list):
 
 ```bash
-curl 'https://console.neon.tech/api/v2/projects/hidden-cell-763301/branches/br-blue-tooth-671580/roles' \
+neon roles list
+```
+
+```text filename="Output"
+┌────────┬──────────────────────┐
+│ Name   │ Created At           │
+├────────┼──────────────────────┤
+│ daniel │ 2023-06-19T18:27:19Z │
+├────────┼──────────────────────┤
+│ alex   │ 2023-07-13T06:42:55Z │
+└────────┴──────────────────────┘
+```
+
+</TabItem>
+
+<TabItem>
+
+List roles with the [List roles](/docs/reference/api/branches/list-project-branch-roles) endpoint:
+
+```bash
+curl 'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/roles' \
   -H 'Accept: application/json' \
   -H "Authorization: Bearer $NEON_API_KEY" | jq
 ```
@@ -225,14 +193,14 @@ For attribute definitions, find the [List roles](/docs/reference/api/branches/li
 {
   "roles": [
     {
-      "branch_id": "br-blue-tooth-671580",
+      "branch_id": "br-morning-meadow-afu2s1jl",
       "name": "daniel",
       "protected": false,
       "created_at": "2023-07-09T17:01:34Z",
       "updated_at": "2023-07-09T17:01:34Z"
     },
     {
-      "branch_id": "br-blue-tooth-671580",
+      "branch_id": "br-morning-meadow-afu2s1jl",
       "name": "alex",
       "protected": false,
       "created_at": "2023-07-13T06:42:55Z",
@@ -244,15 +212,105 @@ For attribute definitions, find the [List roles](/docs/reference/api/branches/li
 
 </details>
 
-### Reset a password with the API
+</TabItem>
 
-The following Neon API method resets the password for the specified role. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/reset-project-branch-role-password).
+</Tabs>
 
-```http
-POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password
+### Delete a role
+
+Deleting a role is a permanent action that cannot be undone, and you cannot delete a role that owns a database. The database must be deleted before deleting the role that owns the database.
+
+<Tabs labels={["Console", "CLI", "API"]}>
+
+<TabItem>
+
+1. Navigate to the [Neon Console](https://console.neon.tech).
+2. Select a project.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Select **Delete role** from the role menu.
+6. On the confirmation modal, click **Delete**.
+
+</TabItem>
+
+<TabItem>
+
+Delete a role with [`neon roles delete`](/docs/cli/roles#delete), passing the role name:
+
+```bash
+neon roles delete alex
 ```
 
-The API method appears as follows when specified in a cURL command. The `project_id`, `branch_id`, and `role_name` are required parameters.
+</TabItem>
+
+<TabItem>
+
+Delete a role with the [Delete role](/docs/reference/api/branches/delete-project-branch-role) endpoint:
+
+```bash
+curl -X 'DELETE' \
+  'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/roles/alex' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $NEON_API_KEY" | jq
+```
+
+<details>
+<summary>Response body</summary>
+
+For attribute definitions, find the [Delete role](/docs/reference/api/branches/delete-project-branch-role) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
+
+```json
+{
+  "role": {
+    "branch_id": "br-morning-meadow-afu2s1jl",
+    "name": "alex",
+    "protected": false,
+    "created_at": "2025-08-04T07:47:05Z",
+    "updated_at": "2025-08-04T07:51:10Z"
+  },
+  "operations": [
+    {
+      "id": "722b9f9b-c50e-424c-845e-78b38151b82f",
+      "project_id": "dry-heart-13671059",
+      "branch_id": "br-morning-meadow-afu2s1jl",
+      "endpoint_id": "ep-holy-heart-afbmgcfx",
+      "action": "apply_config",
+      "status": "running",
+      "failures_count": 0,
+      "created_at": "2025-08-04T07:53:22Z",
+      "updated_at": "2025-08-04T07:53:22Z",
+      "total_duration_ms": 0
+    }
+  ]
+}
+```
+
+</details>
+
+</TabItem>
+
+</Tabs>
+
+### Reset a password
+
+You can reset a role's password from the Neon Console or API. There's no CLI command for this operation. Resetting in the Console sets a generated password; to set your own value, use [SQL](#manage-roles-with-sql).
+
+<Tabs labels={["Console", "API"]}>
+
+<TabItem>
+
+1. Navigate to the [Neon Console](https://console.neon.tech).
+2. Select a project.
+3. In the sidebar, select your branch from the **BRANCH** selector.
+4. Under **Postgres database**, select **Roles**.
+5. Select **Reset password** from the role menu.
+6. On the **Reset password** modal, click **Reset**. A reset password modal is displayed with your new password.
+
+</TabItem>
+
+<TabItem>
+
+Reset a role's password with the [Reset role password](/docs/reference/api/branches/reset-project-branch-role-password) endpoint:
 
 ```bash
 curl -X 'POST' \
@@ -295,55 +353,23 @@ For attribute definitions, find the [Reset role password](/docs/reference/api/br
 
 </details>
 
-### Delete a role with the API
+</TabItem>
 
-The following Neon API method deletes the specified role. To view the API documentation for this method, refer to the [Neon API Reference](/docs/reference/api/branches/delete-project-branch-role).
+</Tabs>
 
-```http
-DELETE /projects/{project_id}/branches/{branch_id}/roles/{role_name}
+<Admonition type="note">
+Resetting a password in the Neon Console resets the password to a generated value. To set your own password value, you can reset the password using the [Neon SQL Editor](/docs/get-started/query-with-neon-sql-editor) or an SQL client like [psql](/docs/connect/query-with-psql-editor) with the following syntax:
+
+```sql
+ALTER USER user_name WITH PASSWORD 'new_password';
 ```
 
-The API method appears as follows when specified in a cURL command. The `project_id`, `branch_id`, and `role_name` are required parameters.
+For password requirements, see [Manage roles with SQL](/docs/manage/roles#manage-roles-with-sql).
+</Admonition>
 
-```bash
-curl -X 'DELETE' \
-  'https://console.neon.tech/api/v2/projects/dry-heart-13671059/branches/br-morning-meadow-afu2s1jl/roles/alex' \
-  -H 'Accept: application/json' \
-  -H "Authorization: Bearer $NEON_API_KEY" | jq
-```
+A password reset takes effect immediately. The old password stops working on the next connection, so copy the new connection string from the **Connect** modal and update it wherever it is stored (deployment environment variables, secret managers, and `.env` files). Resets are branch-scoped, so reset the role on each branch where it is used.
 
-<details>
-<summary>Response body</summary>
-
-For attribute definitions, find the [Delete role](/docs/reference/api/branches/delete-project-branch-role) endpoint in the [Neon API Reference](/docs/reference/api). Definitions are provided in the **Responses** section.
-
-```json
-{
-  "role": {
-    "branch_id": "br-morning-meadow-afu2s1jl",
-    "name": "alex",
-    "protected": false,
-    "created_at": "2025-08-04T07:47:05Z",
-    "updated_at": "2025-08-04T07:51:10Z"
-  },
-  "operations": [
-    {
-      "id": "722b9f9b-c50e-424c-845e-78b38151b82f",
-      "project_id": "dry-heart-13671059",
-      "branch_id": "br-morning-meadow-afu2s1jl",
-      "endpoint_id": "ep-holy-heart-afbmgcfx",
-      "action": "apply_config",
-      "status": "running",
-      "failures_count": 0,
-      "created_at": "2025-08-04T07:53:22Z",
-      "updated_at": "2025-08-04T07:53:22Z",
-      "total_duration_ms": 0
-    }
-  ]
-}
-```
-
-</details>
+Resetting a password is also how you rotate the credential behind a connection string. To rotate after a leak or as routine security practice, see [Rotate credentials](/docs/security/security-overview#rotate-credentials).
 
 ## Manage roles with SQL
 

--- a/content/docs/security/security-overview.md
+++ b/content/docs/security/security-overview.md
@@ -11,7 +11,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/security/security
   - /docs/security
-updatedOn: '2026-06-23T22:05:54.707Z'
+updatedOn: '2026-08-26T13:16:52.511Z'
 ---
 
 At Neon, security is our highest priority. We are committed to implementing best practices and earning the trust of our users. A key aspect of earning this trust is by ensuring that every touchpoint in our system, from connections, to data storage, to our internal processes, adheres to the highest security standards.
@@ -138,7 +138,7 @@ If a credential is exposed, for example through a leaked `.env` file, a compromi
 4. Tighten your [IP allowlist](#ip-allowlist-support) to limit which addresses can connect.
 5. Audit your roles and remove any you do not recognize.
 
-Neon has no single command to rotate everything at once. To rotate many roles, list every project, branch, and role, then loop the [reset-password API](/docs/manage/roles#reset-a-password-with-the-api).
+Neon has no single command to rotate everything at once. To rotate many roles, list every project, branch, and role, then loop the [reset-password API](/docs/manage/roles#reset-a-password).
 
 ### Rotate without downtime
 

--- a/content/docs/storage/logs.md
+++ b/content/docs/storage/logs.md
@@ -67,4 +67,10 @@ Most of what shows up here is routine S3 traffic. A few entries look worse than 
 
 For details on filtering by level or service name, searching log bodies, live tail, downloading logs, and the 3-day retention window, see [Monitor logs](/docs/introduction/monitor-logs).
 
+You can also read storage logs from the terminal with [`neon logs query`](/docs/cli/logs), scoped with `--source storage`:
+
+```bash
+neon logs query --source storage --since 1h
+```
+
 <NeedHelp/>


### PR DESCRIPTION
## Overview

Follow-up to the API reference CLI coverage work (#5636), extending the same idea into
the feature docs. Where an operation can be done in more than one place, the docs now show
Console/CLI/API tabs, with each tab doing the same thing using the same example project,
branch, and resource names. Where a page previously documented only the Console or API,
the Neon CLI is added alongside.

- manage/branches, computes, databases, roles and introduction/read-replicas: per-operation
  Console/CLI/API tabs, example output preserved, values normalized per page.
- manage/api-keys, manage/projects, introduction/monitor-logs, compute/functions/logs,
  storage/logs, data-api/get-started: CLI references added next to the existing steps.
- Neon Auth guides (overview, configure-domains, setup-oauth, webhooks, email-verification,
  manage-auth-api, production-checklist, plugins): CLI references, several as full tabs.
- Fixes: a stale `neon logs` example using an unsupported flag, and three pre-existing
  broken internal links in branches.md.

Every documented `neon` invocation is validated by the CLI docs checker, and API paths,
request bodies, and reference links were verified against the OpenAPI spec.

This pull request and its description were written by Isaac.
