### PR TITLE
docs: update @neon/sdk examples for 3.0 create / createAndConnect

### DIFF
--- a/content/blog/posts/neon-sdk.md
+++ b/content/blog/posts/neon-sdk.md
@@ -49,7 +49,7 @@ Most importantly, you can install `@neon/sdk` today:
 npm install @neon/sdk
 ```
 
-And use ergonomic functions like `createAndConnect` to provision a Neon project, wait for the provisioning operations to finish and hand you back a ready-to-use Postgres connection string, all in a single call:
+And use ergonomic functions like `createAndConnect` to provision a Neon project, wait for the provisioning operations to finish, and hand you back `{ project, connectionString }` in a single call:
 
 ```ts
 import { createNeonClient } from "@neon/sdk";
@@ -79,7 +79,7 @@ import { createNeonClient, raw } from "@neon/sdk";
 - **`createNeonClient`**: the high-level ergonomic client, organized into resource namespaces like `neon.projects` and `neon.branches`.
 - **`raw`**: the low-level generated surface, every endpoint as a standalone, tree-shakeable function.
 
-Take readiness polling as an example. The Neon API provisions real infrastructure and a lot of that work happens in the background, so most mutations don't hand you a ready-to-use resource. They return `operations` that you'd normally poll yourself until the resource is ready. `@neon/sdk` offers an abstraction that does that polling behind the scenes, so a call only resolves once the resource is actually ready. `createAndConnect` does this by default and you can opt any other mutation into the same behavior.
+Take readiness polling as an example. The Neon API provisions real infrastructure and a lot of that work happens in the background, so most mutations don't hand you a ready-to-use resource. They return `operations` that you'd normally poll yourself until the resource is ready. `@neon/sdk` offers an abstraction that does that polling behind the scenes, so a call only resolves once the resource is actually ready. `projects.create`, `branches.create`, and both `createAndConnect` workflows poll by default. Other mutations take `{ waitForReadiness: true }`.
 
 We hope `createNeonClient` covers most of what you need to build platforms and programmatic automations on Neon: a type-safe, ergonomic way to use Neon's capabilities. That said, you can always reach for the raw API methods directly.
 
@@ -116,9 +116,9 @@ await neon.projects.transfer({
 });
 ```
 
-### Create a branch with its own compute
+### Create a branch and get a connection string
 
-`branches.create` attaches a read-write endpoint by default. `createAndConnect` does the same, waits until the branch is ready, and returns a connection string:
+`branches.create` attaches a read-write endpoint by default and returns the branch. `createAndConnect` does the same, waits until the branch is ready, and returns `{ branch, endpoint, connectionString }`:
 
 ```ts
 const { data, error } = await neon.branches.createAndConnect(projectId, {

--- a/content/blog/posts/neon-sdk.md
+++ b/content/blog/posts/neon-sdk.md
@@ -118,15 +118,10 @@ await neon.projects.transfer({
 
 ### Create a branch with its own compute
 
-If you create a Neon branch through the API, you have to chain two calls:
-
-1. Create the branch
-2. Provision compute for the branch
-
-If you're used to the Neon UI, this is done automatically for you, but over the REST API it's split into two calls, which usually takes both devs and agents a few attempts to get right. `createWithCompute` creates the branch, spins up a read-write endpoint, waits for it to be ready and returns a connection string, all in one call:
+`branches.create` attaches a read-write endpoint by default. `createAndConnect` does the same, waits until the branch is ready, and returns a connection string:
 
 ```ts
-const { data, error } = await neon.branches.createWithCompute(projectId, {
+const { data, error } = await neon.branches.createAndConnect(projectId, {
   name: "preview/pr-123",
   compute: { minCu: 0.25, maxCu: 2 },
 });

--- a/content/docs/reference/migrate-api-client-to-sdk.md
+++ b/content/docs/reference/migrate-api-client-to-sdk.md
@@ -7,7 +7,7 @@ summary: >-
   layer 1.0 breaking changes. Use this page when updating scripts, CI jobs, or
   apps that call the Neon Platform API with TypeScript.
 enableTableOfContents: true
-updatedOn: '2026-08-27T18:03:21.795Z'
+updatedOn: '2026-08-27T18:25:57.494Z'
 ---
 
 <Admonition type="note" title="@neondatabase/api-client still works">
@@ -154,7 +154,7 @@ const response = await apiClient.createProject({
 });
 const uri = response.data.connection_uris[0].connection_uri;
 
-// After — waits for provisioning and returns a ready connection string
+// After — waits for provisioning; data is { project, connectionString }
 const { data, error } = await neon.projects.createAndConnect({
   name: 'my-app',
   region_id: 'aws-us-east-1',
@@ -175,13 +175,13 @@ await apiClient.createProjectBranch(projectId, {
   endpoints: [{ type: EndpointType.ReadWrite }],
 });
 
-// After
-const { data, error } = await neon.branches.createAndConnect(projectId, {
+// After — read-write compute is attached by default
+const { data, error } = await neon.branches.create(projectId, {
   name: 'dev-1',
-  parentId: parentBranchId,
+  parent_id: parentBranchId,
 });
 if (error) throw error;
-const { branch, endpoint, connectionString } = data;
+const branch = data;
 ```
 
 ### Create a database
@@ -241,7 +241,7 @@ Some generated type names changed (for example, `DataAPI*` → `DataApi*`). Endp
 
 ## What you gain
 
-- **Workflow helpers** such as `projects.createAndConnect` and `branches.createAndConnect` that poll operations and return connection strings. `create` returns the resource; `branches.create` attaches a read-write endpoint unless you pass `noCompute: true`.
+- **Workflow helpers** such as `projects.createAndConnect` and `branches.createAndConnect` that poll operations and return `{ project, connectionString }` or `{ branch, endpoint, connectionString }`. `create` returns the resource; `branches.create` attaches a read-write endpoint unless you pass `noCompute: true`.
 - **Readiness polling** via `waitForReadiness` and `neon.operations.waitFor`
 - **Automatic retries** on safe statuses (`423`, `429`, `503`)
 - **Ergonomic beta APIs** for storage, functions, credentials, AI gateway, snapshots, and branch-scoped Managed Better Auth (`neon.auth`, `neon.storage`, …)

--- a/content/docs/reference/migrate-api-client-to-sdk.md
+++ b/content/docs/reference/migrate-api-client-to-sdk.md
@@ -7,7 +7,7 @@ summary: >-
   layer 1.0 breaking changes. Use this page when updating scripts, CI jobs, or
   apps that call the Neon Platform API with TypeScript.
 enableTableOfContents: true
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-08-27T18:03:21.795Z'
 ---
 
 <Admonition type="note" title="@neondatabase/api-client still works">
@@ -71,24 +71,24 @@ const neon = createNeonClient({
 
 Common Platform API calls and their `@neon/sdk` equivalents:
 
-| `@neondatabase/api-client`             | `@neon/sdk`                                                                      |
-| -------------------------------------- | -------------------------------------------------------------------------------- |
-| `getCurrentUserOrganizations()`        | `neon.user.organizations()`                                                      |
-| `getCurrentUserInfo()`                 | `neon.user.me()`                                                                 |
-| `listProjects({ org_id })`             | `neon.projects.list({ org_id }).page()` or `.all()`                              |
-| `createProject({ project })`           | `neon.projects.create({ name, region_id, … })`                                   |
-| `getProject(projectId)`                | `neon.projects.get(projectId)`                                                   |
-| `deleteProject(projectId)`             | `neon.projects.delete(projectId)`                                                |
-| `listProjectBranches({ projectId })`   | `neon.branches.list(projectId).page()` or `.all()`                               |
-| `createProjectBranch(projectId, body)` | `neon.branches.create(projectId, input)` or `neon.branches.createWithCompute(…)` |
-| `getConnectionUri(projectId, query)`   | `neon.postgres.connectionString({ projectId, … })`                               |
-| `listProjectBranchDatabases(…)`        | `neon.postgres.databases.list(…)`                                                |
-| `createProjectBranchDatabase(…)`       | `neon.postgres.databases.create(…)`                                              |
-| `listProjectBranchRoles(…)`            | `neon.postgres.roles.list(…)`                                                    |
-| `createProjectBranchRole(…)`           | `neon.postgres.roles.create(…)`                                                  |
-| `listProjectEndpoints(projectId)`      | `neon.postgres.endpoints.list(projectId)`                                        |
-| `listApiKeys()`                        | `neon.apiKeys.list()`                                                            |
-| `getActiveRegions()`                   | `neon.regions.list()`                                                            |
+| `@neondatabase/api-client`             | `@neon/sdk`                                                                     |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| `getCurrentUserOrganizations()`        | `neon.user.organizations()`                                                     |
+| `getCurrentUserInfo()`                 | `neon.user.me()`                                                                |
+| `listProjects({ org_id })`             | `neon.projects.list({ org_id }).page()` or `.all()`                             |
+| `createProject({ project })`           | `neon.projects.create({ name, region_id, … })`                                  |
+| `getProject(projectId)`                | `neon.projects.get(projectId)`                                                  |
+| `deleteProject(projectId)`             | `neon.projects.delete(projectId)`                                               |
+| `listProjectBranches({ projectId })`   | `neon.branches.list(projectId).page()` or `.all()`                              |
+| `createProjectBranch(projectId, body)` | `neon.branches.create(projectId, input)` or `neon.branches.createAndConnect(…)` |
+| `getConnectionUri(projectId, query)`   | `neon.postgres.connectionString({ projectId, … })`                              |
+| `listProjectBranchDatabases(…)`        | `neon.postgres.databases.list(…)`                                               |
+| `createProjectBranchDatabase(…)`       | `neon.postgres.databases.create(…)`                                             |
+| `listProjectBranchRoles(…)`            | `neon.postgres.roles.list(…)`                                                   |
+| `createProjectBranchRole(…)`           | `neon.postgres.roles.create(…)`                                                 |
+| `listProjectEndpoints(projectId)`      | `neon.postgres.endpoints.list(projectId)`                                       |
+| `listApiKeys()`                        | `neon.apiKeys.list()`                                                           |
+| `getActiveRegions()`                   | `neon.regions.list()`                                                           |
 
 Endpoints that are not wrapped in an ergonomic namespace remain available through [`raw`](/docs/reference/typescript-sdk#raw-layer).
 
@@ -176,7 +176,7 @@ await apiClient.createProjectBranch(projectId, {
 });
 
 // After
-const { data, error } = await neon.branches.createWithCompute(projectId, {
+const { data, error } = await neon.branches.createAndConnect(projectId, {
   name: 'dev-1',
   parentId: parentBranchId,
 });
@@ -241,7 +241,7 @@ Some generated type names changed (for example, `DataAPI*` → `DataApi*`). Endp
 
 ## What you gain
 
-- **Workflow helpers** such as `projects.createAndConnect` and `branches.createWithCompute` that poll operations and return connection strings
+- **Workflow helpers** such as `projects.createAndConnect` and `branches.createAndConnect` that poll operations and return connection strings. `create` returns the resource; `branches.create` attaches a read-write endpoint unless you pass `noCompute: true`.
 - **Readiness polling** via `waitForReadiness` and `neon.operations.waitFor`
 - **Automatic retries** on safe statuses (`423`, `429`, `503`)
 - **Ergonomic beta APIs** for storage, functions, credentials, AI gateway, snapshots, and branch-scoped Managed Better Auth (`neon.auth`, `neon.storage`, …)

--- a/content/docs/reference/typescript-sdk.md
+++ b/content/docs/reference/typescript-sdk.md
@@ -157,7 +157,6 @@ const { data: branch, error } = await neon.branches.create(projectId, {
   name: "preview",
 });
 if (error) throw error;
-branch; // Branch with a read-write endpoint. No connectionString.
 
 const { data, error: connectError } = await neon.branches.createAndConnect(
   projectId,
@@ -244,11 +243,12 @@ await neon.branches.create(projectId, {
   noCompute: true,
 });
 
-const { data } = await neon.branches.createAndConnect(projectId, {
+const { data, error } = await neon.branches.createAndConnect(projectId, {
   name: "preview/pr-123-uri",
   parentId: prod?.id,
   compute: { minCu: 0.25, maxCu: 2 },
 });
+if (error) throw error;
 const { connectionString } = data;
 ```
 

--- a/content/docs/reference/typescript-sdk.md
+++ b/content/docs/reference/typescript-sdk.md
@@ -10,7 +10,7 @@ summary: >-
   automatic retries, readiness polling, and auto-pagination built in. A raw
   1:1 layer exposes every endpoint and is generated from the Neon OpenAPI spec.
 enableTableOfContents: true
-updatedOn: '2026-09-03T00:51:45.020Z'
+updatedOn: '2026-09-03T02:30:00.000Z'
 ---
 
 <InfoBlock>
@@ -146,21 +146,26 @@ for await (const project of neon.projects.list()) {
 
 ### Async workflows
 
-Neon mutations return operations that complete in the background. A few convenience methods, noted as "creates, then polls until ready" in the reference below (`projects.createAndConnect`, `branches.createWithCompute`), do this polling for you and hand back a ready-to-use result, such as a connection string, in a single call. The primitive underneath is `neon.operations.waitFor(operations)`.
+Neon mutations return operations that complete in the background. The client-wide `waitForReadiness` default is `false`. `projects.create`, `branches.create`, and both `createAndConnect` workflows turn polling on for that call.
 
-On any namespaced mutation, pass `{ waitForReadiness: true }` as the trailing options argument to poll before the call resolves:
+`create` returns the resource. `createAndConnect` also waits, then returns a connection string. The primitive underneath is `neon.operations.waitFor(operations)`.
 
 ```ts
-const { data, error } = await neon.branches.create(
-  projectId,
-  { name: "preview" },
-  { waitForReadiness: true }
-);
+const { data: branch, error } = await neon.branches.create(projectId, {
+  name: "preview",
+});
 if (error) throw error;
-data; // Branch — provisioning finished
+branch; // Branch with a read-write endpoint. No connection string.
+
+const { data, error: connectError } = await neon.branches.createAndConnect(
+  projectId,
+  { name: "preview" }
+);
+if (connectError) throw connectError;
+data; // { branch, endpoint, connectionString }
 ```
 
-For raw API calls that return an `operations` array, use [`neon.operations.waitFor`](#neonoperations) instead.
+On any other namespaced mutation, pass `{ waitForReadiness: true }` as the trailing options argument to poll before the call resolves. For raw API calls that return an `operations` array, use [`neon.operations.waitFor`](#neonoperations) instead.
 
 ## Namespaces
 
@@ -174,17 +179,17 @@ Account-level surfaces round out the client: [`consumption`](#neonconsumption) f
 
 Create, manage, and share Neon projects. One API call per method; `list` is paginated. <small>REST: [Projects API](/docs/reference/api/projects)</small>
 
-| Method                            | Returns                                                      | Arguments                                                                                                               |
-| --------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `list(query?)`                    | [`Paginated`](#lazy-auto-paginated-lists)`<ProjectListItem>` | `query`: `{ search?, org_id?, limit? }`                                                                                 |
-| `get(id)`                         | `Project`                                                    |                                                                                                                         |
-| `create(input?)`                  | `Project`                                                    | `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
-| `createAndConnect(input?, opts?)` | `{ project: Project, connectionString: string }`             | Creates, then polls until ready. `opts`: `{ pooled? }` (default `true`)                                                 |
-| `update(id, input)`               | `Project`                                                    | `input`: `{ name?, settings? }`                                                                                         |
-| `delete(id)`                      | `Project`                                                    |                                                                                                                         |
-| `recover(id)`                     | `Project`                                                    | Recover a soft-deleted project within its retention window                                                              |
-| `transfer(input)`                 | `void`                                                       | `input`: `{ fromOrgId?, toOrgId, projectIds }` (`fromOrgId` defaults to the client `orgId`)                             |
-| `transferFromUser(input)`         | `void`                                                       | `input`: `{ toOrgId, projectIds }`                                                                                      |
+| Method                            | Returns                                                      | Arguments                                                                                                                                                                                                                 |
+| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list(query?)`                    | [`Paginated`](#lazy-auto-paginated-lists)`<ProjectListItem>` | `query`: `{ search?, org_id?, limit? }`                                                                                                                                                                                   |
+| `get(id)`                         | `Project`                                                    |                                                                                                                                                                                                                           |
+| `create(input?)`                  | `Project`                                                    | Default-branch compute is always attached. No connection string. Readiness polling on by default. `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
+| `createAndConnect(input?, opts?)` | `{ project: Project, connectionString: string }`             | Creates, then polls until ready, and returns a URI. `opts`: `{ pooled? }` (default `true`)                                                                                                                                |
+| `update(id, input)`               | `Project`                                                    | `input`: `{ name?, settings? }`                                                                                                                                                                                           |
+| `delete(id)`                      | `Project`                                                    |                                                                                                                                                                                                                           |
+| `recover(id)`                     | `Project`                                                    | Recover a soft-deleted project within its retention window                                                                                                                                                                |
+| `transfer(input)`                 | `void`                                                       | `input`: `{ fromOrgId?, toOrgId, projectIds }` (`fromOrgId` defaults to the client `orgId`)                                                                                                                               |
+| `transferFromUser(input)`         | `void`                                                       | `input`: `{ toOrgId, projectIds }`                                                                                                                                                                                        |
 
 ```ts
 // Provision a project, poll until ready, return a pooled connection string
@@ -207,24 +212,35 @@ Share a project with additional users by email.
 
 ## neon.branches
 
-Branch a project's data and schema; optionally attach compute in one workflow. <small>REST: [Branches API](/docs/reference/api/branches)</small>
+Branch a project's data and schema. `create` attaches a read-write endpoint by default. <small>REST: [Branches API](/docs/reference/api/branches)</small>
 
-| Method                                         | Returns                                                            | Arguments                                                                                                              |
-| ---------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `list(projectId, query?)`                      | [`Paginated`](#lazy-auto-paginated-lists)`<Branch>`                | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }`                                                        |
-| `get(projectId, branchId)`                     | `Branch`                                                           |                                                                                                                        |
-| `create(projectId, input?)`                    | `Branch`                                                           | `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected? }`                                           |
-| `createWithCompute(projectId, input, opts?)`   | `{ branch: Branch, endpoint: Endpoint, connectionString: string }` | Creates, then polls until ready. `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
-| `update(projectId, branchId, input)`           | `Branch`                                                           | `input`: `{ name?, protected?, expires_at? }`                                                                          |
-| `delete(projectId, branchId)`                  | `void`                                                             |                                                                                                                        |
-| `getDefault(projectId)`                        | `Branch`                                                           | Resolve the project's default branch by flag, not by name                                                              |
-| `setDefault(projectId, branchId)`              | `Branch`                                                           |                                                                                                                        |
-| `finalizeRestore(projectId, branchId, input?)` | `void`                                                             | Commit a restore previewed with `snapshots.restore({ finalize: false })`                                               |
+| Method                                         | Returns                                                            | Arguments                                                                                                                                                                                                                                                           |
+| ---------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list(projectId, query?)`                      | [`Paginated`](#lazy-auto-paginated-lists)`<Branch>`                | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }`                                                                                                                                                                                                     |
+| `get(projectId, branchId)`                     | `Branch`                                                           |                                                                                                                                                                                                                                                                     |
+| `create(projectId, input?)`                    | `Branch`                                                           | Read-write compute on by default; `noCompute: true` skips it. No connection string. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
+| `createAndConnect(projectId, input?, opts?)`   | `{ branch: Branch, endpoint: Endpoint, connectionString: string }` | Creates, then polls until ready, and returns a URI. `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }`. `opts`: `{ pooled? }`                                                                                                    |
+| `update(projectId, branchId, input)`           | `Branch`                                                           | `input`: `{ name?, protected?, expires_at? }`                                                                                                                                                                                                                       |
+| `delete(projectId, branchId)`                  | `void`                                                             |                                                                                                                                                                                                                                                                     |
+| `getDefault(projectId)`                        | `Branch`                                                           | Resolve the project's default branch by flag, not by name                                                                                                                                                                                                           |
+| `setDefault(projectId, branchId)`              | `Branch`                                                           |                                                                                                                                                                                                                                                                     |
+| `finalizeRestore(projectId, branchId, input?)` | `void`                                                             | Commit a restore previewed with `snapshots.restore({ finalize: false })`                                                                                                                                                                                            |
 
 ```ts
-// Branch off the default ("production") branch with its own compute
 const { data: prod } = await neon.branches.getDefault(projectId);
-const { data } = await neon.branches.createWithCompute(projectId, {
+
+await neon.branches.create(projectId, {
+  name: "preview/pr-123",
+  parent_id: prod?.id,
+});
+
+await neon.branches.create(projectId, {
+  name: "schema-only",
+  parent_id: prod?.id,
+  noCompute: true,
+});
+
+const { data } = await neon.branches.createAndConnect(projectId, {
   name: "preview/pr-123",
   parentId: prod?.id,
   compute: { minCu: 0.25, maxCu: 2 },

--- a/content/docs/reference/typescript-sdk.md
+++ b/content/docs/reference/typescript-sdk.md
@@ -148,21 +148,23 @@ for await (const project of neon.projects.list()) {
 
 Neon mutations return operations that complete in the background. The client-wide `waitForReadiness` default is `false`. `projects.create`, `branches.create`, and both `createAndConnect` workflows turn polling on for that call.
 
-`create` returns the resource. `createAndConnect` also waits, then returns a connection string. The primitive underneath is `neon.operations.waitFor(operations)`.
+`create` returns the resource. `createAndConnect` also waits, then returns `{ branch, endpoint, connectionString }` (or `{ project, connectionString }`). The primitive underneath is `neon.operations.waitFor(operations)`.
+
+Pick one. `create` uses REST field names (`parent_id`). `createAndConnect` uses `{ name?, parentId?, compute? }`.
 
 ```ts
 const { data: branch, error } = await neon.branches.create(projectId, {
   name: "preview",
 });
 if (error) throw error;
-branch; // Branch with a read-write endpoint. No connection string.
+branch; // Branch with a read-write endpoint. No connectionString.
 
 const { data, error: connectError } = await neon.branches.createAndConnect(
   projectId,
-  { name: "preview" }
+  { name: "preview-uri" }
 );
 if (connectError) throw connectError;
-data; // { branch, endpoint, connectionString }
+const { connectionString } = data;
 ```
 
 On any other namespaced mutation, pass `{ waitForReadiness: true }` as the trailing options argument to poll before the call resolves. For raw API calls that return an `operations` array, use [`neon.operations.waitFor`](#neonoperations) instead.
@@ -184,7 +186,7 @@ Create, manage, and share Neon projects. One API call per method; `list` is pagi
 | `list(query?)`                    | [`Paginated`](#lazy-auto-paginated-lists)`<ProjectListItem>` | `query`: `{ search?, org_id?, limit? }`                                                                                                                                                                                   |
 | `get(id)`                         | `Project`                                                    |                                                                                                                                                                                                                           |
 | `create(input?)`                  | `Project`                                                    | Default-branch compute is always attached. No connection string. Readiness polling on by default. `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
-| `createAndConnect(input?, opts?)` | `{ project: Project, connectionString: string }`             | Creates, then polls until ready, and returns a URI. `opts`: `{ pooled? }` (default `true`)                                                                                                                                |
+| `createAndConnect(input?, opts?)` | `{ project: Project, connectionString: string }`             | Creates, then polls until ready. `opts`: `{ pooled? }` (default `true`)                                                                                                                                                   |
 | `update(id, input)`               | `Project`                                                    | `input`: `{ name?, settings? }`                                                                                                                                                                                           |
 | `delete(id)`                      | `Project`                                                    |                                                                                                                                                                                                                           |
 | `recover(id)`                     | `Project`                                                    | Recover a soft-deleted project within its retention window                                                                                                                                                                |
@@ -219,12 +221,14 @@ Branch a project's data and schema. `create` attaches a read-write endpoint by d
 | `list(projectId, query?)`                      | [`Paginated`](#lazy-auto-paginated-lists)`<Branch>`                | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }`                                                                                                                                                                                                     |
 | `get(projectId, branchId)`                     | `Branch`                                                           |                                                                                                                                                                                                                                                                     |
 | `create(projectId, input?)`                    | `Branch`                                                           | Read-write compute on by default; `noCompute: true` skips it. No connection string. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
-| `createAndConnect(projectId, input?, opts?)`   | `{ branch: Branch, endpoint: Endpoint, connectionString: string }` | Creates, then polls until ready, and returns a URI. `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }`. `opts`: `{ pooled? }`                                                                                                    |
+| `createAndConnect(projectId, input?, opts?)`   | `{ branch: Branch, endpoint: Endpoint, connectionString: string }` | Creates, then polls until ready. `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }`. `opts`: `{ pooled? }`                                                                                                                       |
 | `update(projectId, branchId, input)`           | `Branch`                                                           | `input`: `{ name?, protected?, expires_at? }`                                                                                                                                                                                                                       |
 | `delete(projectId, branchId)`                  | `void`                                                             |                                                                                                                                                                                                                                                                     |
 | `getDefault(projectId)`                        | `Branch`                                                           | Resolve the project's default branch by flag, not by name                                                                                                                                                                                                           |
 | `setDefault(projectId, branchId)`              | `Branch`                                                           |                                                                                                                                                                                                                                                                     |
 | `finalizeRestore(projectId, branchId, input?)` | `void`                                                             | Commit a restore previewed with `snapshots.restore({ finalize: false })`                                                                                                                                                                                            |
+
+Three modes: default compute, schema-only (`noCompute: true`), and create-plus-URI.
 
 ```ts
 const { data: prod } = await neon.branches.getDefault(projectId);
@@ -241,11 +245,11 @@ await neon.branches.create(projectId, {
 });
 
 const { data } = await neon.branches.createAndConnect(projectId, {
-  name: "preview/pr-123",
+  name: "preview/pr-123-uri",
   parentId: prod?.id,
   compute: { minCu: 0.25, maxCu: 2 },
 });
-// data: { branch, endpoint, connectionString }
+const { connectionString } = data;
 ```
 
 ## neon.postgres

--- a/content/guides/cloudflare-sandbox-neon-branching.md
+++ b/content/guides/cloudflare-sandbox-neon-branching.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to build Full-Stack Cloud Agents using Cloudflare Sandboxes
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-03-16T00:00:00.000Z'
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-27T18:03:21.795Z'
 ---
 
 ![Cloudflare Sandbox and Neon Branching architecture](/docs/guides/cloudflare_sandbox_neon_branching.png)
@@ -185,11 +185,11 @@ async function createNeonBranch(
     throwOnError: true
   })
 
-  const branch = await neon.branches.createWithCompute(projectId, {
+  const { connectionString } = await neon.branches.createAndConnect(projectId, {
     name: branchName
   })
 
-  return branch.connectionString
+  return connectionString
 }
 
 async function run(sandbox: ReturnType<typeof getSandbox>, cmd: string) {

--- a/content/guides/vercel-eve-neon.md
+++ b/content/guides/vercel-eve-neon.md
@@ -4,7 +4,7 @@ subtitle: "Learn how to build a Slack-based database assistant with Eve that pro
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: "2026-06-23T00:00:00.000Z"
-updatedOn: '2026-07-15T00:58:07.525Z'
+updatedOn: '2026-08-27T18:03:21.795Z'
 ---
 
 [Eve](https://eve.dev) by [Vercel](https://vercel.com) is a filesystem‑first framework for building durable backend agents. You define an agent as files (its instructions, tools, skills, channels, and schedules), and Eve takes care of the rest: stable HTTP routes, reconnectable session streams, durable state, and native human‑in‑the‑loop approvals. Agents built with Eve can run for days, pause for human review, and resume exactly where they left off.
@@ -207,11 +207,6 @@ export async function createBranch(name: string): Promise<Branch> {
   const branch = await neon.branches.create(projectId, {
     name,
     expires_at: expiresAt,
-  });
-
-  await neon.postgres.endpoints.create(projectId, {
-    branch_id: branch.id,
-    type: "read_write",
   });
 
   const connectionUri = await neon.postgres.connectionString({

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@commitlint/config-conventional": "^19.2.2",
         "@eslint/compat": "^1.2.0",
         "@eslint/js": "^9.0.0",
-        "@neon/sdk": "^2.0.0",
+        "@neon/sdk": "^3.0.0",
         "@next/eslint-plugin-next": "16.3.3",
         "@playwright/test": "1.61.1",
         "@scalar/openapi-parser": "^0.28.2",
@@ -4286,9 +4286,9 @@
       }
     },
     "node_modules/@neon/sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@neon/sdk/-/sdk-2.0.0.tgz",
-      "integrity": "sha512-pg08olEnIf1FOGynAS9h22hPI11pBfk2DLjFq7RASHS3nXV6ljqSBaZ/fLhypT430VJK3YnTOhYQCcDDn8ASUA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@neon/sdk/-/sdk-3.0.0.tgz",
+      "integrity": "sha512-HoWXk7t6MqTo0s5tbFinYNcuojsLAperd8I6oouibBLie2pnucIfTP10FtQZPfZVABvnU2SGm+QT9pQDmVfGeA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -18853,7 +18853,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@commitlint/config-conventional": "^19.2.2",
     "@eslint/compat": "^1.2.0",
     "@eslint/js": "^9.0.0",
-    "@neon/sdk": "^2.0.0",
+    "@neon/sdk": "^3.0.0",
     "@next/eslint-plugin-next": "16.3.3",
     "@playwright/test": "1.61.1",
     "@scalar/openapi-parser": "^0.28.2",


### PR DESCRIPTION
## Problem

Copy-paste samples on the TypeScript SDK reference, the api-client migration guide, the SDK blog post and the Cloudflare sandbox guide call `neon.branches.createWithCompute`. `@neon/sdk` 3.0.0 doesn't have that method. A reader on 3.0.0 fails at the call.

The Eve guide still follows `branches.create` with `postgres.endpoints.create({ type: "read_write" })`. On 3.0.0 `branches.create` already attaches a read-write endpoint.

The site's own dependency was `@neon/sdk@^2.0.0`.

## Diagnosis

`@neon/sdk` 3.0.0 splits the job by return value. Website copy was written for 2.x. Compute-plus-connection-string lived on `createWithCompute`. `branches.create` was branch-only.

3.0.0:

- `create` returns the resource. `projects.create` always attaches default-branch compute. `branches.create` attaches a read-write endpoint unless you pass `noCompute: true`. Both turn readiness polling on for that call.
- `createAndConnect` polls, then returns `{ project, connectionString }` or `{ branch, endpoint, connectionString }`.
- Input field names differ. `create` uses REST names (`parent_id`). `createAndConnect` uses `{ name?, parentId?, compute? }`.
- The client-wide `waitForReadiness` default stays `false`. Other mutations still pass `{ waitForReadiness: true }`.

A follow-up `endpoints.create` after `branches.create` is a second read-write endpoint. The 2.x `createWithCompute` workflow is `createAndConnect`.

## The user-facing interface

This PR updates neon.com samples and the site's `@neon/sdk` pin. The npm package already shipped.

```ts
const { data: branch, error } = await neon.branches.create(projectId, {
  name: "preview",
});
if (error) throw error;

const { data, error: connectError } = await neon.branches.createAndConnect(
  projectId,
  { name: "preview-uri" }
);
if (connectError) throw connectError;
const { connectionString } = data;
```

Branch reference, three modes (`create` uses `parent_id`; `createAndConnect` uses `parentId`):

```ts
await neon.branches.create(projectId, {
  name: "preview/pr-123",
  parent_id: prod?.id,
});

await neon.branches.create(projectId, {
  name: "schema-only",
  parent_id: prod?.id,
  noCompute: true,
});

const { data, error } = await neon.branches.createAndConnect(projectId, {
  name: "preview/pr-123-uri",
  parentId: prod?.id,
  compute: { minCu: 0.25, maxCu: 2 },
});
if (error) throw error;
const { connectionString } = data;
```

Project helper:

```ts
const { data, error } = await neon.projects.createAndConnect({
  name: "my-app",
});
if (error) throw error;
const { project, connectionString } = data;
```

Migration guide, branch with compute (returns `Branch`):

```ts
const { data, error } = await neon.branches.create(projectId, {
  name: "dev-1",
  parent_id: parentBranchId,
});
if (error) throw error;
const branch = data;
```

`createProjectBranch` maps to `branches.create` or `branches.createAndConnect`.

Cloudflare sandbox guide (`throwOnError: true`):

```ts
const { connectionString } = await neon.branches.createAndConnect(projectId, {
  name: branchName
})
```

Eve guide keeps `branches.create` plus `postgres.connectionString` and removes the extra `endpoints.create`.

| Method | Returns |
| --- | --- |
| `projects.create` | `Project` |
| `projects.createAndConnect` | `{ project: Project, connectionString: string }` |
| `branches.create` | `Branch` (read-write compute unless `noCompute: true`) |
| `branches.createAndConnect` | `{ branch, endpoint, connectionString }` |

Pagination, retries, `raw` and the other namespaces are unchanged.

## Also in here

- `package.json`, `package-lock.json` and `scripts/deps-proxy-allowlist.json` pin `@neon/sdk` at `3.0.0`.
- The branches method table drops `recover`. `@neon/sdk` 2.0.0 already removed `neon.branches.recover` from the ergonomic client. `projects.recover` stays.
- `updatedOn` on the four content files.
- The lockfile drops a `dev` flag on optional `fsevents`; that came with the install.

## Verification

- The files this PR edits no longer call `createWithCompute`.
- `package.json` is `@neon/sdk@^3.0.0`. `scripts/deps-proxy-allowlist.json` is `@neon/sdk@3.0.0`.
- Reference tables and samples use the 3.0.0 return types: `create` returns the resource; `createAndConnect` returns `{ project, connectionString }` or `{ branch, endpoint, connectionString }`.

Not verified: compiling the snippets against `node_modules/@neon/sdk@3.0.0` in this worktree (no install here). Playwright doesn't typecheck Markdown samples. Pages not rendered in the browser.

`rg createWithCompute` still has hits. See below.

## For your attention

- `public/docs/ai/skills/neon-postgres-agent-platforms/SKILL.md` still names `branches.createWithCompute` as a `@neon/tools` selector, in prose and in two `tools:` arrays. `check:skills-sync` requires that file to match upstream 1:1; a hand-edit in this repo fails CI. `check:docs-api-consistency` matches `neon.branches.createWithCompute(` (an SDK client call). The skill uses `"branches.createWithCompute"` tool ids, so that check stays green. The fix is an upstream skill refresh, then re-sync.
- The migration sample titled "Create a branch with compute" now returns `Branch`. Callers who copied it for `{ branch, endpoint, connectionString }` need `createAndConnect`; the mapping table lists both.
- `create` vs `createAndConnect` disagree on `parent_id` / `parentId`. Copying fields across the two calls will not typecheck.
- `branches.recover` is dropped from the reference table. The 2.0.0 changelog documents a raw `client.post` path for that endpoint.
