### PR TITLE
Sync the hosted neon skill and drop git SHA pins

### DIFF
--- a/config/skills.json
+++ b/config/skills.json
@@ -4,7 +4,7 @@
     { "name": "neon-postgres", "ref": "main" },
     { "name": "neon-postgres-egress-optimizer", "ref": "main" },
     { "name": "neon-postgres-branches", "ref": "main" },
-    { "name": "neon", "ref": "5460c18205b8f7a5bb3bafa173b82e5f53d7f605" },
+    { "name": "neon", "ref": "main" },
     {
       "name": "neon-postgres-agent-platforms",
       "ref": "main",

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -27,7 +27,7 @@
       "type": "skill-md",
       "description": "Overview of Neon, a complete set of cloud backend primitives for apps and agents, spanning Lakebase Postgres, Auth, the Data API, Object Storage, Compute Functions, and the AI Gateway. Start here to route to the right Neon skill, set up the CLI or MCP server, and follow the branch-first workflow. Use when \"Neon\" or \"Lakebase Postgres\" is mentioned, or when any of its individual capabilities are the trigger: \"object storage\" or \"S3\", \"buckets\", \"serverless functions\", \"AI gateway\", \"call an LLM\", \"logs\", \"branch logs\", \"query logs\", \"log export\", \"Loki\", \"Grafana\", \"observability\", \"telemetry\", \"postgres\", \"database\", or \"backend\". Also use when there is no Neon account yet, the user cannot sign in or provide an API key right now and needs a project they can claim later, or the user asks for a throwaway DATABASE_URL, Claimable Neon, Claimable Postgres, neon.new, claimable.neon.tech, instant Postgres, a no-signup database, temporary postgres, quick postgres, a no credit card database, or npx neon-new.",
       "url": "/.well-known/agent-skills/neon/SKILL.md",
-      "digest": "sha256:29517ac4c13fed5574d9cc99ccf2dd9c7d78b2e966c220b400eeeb4f0f5b2128"
+      "digest": "sha256:9540789af742962ecab2626a73434b8f906f99cec02f2e152791535ee89705f1"
     },
     {
       "name": "neon-postgres-agent-platforms",

--- a/public/docs/.well-known/agent-skills/index.json
+++ b/public/docs/.well-known/agent-skills/index.json
@@ -27,7 +27,7 @@
       "type": "skill-md",
       "description": "Overview of Neon, a complete set of cloud backend primitives for apps and agents, spanning Lakebase Postgres, Auth, the Data API, Object Storage, Compute Functions, and the AI Gateway. Start here to route to the right Neon skill, set up the CLI or MCP server, and follow the branch-first workflow. Use when \"Neon\" or \"Lakebase Postgres\" is mentioned, or when any of its individual capabilities are the trigger: \"object storage\" or \"S3\", \"buckets\", \"serverless functions\", \"AI gateway\", \"call an LLM\", \"logs\", \"branch logs\", \"query logs\", \"log export\", \"Loki\", \"Grafana\", \"observability\", \"telemetry\", \"postgres\", \"database\", or \"backend\". Also use when there is no Neon account yet, the user cannot sign in or provide an API key right now and needs a project they can claim later, or the user asks for a throwaway DATABASE_URL, Claimable Neon, Claimable Postgres, neon.new, claimable.neon.tech, instant Postgres, a no-signup database, temporary postgres, quick postgres, a no credit card database, or npx neon-new.",
       "url": "/docs/.well-known/agent-skills/neon/SKILL.md",
-      "digest": "sha256:29517ac4c13fed5574d9cc99ccf2dd9c7d78b2e966c220b400eeeb4f0f5b2128"
+      "digest": "sha256:9540789af742962ecab2626a73434b8f906f99cec02f2e152791535ee89705f1"
     },
     {
       "name": "neon-postgres-agent-platforms",

--- a/public/docs/ai/skills/neon/SKILL.md
+++ b/public/docs/ai/skills/neon/SKILL.md
@@ -160,7 +160,7 @@ The above `init` command will install the Neon CLI, but the CLI can also be inst
 
 These commands are included in the `init` command but can be run manually as needed.
 
-1. `neon link` — Interactively links the workspace to a Neon org, project, and branch, writing the IDs to a git-ignored `.neon` file. Run once per project. Once linked, project- and branch-scoped commands no longer need `--project-id` or `--branch` (for example, `neon branch list`). `neon link --agent` can be used to run in a non-interactive, state-machine mode.
+1. `neon link` — Interactively links the workspace to a Neon org, project, and branch, writing the IDs to a git-ignored `.neon` file. Run once per project. Once linked, project- and branch-scoped commands no longer need `--project-id` or `--branch` (for example, `neon branch list`).
 2. `neon checkout <branch-name>` — Pins a different branch in `.neon`, creating it if it doesn't exist yet, and pulls that branch's env. It drives the [Branch-First Dev Flow](#branch-first-dev-flow) described below.
 3. `neon config init` — Initializes a `neon.ts` file, which declares how you provision and manage Neon services, in the root of the project.
 4. `neon env pull` — Fetches the current branch's Neon environment variables (`DATABASE_URL`, …) into your existing `.env`, or `.env.local` if you don't have one (override the target with `--file`). No branch ID needed; it reads `.neon`. **`link` and `checkout` run this for you by default**, so you rarely call it directly.

--- a/public/docs/ai/skills/neon/references/claimable-neon.md
+++ b/public/docs/ai/skills/neon/references/claimable-neon.md
@@ -47,7 +47,7 @@ A claim code expires in `expires_in` seconds (15 minutes / 900 today). If the un
 
 Continuing to Neon starts a transfer with a new 15-minute window and leaves the project key and database password revoked. If that window expires before the human accepts, mint again. Do not restore pre-claim `DATABASE_URL`.
 
-When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay if they were granted. The human signs in with `neon auth`. Then the agent runs `neon link --agent` and `neon env pull` to write the new `DATABASE_URL`. `neon link --agent` discovers the project after that sign-in.
+When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay if they were granted. The human signs in with `neon auth`. Then the agent runs `neon link` and `neon env pull` to write the new `DATABASE_URL`. `neon link` discovers the project after that sign-in.
 
 Auth and the Data API stay off unless requested at create or enabled later. On the unclaimed project, `neon.ts` plus `neon deploy` enables them. After claim, the same config talks to Neon directly. An external JWKS is only accepted after claim. Data API with the default auth provider requires Auth:
 


### PR DESCRIPTION
## Problem

Agents that load `https://neon.com/docs/ai/skills/neon/SKILL.md` are told to run `neon link --agent`. That flag is gone from the CLI. Those steps fail.

The claimable reference does the same after the human signs in with `neon auth`: `neon link --agent`, then `neon env pull`.

## Diagnosis

`public/docs/ai/skills/` is a committed copy of upstream skill trees. [website#5646](https://github.com/neondatabase/website/pull/5646) set the neon skill's `ref` to `5460c18205b8f7a5bb3bafa173b82e5f53d7f605` so the hosted files could match [agent-skills#99](https://github.com/neondatabase/agent-skills/pull/99) before that work was on `main`. [agent-skills#100](https://github.com/neondatabase/agent-skills/pull/100) then dropped `--agent` from `neon link` on `main`. The pin left neon.com on the old commit.

`config/skills.json` had a `ref` field. `src/scripts/sync-skills.js` and `scripts/check-skills-sync.mjs` fetched it. That is how a hosted skill sits on a SHA while `main` moves.

## The user-facing interface

Hosted `SKILL.md` useful CLI commands:

```bash
neon link
```

Hosted `references/claimable-neon.md`, after claim, once the human has signed in with `neon auth`:

```markdown
When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay if they were granted. The human signs in with `neon auth`. Then the agent runs `neon link` and `neon env pull` to write the new `DATABASE_URL`. `neon link` discovers the project after that sign-in.
```

`neon init --agent` in that skill is unchanged:

```bash
npx neon@latest init --agent
```

`config/skills.json`:

```json
{
  "primary": "neon-postgres",
  "skills": [
    { "name": "neon-postgres" },
    { "name": "neon-postgres-egress-optimizer" },
    { "name": "neon-postgres-branches" },
    { "name": "neon" },
    {
      "name": "neon-postgres-agent-platforms",
      "repo": "neondatabase/neon-for-agent-platforms"
    },
    { "name": "neon-object-storage" },
    { "name": "neon-ai-gateway" },
    { "name": "neon-functions" }
  ]
}
```

`neon-postgres-agent-platforms` still sets `repo` and tracks that repo's `main`.

Sync and the drift check fetch `main`. A present `ref` field throws, including `"main"`:

```text
config/skills.json skill "neon" has "ref": "main". Hosted skills always track main; remove the field.
```

## Also in here

Neon skill digests in `public/.well-known/agent-skills/index.json` and `public/docs/.well-known/agent-skills/index.json` match the updated `SKILL.md` bytes.

The Skills Read-Only workflow comment no longer describes a pin in `config/skills.json`.

`scripts/check-skills-sync.mjs` uses the same `resolveSkillRef` helper as `src/scripts/sync-skills.js`.

## Verification

```bash
npm run test:unit:run -- src/scripts/sync-skills.test.js
```

11 passed. Cases added:

- `resolveSkillRef` returns `main` when the skill has no `ref`
- it throws when `ref` is present, including `"main"`, a SHA, `null` and `undefined`
- `config/skills.json` has no `ref` key on any skill

```bash
GITHUB_TOKEN=... node scripts/check-skills-sync.mjs
```

All 8 configured skills match upstream `main`. `neon` is 2 files from `neondatabase/agent-skills@main`. `neon-postgres-agent-platforms` is 28 files from `neondatabase/neon-for-agent-platforms@main`.

Live neon.com URLs were not fetched. They update when this deploys.

## For your attention

- A hosted skill change has to be on the source repo's `main` before sync. Putting `ref` in `config/skills.json` fails sync and the drift check.
- Skill listings outside this repo are out of scope.