### PR TITLE
docs: align MCP category lists with the hosted server

### DIFF
--- a/.github/workflows/mcp-categories-sync.yml
+++ b/.github/workflows/mcp-categories-sync.yml
@@ -1,23 +1,25 @@
 name: MCP Categories Sync
 
 # The Neon MCP server owns the list of tool categories (`?category=` values).
-# Two places here restate it for readers and silently rot when the server gains
-# or drops one: SCOPE_CATEGORIES in the docs config generator, and the
-# "Available tools" table in content/docs/shared-content/mcp-tools.md. A missing
-# entry in the generator is the worst case — it emits a `?category=` URL that
-# quietly disables tools the user never chose to turn off.
+# Three places here restate it for readers and silently rot when the server
+# gains or drops one: SCOPE_CATEGORIES in the docs config generator, the
+# "Available tools" table in content/docs/shared-content/mcp-tools.md, and the
+# `--category` list in content/docs/cli/mcp.md. A missing entry in the
+# generator emits a `?category=` URL that quietly disables tools the user
+# never chose to turn off.
 #
-#   - Pull requests touching either surface -> offline check (no network): the
-#     generator and the docs table must agree.
-#   - Daily schedule / manual dispatch -> --live: both are additionally compared
-#     against mcp.neon.tech's advertised x-neon-scope-categories, and drift
-#     opens/updates a tracking issue so a new category can't rot silently.
+#   - Pull requests touching any of those surfaces -> offline check (no
+#     network): the generator, the docs table, and the CLI list must agree.
+#   - Daily schedule / manual dispatch -> --live: all three are additionally
+#     compared against mcp.neon.tech's advertised x-neon-scope-categories, and
+#     drift opens/updates a tracking issue so a new category can't rot silently.
 
 on:
   pull_request:
     paths:
       - 'src/components/pages/doc/mcp-setup-configurator/**'
       - 'content/docs/shared-content/mcp-tools.md'
+      - 'content/docs/cli/mcp.md'
       - 'scripts/check-mcp-categories-sync.mjs'
       - '.github/workflows/mcp-categories-sync.yml'
   schedule:

--- a/content/docs/auth/guides/manage-auth-api.md
+++ b/content/docs/auth/guides/manage-auth-api.md
@@ -20,7 +20,7 @@ updatedOn: '2026-08-26T13:16:52.511Z'
 
 <FeatureBetaProps feature_name="Managed Better Auth" />
 
-You can manage Managed Better Auth programmatically using the [Neon API](/docs/reference/api), or from the terminal with the [Neon CLI](/docs/cli/neon-auth) (`neon neon-auth`), which wraps these same operations. You can also enable and configure Managed Better Auth from an AI editor using the [Neon MCP server](/docs/ai/neon-mcp-server#supported-actions-tools) (`provision_neon_auth`, `configure_neon_auth`, `get_neon_auth_config`). See [Set up with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor).
+You can manage Managed Better Auth programmatically using the [Neon API](/docs/reference/api), or from the terminal with the [Neon CLI](/docs/cli/neon-auth) (`neon neon-auth`), which wraps these same operations. You can also enable and configure Managed Better Auth from an AI editor using the [Neon MCP server](/docs/ai/neon-mcp-server#available-tools) (`provision_neon_auth`, `update_auth_config`, `add_auth_oauth_provider`, `get_neon_auth_config`). See [Set up with your AI editor](/docs/auth/overview#set-up-with-your-ai-editor).
 
 <Admonition type="note">
 Managed Better Auth operates at the **branch level**. Each branch can have its own independent auth configuration, which means preview and development branches can have separate auth state from your production branch.

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -47,7 +47,7 @@ The supported agents are `antigravity`, `cline`, `cline-cli`, `claude-code`, `co
 By default the server exposes every MCP tool. Use these flags to narrow what an agent can do:
 
 - `--read-only` hides the write tools by adding `?readonly=true` to the server URL.
-- `--category <name>` limits tools to one or more categories (repeatable, or comma-separated). Categories are `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, and `docs`.
+- `--category <name>` limits tools to one or more categories (repeatable, or comma-separated). Categories are `projects`, `branches`, `endpoints`, `snapshots`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, `docs`, `functions`, and `storage`.
 - `--project-id <id>` pins the tools to a single Neon project with `?projectId=`, and limits a newly minted key to that project.
 
 `--read-only` and `--category` shape the server URL only; they don't change a key's scope, and neither does reusing an already-configured key.

--- a/content/docs/data-api/get-started.md
+++ b/content/docs/data-api/get-started.md
@@ -25,7 +25,7 @@ This guide walks you through enabling the Data API, creating a table with RLS, a
 ## Enable the Data API
 
 <Admonition type="tip" title="Enable programmatically">
-You can also enable the Data API from the terminal with [`neon data-api create`](/docs/cli/data-api#create), using the [Neon API](/docs/data-api/manage#manage-via-the-neon-api), or with the [Neon MCP Server](/docs/ai/neon-mcp-server#supported-actions-tools) (`provision_neon_data_api` tool).
+You can also enable the Data API from the terminal with [`neon data-api create`](/docs/cli/data-api#create), using the [Neon API](/docs/data-api/manage#manage-via-the-neon-api), or with the [Neon MCP Server](/docs/ai/neon-mcp-server#available-tools) (`provision_neon_data_api` tool).
 </Admonition>
 
 ### 1. Navigate to the Data API page

--- a/content/docs/shared-content/auth-ai-setup.md
+++ b/content/docs/shared-content/auth-ai-setup.md
@@ -12,10 +12,10 @@ This command configures the [Neon MCP server](/docs/ai/neon-mcp-server) and inst
 
 1. **Configure Managed Better Auth on your branch (MCP).** After `init`, ask your assistant to enable and configure auth in natural language. The MCP server exposes:
    - `provision_neon_auth`: Enable Managed Better Auth on a branch
-   - `configure_neon_auth`: Set OAuth providers, email, sign-in methods, trusted domains, and more
-   - `get_neon_auth_config`: Read the current configuration
+   - `add_auth_oauth_provider`, `add_auth_trusted_domain`, `update_auth_config`: Change Auth settings
+   - `get_neon_auth_config`: Read the current configuration (secrets redacted)
 
-   See [Neon MCP Server: Managed Better Auth tools](/docs/ai/neon-mcp-server#supported-actions-tools) for details.
+   See [Available tools](/docs/ai/neon-mcp-server#available-tools) (`neon_auth`) for the full set.
 
 2. **Add Managed Better Auth to your application (Agent Skills).** Skills teach your assistant how to install the SDK, environment variables, and routes for your framework. Use the quick start guides on this page, or ask your assistant directly.
 

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -16,7 +16,7 @@ Tools are grouped into categories. Use the `?category=` URL parameter to restric
 | SQL (`querying`)                  | Execute queries and transactions; apply schema changes on a temporary branch; run the same diagnostics as `neon inspect db` |
 | Managed Better Auth (`neon_auth`) | Provision Auth; manage OAuth providers, trusted domains, and users                                                          |
 | Neon Data API (`data_api`)        | Enable, update, and disable the Data API for a branch                                                                       |
-| Observability (`observability`)   | Query function and storage logs; inspect AI Gateway usage                                                                   |
+| Observability (`observability`)   | Query function and storage logs; check AI Gateway availability                                                              |
 | Documentation (`docs`)            | Look up Neon documentation from within your assistant (no OAuth required)                                                   |
 | Functions (`functions`)           | List, deploy, update, and delete Neon Functions                                                                             |
 | Object storage (`storage`)        | Manage buckets and objects; create presigned URLs                                                                           |

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -8,7 +8,7 @@ Tools are grouped into categories. Use the `?category=` URL parameter to restric
 
 | Category                          | What it enables                                                                                                             |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Project management (`projects`)   | List, create, describe, and delete projects and organizations                                                               |
+| Project management (`projects`)   | List, create, describe, and delete projects; list organizations                                                             |
 | Branch management (`branches`)    | Create, reset, and delete branches; manage Postgres roles and databases                                                     |
 | Compute endpoints (`endpoints`)   | List, create, start, suspend, and restart branch computes                                                                   |
 | Snapshots (`snapshots`)           | Create, restore, and schedule snapshots                                                                                     |
@@ -16,7 +16,7 @@ Tools are grouped into categories. Use the `?category=` URL parameter to restric
 | SQL (`querying`)                  | Execute queries and transactions; apply schema changes on a temporary branch; run the same diagnostics as `neon inspect db` |
 | Managed Better Auth (`neon_auth`) | Provision Auth; manage OAuth providers, trusted domains, and users                                                          |
 | Neon Data API (`data_api`)        | Enable, update, and disable the Data API for a branch                                                                       |
-| Observability (`observability`)   | Query logs from your serverless functions and storage                                                                       |
+| Observability (`observability`)   | Query function and storage logs; inspect AI Gateway usage                                                                   |
 | Documentation (`docs`)            | Look up Neon documentation from within your assistant (no OAuth required)                                                   |
 | Functions (`functions`)           | List, deploy, update, and delete Neon Functions                                                                             |
 | Object storage (`storage`)        | Manage buckets and objects; create presigned URLs                                                                           |

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -6,20 +6,20 @@ updatedOn: '2026-08-24T20:23:46.738Z'
 
 Tools are grouped into categories. Use the `?category=` URL parameter to restrict which categories are active. You can pass it more than once to enable multiple categories.
 
-| Category                          | What it enables                                                                     |
-| --------------------------------- | ----------------------------------------------------------------------------------- |
-| Project management (`projects`)   | List, create, describe, and delete projects and organizations                       |
-| Branch management (`branches`)    | Create, reset, and delete branches; manage Postgres roles and databases             |
-| Compute endpoints (`endpoints`)   | List, create, start, suspend, and restart branch computes                           |
-| Snapshots (`snapshots`)           | Create, restore, and schedule snapshots                                             |
-| Schema (`schema`)                 | Inspect tables and columns; compare schemas; run migrations on a temporary branch   |
-| SQL (`querying`)                  | Execute queries and transactions; run the same diagnostics as `neon inspect db`     |
-| Managed Better Auth (`neon_auth`) | Provision Auth; manage OAuth providers, trusted domains, and users                  |
-| Neon Data API (`data_api`)        | Enable, update, and disable the Data API for a branch                               |
-| Observability (`observability`)   | Query logs from your serverless functions and storage                               |
-| Documentation (`docs`)            | Look up Neon documentation from within your assistant (no OAuth required)           |
-| Functions (`functions`)           | List, deploy, update, and delete Neon Functions                                     |
-| Object storage (`storage`)        | Manage buckets and objects; create presigned URLs                                   |
+| Category                          | What it enables                                                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Project management (`projects`)   | List, create, describe, and delete projects and organizations                                                               |
+| Branch management (`branches`)    | Create, reset, and delete branches; manage Postgres roles and databases                                                     |
+| Compute endpoints (`endpoints`)   | List, create, start, suspend, and restart branch computes                                                                   |
+| Snapshots (`snapshots`)           | Create, restore, and schedule snapshots                                                                                     |
+| Schema (`schema`)                 | Inspect tables and columns; compare schemas                                                                                 |
+| SQL (`querying`)                  | Execute queries and transactions; apply schema changes on a temporary branch; run the same diagnostics as `neon inspect db` |
+| Managed Better Auth (`neon_auth`) | Provision Auth; manage OAuth providers, trusted domains, and users                                                          |
+| Neon Data API (`data_api`)        | Enable, update, and disable the Data API for a branch                                                                       |
+| Observability (`observability`)   | Query logs from your serverless functions and storage                                                                       |
+| Documentation (`docs`)            | Look up Neon documentation from within your assistant (no OAuth required)                                                   |
+| Functions (`functions`)           | List, deploy, update, and delete Neon Functions                                                                             |
+| Object storage (`storage`)        | Manage buckets and objects; create presigned URLs                                                                           |
 
 Search and navigation tools (search across projects, fetch resource details by ID) are available by default but disabled in [project-scoped mode](/docs/ai/neon-mcp-server#project-scoped-mode).
 

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -9,13 +9,17 @@ Tools are grouped into categories. Use the `?category=` URL parameter to restric
 | Category                          | What it enables                                                                     |
 | --------------------------------- | ----------------------------------------------------------------------------------- |
 | Project management (`projects`)   | List, create, describe, and delete projects and organizations                       |
-| Branch management (`branches`)    | Create branches, compare schemas, reset branches to parent state                    |
-| Schema (`schema`)                 | Inspect tables and columns; run schema changes via a safe temporary branch workflow |
+| Branch management (`branches`)    | Create, reset, and delete branches; manage Postgres roles and databases             |
+| Compute endpoints (`endpoints`)   | List, create, start, suspend, and restart branch computes                           |
+| Snapshots (`snapshots`)           | Create, restore, and schedule snapshots                                             |
+| Schema (`schema`)                 | Inspect tables and columns; compare schemas; run migrations on a temporary branch   |
 | SQL (`querying`)                  | Execute queries and transactions; run the same diagnostics as `neon inspect db`     |
-| Managed Better Auth (`neon_auth`) | Set up and configure app authentication for a branch                                |
-| Neon Data API (`data_api`)        | Enable HTTP-based Data API access for a branch                                      |
+| Managed Better Auth (`neon_auth`) | Provision Auth; manage OAuth providers, trusted domains, and users                  |
+| Neon Data API (`data_api`)        | Enable, update, and disable the Data API for a branch                               |
 | Observability (`observability`)   | Query logs from your serverless functions and storage                               |
 | Documentation (`docs`)            | Look up Neon documentation from within your assistant (no OAuth required)           |
+| Functions (`functions`)           | List, deploy, update, and delete Neon Functions                                     |
+| Object storage (`storage`)        | Manage buckets and objects; create presigned URLs                                   |
 
 Search and navigation tools (search across projects, fetch resource details by ID) are available by default but disabled in [project-scoped mode](/docs/ai/neon-mcp-server#project-scoped-mode).
 

--- a/content/guides/vercel-neon-mcp.md
+++ b/content/guides/vercel-neon-mcp.md
@@ -57,7 +57,7 @@ Run the following in your project directory:
 npx neon@latest init
 ```
 
-Follow the prompts in your browser to authenticate. Once complete, Claude Code will have access to [Neon MCP tools](/docs/ai/neon-mcp-server#supported-actions-tools) and the installed agent skills.
+Follow the prompts in your browser to authenticate. Once complete, Claude Code will have access to [Neon MCP tools](/docs/ai/neon-mcp-server#available-tools) and the installed agent skills.
 
 ## Step 2: Set up the Vercel MCP server
 

--- a/scripts/check-mcp-categories-sync.mjs
+++ b/scripts/check-mcp-categories-sync.mjs
@@ -47,6 +47,7 @@ const CONFIGURATOR_PATH = path.join(
   'src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx'
 );
 const DOCS_TABLE_PATH = path.join(ROOT, 'content/docs/shared-content/mcp-tools.md');
+const CLI_MCP_PATH = path.join(ROOT, 'content/docs/cli/mcp.md');
 
 const DEFAULT_SERVER = 'https://mcp.neon.tech';
 const WELL_KNOWN_PATH = '/.well-known/oauth-authorization-server';
@@ -87,6 +88,18 @@ export function parseDocsTableCategories(markdown) {
   }
   if (slugs.length === 0) {
     throw new Error('the "Available tools" table listed no `category` slugs');
+  }
+  return slugs;
+}
+
+export function parseCliMcpCategories(markdown) {
+  const match = markdown.match(/Categories are ([^.]+)\./);
+  if (!match) {
+    throw new Error('could not find a "Categories are ..." sentence');
+  }
+  const slugs = [...match[1].matchAll(/`([^`]+)`/g)].map((entry) => entry[1]);
+  if (slugs.length === 0) {
+    throw new Error('the "Categories are ..." sentence listed no `category` slugs');
   }
   return slugs;
 }
@@ -143,6 +156,7 @@ const REMEDIATION = [
   '    src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx',
   '    (each entry also needs a user-facing label and description)',
   '  - docs table: the "Available tools" table in content/docs/shared-content/mcp-tools.md',
+  '  - CLI mcp docs: the "Categories are ..." sentence in content/docs/cli/mcp.md',
   'The server list is authoritative:',
   `  curl -s ${DEFAULT_SERVER}${WELL_KNOWN_PATH} | jq '."${CATEGORIES_FIELD}"'`,
 ].join('\n');
@@ -160,11 +174,13 @@ async function main() {
 
   const configurator = parseConfiguratorCategories(fs.readFileSync(CONFIGURATOR_PATH, 'utf8'));
   const docsTable = parseDocsTableCategories(fs.readFileSync(DOCS_TABLE_PATH, 'utf8'));
+  const cliMcp = parseCliMcpCategories(fs.readFileSync(CLI_MCP_PATH, 'utf8'));
 
-  // Offline, the generator is the reference the docs table is compared against;
-  // live, both are compared against the server, which actually owns the list.
   let reference = { label: 'config generator', categories: configurator };
-  const sources = [{ label: 'docs table', categories: docsTable }];
+  const sources = [
+    { label: 'docs table', categories: docsTable },
+    { label: 'CLI mcp docs', categories: cliMcp },
+  ];
 
   if (live) {
     reference = { label: 'MCP server', categories: await fetchServerCategories(serverBase) };

--- a/scripts/check-mcp-categories-sync.mjs
+++ b/scripts/check-mcp-categories-sync.mjs
@@ -3,25 +3,26 @@
  * MCP tool-category drift check.
  *
  * The Neon MCP server owns the list of tool categories (`?category=` values).
- * Two places in this repo restate that list for readers, and both silently rot
- * when the server gains or drops a category:
+ * Three places in this repo restate that list for readers, and all three
+ * silently rot when the server gains or drops a category:
  *
  *   1. SCOPE_CATEGORIES in the config generator
  *      (src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx)
  *      — a missing entry means the generator emits a `?category=` URL that
  *      quietly disables tools the user never chose to turn off.
  *   2. The "Available tools" table in content/docs/shared-content/mcp-tools.md.
+ *   3. The `--category` sentence in content/docs/cli/mcp.md.
  *
  * The server advertises its own list at
  * https://mcp.neon.tech/.well-known/oauth-authorization-server under
  * `x-neon-scope-categories`, so drift is detectable rather than guessable.
  *
- *   - Offline (default, PR gate): the generator and the docs table must list the
- *     same categories in the same order. Deterministic, no network. This alone
- *     catches the common case where one of the two gets updated and the other
- *     doesn't.
+ *   - Offline (default, PR gate): the generator, the docs table, and the CLI
+ *     list must list the same categories in the same order. Deterministic, no
+ *     network. This alone catches the common case where one of the three gets
+ *     updated and the others don't.
  *   - --live (daily schedule / manual): additionally fetches the well-known
- *     document and requires both local lists to match the server exactly. This
+ *     document and requires every local list to match the server exactly. This
  *     is what catches a category added to the MCP server that nobody mirrored
  *     here at all.
  *

--- a/scripts/check-mcp-categories-sync.test.js
+++ b/scripts/check-mcp-categories-sync.test.js
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseConfiguratorCategories,
   parseDocsTableCategories,
+  parseCliMcpCategories,
   describeDrift,
 } from './check-mcp-categories-sync.mjs';
 
@@ -64,6 +65,33 @@ describe('parseDocsTableCategories', () => {
       '\n'
     );
     expect(() => parseDocsTableCategories(noSlugs)).toThrow(/no `category` slugs/);
+  });
+});
+
+describe('parseCliMcpCategories', () => {
+  const markdown = [
+    '## neon mcp',
+    '',
+    '- `--category <name>` limits tools to one or more categories (repeatable, or comma-separated). Categories are `projects`, `branches`, `endpoints`, and `storage`.',
+    '',
+    'Other `categories` in backticks should not be parsed.',
+  ].join('\n');
+
+  it('reads slugs from the Categories are sentence in source order', () => {
+    expect(parseCliMcpCategories(markdown)).toEqual([
+      'projects',
+      'branches',
+      'endpoints',
+      'storage',
+    ]);
+  });
+
+  it('throws when the sentence is missing', () => {
+    expect(() => parseCliMcpCategories('# Nothing here')).toThrow(/Categories are/);
+  });
+
+  it('throws when the sentence has no backticked slugs', () => {
+    expect(() => parseCliMcpCategories('Categories are none.')).toThrow(/no `category` slugs/);
   });
 });
 

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -42,7 +42,7 @@ const SCOPE_CATEGORIES = [
   { id: 'querying', label: 'Querying', description: 'SQL, explain plans, and migrations' },
   { id: 'neon_auth', label: 'Neon Auth', description: 'Provision and configure Auth' },
   { id: 'data_api', label: 'Data API', description: 'Enable, update, and disable the Data API' },
-  { id: 'observability', label: 'Observability', description: 'Function and storage logs' },
+  { id: 'observability', label: 'Observability', description: 'Function logs, storage logs, and AI Gateway' },
   { id: 'docs', label: 'Docs', description: 'Search and fetch docs' },
   { id: 'functions', label: 'Functions', description: 'List, deploy, and update functions' },
   { id: 'storage', label: 'Storage', description: 'Buckets, objects, and presigned URLs' },

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -39,7 +39,7 @@ const SCOPE_CATEGORIES = [
   { id: 'endpoints', label: 'Endpoints', description: 'Start, suspend, and manage computes' },
   { id: 'snapshots', label: 'Snapshots', description: 'Create, restore, and schedule snapshots' },
   { id: 'schema', label: 'Schema', description: 'Tables, columns, and schema compare' },
-  { id: 'querying', label: 'Querying', description: 'Run SQL and explain plans' },
+  { id: 'querying', label: 'Querying', description: 'SQL, explain plans, and migrations' },
   { id: 'neon_auth', label: 'Neon Auth', description: 'Provision and configure Auth' },
   { id: 'data_api', label: 'Data API', description: 'Enable, update, and disable the Data API' },
   { id: 'observability', label: 'Observability', description: 'Function and storage logs' },

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -33,20 +33,19 @@ const AUTH_MODES = [
   },
 ];
 
-// Must stay in sync with the MCP server's own category list, advertised at
-// https://mcp.neon.tech/.well-known/oauth-authorization-server as
-// `x-neon-scope-categories`, and with the table in
-// content/docs/shared-content/mcp-tools.md. Enforced by
-// `npm run check:mcp-categories` — see scripts/check-mcp-categories-sync.mjs.
 const SCOPE_CATEGORIES = [
   { id: 'projects', label: 'Projects', description: 'Create and manage projects' },
-  { id: 'branches', label: 'Branches', description: 'Create, reset, delete branches' },
-  { id: 'schema', label: 'Schema', description: 'Tables, columns, indexes' },
+  { id: 'branches', label: 'Branches', description: 'Branches, roles, and databases' },
+  { id: 'endpoints', label: 'Endpoints', description: 'Start, suspend, and manage computes' },
+  { id: 'snapshots', label: 'Snapshots', description: 'Create, restore, and schedule snapshots' },
+  { id: 'schema', label: 'Schema', description: 'Tables, columns, and schema compare' },
   { id: 'querying', label: 'Querying', description: 'Run SQL and explain plans' },
-  { id: 'neon_auth', label: 'Neon Auth', description: 'Users and sessions' },
-  { id: 'data_api', label: 'Data API', description: 'RESTful data endpoints' },
+  { id: 'neon_auth', label: 'Neon Auth', description: 'Provision and configure Auth' },
+  { id: 'data_api', label: 'Data API', description: 'Enable, update, and disable the Data API' },
   { id: 'observability', label: 'Observability', description: 'Function and storage logs' },
   { id: 'docs', label: 'Docs', description: 'Search and fetch docs' },
+  { id: 'functions', label: 'Functions', description: 'List, deploy, and update functions' },
+  { id: 'storage', label: 'Storage', description: 'Buckets, objects, and presigned URLs' },
 ];
 const SCOPE_IDS = SCOPE_CATEGORIES.map((scope) => scope.id);
 const SCOPE_ID_SET = new Set(SCOPE_IDS);

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -453,8 +453,8 @@ const McpSetupConfigurator = () => {
               </button>
             </div>
             <p className={clsx('mt-2 mb-3', HELPER_TEXT_CLASS)}>
-              Pick which capability groups the agent can access. Unselected categories are excluded
-              via the{' '}
+              All tools are available by default; select categories to narrow the agent's access
+              through the{' '}
               <code className="rounded bg-gray-new-94 px-1 py-0.5 text-[12px] dark:bg-gray-new-15">
                 category
               </code>{' '}

--- a/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
+++ b/src/components/pages/doc/mcp-setup-configurator/mcp-setup-configurator.jsx
@@ -42,7 +42,7 @@ const SCOPE_CATEGORIES = [
   { id: 'querying', label: 'Querying', description: 'SQL, explain plans, and migrations' },
   { id: 'neon_auth', label: 'Neon Auth', description: 'Provision and configure Auth' },
   { id: 'data_api', label: 'Data API', description: 'Enable, update, and disable the Data API' },
-  { id: 'observability', label: 'Observability', description: 'Function logs, storage logs, and AI Gateway' },
+  { id: 'observability', label: 'Observability', description: 'Logs and AI Gateway availability' },
   { id: 'docs', label: 'Docs', description: 'Search and fetch docs' },
   { id: 'functions', label: 'Functions', description: 'List, deploy, and update functions' },
   { id: 'storage', label: 'Storage', description: 'Buckets, objects, and presigned URLs' },

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -26,7 +26,7 @@ Tools are grouped into categories. Use the \`?category=\` URL parameter to restr
 
 | Category                          | What it enables                                                                                                             |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Project management (\`projects\`)   | List, create, describe, and delete projects and organizations                                                               |
+| Project management (\`projects\`)   | List, create, describe, and delete projects; list organizations                                                             |
 | Branch management (\`branches\`)    | Create, reset, and delete branches; manage Postgres roles and databases                                                     |
 | Compute endpoints (\`endpoints\`)   | List, create, start, suspend, and restart branch computes                                                                   |
 | Snapshots (\`snapshots\`)           | Create, restore, and schedule snapshots                                                                                     |
@@ -34,7 +34,7 @@ Tools are grouped into categories. Use the \`?category=\` URL parameter to restr
 | SQL (\`querying\`)                  | Execute queries and transactions; apply schema changes on a temporary branch; run the same diagnostics as \`neon inspect db\` |
 | Managed Better Auth (\`neon_auth\`) | Provision Auth; manage OAuth providers, trusted domains, and users                                                          |
 | Neon Data API (\`data_api\`)        | Enable, update, and disable the Data API for a branch                                                                       |
-| Observability (\`observability\`)   | Query logs from your serverless functions and storage                                                                       |
+| Observability (\`observability\`)   | Query function and storage logs; inspect AI Gateway usage                                                                   |
 | Documentation (\`docs\`)            | Look up Neon documentation from within your assistant (no OAuth required)                                                   |
 | Functions (\`functions\`)           | List, deploy, update, and delete Neon Functions                                                                             |
 | Object storage (\`storage\`)        | Manage buckets and objects; create presigned URLs                                                                           |

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -24,20 +24,20 @@ exports[`MDX to Markdown Conversion > Component conversion test page (snapshot) 
 
 Tools are grouped into categories. Use the \`?category=\` URL parameter to restrict which categories are active. You can pass it more than once to enable multiple categories.
 
-| Category                          | What it enables                                                                   |
-| --------------------------------- | --------------------------------------------------------------------------------- |
-| Project management (\`projects\`)   | List, create, describe, and delete projects and organizations                     |
-| Branch management (\`branches\`)    | Create, reset, and delete branches; manage Postgres roles and databases           |
-| Compute endpoints (\`endpoints\`)   | List, create, start, suspend, and restart branch computes                         |
-| Snapshots (\`snapshots\`)           | Create, restore, and schedule snapshots                                           |
-| Schema (\`schema\`)                 | Inspect tables and columns; compare schemas; run migrations on a temporary branch |
-| SQL (\`querying\`)                  | Execute queries and transactions; run the same diagnostics as \`neon inspect db\`   |
-| Managed Better Auth (\`neon_auth\`) | Provision Auth; manage OAuth providers, trusted domains, and users                |
-| Neon Data API (\`data_api\`)        | Enable, update, and disable the Data API for a branch                             |
-| Observability (\`observability\`)   | Query logs from your serverless functions and storage                             |
-| Documentation (\`docs\`)            | Look up Neon documentation from within your assistant (no OAuth required)         |
-| Functions (\`functions\`)           | List, deploy, update, and delete Neon Functions                                   |
-| Object storage (\`storage\`)        | Manage buckets and objects; create presigned URLs                                 |
+| Category                          | What it enables                                                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Project management (\`projects\`)   | List, create, describe, and delete projects and organizations                                                               |
+| Branch management (\`branches\`)    | Create, reset, and delete branches; manage Postgres roles and databases                                                     |
+| Compute endpoints (\`endpoints\`)   | List, create, start, suspend, and restart branch computes                                                                   |
+| Snapshots (\`snapshots\`)           | Create, restore, and schedule snapshots                                                                                     |
+| Schema (\`schema\`)                 | Inspect tables and columns; compare schemas                                                                                 |
+| SQL (\`querying\`)                  | Execute queries and transactions; apply schema changes on a temporary branch; run the same diagnostics as \`neon inspect db\` |
+| Managed Better Auth (\`neon_auth\`) | Provision Auth; manage OAuth providers, trusted domains, and users                                                          |
+| Neon Data API (\`data_api\`)        | Enable, update, and disable the Data API for a branch                                                                       |
+| Observability (\`observability\`)   | Query logs from your serverless functions and storage                                                                       |
+| Documentation (\`docs\`)            | Look up Neon documentation from within your assistant (no OAuth required)                                                   |
+| Functions (\`functions\`)           | List, deploy, update, and delete Neon Functions                                                                             |
+| Object storage (\`storage\`)        | Manage buckets and objects; create presigned URLs                                                                           |
 
 Search and navigation tools (search across projects, fetch resource details by ID) are available by default but disabled in [project-scoped mode](https://neon.com/docs/ai/neon-mcp-server#project-scoped-mode).
 

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -24,16 +24,20 @@ exports[`MDX to Markdown Conversion > Component conversion test page (snapshot) 
 
 Tools are grouped into categories. Use the \`?category=\` URL parameter to restrict which categories are active. You can pass it more than once to enable multiple categories.
 
-| Category                          | What it enables                                                                     |
-| --------------------------------- | ----------------------------------------------------------------------------------- |
-| Project management (\`projects\`)   | List, create, describe, and delete projects and organizations                       |
-| Branch management (\`branches\`)    | Create branches, compare schemas, reset branches to parent state                    |
-| Schema (\`schema\`)                 | Inspect tables and columns; run schema changes via a safe temporary branch workflow |
-| SQL (\`querying\`)                  | Execute queries and transactions; run the same diagnostics as \`neon inspect db\`     |
-| Managed Better Auth (\`neon_auth\`) | Set up and configure app authentication for a branch                                |
-| Neon Data API (\`data_api\`)        | Enable HTTP-based Data API access for a branch                                      |
-| Observability (\`observability\`)   | Query logs from your serverless functions and storage                               |
-| Documentation (\`docs\`)            | Look up Neon documentation from within your assistant (no OAuth required)           |
+| Category                          | What it enables                                                                   |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| Project management (\`projects\`)   | List, create, describe, and delete projects and organizations                     |
+| Branch management (\`branches\`)    | Create, reset, and delete branches; manage Postgres roles and databases           |
+| Compute endpoints (\`endpoints\`)   | List, create, start, suspend, and restart branch computes                         |
+| Snapshots (\`snapshots\`)           | Create, restore, and schedule snapshots                                           |
+| Schema (\`schema\`)                 | Inspect tables and columns; compare schemas; run migrations on a temporary branch |
+| SQL (\`querying\`)                  | Execute queries and transactions; run the same diagnostics as \`neon inspect db\`   |
+| Managed Better Auth (\`neon_auth\`) | Provision Auth; manage OAuth providers, trusted domains, and users                |
+| Neon Data API (\`data_api\`)        | Enable, update, and disable the Data API for a branch                             |
+| Observability (\`observability\`)   | Query logs from your serverless functions and storage                             |
+| Documentation (\`docs\`)            | Look up Neon documentation from within your assistant (no OAuth required)         |
+| Functions (\`functions\`)           | List, deploy, update, and delete Neon Functions                                   |
+| Object storage (\`storage\`)        | Manage buckets and objects; create presigned URLs                                 |
 
 Search and navigation tools (search across projects, fetch resource details by ID) are available by default but disabled in [project-scoped mode](https://neon.com/docs/ai/neon-mcp-server#project-scoped-mode).
 

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -34,7 +34,7 @@ Tools are grouped into categories. Use the \`?category=\` URL parameter to restr
 | SQL (\`querying\`)                  | Execute queries and transactions; apply schema changes on a temporary branch; run the same diagnostics as \`neon inspect db\` |
 | Managed Better Auth (\`neon_auth\`) | Provision Auth; manage OAuth providers, trusted domains, and users                                                          |
 | Neon Data API (\`data_api\`)        | Enable, update, and disable the Data API for a branch                                                                       |
-| Observability (\`observability\`)   | Query function and storage logs; inspect AI Gateway usage                                                                   |
+| Observability (\`observability\`)   | Query function and storage logs; check AI Gateway availability                                                              |
 | Documentation (\`docs\`)            | Look up Neon documentation from within your assistant (no OAuth required)                                                   |
 | Functions (\`functions\`)           | List, deploy, update, and delete Neon Functions                                                                             |
 | Object storage (\`storage\`)        | Manage buckets and objects; create presigned URLs                                                                           |


### PR DESCRIPTION
## Problem

The setup configurator, Available tools table, and CLI reference listed eight tool categories. The hosted MCP server advertises twelve.

Selecting a subset adds a category allowlist to the generated URL. Since `endpoints`, `snapshots`, `functions`, and `storage` had no configurator option, narrowing access also hid those tools with no way to include them.

## Diagnosis

The hosted server advertises this list:

```json
[
  "projects",
  "branches",
  "endpoints",
  "snapshots",
  "schema",
  "querying",
  "neon_auth",
  "data_api",
  "observability",
  "docs",
  "functions",
  "storage"
]
```

The configurator, Available tools table, and CLI reference each keep a copy of that list. The existing sync check covered the first two copies but not the CLI reference.

The configurator omits the `category` query parameter for both an empty selection and a full selection. A partial selection adds the chosen categories.

## User-facing interface

The configurator now offers all twelve categories and explains the default:

```text
All tools are available by default; select categories to narrow the agent's access through the category query param.
```

An empty or full selection generates:

```text
https://mcp.neon.tech/mcp
```

A subset generates an allowlist:

```text
https://mcp.neon.tech/mcp?category=endpoints
```

The CLI `--category` list is the same twelve. CLI behavior is unchanged:

```bash
neon mcp --category querying --category schema
```

Auth setup copy now names the live tools:

```text
provision_neon_auth
add_auth_oauth_provider, add_auth_trusted_domain, update_auth_config
get_neon_auth_config
```

Links point at `#available-tools`.

## Also in here

- Expands the Available tools table with current descriptions for all twelve categories.
- Adds the CLI reference to the pull request and scheduled category sync checks.
- Updates related MCP links that pointed at `#supported-actions-tools`.
- Refreshes the generated LLM markdown snapshot.

## Verification

- `npx vitest run scripts/check-mcp-categories-sync.test.js`
- `npx vitest run src/scripts/process-md-for-llms.test.js`
- `npm run check:mcp-categories`
- `npm run check:mcp-categories:live`
- Preview: all twelve toggles; helper copy as above; Clear all leaves `https://mcp.neon.tech/mcp` with every checkbox off; selecting Endpoints only emits `?category=endpoints`.

## For your attention

- Clearing every checkbox still exposes all tools, because an empty selection omits `category`. The helper copy now states the default.
- `scripts/data/mcp-tool-definitions.json` still describes the previous MCP catalog. Regenerating it is a separate change.
- `content/docs/introduction/roadmap.md` still names `configure_neon_auth` as a shipped-feature bullet. Left as history.