### PR TITLE
Show OpenAI SDK examples for gpt-oss and qwen35

### DIFF
--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   Use short model IDs like gpt-5-mini or gemini-3-flash. The databricks- prefix
   is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-08-17T22:56:05.062Z'
+updatedOn: '2026-08-27T22:18:16.922Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -72,7 +72,7 @@ All paths below are appended to your branch's bare AI Gateway host (`NEON_AI_GAT
 | Meta, Alibaba, Zhipu AI, Thinking Machines, Moonshot AI | `/v1/chat/completions` | Chat completions only                                                                        |
 
 <Admonition type="warning" title="Content shape varies by model">
-For most models, `message.content` in a chat completions response is a plain string. For some models, confirmed on Gemini 3.x (`gemini-3-5-flash`, `gemini-3-1-pro`), `gpt-oss-120b`, and `qwen35-122b-a10b`, it's an array of typed content blocks instead (`{ type: 'reasoning', ... }`, `{ type: 'text', text: ... }`), matching how those models represent output natively. A low `max_tokens` value can also cut a response off before the `text` block appears, leaving only a `reasoning` block. Handle both shapes:
+For most models, `message.content` in a chat completions response is a plain string. For some models, confirmed on Gemini 3.x (`gemini-3-5-flash`, `gemini-3-1-pro`) and Claude 5 (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`), it's an array of typed content blocks instead (`{ type: 'reasoning', ... }`, `{ type: 'text', text: ... }`). A low `max_tokens` value can also cut a response off before the `text` block appears, leaving only a `reasoning` block. Handle both shapes:
 
 ```typescript
 const { content } = response.choices[0].message;

--- a/src/app/models/capabilities.json
+++ b/src/app/models/capabilities.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Measured behaviour of every model the Neon AI Gateway serves. Produced by calling each model on /v1/chat/completions, its provider-native dialect, and /openai/v1/responses with the web_search and image_generation tools. This is what the gateway DID; models.json is what each model CLAIMS. /models needs both to know which code examples are correct.",
   "$howToRegenerate": "Generated from the conformance record in neondatabase/neon-console-code-examples: run `bun run probe:conformance` there, then copy its conformance.json into the shape below. One probe feeds both repos so the console and /models cannot disagree. Fields per model: id, owner, entitled, chat (conforms | array-content | not-served | not-entitled), deviations[], nativeDialect (anthropic | openai-responses | gemini | none), responses, webSearch, imageGeneration. Conformance MUST be measured with a prompt that makes the model reason as well as a trivial one, taking the worse shape: claude-opus-5, claude-sonnet-5 and claude-fable-5 return a compliant string for a trivial prompt and an array of {reasoning, text} parts once they think, and an easy-prompt-only probe is what published all three as `conforms`. CI checks completeness, not freshness - see the models-rest validator in scripts/verify-agent-endpoints.mjs.",
-  "probedAt": "2026-08-07T13:40:27.012Z",
+  "probedAt": "2026-08-27T22:10:03.308Z",
   "models": [
     {
       "id": "claude-fable-5",
@@ -138,7 +138,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 356, but prompt + completion is 212",
+        "`usage.total_tokens` is 357, but prompt + completion is 214",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -154,7 +154,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 585, but prompt + completion is 240",
+        "`usage.total_tokens` is 563, but prompt + completion is 265",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -170,7 +170,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 469, but prompt + completion is 217",
+        "`usage.total_tokens` is 533, but prompt + completion is 214",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -186,7 +186,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 572, but prompt + completion is 218",
+        "`usage.total_tokens` is 572, but prompt + completion is 226",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -202,7 +202,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 387, but prompt + completion is 195",
+        "`usage.total_tokens` is 532, but prompt + completion is 190",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -218,7 +218,7 @@
       "deviations": [
         "`id` is null; the spec requires a string",
         "`content` is an array[1] of {text} with keys {text, thoughtSignature, type}; the spec requires a string",
-        "`usage.total_tokens` is 619, but prompt + completion is 225",
+        "`usage.total_tokens` is 499, but prompt + completion is 203",
         "`usage.reasoning_tokens` is top-level; the spec nests it under `completion_tokens_details`"
       ],
       "nativeDialect": "gemini",
@@ -406,10 +406,8 @@
       "id": "gpt-oss-120b",
       "owner": "databricks",
       "entitled": true,
-      "chat": "array-content",
-      "deviations": [
-        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
-      ],
+      "chat": "conforms",
+      "deviations": [],
       "nativeDialect": "none",
       "responses": false,
       "webSearch": false,
@@ -419,10 +417,8 @@
       "id": "gpt-oss-20b",
       "owner": "databricks",
       "entitled": true,
-      "chat": "array-content",
-      "deviations": [
-        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
-      ],
+      "chat": "conforms",
+      "deviations": [],
       "nativeDialect": "none",
       "responses": false,
       "webSearch": false,
@@ -498,10 +494,8 @@
       "id": "qwen35-122b-a10b",
       "owner": "alibaba",
       "entitled": true,
-      "chat": "array-content",
-      "deviations": [
-        "`content` is an array[2] of {reasoning, text} with keys {summary, text, type}; the spec requires a string"
-      ],
+      "chat": "conforms",
+      "deviations": [],
       "nativeDialect": "none",
       "responses": false,
       "webSearch": false,

--- a/src/app/models/route.test.js
+++ b/src/app/models/route.test.js
@@ -134,13 +134,34 @@ describe('GET /models', () => {
       expect(curl.variantReason).toBeTruthy();
     });
 
-    it('keeps cURL on chat completions for an array-content model with no native dialect', async () => {
-      const res = await GET(request('?model=gpt-oss-20b'));
-      const { model } = await body(res);
-      const curl = model.examples.find((e) => e.id === 'curl');
+    it.each(['gpt-oss-20b', 'gpt-oss-120b', 'qwen35-122b-a10b'])(
+      'serves OpenAI SDK examples for conforming %s',
+      async (id) => {
+        const res = await GET(request(`?model=${id}`));
+        const { model } = await body(res);
+        const ids = model.examples.map((e) => e.id);
+        const mastra = model.examples.find((e) => e.id === 'mastra');
+        const curl = model.examples.find((e) => e.id === 'curl');
 
-      expect(model.capabilities.native_dialect).toBe('none');
-      expect(curl.endpoint).toBe('/v1/chat/completions');
+        expect(model.capabilities.chat).toBe('conforms');
+        expect(model.capabilities.native_dialect).toBe('none');
+        expect(ids).toEqual(
+          expect.arrayContaining(['ai-sdk', 'mastra', 'typescript', 'python', 'curl'])
+        );
+        expect(mastra.files[0].content).toContain(`model: "neon/${id}"`);
+        expect(mastra.files[0].content).not.toContain('neon(');
+        expect(curl.endpoint).toBe('/v1/chat/completions');
+      }
+    );
+
+    it('has no array-content model without a native dialect to fall back to', async () => {
+      const res = await GET(request());
+      const { models } = await body(res);
+      const stranded = models.filter(
+        (m) => m.capabilities.chat === 'array-content' && m.capabilities.native_dialect === 'none'
+      );
+
+      expect(stranded.map((m) => m.id)).toEqual([]);
     });
 
     it('points cURL at Anthropic Messages for a Claude model that returns array content', async () => {

--- a/src/components/pages/doc/ai-gateway-model-index/model-examples.test.js
+++ b/src/components/pages/doc/ai-gateway-model-index/model-examples.test.js
@@ -21,6 +21,17 @@ describe('AI Gateway model examples', () => {
     expect(languages.find(({ key }) => key === 'ts')?.code).toContain('client.responses.create');
   });
 
+  it.each(['gpt-oss-20b', 'gpt-oss-120b', 'qwen35-122b-a10b'])(
+    'renders OpenAI SDK examples for conforming %s',
+    (id) => {
+      const languages = getLanguagesForMode(getExamplesByMode(id), 'text');
+
+      expect(languages.map(({ key }) => key)).toEqual(['aisdk', 'mastra', 'ts', 'python', 'curl']);
+      expect(languages.find(({ key }) => key === 'mastra')?.code).toContain(`model: "neon/${id}"`);
+      expect(languages.find(({ key }) => key === 'curl')?.code).toContain('/v1/chat/completions');
+    }
+  );
+
   it('uses model-specific Gemini examples and install commands', () => {
     const languages = getLanguagesForMode(getExamplesByMode('gemini-3-5-flash'), 'text');
 


### PR DESCRIPTION
## Problem

The latest chat-completions measurement records `gpt-oss-20b`, `gpt-oss-120b`, and `qwen35-122b-a10b` as conforming: `message.content` is a string and `deviations` is empty.

The site still classified all three as `array-content`. `/models` and neon.com/models therefore omitted their TypeScript and Python OpenAI SDK examples. The docs warning also listed two of these models as returning array content.

## Diagnosis

The example selector excludes OpenAI SDK snippets when `capabilities.chat` is `array-content`, because those SDKs type `message.content` as a string. The stale capability records activated that branch for these three models.

The refreshed measurement still records array content for Gemini 3.x and Claude 5. Those are now the model groups named in the warning.

## Solution

- Mark `gpt-oss-20b`, `gpt-oss-120b`, and `qwen35-122b-a10b` as `conforms` with no deviations.
- Verify that `/models` and the model page expose AI SDK, Mastra, TypeScript, Python, and cURL examples for each model.
- Verify that every remaining array-content model has a provider-native fallback.
- Retarget the docs warning at Gemini 3.x and Claude 5.
- Refresh the recorded Gemini token-accounting deviations from the same measurement.

The `/models` response structure and existing example templates remain unchanged. These models now select the conforming example set.

## User-facing API/UI

`GET /models?model=gpt-oss-20b` now includes these relevant fields:

```json
{
  "use_case": "chat",
  "model": {
    "id": "gpt-oss-20b",
    "capabilities": {
      "entitled": true,
      "chat": "conforms",
      "deviations": [],
      "native_dialect": "none",
      "responses": false,
      "web_search": false,
      "image_generation": false
    },
    "examples": [
      { "id": "ai-sdk", "endpoint": "/v1/chat/completions (via provider)" },
      { "id": "mastra", "endpoint": "/v1/chat/completions" },
      { "id": "typescript", "endpoint": "/v1/chat/completions" },
      { "id": "python", "endpoint": "/v1/chat/completions" },
      { "id": "curl", "endpoint": "/v1/chat/completions" }
    ]
  }
}
```

The same example set applies to `gpt-oss-120b` and `qwen35-122b-a10b`. Their model pages now offer AI SDK, Mastra, TypeScript, Python, and cURL in the language dropdown.

The docs warning ships as:

````mdx
<Admonition type="warning" title="Content shape varies by model">
For most models, `message.content` in a chat completions response is a plain string. For some models, confirmed on Gemini 3.x (`gemini-3-5-flash`, `gemini-3-1-pro`) and Claude 5 (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`), it's an array of typed content blocks instead (`{ type: 'reasoning', ... }`, `{ type: 'text', text: ... }`). A low `max_tokens` value can also cut a response off before the `text` block appears, leaving only a `reasoning` block. Handle both shapes:

```typescript
const { content } = response.choices[0].message;
const text = typeof content === 'string'
  ? content
  : content.find((block) => block.type === 'text')?.text ?? '';
```

</Admonition>
````

## Usage examples

```typescript
import OpenAI from "openai";

const client = new OpenAI({
  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/v1`,
});

const resp = await client.chat.completions.create({
  model: "gpt-oss-20b",
  messages: [{ role: "user", content: "Explain Serverless Postgres." }],
});
console.log(resp.choices[0].message.content);
```

```python
import os
from openai import OpenAI

client = OpenAI(
    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/v1",
)

resp = client.chat.completions.create(
    model="gpt-oss-20b",
    messages=[{"role": "user", "content": "Explain Serverless Postgres."}],
)
print(resp.choices[0].message.content)
```

Replace the model ID with `gpt-oss-120b` or `qwen35-122b-a10b` for the other two models.

## Verification

- Vitest against `route.test.js`, `model-examples.test.js`, `generate-ai-gateway-model-markdown.test.js`, and `model-rows.test.js`: 42 passed.
- `npm run check:models-endpoint-sync`: 42 models in sync.
- Pre-push hook: full unit suite passed (787 tests).

## Gaps

Live gateway output and the deployed model pages were not rechecked from this website worktree. The update relies on the committed conformance measurement and automated route/UI coverage. Gemini 3.x and Claude 5 still return array `content` on `/v1/chat/completions`; their OpenAI SDK examples stay hidden from the language dropdown.
