### PR TITLE
docs: refresh CLI reference for Neon CLI 4.7.0

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -14,7 +14,7 @@ redirectFrom:
   - /docs/reference/cli-create-app
   - /docs/neonctl
   - /docs/get-started/neonctl
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-26T22:59:45.286Z'
 ---
 
 One CLI for every Neon surface: manage Postgres, Functions, Storage, the Data API, and Managed Better Auth from the terminal, with branch-scoped workflows built in.
@@ -35,7 +35,7 @@ npm i -g neon
 Use Neon CLI with Claude Code, Cursor, Codex, and other AI development tools.
 
 <Admonition type="note">
-Every command supports `--output json` for machine-readable results, and setting the `NEON_API_KEY` environment variable authenticates non-interactively. For AI agents, [`neon link --agent`](/docs/cli/link) emits a JSON state-machine response with a discriminated `status` field describing the next step, instead of prompting.
+Every command supports `--output json` for machine-readable results, and setting the `NEON_API_KEY` environment variable authenticates non-interactively. Agents bind a directory to a project with [`neon link`](/docs/cli/link)'s non-interactive flags, the same ones used for CI and scripts.
 </Admonition>
 
 ## Commands reference

--- a/content/docs/cli/link.md
+++ b/content/docs/cli/link.md
@@ -3,10 +3,10 @@ title: 'Neon CLI command: link'
 subtitle: Link a directory to a Neon project and write a `.neon` context file
 summary: >-
   Covers the usage of the `link` command in the Neon CLI to bind the current
-  directory to a Neon project, including interactive, non-interactive, and
-  agent-oriented workflows.
+  directory to a Neon project, including interactive and non-interactive
+  workflows for CI, scripts, and AI agents.
 enableTableOfContents: true
-updatedOn: '2026-07-11T13:23:16.265Z'
+updatedOn: '2026-08-26T22:59:45.286Z'
 redirectFrom:
   - /docs/reference/cli-link
 ---
@@ -51,7 +51,7 @@ Linked .neon:
 
 ## Non-interactive mode
 
-Use flags or a `--params` JSON blob for scripts and CI:
+Use flags or a `--params` JSON blob for scripts, CI, and AI agents:
 
 ```bash
 # Link to an existing project
@@ -66,39 +66,7 @@ neon link --params '{"orgId":"org-abc123","projectName":"my-app","regionId":"aws
 
 Flags take precedence over fields in `--params`.
 
-## Agent mode
-
-Use `--agent` for a JSON state machine designed for AI coding assistants. Each invocation returns a single JSON object with a `status` discriminator describing the next step, the available options, and the exact follow-up command to run.
-
-```bash
-neon link --agent
-```
-
-Example response when an organization must be selected:
-
-```json
-{
-  "status": "needs_org",
-  "instruction": "Ask the user which of these 2 organizations they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.",
-  "options": [
-    { "id": "org-abc123", "name": "Personal Org" },
-    { "id": "org-team", "name": "Team Org" }
-  ],
-  "next_command_template": "neon link --agent --org-id <org_id>"
-}
-```
-
-When linking completes, the response includes `status: "linked"` with the context file path and project details.
-
-Any unexpected failure in `--agent` mode is reported as JSON to stdout with exit code 1:
-
-```json
-{
-  "status": "error",
-  "code": "CLIENT_ERROR",
-  "message": "user has no access to projects"
-}
-```
+Agents find the IDs with `neon orgs list --output json` and `neon projects list --org-id <org-id> --output json`, then link with `--project-id` (or create a project with `--org-id`, `--project-name`, and `--region-id`).
 
 ## The `.neon` context file
 
@@ -125,5 +93,4 @@ Neon does not save confidential information to the context file (for example, au
 Organization-scoped API keys (those created at the organization level rather than the user level) cannot list user organizations or call the regions endpoint. `link` handles this transparently:
 
 - If the API key is org-scoped and at least one project already exists in the org, the CLI auto-detects the `org_id` from the first project.
-- If the API key is org-scoped and no projects exist yet, `--agent` returns a `needs_org` response with `options: []` and an instruction to find the org ID in the Neon Console. Interactive mode prints an error pointing to `--org-id`.
 - When the regions endpoint is not allowed, `link` falls back to a built-in static region list.

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.6.0",
+  "neonctlVersion": "4.7.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -1987,8 +1987,7 @@
       "options": {
         "agent": {
           "type": "boolean",
-          "describe": "Emit a JSON state-machine response designed for AI agents instead of prompting. The output is a single JSON object with a discriminated `status` field describing the next step.",
-          "default": false
+          "hidden": true
         },
         "branch": {
           "type": "string",


### PR DESCRIPTION
## Overview

Refreshes the Neon CLI reference for version 4.7.0. The notable change this release is that
`neon link --agent` was removed (the flag is now hidden and errors with guidance pointing to
the non-interactive commands). The link page drops its agent-mode JSON section and its
org-scoped `--agent` note, and now sends agents to the same non-interactive flags used for CI
and scripts. The CLI overview's agent note is updated to match.

Verified against the CLI source at `neon@4.7.0` and a live 4.7.0 binary; `npm run cli-docs -- check` passes.

Note for reviewers: the vendored agent-skills copies under `public/docs/ai/skills/neon/` still
reference `neon link --agent`. Those are read-only mirrors of neondatabase/agent-skills and need
a separate upstream fix, not a change here.

This pull request and its description were written by Isaac.
