### PR TITLE
docs: refresh CLI reference for Neon CLI 4.6.0

### DIFF
--- a/content/docs/cli/bootstrap.md
+++ b/content/docs/cli/bootstrap.md
@@ -4,9 +4,8 @@ subtitle: Scaffold a new project from a Neon starter template
 summary: >-
   Covers the usage of the `bootstrap` command in the Neon CLI to scaffold a
   new application from a Neon starter template, including the interactive
-  template picker, the `--default` quick start, post-scaffold setup steps
-  (dependency install, git init, project linking), and the `--agent` JSON
-  output mode for AI agents.
+  template picker, the `--default` quick start, and post-scaffold setup steps
+  (dependency install, git init, project linking).
 enableTableOfContents: true
 ---
 
@@ -22,7 +21,7 @@ The directory argument is optional. Use `.` to scaffold into the current directo
 
 <CliOptions command="bootstrap" />
 
-Run with `--list-templates` to see the available templates, and pass one with `--template` to skip the interactive picker.
+Run with `--list-templates` to see the available templates (add `--output json` for a machine-readable catalog), and pass one with `--template` to skip the interactive picker.
 
 The post-scaffold steps (`--install`, `--git`, `--link`) all default to on. In interactive mode, bootstrap asks about each one; use the negated form (`--no-install`, `--no-git`, `--no-link`) to skip a step without being asked. With `--link`, bootstrap runs [`neon link`](/docs/cli/link) in the scaffolded directory after installing.
 
@@ -48,10 +47,19 @@ Quick start: scaffold the default template and run setup without prompting:
 neon bootstrap my-app --default
 ```
 
-## Agent mode
-
-Pass `--agent` to skip the prompts and emit a JSON state-machine response designed for AI agents. The output is a single JSON object with a discriminated `status` field describing the next step.
+List the template catalog as JSON, for scripting or driving `bootstrap` from an agent. Each entry's `id` is what you pass to `--template`:
 
 ```bash
-neon bootstrap my-app --template hono --agent
+neon bootstrap --list-templates --output json
+```
+
+The command prints an array of template objects, each shaped like:
+
+```json
+{
+  "id": "hono",
+  "title": "REST API",
+  "description": "A Hono REST API on Neon Functions, backed by Lakebase Postgres via Drizzle.",
+  "services": ["Postgres", "Functions"]
+}
 ```

--- a/content/docs/cli/claim.md
+++ b/content/docs/cli/claim.md
@@ -44,7 +44,7 @@ After create, regular Neon CLI commands use the saved assertion. Explicit Neon a
 
 ## neon claim status (#status)
 
-Shows the linked claimable project's lifecycle and claim status.
+Shows a claimable project's lifecycle and claim status. Pass a project ID from `neon claim list`, or omit it to use the project linked in the current directory.
 
 <CliUsage command="claim status" />
 
@@ -82,7 +82,7 @@ neon claim list
 
 ## neon claim delete (#delete)
 
-Permanently deletes the linked unclaimed project. Pass `--yes` to skip the confirmation prompt.
+Permanently deletes an unclaimed project, or drops a local record that can no longer reach the service. Pass a project ID from `neon claim list`, or omit it to use the linked project. Pass `--yes` to skip the confirmation prompt.
 
 <CliUsage command="claim delete" />
 

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -64,7 +64,7 @@ Run the interactive install. It walks you through config location, agents, and a
 neon mcp
 ```
 
-Install non-interactively into every detected agent, using global config and a freshly minted API key. You need to be signed in already for the mint to succeed:
+Install non-interactively into every detected agent, using global config. It reuses an API key already configured for an agent, or mints a new one (you must be signed in to mint):
 
 ```bash
 neon mcp -y

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.4.0",
+  "neonctlVersion": "4.6.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -237,8 +237,7 @@
       "options": {
         "agent": {
           "type": "boolean",
-          "describe": "Emit a JSON state-machine response designed for AI agents instead of prompting. The output is a single JSON object with a discriminated `status` field describing the next step.",
-          "default": false
+          "hidden": true
         },
         "default": {
           "type": "boolean",
@@ -268,7 +267,7 @@
         },
         "list-templates": {
           "type": "boolean",
-          "describe": "List available templates and exit.",
+          "describe": "List available templates and exit. --output json and --output yaml print a machine-readable catalog.",
           "default": false,
           "alias": [
             "list",
@@ -297,8 +296,8 @@
           "description": "Quick start: scaffold the default template and run setup without prompting"
         },
         {
-          "command": "$0 bootstrap my-app --template hono --agent",
-          "description": "Scaffold without prompting and emit the JSON state machine for AI agents"
+          "command": "$0 bootstrap --list-templates --output json",
+          "description": "Print the template catalog as JSON"
         }
       ]
     },
@@ -910,7 +909,13 @@
         "accept": {
           "name": "accept",
           "aliases": [],
-          "positionals": [],
+          "positionals": [
+            {
+              "name": "project-id",
+              "describe": "Project from `neon claim list`. Defaults to the project linked in this directory",
+              "type": "string"
+            }
+          ],
           "options": {
             "open": {
               "type": "boolean",
@@ -950,7 +955,13 @@
         "delete": {
           "name": "delete",
           "aliases": [],
-          "positionals": [],
+          "positionals": [
+            {
+              "name": "project-id",
+              "describe": "Project from `neon claim list`. Defaults to the project linked in this directory",
+              "type": "string"
+            }
+          ],
           "options": {
             "yes": {
               "type": "boolean",
@@ -960,7 +971,7 @@
             }
           },
           "commands": {},
-          "describe": "Permanently delete the linked unclaimed project"
+          "describe": "Permanently delete an unclaimed project, or drop a local record that can no longer reach the service"
         },
         "list": {
           "name": "list",
@@ -973,10 +984,16 @@
         "status": {
           "name": "status",
           "aliases": [],
-          "positionals": [],
+          "positionals": [
+            {
+              "name": "project-id",
+              "describe": "Project from `neon claim list`. Defaults to the project linked in this directory",
+              "type": "string"
+            }
+          ],
           "options": {},
           "commands": {},
-          "describe": "Show the linked claimable project's lifecycle and claim status"
+          "describe": "Show a claimable project's lifecycle and claim status"
         }
       },
       "describe": "Create and claim temporary Neon projects",
@@ -2222,12 +2239,12 @@
       "options": {
         "agent": {
           "type": "array",
-          "describe": "Coding agent to install into (repeatable). Skips the agent picker",
+          "describe": "Coding agent to install into (repeatable). Skips the agent picker. Values listed below",
           "alias": "a"
         },
         "category": {
           "type": "array",
-          "describe": "MCP tool category (repeatable or comma-separated). Default: all"
+          "describe": "MCP tool category (repeatable or comma-separated). Default: all. Values listed below"
         },
         "oauth": {
           "type": "boolean",
@@ -2251,7 +2268,7 @@
         },
         "yes": {
           "type": "boolean",
-          "describe": "Skip prompts. Defaults to global config, every detected agent and a minted account-wide API key. --project, --oauth, --agent, --read-only, --project-id and --category still apply",
+          "describe": "Skip prompts. Defaults listed below. --project, --oauth, --agent, --read-only, --project-id and --category still apply",
           "default": false,
           "alias": "y"
         }
@@ -2266,7 +2283,7 @@
         },
         {
           "command": "$0 mcp -y",
-          "description": "Global config, detected agents, minted API key"
+          "description": "Global config, detected agents, reuse or mint an API key"
         },
         {
           "command": "$0 mcp --oauth",
@@ -2934,7 +2951,7 @@
       "options": {
         "agent": {
           "type": "array",
-          "describe": "Coding agent to install into (repeatable). Skips the agent picker",
+          "describe": "Coding agent to install into (repeatable). Skips the agent picker. Values listed below",
           "alias": "a"
         },
         "global": {
@@ -3413,7 +3430,7 @@
       "options": {
         "agent": {
           "type": "array",
-          "describe": "Coding agent to install into (repeatable). Skips the agent picker",
+          "describe": "Coding agent to install into (repeatable). Skips the agent picker. Values listed below",
           "alias": "a"
         },
         "global": {
@@ -3423,7 +3440,7 @@
         },
         "skill": {
           "type": "array",
-          "describe": "Skill to install (repeatable). Skips the skill picker",
+          "describe": "Skill to install (repeatable). Skips the skill picker. Values listed below",
           "alias": "s"
         },
         "yes": {


### PR DESCRIPTION
## Overview

Refreshes the generated CLI reference to Neon CLI 4.6.0.

- schema.json bumped from 4.4.0 to 4.6.0.
- bootstrap: the removed --agent option is dropped; the reference now shows
  --list-templates --output json for the machine-readable catalog.
- claim: status and delete take an optional project id, and delete can drop a
  local record that can no longer reach the service.
- mcp: neon mcp -y reuses an API key already configured for an agent, or mints one.

Verified every neon invocation with the CLI docs checker and the changed
descriptions against the CLI source.

This pull request and its description were written by Isaac.
