### PR TITLE
chore: update AI Gateway model pricing

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -563,8 +563,8 @@
           "output": 25000
         },
         "cost": {
-          "input": 0.072,
-          "output": 0.28
+          "input": 0.15,
+          "output": 0.6
         }
       },
       "gpt-oss-20b": {
@@ -603,8 +603,8 @@
           "output": 25000
         },
         "cost": {
-          "input": 0.05,
-          "output": 0.2
+          "input": 0.07,
+          "output": 0.3
         }
       },
       "gpt-5": {
@@ -1211,14 +1211,16 @@
           "output": 128000
         },
         "cost": {
-          "input": 1,
-          "output": 6,
-          "cache_read": 0.1,
+          "input": 0.2,
+          "output": 1.2,
+          "cache_read": 0.02,
+          "cache_write": 0.25,
           "tiers": [
             {
-              "input": 2,
-              "output": 9,
-              "cache_read": 0.2,
+              "input": 0.4,
+              "output": 1.8,
+              "cache_read": 0.04,
+              "cache_write": 0.5,
               "tier": {
                 "type": "context",
                 "size": 272000
@@ -1226,9 +1228,10 @@
             }
           ],
           "context_over_200k": {
-            "input": 2,
-            "output": 9,
-            "cache_read": 0.2
+            "input": 0.4,
+            "output": 1.8,
+            "cache_read": 0.04,
+            "cache_write": 0.5
           }
         }
       },
@@ -1279,11 +1282,13 @@
           "input": 5,
           "output": 30,
           "cache_read": 0.5,
+          "cache_write": 6.25,
           "tiers": [
             {
               "input": 10,
               "output": 45,
               "cache_read": 1,
+              "cache_write": 12.5,
               "tier": {
                 "type": "context",
                 "size": 272000
@@ -1293,7 +1298,8 @@
           "context_over_200k": {
             "input": 10,
             "output": 45,
-            "cache_read": 1
+            "cache_read": 1,
+            "cache_write": 12.5
           }
         }
       },
@@ -1341,14 +1347,16 @@
           "output": 128000
         },
         "cost": {
-          "input": 2.5,
-          "output": 15,
-          "cache_read": 0.25,
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "cache_write": 2.5,
           "tiers": [
             {
-              "input": 5,
-              "output": 22.5,
-              "cache_read": 0.5,
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "cache_write": 5,
               "tier": {
                 "type": "context",
                 "size": 272000
@@ -1356,9 +1364,10 @@
             }
           ],
           "context_over_200k": {
-            "input": 5,
-            "output": 22.5,
-            "cache_read": 0.5
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4,
+            "cache_write": 5
           }
         }
       },
@@ -1948,6 +1957,11 @@
         "limit": {
           "context": 1048576,
           "output": 65536
+        },
+        "cost": {
+          "input": 1,
+          "output": 4.05,
+          "cache_read": 0.17
         }
       },
       "kimi-k3": {


### PR DESCRIPTION
## Overview

Updates the AI Gateway model catalog with current pricing. Refreshes rates for several OpenAI and open-weight models. Adds cache-write pricing to the GPT-5.6 models (Sol, Terra, Luna), and prices Inkling, which previously had no cost entry at all, including its cache-read rate.

This pull request and its description were written by Isaac.
