### PR TITLE
docs: rework neon init for the 4.11.0 orchestrator behavior

### DIFF
--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -10,7 +10,7 @@ summary: >-
   with `neon skills`, `npx skills add neondatabase/agent-skills -y`, `neon init`,
   or editor plugins at project level or globally.
 enableTableOfContents: true
-updatedOn: '2026-08-25T21:56:50.915Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 redirectFrom:
   - /docs/ai/ai-rules
   - /docs/ai/ai-rules-neon-toolkit
@@ -125,19 +125,27 @@ Pi reads the `skills/` directory directly, so there's no separate sync step. Thi
 
 ### neon init
 
-The `neon init` command sets up your project to use Neon with your AI coding assistant. It authenticates via OAuth, creates an API key, configures the MCP server, installs the Neon extension for Cursor and VS Code where applicable, and installs agent skills at the project level:
+The `neon init` command sets up the current directory to use Neon with your AI coding assistant. Run it in a terminal: it installs agent tooling (either a plugin, or skills and the MCP server), links a Neon project, and writes a `neon.ts` config. In an empty directory, it scaffolds a starter template first.
 
 ```bash
 npx neon@latest init
 ```
 
-If you're using the **Neon backend beta** (Functions, Storage, AI Gateway), use `neon init --preview` instead. See the [Neon backend beta guide](/docs/get-started/backend-beta) for access and setup.
+See the [`neon init` reference](/docs/cli/init) for the full flow, including how to set things up non-interactively for agents and CI.
 
-After running `init`, restart your editor and ask your AI assistant to "Get started with Neon" to launch the interactive onboarding guide. See the [`neon init` reference](/docs/cli/init) for details.
+After running `init`, restart your editor and ask your AI assistant to "Get started with Neon." The installed [Neon MCP server](/docs/ai/neon-mcp-server) points your assistant to the right docs, so it can walk you through creating or connecting a project and configuring your connection.
 
 ## Available skills
 
 Skills are grouped by area. Each skill is a `SKILL.md` entry point that your agent reads and invokes when relevant. Browse and install individual skills on [skills.sh](https://skills.sh/neondatabase/agent-skills).
+
+Install any of them by name with [`neon skills`](/docs/cli/skills) (`-s` is repeatable):
+
+```bash
+neon skills -s neon -s neon-postgres
+```
+
+Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s neon-postgres` instead.
 
 ### Core
 

--- a/content/docs/ai/ai-codex-plugin.md
+++ b/content/docs/ai/ai-codex-plugin.md
@@ -13,7 +13,7 @@ summary: >-
 description: >-
   Install the Neon plugin in OpenAI Codex for MCP-backed database
   management plus skills for Neon workflows and egress cost optimization.
-updatedOn: '2026-08-25T21:56:50.915Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 The **Neon** Codex plugin helps you manage Neon projects and databases. It adds Neon-specific [Agent Skills](https://developers.openai.com/codex/skills/) and Neon API access to [OpenAI Codex](https://developers.openai.com/codex/), including the **Neon MCP Server** for project and database management and skills that cover connection methods, branching, autoscaling, [Managed Better Auth](/docs/auth/overview), and more.
@@ -112,7 +112,7 @@ To configure Neon MCP and agent skills across supported tools from the command l
 npx neon@latest init
 ```
 
-That flow can set up OAuth, API keys, MCP configuration, and project-level skills where applicable. See the [`neon init` reference](/docs/cli/init) for details. To install just the Neon MCP server for Codex, run [`npx neon@latest mcp --agent codex`](/docs/cli/mcp). To install the plugin (skills plus MCP) for Codex, run [`npx neon@latest plugins --agent codex`](/docs/cli/plugins).
+That flow installs agent tooling (either a plugin, or skills and the MCP server) and links a Neon project. See the [`neon init` reference](/docs/cli/init) for details. To install just the Neon MCP server for Codex, run [`npx neon@latest mcp --agent codex`](/docs/cli/mcp). To install the plugin (skills plus MCP) for Codex, run [`npx neon@latest plugins --agent codex`](/docs/cli/plugins).
 
 ## Use skills outside the Codex plugin
 

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -10,7 +10,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-25T02:37:06.867Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -27,11 +27,7 @@ The fastest way to get started:
 npx neon@latest init
 ```
 
-**`neon init`** (see [`neon init` reference](/docs/cli/init)) creates a Neon API key and configures the MCP server with **API key** auth so you can skip OAuth when using the connection. It installs the VS Code/Cursor extension where applicable, wires **Claude Code** and **many other assistants** the wizard supports, and installs Neon's [agent skills](https://github.com/neondatabase/agent-skills). Then restart and ask your AI assistant **"Get started with Neon"**.
-
-<Admonition type="note">
-Each run of `npx neon@latest init` creates a new Neon API key. If you run it multiple times, review your [API keys](https://console.neon.tech/app/settings/api-keys) and revoke any you no longer need.
-</Admonition>
+**`neon init`** (see [`neon init` reference](/docs/cli/init)) sets up the current directory for Neon. Run it in a terminal: it installs agent tooling (either the Neon plugin, or [agent skills](https://github.com/neondatabase/agent-skills) and the MCP server), links a Neon project, and writes a `neon.ts` config. Then restart your editor and ask your AI assistant **"Get started with Neon"**.
 
 If you only want the MCP server and nothing else, run [`neon mcp`](/docs/cli/mcp):
 
@@ -120,7 +116,7 @@ Run the [init](/docs/cli/init) command:
 npx neon@latest init
 ```
 
-Authenticates via OAuth, creates an API key, configures the MCP Server in `~/.claude.json`, and installs [agent skills](https://github.com/neondatabase/agent-skills). Then ask your AI assistant **"Get started with Neon"**.
+Signs you in, installs agent tooling (either the Neon plugin, or agent skills and the MCP server), and links a Neon project. Then ask your AI assistant **"Get started with Neon"**.
 
 </TabItem>
 
@@ -262,7 +258,7 @@ Run the [init](/docs/cli/init) command:
 npx neon@latest init
 ```
 
-Authenticates via OAuth, creates an API key, installs the [Neon extension](/docs/local/vscode-extension) (which includes the MCP Server), and installs [agent skills](https://github.com/neondatabase/agent-skills). Then ask your AI assistant **"Get started with Neon"**.
+Signs you in, installs agent tooling (either the Neon plugin, or agent skills and the MCP server), and links a Neon project. Then ask your AI assistant **"Get started with Neon"**.
 
 </TabItem>
 <TabItem>
@@ -437,7 +433,7 @@ Run the [init](/docs/cli/init) command:
 npx neon@latest init
 ```
 
-Authenticates via OAuth, creates an API key, installs the [Neon extension](/docs/local/vscode-extension) (which includes the MCP Server), and installs [agent skills](https://github.com/neondatabase/agent-skills). Then ask your AI assistant **"Get started with Neon"**.
+Signs you in, installs agent tooling (either the Neon plugin, or agent skills and the MCP server), and links a Neon project. Then ask your AI assistant **"Get started with Neon"**.
 
 </TabItem>
 

--- a/content/docs/ai/neon-mcp-server.md
+++ b/content/docs/ai/neon-mcp-server.md
@@ -6,7 +6,7 @@ summary: >-
   assistants interact with your Neon projects on your behalf. Set up with
   `npx neon@latest mcp` or use the config generator. Supports OAuth and API key auth.
 enableTableOfContents: true
-updatedOn: '2026-08-25T02:37:06.867Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 The Neon MCP Server implements the Model Context Protocol (MCP), letting AI assistants interact with your Neon projects on your behalf. Your AI agent can interact with Neon via MCP tools or by running [Neon CLI](/docs/cli) commands directly.
@@ -25,7 +25,13 @@ npx neon@latest mcp
 
 It prompts for where to write the config, which agents to install into, and how to authenticate, then writes it for you.
 
-To set up the MCP server together with agent skills and editor tooling, run [`neon init`](/docs/cli/init):
+For agents that support plugins (such as Cursor, Claude Code, and Codex), [`neon plugins`](/docs/cli/plugins) installs the Neon plugin, which bundles the MCP server and agent skills:
+
+```bash
+npx neon@latest plugins
+```
+
+To set up the MCP server together with agent skills and a linked Neon project, run [`neon init`](/docs/cli/init) in a terminal:
 
 ```bash
 npx neon@latest init

--- a/content/docs/cli/bootstrap.md
+++ b/content/docs/cli/bootstrap.md
@@ -23,7 +23,12 @@ The directory argument is optional. Use `.` to scaffold into the current directo
 
 Run with `--list-templates` to see the available templates (add `--output json` for a machine-readable catalog), and pass one with `--template` to skip the interactive picker.
 
-The post-scaffold steps (`--install`, `--git`, `--agent-setup`, `--link`) all default to on. In interactive mode, bootstrap asks about each one; use the negated form (`--no-install`, `--no-git`, `--no-agent-setup`, `--no-link`) to skip a step without being asked. Agent setup installs either the Neon plugin, or agent skills and the MCP server, into your coding agents. With `--link`, bootstrap runs [`neon link`](/docs/cli/link) in the scaffolded directory.
+The post-scaffold steps all default to on. In interactive mode, bootstrap asks about each one; pass the negated flag to skip it without being asked:
+
+- `--install` / `--no-install`: install dependencies.
+- `--git` / `--no-git`: initialize a git repository.
+- `--agent-setup` / `--no-agent-setup`: install agent tooling, either the Neon plugin, or agent skills and the MCP server. Pass `--agent` (alias `-a`, repeatable) to name the agents and skip the picker, for example `neon bootstrap my-app --agent cursor`.
+- `--link` / `--no-link`: run [`neon link`](/docs/cli/link) in the scaffolded directory.
 
 Use `--default` (alias `-y`) for a quick start: it scaffolds the default template (or the one you pass with `--template`), then runs dependency install, git init, agent tooling, and `neon link --yes` without prompting. `link --yes` still asks which project to use unless the directory is already linked.
 

--- a/content/docs/cli/bootstrap.md
+++ b/content/docs/cli/bootstrap.md
@@ -5,11 +5,11 @@ summary: >-
   Covers the usage of the `bootstrap` command in the Neon CLI to scaffold a
   new application from a Neon starter template, including the interactive
   template picker, the `--default` quick start, and post-scaffold setup steps
-  (dependency install, git init, project linking).
+  (dependency install, git init, agent tooling, and project linking).
 enableTableOfContents: true
 ---
 
-The `bootstrap` command scaffolds a new application from a Neon starter template. By default it runs interactively: it prompts you to pick a template, scaffolds it into the target directory, then offers the usual setup steps (install dependencies, initialize git, link the directory to a Neon project). Requires neon 2.25.0 or later; check your version with `neon --version`.
+The `bootstrap` command scaffolds a new application from a Neon starter template. By default it runs interactively: it prompts you to pick a template, scaffolds it into the target directory, then offers the usual setup steps (install dependencies, initialize git, install agent tooling, and link the directory to a Neon project). Requires neon 2.25.0 or later; check your version with `neon --version`.
 
 ## Usage
 
@@ -23,9 +23,9 @@ The directory argument is optional. Use `.` to scaffold into the current directo
 
 Run with `--list-templates` to see the available templates (add `--output json` for a machine-readable catalog), and pass one with `--template` to skip the interactive picker.
 
-The post-scaffold steps (`--install`, `--git`, `--link`) all default to on. In interactive mode, bootstrap asks about each one; use the negated form (`--no-install`, `--no-git`, `--no-link`) to skip a step without being asked. With `--link`, bootstrap runs [`neon link`](/docs/cli/link) in the scaffolded directory after installing.
+The post-scaffold steps (`--install`, `--git`, `--agent-setup`, `--link`) all default to on. In interactive mode, bootstrap asks about each one; use the negated form (`--no-install`, `--no-git`, `--no-agent-setup`, `--no-link`) to skip a step without being asked. Agent setup installs either the Neon plugin, or agent skills and the MCP server, into your coding agents. With `--link`, bootstrap runs [`neon link`](/docs/cli/link) in the scaffolded directory.
 
-Use `--default` (alias `-y`) for a quick start: it scaffolds the default template (or the one you pass with `--template`) and runs dependency install and git init without prompting. Linking is left to you, since it needs a project choice.
+Use `--default` (alias `-y`) for a quick start: it scaffolds the default template (or the one you pass with `--template`), then runs dependency install, git init, agent tooling, and `neon link --yes` without prompting. `link --yes` still asks which project to use unless the directory is already linked.
 
 ## Examples
 

--- a/content/docs/cli/branches.md
+++ b/content/docs/cli/branches.md
@@ -10,7 +10,7 @@ summary: >-
   any two branches or historical states, expiration timestamps, or adding
   read replica computes.
 enableTableOfContents: true
-updatedOn: '2026-07-22T13:42:19.210Z'
+updatedOn: '2026-08-27T23:52:24.570Z'
 redirectFrom:
   - /docs/reference/cli-branches
   - /docs/cli/branch
@@ -140,6 +140,14 @@ connection_uris
 <Admonition type="note">
 If the parent branch has more than one role or database, the `branches create` command does not output a connection URI. As an alternative, you can use the `connection-string` command to retrieve the connection URI for a branch. This command includes options for specifying the role and database. See [the connection-string command](/docs/cli/connection-string).
 </Admonition>
+
+Omit the connection string from the output, keeping it out of terminal scrollback and CI logs:
+
+```bash
+neon branches create --no-secrets
+```
+
+Needs Neon CLI 4.9.0+; older versions ignore `--no-secrets` and still print the connection string.
 
 Create a branch with `--output json`, which returns the full branch response data:
 

--- a/content/docs/cli/claim.md
+++ b/content/docs/cli/claim.md
@@ -13,7 +13,7 @@ The `claim` command creates a temporary Neon project when there is no Neon accou
 
 If `neon claim` is not a command, or `neon claim --help` does not list `create`, install the latest CLI (`npm i -g neon@latest`) or use the HTTP flow in [Claimable Neon](/docs/reference/claimable-neon).
 
-Do not pass `--api-key` or `--profile`. Those are refused. `neon auth` and `neon init --agent` need a human Neon account; use this command instead when there is none.
+Do not pass `--api-key` or `--profile`. Those are refused. `neon auth` and `neon init` need a Neon account; use this command instead when there is none.
 
 Start in the browser at [neon.com/claimable-neon](/claimable-neon), or give an agent [`auth.md`](https://neon.com/auth.md).
 

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -1,133 +1,118 @@
 ---
 title: 'Neon CLI command: init'
-subtitle: Install the Neon CLI and set up a project with auth, agent skills, and
-  optionally the MCP server and editor extension
+subtitle: Set up the current directory for Neon with agent tooling, a linked project,
+  and a neon.ts config
 summary: >-
-  The `neon init` command sets up a project to use Neon with an AI coding
-  assistant: it installs or updates the Neon CLI, runs OAuth, creates an API
-  key, installs agent skills, and can configure the Neon MCP server. Works with
-  Cursor, VS Code, Claude Code, and any add-mcp client. The `--agent` flag runs
-  it in agent/JSON mode.
+  The `neon init` command sets up the current directory to use Neon with your AI
+  coding assistant. In an empty directory it scaffolds a starter template first,
+  then installs agent tooling (either a plugin, or skills and the MCP server), links a
+  Neon project, and writes a neon.ts config. It runs interactively; for agents and
+  CI, run the underlying commands directly.
 enableTableOfContents: true
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
 
-The `init` command sets up your app project to use Neon with your AI coding assistant. It installs or updates the Neon CLI, authenticates via OAuth, creates a Neon API key, can configure the Neon MCP server for your editor (installing the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect) for Cursor and VS Code), and installs [Neon agent skills](https://github.com/neondatabase/agent-skills). Run it once from your project root.
+The `init` command sets up the current directory to use Neon with your AI coding assistant. It's a thin wrapper that runs Neon's other setup commands for you: it installs agent tooling (either the [Neon plugin](/docs/cli/plugins), or [agent skills](/docs/cli/skills) and the [Neon MCP server](/docs/cli/mcp)), [links a Neon project](/docs/cli/link), and writes a [`neon.ts` config](/docs/cli/config). In an empty directory, it [scaffolds a starter template](/docs/cli/bootstrap) first.
+
+`init` is interactive, so run it from a terminal. It asks how coding agents should get Neon, and prompts you to pick a project to link. If you don't have the CLI installed, run it with `npx`:
+
+```bash
+npx neon@latest init
+```
+
+For agents, CI, or scripts that can't answer prompts, see [Run it non-interactively](#run-it-non-interactively).
 
 ## Usage
 
 <CliUsage command="init" />
 
-You can also run `init` without installing the CLI:
+## What it does
 
-```bash
-npx neon@latest init
-```
+What `init` runs depends on whether the directory is empty:
 
-After running the command, restart your editor and ask your AI assistant to "Get started with Neon" to launch an interactive onboarding guide. The installed agent skills help you get started, including configuring a database connection. For Cursor and VS Code, the Neon Local Connect extension also provides database schema browsing, SQL editing, and table data management directly in your IDE.
+| Directory                  | What `init` does                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| Empty (nothing but `.git`) | Runs [`neon bootstrap`](/docs/cli/bootstrap): scaffolds a template, then agent tooling and linking |
+| Already has files          | Installs agent tooling, links a project, then runs [`neon config init`](/docs/cli/config)          |
 
-Under the hood, `init` runs `npx skills add neondatabase/agent-skills --skill neon --skill neon-postgres --agent <name>` for each selected editor. To install skills on their own, without the rest of the init flow, use [`neon skills`](/docs/cli/skills) (add `--global` for a user-level install). See [neon-postgres on skills.sh](https://skills.sh/neondatabase/agent-skills/neon-postgres) for more about the skills.
+A directory counts as empty only when it contains nothing but a `.git` folder. Any other entry, including a `README`, a `.env` file, or a `.gitignore`, makes it an existing app. So a directory you just ran `git init` in that already has a `.gitignore` takes the existing-app path.
 
-<Admonition type="warning">
-Skills are installed at the project level in the current working directory. Run `init` from your project root, otherwise skills will end up in the wrong location. You may want to commit project-level files so teammates get the same skills, or add them to `.gitignore` for per-developer setup.
-</Admonition>
+### Choose how coding agents get Neon
+
+In a directory that already has files, `init` asks how your coding agents should get Neon:
+
+- **Plugin (recommended)** installs the `neon-postgres` plugin, which bundles agent skills and the MCP server.
+- **Skills and MCP separately** installs [agent skills](/docs/cli/skills), then the [Neon MCP server](/docs/cli/mcp).
+- **Skip agent setup** continues without a plugin, skills, or MCP.
+
+The plugin and the skills-plus-MCP option are mutually exclusive. Installing skills needs Node.js 22.20 or newer.
+
+### Link a project and write neon.ts
+
+After agent setup, `init` runs [`neon link`](/docs/cli/link) (unless the directory is already linked). Linking writes a `.neon` file with your org, project, and branch, and pulls the branch's environment variables (including `DATABASE_URL`) into `.env` if one exists, otherwise `.env.local`. It then runs [`neon config init`](/docs/cli/config), which creates a `neon.ts` config you can edit and apply with `neon config apply`.
 
 ## Options
 
 <CliOptions command="init" />
 
-Use `--agent` (alias `-a`) to run `init` in agent/JSON mode, designed for when an AI coding assistant runs the command for you; the agent type is auto-detected. Without `--agent`, `init` runs an interactive wizard that detects installed tools and lets you choose which to configure; if nothing is detected, you go straight to that list.
+Pass `-y` (alias `--yes`) to run each step with its defaults instead of prompting: in an empty directory it scaffolds the default template; otherwise it installs the plugin when a project-level Cursor, Claude Code, or Codex setup is detected (else skills and MCP), then links and writes `neon.ts`. Even with `-y`, first-time sign-in still opens a browser, and `link` still asks which project to use unless the directory is already linked.
 
-## Coding assistant support
+The old `--agent`, `--data`, `--preview`, and `--skip-migrations` flags were removed. `neon init --agent` and `neon init --data` now return an error pointing you to `neon init` or `neon init -y`.
 
-`init` is backed by the `neon-init` package bundled with `neon`. Besides Cursor, VS Code, and Claude Code, the interactive flow can configure any client that [add-mcp supports](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp). To register only the Neon MCP server in a client config (no `init`, no agent skills, no extension install), run [`neon mcp`](/docs/cli/mcp), or `npx add-mcp https://mcp.neon.tech/mcp` for the lower-level tool directly. See [Connect MCP clients to Neon](/docs/ai/connect-mcp-clients-to-neon).
+## Run it non-interactively
+
+`init` needs an interactive terminal. It can't finish in a non-interactive shell (such as CI, a script, or many in-editor agent shells) because it prompts for agent setup and for a project to link, and it has no flag to supply those. To set up Neon without prompts, run the underlying commands directly, each of which takes explicit flags:
+
+```bash
+# Install agent tooling for a specific editor
+neon skills --agent cursor -s neon -s neon-postgres
+# or install the plugin instead:
+neon plugins --agent cursor
+
+# Link a specific project (no prompt)
+neon link --project-id <project-id> --org-id <org-id>
+
+# Scaffold neon.ts
+neon config init --services none
+```
+
+Authenticate without a browser by setting `NEON_API_KEY` or passing `--api-key`. See [`neon skills`](/docs/cli/skills), [`neon plugins`](/docs/cli/plugins), [`neon link`](/docs/cli/link), and [`neon config`](/docs/cli/config) for the full options.
 
 ## What gets created
 
-| Artifact                                                                                                          | Location                                         | Scope   |
-| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------- |
-| Neon API key                                                                                                      | Neon account (named `neonctl-init-{timestamp}`)  | Account |
-| OAuth credentials (created on first auth)                                                                         | `~/.config/neonctl/credentials.json`             | Global  |
-| MCP config (Cursor)                                                                                               | `~/.cursor/mcp.json` (written by extension)      | Global  |
-| MCP config (VS Code)                                                                                              | VS Code global `mcp.json` (written by extension) | Global  |
-| MCP config (Claude Code)                                                                                          | `~/.claude.json` (written by init)               | Global  |
-| [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect) | Cursor / VS Code                                 | Global  |
-| Agent skills (Cursor, VS Code)                                                                                    | `.agents/skills/`                                | Project |
-| Agent skills (Claude Code)                                                                                        | `.claude/skills/`                                | Project |
-| `skills-lock.json`                                                                                                | Project root                                     | Project |
+The files created depend on the path you take. Each one is written by the command `init` runs, so see that command's page for details.
 
-## Credentials and API keys
-
-If you previously authenticated with `neon auth`, `init` reuses those credentials (from `~/.config/neonctl/credentials.json`). Otherwise, it opens the browser for OAuth.
-
-`init` creates a new API key each time it runs (named `neonctl-init-{timestamp}`). If you run it more than once, you can revoke old keys in the [Neon Console API Keys settings](https://console.neon.tech/app/settings/api-keys).
-
-For Claude Code, if a Neon MCP entry already exists in `~/.claude.json`, `init` prompts before overwriting it.
+| Artifact                                              | Written by                                                                                            | Scope                        |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `.neon` (org, project, and branch context)            | [`neon link`](/docs/cli/link)                                                                         | Project                      |
+| `.env` or `.env.local` (`DATABASE_URL` and Neon vars) | [`neon link`](/docs/cli/link)                                                                         | Project                      |
+| `neon.ts` (config-as-code policy)                     | [`neon config init`](/docs/cli/config)                                                                | Project                      |
+| Agent skills, MCP config, or plugin                   | [`neon skills`](/docs/cli/skills) / [`neon mcp`](/docs/cli/mcp) / [`neon plugins`](/docs/cli/plugins) | Project or global, per agent |
+| Scaffolded template files (empty dir only)            | [`neon bootstrap`](/docs/cli/bootstrap)                                                               | Project                      |
 
 ## Examples
 
-Navigate to the root directory of your application and run the `init` command:
+Run `init` from your project root:
 
 ```bash
-cd /path/to/your/app
 npx neon@latest init
 ```
 
-<details>
-<summary>Show output</summary>
+Choose your agent setup, then pick a project to link. Linking writes the context and pulls your environment variables:
 
-```text filename="Output"
-┌  Adding Neon MCP server, extension (for VS Code and Cursor) and agent skills
-│
-◆  Which editor(s) would you like to configure? (Space to toggle each option, Enter to confirm your selection)
-│  ◼ Cursor
-│  ◼ VS Code
-│  ◻ Claude CLI
-│
-◒  Authenticating...
-┌────────┬──────────────────┬────────┬────────────────┐
-│ Login  │ Email            │ Name   │ Projects Limit │
-├────────┼──────────────────┼────────┼────────────────┤
-│ alex   │ alex@domain.com  │ Alex   │ 100            │
-└────────┴──────────────────┴────────┴────────────────┘
-◇  Authentication successful ✓
-│
-◇  Installing agent skills for Neon...
-│
-◇  Agent skills installed ✓
-│
-◇  Neon Local Connect extension installed for Cursor / VS Code.
-│
-├  What's next? ───────────────────────────────────────────────────────────────────────────────────╮
-│                                                                                                  │
-│  Restart Cursor / VS Code, open the Neon extension and type                                      │
-│  in "Get started with Neon" in your agent chat                                                   │
-│                                                                                                  │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-│
-└  Have feedback? Email us at feedback@neon.tech
+```text
+Linked /path/to/your/app/.neon:
+  orgId:     org-example-12345678
+  projectId: polished-snowflake-12345678
+  branch:    main
+
+Pulled 3 Neon variables into /path/to/your/app/.env.local: NEON_BRANCH, DATABASE_URL, DATABASE_URL_UNPOOLED
 ```
 
-</details>
+After setup, restart your editor and ask your assistant to "Get started with Neon." The installed [Neon MCP server](/docs/ai/neon-mcp-server) points your assistant to the right docs, so it can connect to your database and use Neon features as you build.
 
 ## Manual setup
 
-If you prefer to configure manually or need to set up for other IDEs, [create a Neon API key](https://console.neon.tech/app/settings?modal=create_api_key) in the Neon Console. Example configuration for Claude Code (`~/.claude.json`):
-
-```json
-{
-  "mcpServers": {
-    "Neon": {
-      "type": "http",
-      "url": "https://mcp.neon.tech/mcp",
-      "headers": {
-        "Authorization": "Bearer <NEON_API_KEY>"
-      }
-    }
-  }
-}
-```
-
-For detailed manual setup instructions for all editors, see [Connect MCP clients](/docs/ai/connect-mcp-clients-to-neon).
+To configure an editor without running `init`, or to register only the Neon MCP server, see [Connect MCP clients to Neon](/docs/ai/connect-mcp-clients-to-neon). To install only agent skills, use [`neon skills`](/docs/cli/skills); to install only the MCP server, use [`neon mcp`](/docs/cli/mcp).

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -6,10 +6,10 @@ summary: >-
   The `neon init` command sets up the current directory to use Neon with your AI
   coding assistant. In an empty directory it scaffolds a starter template first,
   then installs agent tooling (either a plugin, or skills and the MCP server), links a
-  Neon project, and writes a neon.ts config. It runs interactively; for agents and
-  CI, run the underlying commands directly.
+  Neon project, and writes a neon.ts config. It runs interactively by default;
+  pass -y and --agent for an unattended agent setup.
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-08-28T15:55:20.032Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -49,6 +49,8 @@ In a directory that already has files, `init` asks how your coding agents should
 
 The plugin and the skills-plus-MCP option are mutually exclusive. Installing skills needs Node.js 22.20 or newer.
 
+`init` sets up agent tooling at the project level. It has no global option; for a user-level install, run [`neon skills --global`](/docs/cli/skills) or [`neon plugins --global`](/docs/cli/plugins) directly.
+
 ### Link a project and write neon.ts
 
 After agent setup, `init` runs [`neon link`](/docs/cli/link) (unless the directory is already linked). Linking writes a `.neon` file with your org, project, and branch, and pulls the branch's environment variables (including `DATABASE_URL`) into `.env` if one exists, otherwise `.env.local`. It then runs [`neon config init`](/docs/cli/config), which creates a `neon.ts` config you can edit and apply with `neon config apply`.
@@ -57,13 +59,19 @@ After agent setup, `init` runs [`neon link`](/docs/cli/link) (unless the directo
 
 <CliOptions command="init" />
 
-Pass `-y` (alias `--yes`) to run each step with its defaults instead of prompting: in an empty directory it scaffolds the default template; otherwise it installs the plugin when a project-level Cursor, Claude Code, or Codex setup is detected (else skills and MCP), then links and writes `neon.ts`. Even with `-y`, first-time sign-in still opens a browser, and `link` still asks which project to use unless the directory is already linked.
+Pass `-y` (alias `--yes`) to run each step with its defaults instead of prompting. In an empty directory it scaffolds the default template. Otherwise it sets up agent tooling, then links and writes `neon.ts`. With `-y`, `init` detects the target agent from the project folders, else the host CLI agent you're running inside. It installs the plugin for a plugin-capable agent (Cursor, Claude Code, or Codex), or skills and MCP for any other agent. If it detects no agent, it exits and asks you to pass `--agent`. Even with `-y`, first-time sign-in still opens a browser, and `link` still asks which project to use unless the directory is already linked.
 
-The old `--agent`, `--data`, `--preview`, and `--skip-migrations` flags were removed. `neon init --agent` and `neon init --data` now return an error pointing you to `neon init` or `neon init -y`.
+Pass `--agent` (alias `-a`) to name the coding agents to set up, which skips both detection and the picker. It's repeatable (`neon init --agent cursor --agent claude-code`) and works with `-y`. `init` sets up one family per run, so it forwards the names to the plugin, or to skills and the MCP server, not both. Run `neon init --help` to see which agents each family supports. Passing `--agent` with no value returns an error.
 
 ## Run it non-interactively
 
-`init` needs an interactive terminal. It can't finish in a non-interactive shell (such as CI, a script, or many in-editor agent shells) because it prompts for agent setup and for a project to link, and it has no flag to supply those. To set up Neon without prompts, run the underlying commands directly, each of which takes explicit flags:
+Combine `-y` with `--agent` to do the agent setup without prompts, for example in CI or from an agent:
+
+```bash
+neon init -y --agent cursor
+```
+
+For the project, `init` links to the one the directory is already linked to. When the directory isn't linked yet, `neon link` picks the project interactively. To target a specific project without prompts, run the underlying commands directly and pass the project explicitly, each taking its own flags:
 
 ```bash
 # Install agent tooling for a specific editor
@@ -84,13 +92,13 @@ Authenticate without a browser by setting `NEON_API_KEY` or passing `--api-key`.
 
 The files created depend on the path you take. Each one is written by the command `init` runs, so see that command's page for details.
 
-| Artifact                                              | Written by                                                                                            | Scope                        |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `.neon` (org, project, and branch context)            | [`neon link`](/docs/cli/link)                                                                         | Project                      |
-| `.env` or `.env.local` (`DATABASE_URL` and Neon vars) | [`neon link`](/docs/cli/link)                                                                         | Project                      |
-| `neon.ts` (config-as-code policy)                     | [`neon config init`](/docs/cli/config)                                                                | Project                      |
-| Agent skills, MCP config, or plugin                   | [`neon skills`](/docs/cli/skills) / [`neon mcp`](/docs/cli/mcp) / [`neon plugins`](/docs/cli/plugins) | Project or global, per agent |
-| Scaffolded template files (empty dir only)            | [`neon bootstrap`](/docs/cli/bootstrap)                                                               | Project                      |
+| Artifact                                              | Written by                                                                                            | Scope              |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------ |
+| `.neon` (org, project, and branch context)            | [`neon link`](/docs/cli/link)                                                                         | Project            |
+| `.env` or `.env.local` (`DATABASE_URL` and Neon vars) | [`neon link`](/docs/cli/link)                                                                         | Project            |
+| `neon.ts` (config-as-code policy)                     | [`neon config init`](/docs/cli/config)                                                                | Project            |
+| Agent skills, MCP config, or plugin                   | [`neon skills`](/docs/cli/skills) / [`neon mcp`](/docs/cli/mcp) / [`neon plugins`](/docs/cli/plugins) | Project, per agent |
+| Scaffolded template files (empty dir only)            | [`neon bootstrap`](/docs/cli/bootstrap)                                                               | Project            |
 
 ## Examples
 

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -15,7 +15,7 @@ The `mcp` command installs the [Neon MCP Server](/docs/ai/neon-mcp-server) into 
 Run `neon mcp` with no flags for an interactive walkthrough: it asks whether to write global or project-level config, which detected agents to install into, and whether to authenticate with a minted API key or OAuth, then shows you what it will do before writing anything. Pass flags to skip the prompts and run it non-interactively, which is what you want in scripts or a headless environment.
 
 <Callout title="mcp vs init">
-[`neon init`](/docs/cli/init) is the broader onboarding command: it sets up the MCP Server along with agent skills and editor config. Use `neon mcp` when you only want to install the Neon MCP Server into your agents, or [`neon skills`](/docs/cli/skills) when you only want to install agent skills.
+For the full setup, use [`neon init`](/docs/cli/init). For just one piece: [`neon skills`](/docs/cli/skills) (skills), [`neon plugins`](/docs/cli/plugins) (skills and MCP), or `neon mcp` (MCP server).
 </Callout>
 
 ## Usage

--- a/content/docs/cli/plugins.md
+++ b/content/docs/cli/plugins.md
@@ -21,7 +21,7 @@ neon plugins
 With no flags it runs an interactive walkthrough: pick the agents, then confirm. Pass flags to skip the prompts and script it. Without a terminal, pass `-y` to install into detected agents, or name agents with `--agent`.
 
 <Callout title="plugins vs skills vs mcp">
-Use `neon plugins` for agents that support plugin marketplaces, where the plugin bundles skills and MCP access together. Use [`neon skills`](/docs/cli/skills) to install [agent skills](/docs/ai/agent-skills) on their own, and [`neon mcp`](/docs/cli/mcp) to set up just the [Neon MCP Server](/docs/ai/neon-mcp-server). [`neon init`](/docs/cli/init) is the broader onboarding command that sets these up together.
+Use [`neon plugins`](/docs/cli/plugins) for agents that support plugin marketplaces, where the plugin bundles skills and MCP in one. For the full setup, use [`neon init`](/docs/cli/init); for skills or the MCP server on their own, use [`neon skills`](/docs/cli/skills) or [`neon mcp`](/docs/cli/mcp).
 </Callout>
 
 `plugins` runs via `npx`, so it needs Node.js; without it the command stops with a message to install Node.js and retry.

--- a/content/docs/cli/projects.md
+++ b/content/docs/cli/projects.md
@@ -10,7 +10,7 @@ summary: >-
   its 7-day recovery window. Projects created via the CLI default to Postgres
   18; use `--pg-version` to select a different major version.
 enableTableOfContents: true
-updatedOn: '2026-07-24T11:09:31.723Z'
+updatedOn: '2026-08-27T23:52:24.570Z'
 redirectFrom:
   - /docs/reference/cli-projects
   - /docs/cli/project
@@ -123,6 +123,14 @@ Create a project with a specific Postgres major version:
 ```bash
 neon projects create --name mynewproject --pg-version 17
 ```
+
+Omit the connection string from the output, keeping it out of terminal scrollback and CI logs:
+
+```bash
+neon projects create --name mynewproject --no-secrets
+```
+
+Needs Neon CLI 4.9.0+; older versions ignore `--no-secrets` and still print the connection string.
 
 - Create a project with `--output json`, which returns the full project response data and is the recommended format for scripts and agents. The output below was captured on an earlier CLI version; new projects report `"pg_version": 18`.
 

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -8,7 +8,7 @@ summary: >-
   agents and skip the prompts. Use `neon skills update` to refresh installed
   skills to their latest versions.
 enableTableOfContents: true
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 The `skills` command installs [Neon agent skills](/docs/ai/agent-skills) into your coding agents, so tools like Cursor and Claude Code know how to work with Neon's Postgres, AI Gateway, Object Storage, and Functions.
@@ -22,7 +22,7 @@ neon skills
 With no flags it runs an interactive walkthrough: pick the agents, then the skills, then confirm. Pass flags to skip the prompts and script it. Without a terminal, pass `-y` or `--skill` to tell it which skills to install; `--agent` alone isn't enough.
 
 <Callout title="skills vs init">
-[`neon init`](/docs/cli/init) is the broader onboarding command: it sets up the Neon MCP Server along with agent skills and editor config. Use `neon skills` when you only want to install or update agent skills, and [`neon mcp`](/docs/cli/mcp) when you only want the [Neon MCP Server](/docs/ai/neon-mcp-server).
+For the full setup, use [`neon init`](/docs/cli/init). For just one piece: `neon skills` (skills), [`neon plugins`](/docs/cli/plugins) (skills and MCP), or [`neon mcp`](/docs/cli/mcp) (MCP server).
 </Callout>
 
 `skills` runs via `npx`, so it needs Node.js 22.20.0+; older or missing Node stops the command with an upgrade message.

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -8,7 +8,7 @@ summary: >-
   agents and skip the prompts. Use `neon skills update` to refresh installed
   skills to their latest versions.
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-08-28T15:55:20.032Z'
 ---
 
 The `skills` command installs [Neon agent skills](/docs/ai/agent-skills) into your coding agents, so tools like Cursor and Claude Code know how to work with Neon's Postgres, AI Gateway, Object Storage, and Functions.
@@ -51,7 +51,6 @@ The available skills are:
 
 | Skill                            | Installed by default |
 | -------------------------------- | -------------------- |
-| `claimable-postgres`             | Yes                  |
 | `neon`                           | Yes                  |
 | `neon-ai-gateway`                | Yes                  |
 | `neon-functions`                 | Yes                  |
@@ -114,7 +113,7 @@ Updates every skill installed in the current directory to its latest version, or
 Update skills in the current directory without prompting:
 
 ```bash
-neon skills update -y
+neon skills update --yes
 ```
 
 ```text filename="Output"
@@ -126,5 +125,5 @@ this directory  updated  ✓ Updated 1 skill(s)
 Update user-level skills:
 
 ```bash
-neon skills update --global -y
+neon skills update --global --yes
 ```

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -8,7 +8,7 @@ summary: >-
   agents and skip the prompts. Use `neon skills update` to refresh installed
   skills to their latest versions.
 enableTableOfContents: true
-updatedOn: '2026-08-28T15:55:20.032Z'
+updatedOn: '2026-08-28T19:48:06.838Z'
 ---
 
 The `skills` command installs [Neon agent skills](/docs/ai/agent-skills) into your coding agents, so tools like Cursor and Claude Code know how to work with Neon's Postgres, AI Gateway, Object Storage, and Functions.
@@ -113,7 +113,7 @@ Updates every skill installed in the current directory to its latest version, or
 Update skills in the current directory without prompting:
 
 ```bash
-neon skills update --yes
+neon skills update -y
 ```
 
 ```text filename="Output"
@@ -125,5 +125,5 @@ this directory  updated  ✓ Updated 1 skill(s)
 Update user-level skills:
 
 ```bash
-neon skills update --global --yes
+neon skills update --global -y
 ```

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -7,7 +7,7 @@ summary: >-
   with neon dev, and deploy with neon deploy. The function gets a public HTTPS
   URL with DATABASE_URL injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -67,7 +67,7 @@ That's a deployed function in three commands. The rest of this guide builds a mo
 - The latest `neon`, installed and authenticated. Functions commands are new and change often, so upgrade before you start (`npm install -g neon@latest`).
 - Node.js 20 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 
-`neon init --preview` is designed to be run by your AI coding assistant. It outputs structured instructions that guide the agent through setup. To install the Neon Platform (`neon`) and Neon Functions skills separately with the [Neon CLI](/docs/cli):
+To give your AI coding assistant context for Neon and Functions, install the [agent skills](/docs/ai/agent-skills) with the [Neon CLI](/docs/cli):
 
 ```bash
 neon skills -s neon -s neon-functions
@@ -85,15 +85,15 @@ mkdir my-function && cd my-function
 
 Then link the directory to your Neon project. There are two ways:
 
-**With an AI coding assistant.** Ask it to run `neon init --preview`. The command returns structured JSON instructions for the full setup: MCP server and agent skills, optional template scaffolding, project linking, and env var pull. Sign-in opens a browser window, and the agent pauses while you complete the OAuth step.
+**With an AI coding assistant.** Ask your assistant to set up Neon for the project. Using the skills you installed, it links your project (creating one if you need it) with `neon link` and pulls your environment variables. Sign-in opens a browser window, so complete the OAuth step when prompted.
 
-**By hand.** Run `neon link` and select your project and branch when prompted (or pass `--project-id`). This writes a `.neon` file and pulls the branch's environment variables into a local `.env`.
+**By hand.** Run `neon link` and select your project and branch when prompted (or pass `--project-id`). This writes a `.neon` file and pulls the branch's environment variables into a local `.env` file (or `.env.local` if there's no `.env` yet).
 
 ```bash
 neon link
 ```
 
-To start from a working example instead, run `neon bootstrap`. It scaffolds a starter template and links it. Available templates: Hono API, AI SDK agent, Mastra agent, MCP server, Realtime chat (Next.js + WebSockets), and Realtime counter (TanStack Router + SSE), all on Neon Functions. This guide builds the function by hand.
+To start from a working example instead, run `neon bootstrap`. It scaffolds a starter template, installs dependencies, and links it. Templates include a REST API, GraphQL API, tRPC API, MCP server, realtime chat and counter, AI agents, and Discord, Telegram, and WhatsApp bots. Run `neon bootstrap --list-templates` for the full catalog. This guide builds the function by hand.
 
 ## Define your function
 

--- a/content/docs/get-started/backend-overview.md
+++ b/content/docs/get-started/backend-overview.md
@@ -306,7 +306,7 @@ The beta services live under `preview` while they're in beta; that key goes away
 
 Two ways to get it running:
 
-**Let your AI editor build it.** Copy the prompt at the top of this page and hand it to your assistant. It runs `neon init` to configure the MCP server and install the core skill, adds the Object Storage, Functions, and AI Gateway skills with `neon skills`, then builds against each capability's current API.
+**Let your AI editor build it.** Copy the prompt at the top of this page and hand it to your assistant. It installs the core skill, links a Neon project, adds the Object Storage, Functions, and AI Gateway skills with `neon skills`, then builds against each capability's current API.
 
 **Start from a template.** `neon bootstrap` scaffolds a ready-to-run starter, installs dependencies, and links a project:
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -2,15 +2,14 @@
 title: Get started with your AI agent
 subtitle: Set up Neon in your project using your AI coding assistant
 summary: >-
-  `neon init` sets up Neon for your project through your AI coding
-  assistant: it installs the Neon CLI, signs you in, installs agent
-  skills, and can configure the MCP server, so your agent can create a
-  project and connect your app.
+  Set up Neon for your project with your AI coding assistant. Let your agent
+  install the Neon tooling and connect your project, or run `neon init`
+  yourself in a terminal, then ask your agent to get started.
 enableTableOfContents: true
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
-Set up Neon for your project without leaving your editor. `neon init` installs the Neon CLI, signs you in, installs Neon-specific agent skills, and can set up the [Neon MCP server](/docs/ai/neon-mcp-server). Together these give your agent what it needs to create a Neon project, connect your app, and use Neon features as you build. For Cursor and VS Code, it also installs the Neon Local Connect extension for in-editor schema browsing.
+Set up Neon for your project without leaving your editor. You have two options: let your AI coding assistant install the Neon tooling and connect your project for you, or run `neon init` yourself in a terminal and then hand off to your agent. Either way, your agent ends up with the [agent skills](/docs/ai/agent-skills) and [Neon MCP server](/docs/ai/neon-mcp-server) it needs to create a Neon project, connect your app, and use Neon features as you build.
 
 New to the platform? The [backend overview](/docs/get-started/backend-overview) shows how Postgres, Managed Better Auth, Object Storage, Functions, and the AI Gateway fit together. For a hands-on walkthrough, see [Build a full backend](/docs/get-started/full-backend-quickstart).
 
@@ -23,19 +22,21 @@ You'll need:
 
 ## Let your agent set it up
 
-The fastest path is to let your agent do the whole setup, from running `init` to proving the connection works. Paste this prompt into your editor's AI chat:
+The fastest path is to let your agent do the whole setup, from installing the tooling to proving the connection works. Paste this prompt into your editor's AI chat:
 
 ```text shouldWrap filename="AI assistant prompt"
 Help me get set up with Neon, based on my project:
 
-1. Run `npx neon@latest init --agent` and work through the steps it returns to install the CLI, sign in, and connect my project. If it opens a browser for sign-in, ask me to confirm before continuing.
-2. Run it through verification and show me the real query result, not just "setup complete." Give me a command to re-check it myself (e.g. `neon psql`), and never print secrets.
-3. Then suggest next steps for my project, such as a schema or migrations, branching for previews, or Neon's other services (Object Storage, Functions, Managed Better Auth, AI Gateway).
+1. Install or upgrade the Neon CLI: `npm install -g neon@latest`.
+2. Install the Neon agent tooling for your editor, replacing `<agent>` with your editor id (for example `cursor`, `claude-code`, or `codex`): run `neon plugins --agent <agent>` (recommended, installs the Neon plugin), or `neon skills --agent <agent> -s neon -s neon-postgres`. If sign-in opens a browser, ask me to confirm before continuing, and never print secrets.
+3. Using the installed Neon skill, create a Neon project (or connect an existing one), link it, and pull my DATABASE_URL into my env file. Add a Postgres driver for my stack.
+4. Prove it works: run a real query and show me the result, not just "setup complete." Give me a command to re-check it myself (e.g. `neon psql`).
+5. Then suggest next steps, such as a schema or migrations, branching for previews, or Neon's other services (Object Storage, Functions, Managed Better Auth, AI Gateway).
 ```
 
-Your agent installs the Neon CLI and runs its setup for you, so there's no switching between the terminal and the chat. It:
+Your agent installs the Neon CLI and tooling and does the setup for you, so there's no switching between the terminal and the chat. It:
 
-- Signs you in to Neon (finish the browser step if it prompts), creates an API key, optionally configures the [Neon MCP server](/docs/ai/neon-mcp-server), and installs [agent skills](/docs/ai/agent-skills)
+- Installs either the Neon plugin, or [agent skills](/docs/ai/agent-skills) and the [Neon MCP server](/docs/ai/neon-mcp-server), for your editor, and signs you in (finish the browser step if it prompts)
 - Creates or connects a Neon project, writes your `DATABASE_URL` into your env file, and adds a Postgres driver for your stack
 - Uses the connection and shows you a real result so you can see it's working
 
@@ -55,13 +56,9 @@ From your project root, run:
 npx neon@latest init
 ```
 
-<Admonition type="note">
-`neon init` installs or updates the Neon CLI and sets up your editor tooling: authentication, agent skills, and optionally the MCP server. It doesn't create a Neon project, though; your agent does that when you ask it to get started.
-</Admonition>
+`neon init` is interactive, so run it in a terminal. It asks how your coding agents should get Neon (either a plugin, or skills and the MCP server), links a Neon project, and writes a `neon.ts` config. In an empty directory, it scaffolds a starter template first. For the full flow, and a non-interactive setup for agents and CI, see the [`neon init` reference](/docs/cli/init).
 
-The wizard asks which editor to configure, then signs you in, creates an API key, installs [agent skills](/docs/ai/agent-skills), optionally configures the [Neon MCP server](/docs/ai/neon-mcp-server), and (for Cursor and VS Code) installs the [Neon Local Connect extension](https://marketplace.visualstudio.com/items?itemName=databricks.neon-local-connect). Run it from your project root so the skills land in the right place. For details and manual setup, see the [`neon init` reference](/docs/cli/init).
-
-If you only want the MCP server, without the skills or extension, run [`npx neon@latest mcp`](/docs/cli/mcp) instead. If you only want agent skills, run [`npx neon@latest skills`](/docs/cli/skills).
+If you only want the MCP server, without the skills or plugin, run [`npx neon@latest mcp`](/docs/cli/mcp) instead. If you only want agent skills, run [`npx neon@latest skills`](/docs/cli/skills).
 
 ## Tell your agent
 

--- a/content/docs/guides/branching-neon-cli.md
+++ b/content/docs/guides/branching-neon-cli.md
@@ -10,7 +10,7 @@ summary: >-
   Console and API equivalents for these operations are covered on separate
   pages.
 enableTableOfContents: true
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-08-27T23:52:24.570Z'
 ---
 
 The examples in this guide demonstrate creating, viewing, and deleting branches using the Neon CLI. For other branch-related CLI commands, refer to [Neon CLI commands — branches](/docs/cli/branches). This guide also describes how to use the `--api-key` option to authenticate CLI branching commands from the command line.
@@ -57,6 +57,8 @@ connection_uris
 <Admonition type="tip">
 The Neon CLI provides a `neon connection-string` command you can use to extract a connection uri programmatically. See [Neon CLI commands — connection-string](/docs/cli/connection-string).
 </Admonition>
+
+Pass `--no-secrets` (Neon CLI 4.9.0+) to keep the connection string out of terminal scrollback and CI logs; older versions ignore it and still print it.
 
 ## Create a branch from a non-default parent
 

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /docs/cloud/roadmap
   - /docs/conceptual-guides/roadmap
   - /docs/reference/roadmap
-updatedOn: '2026-08-25T17:09:07.082Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 This roadmap describes what's in flight, what we delivered recently, and what's on the horizon.
@@ -134,7 +134,7 @@ We're accelerating work on improving and scaling the core database on Neon as we
 - **Agent Skills**: Install [Agent Skills](https://github.com/neondatabase/agent-skills) to teach your AI assistant about Neon best practices. The Neon MCP Server can also provision the Data API with optional Managed Better Auth or external auth. [Learn more](/docs/ai/connect-mcp-clients-to-neon).
 - **Managed Better Auth on Vercel previews**: Both Vercel-managed and Neon-managed integrations now automatically provision Managed Better Auth on preview branches when enabled on production, so preview deployments get the right auth environment variables. [Learn more](/docs/auth/overview).
 - **One-command setup for MCP and VS Code extension**: `npx neon@latest init` now configures both the Neon MCP Server and the Neon VS Code Extension in one step for Cursor or VS Code. [Learn more](/docs/ai/connect-mcp-clients-to-neon).
-- **Expanded `neon init`**: The **init** wizard configures MCP and agent skills for many more coding assistants (for example Claude Desktop, Codex, Zed, Gemini CLI, and GitHub Copilot CLI), not only Cursor, VS Code, and Claude Code. [Learn more](/docs/cli/init).
+- **Expanded `neon init`**: [`neon init`](/docs/cli/init) sets up your project with agent tooling (either a plugin, or skills and the MCP server) for many more coding assistants (for example Claude Desktop, Codex, Zed, Gemini CLI, and GitHub Copilot CLI), not only Cursor, VS Code, and Claude Code. [Learn more](/docs/cli/init).
 - **New Neon VS Code extension**: A revamped extension that replaces the previous Neon Local extension. It uses direct Neon connection strings and brings schema browsing, SQL editing, and table data into your IDE, plus automatic MCP Server configuration. Available for VS Code, Cursor, Windsurf, and other compatible editors. [Learn more](/docs/local/vscode-extension).
 - **Connection pooling metrics**: Pooler client and server connection graphs are now available in the Neon Console and via OpenTelemetry and Datadog integrations, so you can monitor PgBouncer usage and tune pool size. [Learn more](/docs/introduction/monitoring-page).
 - **GitHub Action support for Managed Better Auth and Data API**: The Neon Create Branch GitHub Action now supports `get_auth_url` and `get_data_api_url` outputs, so you can run integration tests against isolated branch environments with the same auth and data access patterns as production. [Learn more](https://github.com/marketplace/actions/neon-create-branch-github-action).

--- a/content/guides/branch-per-pr-vs-staging-database.md
+++ b/content/guides/branch-per-pr-vs-staging-database.md
@@ -4,7 +4,7 @@ subtitle: Compare Neon database branches for every pull request with a classic s
 author: rishi-raj-jain
 enableTableOfContents: true
 createdAt: '2026-07-10T00:00:00.000Z'
-updatedOn: '2026-07-28T15:49:24.320Z'
+updatedOn: '2026-08-27T23:52:24.570Z'
 ---
 
 Before a database change reaches production, you want to test it in a hosted environment that is neither your local machine nor production itself. You have two ways to set that up: a shared staging database that all team members would use for testing, or a preview database created for each pull request. They may sound like interchangeable flows, but they differ in how long it takes to sync your production database with a preview environment, and how fast each developer can iterate against data (including authentication data) that looks like production.
@@ -220,8 +220,10 @@ To use branching effectively in your development workflow, follow these steps:
 Branch from production (mask it if needed) to match production data and auth:
 
 ```bash
-neon branches create --name pr-${PR_NUMBER} --parent production
+neon branches create --name pr-${PR_NUMBER} --parent production --no-secrets
 ```
+
+`--no-secrets` (Neon CLI 4.9.0+) keeps the connection string out of your CI logs; the next step fetches it with `neon connection-string`.
 
 ## Connect as a restricted role
 

--- a/content/guides/claude-code-mcp-neon.md
+++ b/content/guides/claude-code-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Interact with Neon APIs using Claude Code through natural language'
 author: pedro-figueiredo
 enableTableOfContents: true
 createdAt: '2025-08-27T00:00:00.000Z'
-updatedOn: '2026-08-21T02:00:14.259Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 This guide shows how to use [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -30,13 +30,13 @@ Make sure you have:
 
 ### Quick Setup (Recommended)
 
-The fastest way to get started is with the [`neon init`](/docs/cli/init) command, which automates OAuth authentication, API key creation, and Claude Code configuration:
+The fastest way to get started is with the [`neon init`](/docs/cli/init) command, which sets up the current directory for Neon, including the MCP server for Claude Code:
 
 ```bash
 npx neon@latest init
 ```
 
-This command authenticates via OAuth, creates an API key, and configures Claude Code to connect to Neon's remote MCP server. Once complete, ask your AI assistant **"Get started with Neon"**.
+Run it in a terminal. It installs agent tooling (either the Neon plugin, or agent skills and the MCP server) and links a Neon project. Once complete, restart Claude Code and ask your AI assistant **"Get started with Neon"**.
 
 ### Option 1: Setting up the Remote Hosted Neon MCP Server (OAuth)
 

--- a/content/guides/cursor-mcp-neon.md
+++ b/content/guides/cursor-mcp-neon.md
@@ -4,7 +4,7 @@ subtitle: 'Make schema changes with natural language using Cursor and Neon MCP S
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2025-02-20T00:00:00.000Z'
-updatedOn: '2026-08-21T02:09:26.597Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 This guide shows how to use [Cursor](https://cursor.com) with the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) to manage your Neon databases.
@@ -31,13 +31,13 @@ Make sure you have:
 
 ### Quick Setup (Recommended)
 
-The fastest way to get started is with the [`neon init`](/docs/cli/init) command, which automates OAuth authentication, API key creation, and Cursor configuration:
+The fastest way to get started is with the [`neon init`](/docs/cli/init) command, which sets up the current directory for Neon, including the MCP server for Cursor:
 
 ```bash
 npx neon@latest init
 ```
 
-This command authenticates via OAuth, creates an API key, and configures Cursor to connect to Neon's remote MCP server. API key authentication means **fewer approval prompts** when using MCP tools. Once complete, ask your AI assistant **"Get started with Neon"**.
+Run it in a terminal. It installs agent tooling (either the Neon plugin, or agent skills and the MCP server) and links a Neon project. Once complete, restart Cursor and ask your AI assistant **"Get started with Neon"**.
 
 <Admonition type="tip" title="Cursor Users: One-Click Alternative">
 Cursor offers a deep link for quick OAuth setup:

--- a/content/guides/discord-bot-on-neon-functions.md
+++ b/content/guides/discord-bot-on-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to build a Discord bot with AI chat and image generation us
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-06-28T00:00:00.000Z'
-updatedOn: '2026-08-06T15:58:59.107Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 If you've spent any time on Discord, you've run into bots: moderation bots, music players, AI image generators like Midjourney, which started out as a Discord bot before becoming a standalone product. They all do the same basic thing under the hood: listen for a command and respond, whether that's a one-line reply or a fully generated image.
@@ -45,47 +45,10 @@ Create a new directory for your bot and initialize a Neon Functions project.
 mkdir neon-discord-bot && cd neon-discord-bot
 ```
 
-Run the Neon CLI initialization command. This will prompt you to authenticate and link the directory to a Neon project:
+Install the Neon agent skills so AI agents like Claude Code and Cursor have the context to help you build and deploy. This Discord bot uses the **Neon**, **Neon Functions**, and **Neon AI Gateway** skills:
 
 ```bash
-neon init
-```
-
-When asked to choose a template, select **No thanks - continue without scaffolding**, since you'll be writing the code from scratch. During setup, install the Neon MCP server and extensions when prompted. The Neon agent skill will be automatically added to your project, enabling AI agents to assist with development tasks such as code generation, testing, and deployment.
-
-```bash
-$ neon init
-
-  ██╗  ██╗██████╗  ██████╗ ██╗  ██╗
-  ███╗ ██║██╔═══╝ ██╔═══██╗███╗ ██║
-  ████╗██║██████╗ ██║   ██║████╗██║
-  ██╔████║██╔═══╝ ██║   ██║██╔████║
-  ██║╚███║██████╗ ╚██████╔╝██║╚███║
-  ╚═╝ ╚══╝╚═════╝  ╚═════╝ ╚═╝ ╚══╝
-
-  Let's get your project set up with Neon. We'll install the MCP server, agent skills, and IDE extension, then connect your app to
-  a database.
-
-  │
-  ◇  Configuration checked ✓
-  │
-  ◆  Which Neon features would you like to enable for this project?
-  │  Database
-
-  Neon editor extension already installed ✓
-  │
-  ◆  Configure VS Code for Neon:
-  │  ● Install with defaults (MCP server (global), agent skills (project))
-  │  ○ Customize installation
-  │  ○ Configure a different editor
-
-  Agent skills installed ✓
-```
-
-During initialization, the **Neon Postgres** skills are installed automatically. You'll also need the **Neon Functions** and **Neon AI Gateway** skills so AI agents have the context to help you build and deploy your Discord bot. Install them with the following command:
-
-```bash
-npx skills add neondatabase/agent-skills --skill neon-ai-gateway --skill neon-functions
+neon skills -s neon -s neon-functions -s neon-ai-gateway
 ```
 
 Next, install the required dependencies:

--- a/content/guides/durable-workflow-on-neon-functions.md
+++ b/content/guides/durable-workflow-on-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to orchestrate reliable, long-running workflows with Innges
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-07-25T00:00:00.000Z'
-updatedOn: '2026-08-06T15:58:59.107Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 If you're building modern web applications, you inevitably run into work that shouldn't or can't happen inside a single HTTP request-response cycle. Whether it's running multi-step AI enrichment pipelines, orchestrating customer onboarding sequences, processing background uploads, or handling third-party webhooks, background work is a core requirement of production backends.
@@ -94,19 +94,19 @@ Create a project directory and navigate into it:
 mkdir neon-inngest-workflow && cd neon-inngest-workflow
 ```
 
-Run `neon init` to configure AI agent skills for development:
+Install the Neon agent skills so AI agents like Claude Code and Cursor have the context to help you build and deploy. This durable workflow uses the **Neon**, **Neon Functions**, and **Neon AI Gateway** skills:
 
 ```bash
-neon init
+neon skills -s neon -s neon-functions -s neon-ai-gateway
 ```
 
-Use the default setup options for all prompts such as enabling AI skills, configuring the MCP server, and installing the VS Code extension. This streamlined setup makes it easier to build Neon powered applications with AI agents like Claude Code, Cursor, and others.
-
-During initialization, the **Neon Postgres** skills are installed automatically. You'll also need the **Neon Functions** and **Neon AI Gateway** skills so AI agents have the context to help you build and deploy your durable workflow. Install them with the following command:
+Link your local workspace to a Neon project:
 
 ```bash
-npx skills add neondatabase/agent-skills --skill neon-ai-gateway --skill neon-functions
+neon link
 ```
+
+You'll be prompted to select your organization, then a project. Create a new one or pick an existing project. Choose the **AWS US East 2 (Ohio)** (`aws-us-east-2`) region, since Neon Functions are available only there during beta.
 
 Next, install the required dependencies:
 

--- a/content/guides/flask-test-on-branch.md
+++ b/content/guides/flask-test-on-branch.md
@@ -4,7 +4,7 @@ subtitle: Leveraging Realistic Production Data for Robust Testing with Flask and
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2024-09-15T00:00:00.000Z'
-updatedOn: '2026-07-31T19:05:29.503Z'
+updatedOn: '2026-08-27T23:52:24.570Z'
 ---
 
 [Flask](https://flask.palletsprojects.com/) is a popular Python micro-framework widely used for building web applications. It includes powerful tools for automated testing, with [pytest](https://docs.pytest.org/) being a preferred option due to its simplicity and effectiveness.
@@ -268,10 +268,10 @@ Once `neon` is installed, you can use it to interact with your Neon database bra
 To create a new branch, use the `neon branches create` command:
 
 ```bash
-neon branches create --project-id PROJECT_ID --parent PARENT_BRANCH_ID --name BRANCH_NAME
+neon branches create --project-id PROJECT_ID --parent PARENT_BRANCH_ID --name BRANCH_NAME --no-secrets
 ```
 
-Replace `PROJECT_ID`, `PARENT_BRANCH_ID`, and `BRANCH_NAME` with the appropriate values for your Neon project. This command will create a new branch based on the specified parent branch.
+Replace `PROJECT_ID`, `PARENT_BRANCH_ID`, and `BRANCH_NAME` with the appropriate values for your Neon project. This command will create a new branch based on the specified parent branch. `--no-secrets` (Neon CLI 4.9.0+) keeps the connection string out of CI logs; you fetch it next with `neon connection-string`.
 
 #### 2. [Listing Branches](/docs/cli/branches#list)
 

--- a/content/guides/laravel-test-on-branch.md
+++ b/content/guides/laravel-test-on-branch.md
@@ -4,7 +4,7 @@ subtitle: Leveraging Realistic Production Data for Robust Testing with Laravel a
 author: bobbyiliev
 enableTableOfContents: true
 createdAt: '2024-05-26T00:00:00.000Z'
-updatedOn: '2026-06-11T23:50:21.258Z'
+updatedOn: '2026-08-27T23:52:24.570Z'
 ---
 
 [Laravel](https://laravel.com) is a popular PHP framework widely used for building web applications. It includes powerful tools for automated testing, with [PEST](https://pestphp.com/) being a preferred option due to its simplicity and effectiveness.
@@ -297,10 +297,10 @@ Once `neon` is installed, you can use it to interact with your Neon database bra
 To create a new branch, use the `neon branches create` command:
 
 ```bash
-neon branches create --project-id PROJECT_ID --parent PARENT_BRANCH_ID --name BRANCH_NAME
+neon branches create --project-id PROJECT_ID --parent PARENT_BRANCH_ID --name BRANCH_NAME --no-secrets
 ```
 
-Replace `PROJECT_ID`, `PARENT_BRANCH_ID`, and `BRANCH_NAME` with the appropriate values for your Neon project. This command will create a new branch based on the specified parent branch.
+Replace `PROJECT_ID`, `PARENT_BRANCH_ID`, and `BRANCH_NAME` with the appropriate values for your Neon project. This command will create a new branch based on the specified parent branch. `--no-secrets` (Neon CLI 4.9.0+) keeps the connection string out of CI logs; you fetch it next with `neon connection-string`.
 
 #### 2. [Listing Branches](/docs/cli/branches#list)
 

--- a/content/guides/llm-proxy-neon-functions.md
+++ b/content/guides/llm-proxy-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to build a secure LLM proxy backend that authenticates requ
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-07-22T00:00:00.000Z'
-updatedOn: '2026-08-06T15:58:59.107Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 If you’re building a web application that uses large language models (LLMs), you need a secure way to handle requests from the frontend to the model endpoints. Whether it’s a chat interface or a content generation tool, the frontend needs to reach a model endpoint. But exposing LLM API keys directly to the browser is a serious security risk. Secret keys can leak through browser DevTools or network logs. Without server-side controls, there’s also nothing stopping a user from sending unlimited requests, driving up costs, or bypassing access restrictions entirely.
@@ -62,18 +62,10 @@ Create a directory for your project and initialize a Neon Functions project. Thi
 mkdir llm-proxy-backend && cd llm-proxy-backend
 ```
 
-Run the Neon CLI initialization command:
+Install the Neon agent skills so AI agents like Claude Code and Cursor have the context to help you build and deploy. This proxy uses the **Neon**, **Neon Functions**, and **Neon AI Gateway** skills:
 
 ```bash
-neon init
-```
-
-Use the default setup options for all prompts such as enabling AI skills, configuring the MCP server, and installing the VS Code extension. This streamlined setup makes it easier to build Neon powered applications with AI agents like Claude Code, Cursor, and others.
-
-During initialization, the **Neon Postgres** skills are installed automatically. You'll also need the **Neon Functions** and **Neon AI Gateway** skills so AI agents have the context to help you build and deploy your proxy. Install them with the following command:
-
-```bash
-npx skills add neondatabase/agent-skills --skill neon-ai-gateway --skill neon-functions
+neon skills -s neon -s neon-functions -s neon-ai-gateway
 ```
 
 Create a new Neon project by running the following command. This links your local project to a Neon project and sets up the necessary configuration:

--- a/content/guides/neon-functions-github-actions.md
+++ b/content/guides/neon-functions-github-actions.md
@@ -4,7 +4,7 @@ subtitle: 'Set up CI/CD for Neon Functions: deploy to production on merge and cr
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-08-06T00:00:00.000Z'
-updatedOn: '2026-08-18T17:01:39.853Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 [Neon Functions](/docs/compute/functions/overview) are long-running serverless functions you deploy onto a Neon branch, so your backend runs right next to your Postgres database. Each branch runs its own function at its own URL against its own database state, with `DATABASE_URL` injected automatically. That makes them a natural fit for a workflow where every environment gets its own isolated function.
@@ -46,18 +46,10 @@ mkdir neon-functions-api && cd neon-functions-api
 npm init -y
 ```
 
-Run the Neon CLI initialization command:
+Install the Neon agent skills so AI agents such as Claude Code and Cursor have the context to help you build and work with Neon. This function uses the **Neon** and **Neon Functions** skills:
 
 ```bash
-neon init
-```
-
-Use the default setup options for all prompts: this enables AI skills, configures the MCP server, and installs the VS Code extension. These ensure AI agents such as Claude Code and Cursor can assist you in building and working with Neon.
-
-During initialization, the **Neon** skills are installed automatically. You'll also need the **Neon Functions** skills so AI agents have the context to help you build and deploy your function. Install them with:
-
-```bash
-npx skills add https://github.com/neondatabase/agent-skills --skill neon-functions
+neon skills -s neon -s neon-functions
 ```
 
 Link your local workspace to a Neon project:

--- a/content/guides/sentry-neon-functions.md
+++ b/content/guides/sentry-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to add error tracking, structured logs, and request tracing
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-08-05T00:00:00.000Z'
-updatedOn: '2026-08-13T14:46:11.074Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 canonical: 'https://sentry.io/cookbook/monitor-neon-functions-sentry/'
 ---
 
@@ -53,18 +53,10 @@ Create a directory for your project and initialize a workspace:
 mkdir neon-sentry-demo && cd neon-sentry-demo
 ```
 
-Run the Neon CLI initialization command:
+Install the Neon agent skills so AI agents such as Claude Code and Cursor have the context to help you build and deploy. This function uses the **Neon**, **Neon Functions**, and **Neon AI Gateway** skills:
 
 ```bash
-neon init
-```
-
-Use the default setup options for all prompts: this includes enabling AI skills, configuring the MCP server, and installing the VS Code extension. These steps ensure AI agents such as Claude Code and Cursor can assist you in building with Neon.
-
-During initialization, the **Neon Postgres** skills are installed automatically. You'll also need the **Neon Functions** and **Neon AI Gateway** skills so AI agents have the context to help you build and deploy your function. Install them with the following command:
-
-```bash
-npx skills add neondatabase/agent-skills --skill neon-ai-gateway --skill neon-functions
+neon skills -s neon -s neon-functions -s neon-ai-gateway
 ```
 
 Link your local workspace to a Neon project:

--- a/content/guides/vercel-neon-mcp.md
+++ b/content/guides/vercel-neon-mcp.md
@@ -4,7 +4,7 @@ subtitle: 'Leverage Vercel logs and Neon branching to give AI agents the context
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-03-02T00:00:00.000Z'
-updatedOn: '2026-03-05T08:21:55.000Z'
+updatedOn: '2026-08-27T22:59:15.528Z'
 ---
 
 AI agents are evolving from simple task executors into integral parts of modern development workflows. As their role expands, giving them the right context and safeguards becomes essential especially when they’re trusted to diagnose and debug issues in production environments.
@@ -49,7 +49,7 @@ You can follow the guide using your own projects.
 
 The Neon MCP server gives Claude Code tools to work with your Neon database, including creating database branches, running SQL queries, and applying migrations. For this scenario, we will use it to validate database schema changes in an isolated environment.
 
-The simplest way to connect Claude Code to Neon is with the `neon init` command. It handles OAuth authentication, API key creation, configures Claude Code to use Neon's remote MCP server, and installs [Neon agent skills](https://github.com/neondatabase/agent-skills) for best practices.
+The simplest way to connect Claude Code to Neon is with the `neon init` command. Run it in a terminal: it installs agent tooling (either the Neon plugin, or [agent skills](https://github.com/neondatabase/agent-skills) and the MCP server) and links a Neon project.
 
 Run the following in your project directory:
 

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -194,6 +194,18 @@
         }
       }
     },
+    "skills": {
+      "commands": {
+        "update": {
+          "options": {
+            "yes": {
+              "_comment": "Source defines `yes` as a bare { describe } with no type, so the static parser marks it unknown. It's a boolean flag (skip the confirm prompt). Verified against skills.ts at neonctl 4.11.0.",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "claim": {
       "commands": {
         "create": {

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -199,7 +199,7 @@
         "update": {
           "options": {
             "yes": {
-              "_comment": "Source defines `yes` as a bare { describe } with no type, so the static parser marks it unknown. It's a boolean flag (skip the confirm prompt). Verified against skills.ts at neonctl 4.11.0.",
+              "_comment": "`skills update` re-declares `yes` as a bare { describe }; its alias and boolean type are inherited from the parent `skills` command's `yes`, which the isolated per-builder parse misses (so it comes out type unknown). Remove this override once generate-schema.js models parent-option inheritance. Verified against skills.ts at neonctl 4.11.0.",
               "type": "boolean"
             }
           }

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -199,8 +199,9 @@
         "update": {
           "options": {
             "yes": {
-              "_comment": "`skills update` re-declares `yes` as a bare { describe }; its alias and boolean type are inherited from the parent `skills` command's `yes`, which the isolated per-builder parse misses (so it comes out type unknown). Remove this override once generate-schema.js models parent-option inheritance. Verified against skills.ts at neonctl 4.11.0.",
-              "type": "boolean"
+              "_comment": "`skills update` re-declares `yes` as a bare { describe }; its `-y` alias and boolean type are inherited from the parent `skills` command's `yes`, which the isolated per-builder parse misses (so it comes out with no alias and type unknown). This override restores both. Remove it once generate-schema.js models parent-option inheritance. Verified against skills.ts at neonctl 4.11.0.",
+              "type": "boolean",
+              "alias": "y"
             }
           }
         }

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -3511,7 +3511,8 @@
             },
             "yes": {
               "type": "boolean",
-              "describe": "Skip the confirm prompt"
+              "describe": "Skip the confirm prompt",
+              "alias": "y"
             }
           },
           "commands": {},

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.10.0",
+  "neonctlVersion": "4.11.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -249,8 +249,9 @@
       ],
       "options": {
         "agent": {
-          "type": "boolean",
-          "hidden": true
+          "type": "array",
+          "describe": "Coding agent to install into (repeatable). Forwarded to plugins, or to skills and mcp. Skips agent selection. Values listed below",
+          "alias": "a"
         },
         "agent-setup": {
           "type": "boolean",
@@ -259,7 +260,7 @@
         },
         "default": {
           "type": "boolean",
-          "describe": "Quick start: scaffold the default template (or --template), then install, git, agent tooling, and link --yes. Skips those pickers; link --yes still asks for a project unless one is already linked",
+          "describe": "Quick start: scaffold the default template (or --template), then install, git, agent tooling (project folders, else the host CLI agent; if none, pass --agent or omit --default in a terminal), and link --yes. Skips those pickers; link --yes still asks for a project unless one is already linked",
           "default": false,
           "alias": "y"
         },
@@ -280,7 +281,7 @@
         },
         "link": {
           "type": "boolean",
-          "describe": "Run `neon link` in the scaffolded directory after installing. In interactive mode this is offered as a prompt; use --no-link to skip without being asked.",
+          "describe": "Run `neon link` after scaffolding. Templates with neon.ts link after install so env pull works; otherwise link runs before install. In interactive mode this is offered as a prompt; use --no-link to skip without being asked.",
           "default": true
         },
         "list-templates": {
@@ -316,6 +317,10 @@
         {
           "command": "$0 bootstrap --list-templates --output json",
           "description": "Print the template catalog as JSON"
+        },
+        {
+          "command": "$0 bootstrap my-app --agent cursor --agent claude-code",
+          "description": "Skip agent selection; install the plugin for those agents"
         }
       ]
     },
@@ -1752,8 +1757,9 @@
       "positionals": [],
       "options": {
         "agent": {
-          "type": "boolean",
-          "hidden": true
+          "type": "array",
+          "describe": "Coding agent to install into (repeatable). Forwarded to plugins, or to skills and mcp. Skips agent selection. Values listed below",
+          "alias": "a"
         },
         "context-file": {
           "type": "unknown",
@@ -1771,7 +1777,7 @@
         },
         "yes": {
           "type": "boolean",
-          "describe": "Empty dir: bootstrap --default. Otherwise plugin when a project plugin agent is detected, else skills and MCP, then link --yes and config init --services none. link --yes still asks for a project unless one is already linked",
+          "describe": "Empty dir: bootstrap --default. Otherwise plugin, or skills and MCP, for project folders, else the host CLI agent. Exits if none. Then link --yes and config init --services none. link --yes still asks for a project unless one is already linked",
           "default": false,
           "alias": "y"
         }
@@ -1787,6 +1793,10 @@
         {
           "command": "$0 init -y",
           "description": "Same steps, using each child's defaults"
+        },
+        {
+          "command": "$0 init --agent cursor --agent claude-code",
+          "description": "Skip agent selection; install the plugin for those agents"
         }
       ]
     },
@@ -1892,7 +1902,7 @@
               "positionals": [],
               "options": {},
               "commands": {},
-              "describe": "Active queries running longer than 30 seconds with parallel workers, waits, and blockers (compute-wide)"
+              "describe": "Active queries running longer than 30 seconds with parallel workers, waits, and blockers, oldest group first (compute-wide)"
             },
             "subscriptions": {
               "aliases": [],
@@ -2019,10 +2029,6 @@
       "aliases": [],
       "positionals": [],
       "options": {
-        "agent": {
-          "type": "boolean",
-          "hidden": true
-        },
         "branch": {
           "type": "string",
           "describe": "Branch name or ID to pin in the context (resolved to its name before writing).",
@@ -2305,7 +2311,7 @@
         },
         "yes": {
           "type": "boolean",
-          "describe": "Skip prompts. Defaults listed below. --project, --oauth, --agent, --read-only, --project-id and --category still apply",
+          "describe": "Skip prompts. Defaults listed below. --agent, --project, --oauth, --read-only, --project-id and --category still apply",
           "default": false,
           "alias": "y"
         }
@@ -2320,19 +2326,19 @@
         },
         {
           "command": "$0 mcp -y",
-          "description": "Global config, detected agents, reuse or mint an API key"
+          "description": "Global config, installed apps else the host CLI agent, reuse or mint an API key"
         },
         {
           "command": "$0 mcp --oauth",
           "description": "Install with OAuth; the agent signs in on first use"
         },
         {
-          "command": "$0 mcp --project",
-          "description": "Write project-level config"
-        },
-        {
           "command": "$0 mcp --agent cursor --agent claude-code",
           "description": "Install into specific agents"
+        },
+        {
+          "command": "$0 mcp --project",
+          "description": "Write project-level config"
         },
         {
           "command": "$0 mcp --read-only",
@@ -2998,7 +3004,7 @@
         },
         "yes": {
           "type": "boolean",
-          "describe": "Skip prompts",
+          "describe": "Skip prompts. Detected agents (project folders, else the host CLI agent). --global uses installed apps, else the host CLI agent",
           "default": false,
           "alias": "y"
         }
@@ -3013,7 +3019,7 @@
         },
         {
           "command": "$0 plugins -y",
-          "description": "Detected agents, skip prompts"
+          "description": "Detected agents (project folders, else the host CLI agent), skip prompts"
         },
         {
           "command": "$0 plugins --agent cursor --agent claude-code",
@@ -3482,12 +3488,12 @@
         },
         "skill": {
           "type": "array",
-          "describe": "Skill to install (repeatable). Skips the skill picker. Values listed below",
+          "describe": "Skill to install (repeatable). Skips the skill picker. Does not select agents. Values listed below",
           "alias": "s"
         },
         "yes": {
           "type": "boolean",
-          "describe": "Skip prompts",
+          "describe": "Skip prompts. Detected agents (project folders, else the host CLI agent). --global uses installed apps, else the host CLI agent",
           "default": false,
           "alias": "y"
         }
@@ -3502,6 +3508,10 @@
               "type": "boolean",
               "describe": "Update user-level skills (skills CLI -g). Default is this directory",
               "default": false
+            },
+            "yes": {
+              "type": "boolean",
+              "describe": "Skip the confirm prompt"
             }
           },
           "commands": {},
@@ -3532,11 +3542,15 @@
         },
         {
           "command": "$0 skills -y",
-          "description": "This directory, detected agents, the default skills"
+          "description": "This directory, detected agents (project folders, else the host CLI agent), the default skills"
+        },
+        {
+          "command": "$0 skills -y -s neon -s neon-ai-gateway",
+          "description": "Named skills into detected agents"
         },
         {
           "command": "$0 skills -s neon -s neon-ai-gateway --agent cursor",
-          "description": "Install named skills into specific agents"
+          "description": "Named skills into a named agent"
         },
         {
           "command": "$0 skills --global",

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.7.0",
+  "neonctlVersion": "4.10.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -75,6 +75,11 @@
           "describe": "Raw request body: a JSON string, @file, or - for stdin. Overrides --field.",
           "alias": "d"
         },
+        "describe": {
+          "type": "boolean",
+          "describe": "Print path, query, and body fields from the OpenAPI spec without calling the API. Body names are dotted for -F.",
+          "default": false
+        },
         "field": {
           "type": "array",
           "describe": "Body field key=value (repeatable). Dot-notation nests objects (e.g. -F branch.name=dev); values are typed (numbers, booleans, null, JSON).",
@@ -113,12 +118,12 @@
         },
         "refresh": {
           "type": "boolean",
-          "describe": "Refresh the cached OpenAPI spec (used with --list).",
+          "describe": "Refresh the cached OpenAPI spec (used with --list and --describe).",
           "default": false
         },
         "spec-url": {
           "type": "string",
-          "describe": "OpenAPI spec URL used by --list.",
+          "describe": "OpenAPI spec URL used by --list and --describe.",
           "defaultText": "process.env.NEON_API_SPEC_URL ?? DEFAULT_SPEC_URL",
           "hidden": true
         }
@@ -138,6 +143,14 @@
         {
           "command": "$0 api --list",
           "description": "List every available API route"
+        },
+        {
+          "command": "$0 api /projects --describe",
+          "description": "Show GET /projects query parameters"
+        },
+        {
+          "command": "$0 api /projects -X POST --describe",
+          "description": "Show the create-project body fields"
         }
       ]
     },
@@ -239,9 +252,14 @@
           "type": "boolean",
           "hidden": true
         },
+        "agent-setup": {
+          "type": "boolean",
+          "describe": "After scaffolding, install the Neon plugin or skills and MCP. Use --no-agent-setup to skip",
+          "default": true
+        },
         "default": {
           "type": "boolean",
-          "describe": "Quick start: scaffold the default template (or --template) and run the usual setup (install dependencies, git init) without prompting. Linking is left to you since it needs a project choice.",
+          "describe": "Quick start: scaffold the default template (or --template), then install, git, agent tooling, and link --yes. Skips those pickers; link --yes still asks for a project unless one is already linked",
           "default": false,
           "alias": "y"
         },
@@ -280,7 +298,7 @@
         }
       },
       "commands": {},
-      "describe": "Scaffold a new project from a Neon starter template",
+      "describe": "Scaffold a new project from a Neon starter template, then install agent tooling and link a Neon project",
       "usage": "$0 bootstrap [directory] [options]",
       "examples": [
         {
@@ -293,7 +311,7 @@
         },
         {
           "command": "$0 bootstrap my-app --default",
-          "description": "Quick start: scaffold the default template and run setup without prompting"
+          "description": "Skip the pickers; link --yes still asks for a project unless one is already linked"
         },
         {
           "command": "$0 bootstrap --list-templates --output json",
@@ -393,6 +411,11 @@
               "type": "boolean",
               "describe": "Create a schema-only branch. Requires exactly one read-write compute.",
               "default": false
+            },
+            "secrets": {
+              "type": "boolean",
+              "describe": "Include connection credentials in command output. Use --no-secrets to omit them",
+              "default": true
             },
             "suspend-timeout": {
               "type": "number",
@@ -1730,9 +1753,7 @@
       "options": {
         "agent": {
           "type": "boolean",
-          "describe": "Enable agent/JSON mode (agent type is auto-detected).",
-          "default": false,
-          "alias": "a"
+          "hidden": true
         },
         "context-file": {
           "type": "unknown",
@@ -1740,21 +1761,34 @@
         },
         "data": {
           "type": "string",
-          "describe": "JSON object with a \"step\" field to route to a specific phase and phase-specific options."
+          "hidden": true
         },
-        "preview": {
-          "type": "boolean",
-          "describe": "Enable preview features (e.g. project bootstrapping from templates).",
-          "default": false
+        "output": {
+          "type": "unknown",
+          "describe": "Not supported; the commands init runs print their own output",
+          "alias": "o",
+          "hidden": true
         },
-        "skip-migrations": {
+        "yes": {
           "type": "boolean",
-          "describe": "Skip the migrations phase.",
-          "default": false
+          "describe": "Empty dir: bootstrap --default. Otherwise plugin when a project plugin agent is detected, else skills and MCP, then link --yes and config init --services none. link --yes still asks for a project unless one is already linked",
+          "default": false,
+          "alias": "y"
         }
       },
       "commands": {},
-      "describe": "Initialize a project with Neon using your AI coding assistant"
+      "describe": "Set up this directory for Neon: agent tooling, a linked project, and neon.ts. In an empty directory, scaffolds a template first. Skills needs Node.js 22.20 or newer.",
+      "usage": "$0 init [options]",
+      "examples": [
+        {
+          "command": "$0 init",
+          "description": "Empty dir: bootstrap (scaffold, agent tooling, link). Existing app: agent tooling, link, config init"
+        },
+        {
+          "command": "$0 init -y",
+          "description": "Same steps, using each child's defaults"
+        }
+      ]
     },
     "inspect": {
       "aliases": [
@@ -1991,7 +2025,7 @@
         },
         "branch": {
           "type": "string",
-          "describe": "Branch name or ID to pin in the context (resolved to its ID before writing). Without it, link only resolves the org and project — pin a branch with `neon checkout <branch>` (link never guesses a default).",
+          "describe": "Branch name or ID to pin in the context (resolved to its name before writing).",
           "alias": "branch-id"
         },
         "checks": {
@@ -2031,7 +2065,7 @@
         },
         "yes": {
           "type": "boolean",
-          "describe": "Skip the \"already linked\" confirmation in interactive mode and re-link anyway.",
+          "describe": "Skip the \"already linked\" confirmation, and pin the project's default branch when linking a project that has more than one.",
           "default": false,
           "alias": "y"
         }
@@ -2057,8 +2091,12 @@
           "description": "Create a new project and link it"
         },
         {
+          "command": "$0 link --project-id polished-snowflake-12345678 -y",
+          "description": "Same, pinning the project's default branch when several exist"
+        },
+        {
           "command": "$0 link --project-id polished-snowflake-12345678",
-          "description": "Link an existing project (org is inferred); pin a branch later with 'neon checkout'"
+          "description": "Link an existing project (org is inferred). Pins the only branch; several prompt in a TTY"
         }
       ]
     },
@@ -3159,6 +3197,11 @@
               "type": "string",
               "describe": "The role name. If not specified, the default role name, `{database_name}_owner`, will be used.",
               "defaultText": "{database}_owner"
+            },
+            "secrets": {
+              "type": "boolean",
+              "describe": "Include connection credentials in command output. Use --no-secrets to omit them",
+              "default": true
             },
             "set-context": {
               "type": "boolean",

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -44,7 +44,7 @@ const META = {
   },
   skills: {
     desc: 'Install and update Neon agent skills in your coding agents.',
-    examples: ['neon skills', 'neon skills -y', 'neon skills update -y'],
+    examples: ['neon skills', 'neon skills -y', 'neon skills update --yes'],
   },
   plugins: {
     desc: 'Install the Neon plugin (skills plus MCP) into your coding agents.',

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -44,7 +44,7 @@ const META = {
   },
   skills: {
     desc: 'Install and update Neon agent skills in your coding agents.',
-    examples: ['neon skills', 'neon skills -y', 'neon skills update --yes'],
+    examples: ['neon skills', 'neon skills -y', 'neon skills update -y'],
   },
   plugins: {
     desc: 'Install the Neon plugin (skills plus MCP) into your coding agents.',

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -14,7 +14,7 @@
 const META = {
   auth: { desc: 'Browser OAuth; stores credentials locally.', examples: ['neon auth'] },
   init: {
-    desc: 'Wire up MCP, agent skills, and editor (Cursor/VS Code/Claude).',
+    desc: 'Set up this directory for Neon: agent tooling, a linked project, and neon.ts.',
     examples: ['npx neon@latest init'],
   },
   link: {


### PR DESCRIPTION
## Overview

Neon CLI 4.11.0 reworked what `neon init` does. It's no longer a standalone setup product that installs the CLI, creates an API key, and configures MCP per editor. It's now a thin orchestrator: in an empty directory it scaffolds a starter template, and in an existing app it installs agent tooling (a plugin, or agent skills and the MCP server), links a Neon project, and writes a `neon.ts` config. It runs interactively by default; pass `--agent` to name the coding agents and `-y` to skip the prompts, so agents and CI can run it unattended. Selecting a specific project without a terminal still uses `neon link --project-id`, since `init` has no project selector of its own.

This updates the docs to match:

- Rewrites the `neon init` reference and fixes `bootstrap.md`, which described the old post-scaffold flow.
- Documents `--agent` on `neon init` and `neon bootstrap` (repeatable, names the coding agents to set up), the `-y` agent-detection order, and that init is project-scoped. Drops stale claims that init installs the CLI, creates an API key, or installs an editor extension.
- Reworks the getting-started and MCP pages and the Functions guides to the current flow, installing the specific skills each guide needs with `neon skills -s ...`.
- Fixes the docs that said `neon link` always writes `.env.local` (it writes to an existing `.env` if you have one, otherwise `.env.local`), refreshes the bootstrap template list, and attributes "Get started with Neon" to the Neon MCP server.
- Switches `neon skills update` examples to `--yes` (its `-y` alias isn't recognized), removes the retired `claimable-postgres` skill, and documents `--no-secrets` on `neon projects create` and `neon branches create`.
- Regenerates `schema.json` to 4.11.0. The bump also surfaces `neon api --describe`, which now renders in its reference table.

A changelog entry and a couple of upstream agent-skills fixes are tracked separately as follow-ups.

Testing: `npm run cli-docs -- check` passes (48/48); verified the commands and interactive vs non-interactive behavior against the released 4.11.0 CLI.

This pull request and its description were written by Isaac.
