### PR TITLE
docs: changelog for 2026-08-28

### DIFF
--- a/content/changelog/2026-08-28.md
+++ b/content/changelog/2026-08-28.md
@@ -44,7 +44,7 @@ We'd love to hear it. Let us know via the [Feedback](https://console.neon.tech/a
 
 ## Postgres minor version rollout history now in the docs
 
-Our [Postgres version support policy](/docs/postgresql/postgres-version-policy#recent-minor-version-rollouts) docs now include a rollout history for recent minor releases. For each one, you can see the date PostgreSQL published it, the versions it included, when it became available on Neon, and how long that took. For example:
+Our [Postgres version support policy](/docs/postgresql/postgres-version-policy#recent-minor-version-rollouts) docs now include a rollout history for recent minor releases. For each release, you can see the date PostgreSQL published it, the versions it included, when it became available on Neon, and how long that took. For example:
 
 | Postgres release date | Versions in the release                                                                                                                                                                                                                                                                   | First available on Neon | Time to availability |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------- |

--- a/content/changelog/2026-08-28.md
+++ b/content/changelog/2026-08-28.md
@@ -8,7 +8,7 @@ Three new Neon CLI commands set up Neon in coding agents like Cursor and Claude 
 
 ### neon mcp
 
-Installs the [Neon MCP Server](/docs/cli/mcp) into your agents by writing their MCP config for you. It points each agent at the hosted server, sets up authentication, and can narrow which tools the agent sees. By default it mints a Neon API key and writes it into the config. Optionally, you can pass the `--oauth` option to skip the key and have the agent sign in to Neon on first use instead.
+Installs the [Neon MCP Server](/docs/cli/mcp) into your agents by writing their MCP config for you. It points each agent at the hosted server, sets up authentication, and can limit which tools the agent sees. By default, it mints a Neon API key and writes it into the config. Alternativevly, pass `--oauth` to skip API-key creation and have the agent sign in to Neon on first use instead.
 
 For example, install into Cursor and Claude Code with read-only tools:
 

--- a/content/changelog/2026-08-28.md
+++ b/content/changelog/2026-08-28.md
@@ -1,0 +1,101 @@
+---
+title: Install Neon into your coding agent, new Neon backend guides, and MCP stalled-query checks
+---
+
+## Add Neon to your coding agent
+
+Three new Neon CLI commands set up Neon in coding agents like Cursor and Claude Code, without manual config steps. Each runs an interactive walkthrough, or takes flags so you can script it.
+
+### neon mcp
+
+Installs the [Neon MCP Server](/docs/cli/mcp) into your agents by writing their MCP config for you. It points each agent at the hosted server, sets up authentication, and can narrow which tools the agent sees. By default it mints a Neon API key and writes it into the config. Optionally, you can pass the `--oauth` option to skip the key and have the agent sign in to Neon on first use instead.
+
+For example, install into Cursor and Claude Code with read-only tools:
+
+```bash
+neon mcp --agent cursor --agent claude-code --read-only
+```
+
+### neon skills
+
+Installs [Neon's agent skills](/docs/cli/skills) so tools like Cursor and Claude Code know how to work with Neon's Postgres, AI Gateway, Object Storage, and Functions. Skills install into the current directory by default, so they travel with the repository, and `neon skills update` refreshes them to their latest versions later.
+
+For example, install the core Postgres and AI Gateway skills into Cursor:
+
+```bash
+neon skills -s neon -s neon-ai-gateway --agent cursor
+```
+
+### neon plugins
+
+Installs the [`neon-postgres` plugin](/docs/cli/plugins) into agents that support plugin marketplaces, such as Claude Code, Cursor, and Codex. The plugin bundles Neon's agent skills and MCP access in one package, so a single install gives the agent both.
+
+For example, install into Claude Code without prompts:
+
+```bash
+neon plugins --agent claude-code -y
+```
+
+The Neon CLI has seen many new additions over the past several weeks. For a tour of other recent additions, from the branch-first workflow to built-in Postgres diagnostics, see [Just landed in the Neon CLI](https://neon.com/blog/just-landed-in-the-neon-cli).
+
+<Admonition type="note" title="Have an idea for the CLI or agent tools?">
+We'd love to hear it. Let us know via the [Feedback](https://console.neon.tech/app/projects?modal=feedback) form in the Neon Console or our [feedback channel](https://discord.com/channels/1176467419317940276/1176788564890112042) on Discord.
+</Admonition>
+
+## Postgres minor version rollout history now in the docs
+
+Our [Postgres version support policy](/docs/postgresql/postgres-version-policy#recent-minor-version-rollouts) docs now include a rollout history for recent minor releases. For each one, you can see the date PostgreSQL published it, the versions it included, when it became available on Neon, and how long that took. For example:
+
+| Postgres release date | Versions in the release                                                                                                                                                                                                                                                                   | First available on Neon | Time to availability |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------- |
+| 2026-08-13            | [18.6](https://www.postgresql.org/docs/release/18.6/), [17.11](https://www.postgresql.org/docs/release/17.11/), [16.15](https://www.postgresql.org/docs/release/16.15/), [15.19](https://www.postgresql.org/docs/release/15.19/), [14.24](https://www.postgresql.org/docs/release/14.24/) | 2026-08-18              | 5 days               |
+
+Each version in the table links to its PostgreSQL release notes, so you can see exactly which bug fixes and CVE patches that minor release contains.
+
+<Admonition type="info">
+Run `SELECT version();` to see which version you're on. Minor version updates are rolled out the next time your compute restarts. To update now, restart your compute yourself, or wait for your compute's next scheduled update. See [Updates](/docs/manage/updates) for details.
+</Admonition>
+
+## Get started building on the Neon backend
+
+Two new guides show what you can build with the [Neon backend](/docs/get-started/backend-overview), where Object Storage, Functions, and the AI Gateway sit next to your database:
+
+- [Build an image processing API with Neon Functions, Sharp, and Neon AI Gateway](/guides/image-processing-api-neon-functions): resize, crop, optimize, analyze, and AI-caption images on [Neon Functions](/docs/compute/functions/overview), then store the results in your branch's [Object Storage](/docs/storage/overview) bucket.
+- [Clean up orphaned S3 objects with Neon Object Storage branching](/guides/clean-up-orphaned-s3-objects-neon-branching): run a real storage-cleanup job on a branch first, where buckets [branch with your database](/docs/storage/objects#object-branching), then promote it to production once you've verified it.
+
+<CTA title="Try the Neon backend, free during the beta" description="Object Storage, Functions, and AI Gateway are in beta in AWS US East (Ohio) and branch with your Postgres database, so your whole stack forks together." buttonText="Get started" buttonUrl="/docs/get-started/backend-beta" />
+
+## Connect fx to Neon's MCP server
+
+[fx](https://fx.sh) is a small, fast coding agent and CLI from Vercel Labs, built to embed in larger systems. You can now connect it to Neon's remote MCP server, using either OAuth or a Neon API key, so the agent can work with your Neon projects directly.
+
+For example, add the server with OAuth:
+
+```bash
+npx add-mcp https://mcp.neon.tech/mcp -a fx
+```
+
+Then authorize from the fx shell:
+
+```text
+/mcp auth neon --open
+```
+
+For the API key option and more detail, see [Connect MCP clients to Neon](/docs/ai/connect-mcp-clients-to-neon#fx).
+
+## Fixes & improvements
+
+<details>
+<summary>**Neon MCP server updates**</summary>
+
+- The `inspect_database` tool now includes a `stalled-queries` check. It returns a compute-wide snapshot of every client backend and parallel worker whose query group has been running longer than 30 seconds, so an agent can see what's blocking a database right now, across every database on the compute and from the moment a query stalls.
+- Stalled queries are now ranked with the oldest query group first, so the longest-running blocker surfaces at the top of the results.
+
+</details>
+
+<details>
+<summary>**New NAT gateway IPs and Private Networking endpoints in us-east-2**</summary>
+
+- Added NAT gateway IP addresses and Private Networking VPC endpoint service names in AWS US East (Ohio) (`us-east-2`). If you allowlist Neon's outbound IPs, add the new addresses from the [Regions](/docs/introduction/regions#nat-gateway-ip-addresses) page, or outbound connections can fail intermittently. If you use Private Networking in this region, add the new service names from the [Private Networking guide](/docs/guides/neon-private-networking).
+
+</details>

--- a/content/docs/postgresql/postgres-version-policy.md
+++ b/content/docs/postgresql/postgres-version-policy.md
@@ -7,7 +7,7 @@ summary: >-
   Minor release downgrades and version skipping are not supported. Upgrading
   to a new major version requires creating a new project and migrating data.
 enableTableOfContents: true
-updatedOn: '2026-08-26T14:40:58.742Z'
+updatedOn: '2026-08-28T13:01:05.062Z'
 ---
 
 This topic outlines [Neon's Postgres Version Support Policy](#neon-version-support-policy).
@@ -65,14 +65,14 @@ Neon does not support skipping minor releases or downgrading to a previous minor
 
 #### Recent minor version rollouts
 
-The table below shows when recent Postgres releases became available on Neon.
+The table below shows when recent Postgres releases became available on Neon. Each version links to its PostgreSQL release notes, which list the bug fixes and CVE patches included in that minor release.
 
-| Postgres release date | Versions in the release          | First available on Neon | Time to availability |
-| --------------------- | -------------------------------- | ----------------------- | -------------------- |
-| 2026-08-13            | 18.6, 17.11, 16.15, 15.19, 14.24 | 2026-08-18              | 5 days               |
-| 2026-05-14            | 18.4, 17.10, 16.14, 15.18, 14.23 | 2026-05-19              | 5 days               |
-| 2026-02-12            | 18.2, 17.8, 16.12, 15.16, 14.21  | 2026-02-13              | 1 day                |
-| 2025-11-13            | 18.1, 17.7, 16.11, 15.15, 14.20  | 2025-12-03              | 20 days              |
+| Postgres release date | Versions in the release                                                                                                                                                                                                                                                                   | First available on Neon | Time to availability |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------- |
+| 2026-08-13            | [18.6](https://www.postgresql.org/docs/release/18.6/), [17.11](https://www.postgresql.org/docs/release/17.11/), [16.15](https://www.postgresql.org/docs/release/16.15/), [15.19](https://www.postgresql.org/docs/release/15.19/), [14.24](https://www.postgresql.org/docs/release/14.24/) | 2026-08-18              | 5 days               |
+| 2026-05-14            | [18.4](https://www.postgresql.org/docs/release/18.4/), [17.10](https://www.postgresql.org/docs/release/17.10/), [16.14](https://www.postgresql.org/docs/release/16.14/), [15.18](https://www.postgresql.org/docs/release/15.18/), [14.23](https://www.postgresql.org/docs/release/14.23/) | 2026-05-19              | 5 days               |
+| 2026-02-12            | [18.2](https://www.postgresql.org/docs/release/18.2/), [17.8](https://www.postgresql.org/docs/release/17.8/), [16.12](https://www.postgresql.org/docs/release/16.12/), [15.16](https://www.postgresql.org/docs/release/15.16/), [14.21](https://www.postgresql.org/docs/release/14.21/)   | 2026-02-13              | 1 day                |
+| 2025-11-13            | [18.1](https://www.postgresql.org/docs/release/18.1/), [17.7](https://www.postgresql.org/docs/release/17.7/), [16.11](https://www.postgresql.org/docs/release/16.11/), [15.15](https://www.postgresql.org/docs/release/15.15/), [14.20](https://www.postgresql.org/docs/release/14.20/)   | 2025-12-03              | 20 days              |
 
 The **First available on Neon** date marks when a release first became available to run, not the point at which every compute is running it; each compute picks it up on the next restart, as described above.
 


### PR DESCRIPTION
Changelog scaffold for the 2026-08-28 release. 

PREVIEW:
https://neon-next-git-changelog-2026-08-28-neondatabase.vercel.app/docs/changelog/2026-08-28