### PR TITLE
chore: model parent-option inheritance in the CLI schema generator

### DIFF
--- a/scripts/docs-checks/neonctl/__tests__/units.test.js
+++ b/scripts/docs-checks/neonctl/__tests__/units.test.js
@@ -14,7 +14,7 @@ const {
   isLikelyCommand,
   buildTopLevelCommands,
 } = require('../extract-examples.js');
-const { parseCommandFile, enumerateConstEntries } = require('../generate-schema.js');
+const { parseCommandFile, enumerateConstEntries, inheritParentOptions } = require('../generate-schema.js');
 const { loadSchema, resolvePath, resolveValidOptions } = require('../schema.js');
 
 // Writes `source` to a temp .ts file and returns its path, for exercising the
@@ -323,5 +323,112 @@ describe('enumerateConstEntries', () => {
 
   it('returns null when the source file does not exist', () => {
     expect(enumerateConstEntries('/no/such/file.ts', 'X', 'describe')).toBeNull();
+  });
+});
+
+describe('inheritParentOptions', () => {
+  it('backfills a subcommand option from the same-named parent option (like skills update yes)', () => {
+    // Mirrors skills.ts: the parent command declares `yes` fully, and the
+    // `update` subcommand re-declares it with only a describe.
+    const file = writeTempSource(`
+      import type yargs from "yargs";
+      export const command = "skills";
+      export const describe = "Install skills";
+      export const builder = (argv: yargs.Argv) =>
+        argv
+          .command("update", "Update skills", (y: yargs.Argv) =>
+            y.options({ yes: { describe: "Skip the confirm prompt" } })
+          )
+          .options({
+            yes: { alias: "y", type: "boolean", default: false, describe: "Skip prompts" },
+            agent: { alias: "a", type: "array", describe: "Coding agent" },
+          });
+    `);
+    const parsed = parseCommandFile(file, new Map());
+    // Before inheritance the subcommand has only its own describe, and the
+    // parser can't infer the type from the bare spec, so it's the `unknown`
+    // sentinel with no alias.
+    expect(parsed.commands.update.options.yes).toEqual({
+      describe: 'Skip the confirm prompt',
+      type: 'unknown',
+    });
+
+    inheritParentOptions(parsed, {});
+
+    const yes = parsed.commands.update.options.yes;
+    // Own describe wins; alias, type, and default are inherited from the parent.
+    expect(yes.describe).toBe('Skip the confirm prompt');
+    expect(yes.alias).toBe('y');
+    expect(yes.type).toBe('boolean');
+    expect(yes.default).toBe(false);
+    // A parent option the subcommand never declared must NOT leak onto it.
+    expect(parsed.commands.update.options.agent).toBeUndefined();
+  });
+
+  it('treats a local type "unknown" as a gap and never shares object references', () => {
+    const inherited = {
+      fmt: { type: 'string', choices: ['a', 'b'], describe: 'Parent format' },
+    };
+    const node = {
+      // `fmt` re-declared with its own describe but an unresolved (unknown) type
+      // and no choices.
+      options: { fmt: { describe: 'Output format', type: 'unknown' } },
+      commands: {},
+    };
+    inheritParentOptions(node, inherited);
+    const fmt = node.options.fmt;
+    expect(fmt.describe).toBe('Output format'); // own field kept
+    expect(fmt.type).toBe('string'); // unknown filled from parent
+    expect(fmt.choices).toEqual(['a', 'b']); // array inherited
+    // The inherited array must be cloned, not shared.
+    expect(fmt.choices).not.toBe(inherited.fmt.choices);
+    fmt.choices.push('c');
+    expect(inherited.fmt.choices).toEqual(['a', 'b']);
+  });
+
+  it('does not inherit a parent `hidden` flag onto a re-declaring child', () => {
+    const node = {
+      options: { debug: { describe: 'Debug output' } },
+      commands: {},
+    };
+    inheritParentOptions(node, {
+      debug: { type: 'boolean', hidden: true, describe: 'Parent debug' },
+    });
+    const debug = node.options.debug;
+    expect(debug.type).toBe('boolean'); // type still inherited
+    expect(debug.describe).toBe('Debug output'); // own field wins
+    expect('hidden' in debug).toBe(false); // hidden is never inherited
+  });
+
+  it('cascades through nested subcommands with the nearest ancestor winning', () => {
+    // grandparent declares `fmt` fully; the mid subcommand re-declares it with
+    // its own alias; the leaf re-declares only a describe.
+    const grandparent = {
+      options: { fmt: { type: 'string', alias: 'x', default: 'gp', describe: 'gp fmt' } },
+      commands: {
+        mid: {
+          options: { fmt: { alias: 'm', describe: 'mid fmt' } },
+          commands: {
+            leaf: { options: { fmt: { describe: 'leaf fmt' } }, commands: {} },
+          },
+        },
+      },
+    };
+    inheritParentOptions(grandparent, {});
+
+    // mid keeps its own alias/describe, inherits type + default from grandparent.
+    expect(grandparent.commands.mid.options.fmt).toEqual({
+      alias: 'm',
+      describe: 'mid fmt',
+      type: 'string',
+      default: 'gp',
+    });
+    // leaf keeps its own describe; alias comes from the nearest ancestor (mid's
+    // 'm', not grandparent's 'x'); grandparent's default still flows through.
+    const leaf = grandparent.commands.mid.commands.leaf.options.fmt;
+    expect(leaf.describe).toBe('leaf fmt');
+    expect(leaf.alias).toBe('m');
+    expect(leaf.type).toBe('string');
+    expect(leaf.default).toBe('gp');
   });
 });

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -819,6 +819,55 @@ function applyDynamicCommands(schema, src) {
   return schema;
 }
 
+// Backfills inherited option fields from a parent command onto the same-named
+// options its subcommands declare. yargs merges a parent command's `.options()`
+// into each subcommand, so a subcommand that re-declares an option only to
+// change its describe (like `skills update`'s `yes: { describe }`) still gets
+// the parent's `alias`, `type`, and `default`. The static parser reads each
+// builder in isolation and misses this, so the subcommand's spec came out
+// missing its alias and typed `unknown`.
+//
+// This is deliberately conservative: it only enriches options a subcommand
+// ALREADY declares, and never copies a parent option a subcommand omits. A
+// subcommand can hide or reject an inherited parent option (`skills update`
+// hides and throws on `--agent`/`--skill`), so blindly propagating every parent
+// option would add flags the subcommand doesn't actually accept. The
+// subcommand's own fields always win; the parent only fills the gaps, and
+// `hidden` is never inherited (a subcommand re-declaring an option means it).
+//
+// Scope: this models command→subcommand inheritance only. Global options are
+// not in the inherited chain (each top-level command is seeded with `{}`), so a
+// subcommand that re-declares a global with a partial spec isn't resolved here.
+// That's fine today: every such case in the CLI is a hidden option, not one
+// docs examples validate against.
+function inheritParentOptions(node, inherited = {}) {
+  const localOptions = node.options || {};
+  for (const [name, spec] of Object.entries(localOptions)) {
+    const parentSpec = inherited[name];
+    if (!parentSpec || typeof parentSpec !== 'object') continue;
+    for (const [key, value] of Object.entries(parentSpec)) {
+      if (key === 'hidden') continue;
+      // A local `type: "unknown"` is the parser's "couldn't tell" sentinel, so
+      // treat it as a gap and let the parent's real type fill it (same rule the
+      // `.positional()` merge uses).
+      const isGap = !(key in spec) || (key === 'type' && spec[key] === 'unknown');
+      if (isGap && value !== 'unknown') {
+        // Clone object/array values (e.g. a `choices` array) so the subcommand
+        // never shares a reference with the parent's spec.
+        spec[key] = value && typeof value === 'object' ? structuredClone(value) : value;
+      }
+    }
+  }
+  const commands = node.commands || {};
+  if (Object.keys(commands).length === 0) return;
+  // Nearest ancestor wins: a subcommand inherits this node's resolved options
+  // layered over what this node itself inherited from higher up.
+  const childInherited = { ...inherited, ...localOptions };
+  for (const sub of Object.values(commands)) {
+    inheritParentOptions(sub, childInherited);
+  }
+}
+
 // Deep-merges `overrides.json` (if present) into the schema. Overrides are
 // the escape hatch for terse or missing upstream descriptions — same shape
 // as the schema itself, merged key-by-key with overrides winning.
@@ -897,6 +946,12 @@ function buildSchema({ src } = {}) {
     if (parsed.describe) entry.describe = parsed.describe;
     if (parsed.usage) entry.usage = parsed.usage;
     if (parsed.examples) entry.examples = parsed.examples;
+    // Backfill options a subcommand inherits from this command (yargs merges a
+    // parent's `.options()` into its subcommands). Runs before overrides so a
+    // hand-written override still has the final say. Dynamic subcommands are
+    // injected later with no options, so running before applyDynamicCommands is
+    // a no-op on them.
+    inheritParentOptions(entry, {});
     commands[parsed.name] = entry;
   }
 
@@ -1008,6 +1063,7 @@ module.exports = {
   parseOptionsObject,
   parseCommandCall,
   enumerateConstEntries,
+  inheritParentOptions,
 };
 
 if (require.main === module) main();

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -194,19 +194,6 @@
         }
       }
     },
-    "skills": {
-      "commands": {
-        "update": {
-          "options": {
-            "yes": {
-              "_comment": "`skills update` re-declares `yes` as a bare { describe }; its `-y` alias and boolean type are inherited from the parent `skills` command's `yes`, which the isolated per-builder parse misses (so it comes out with no alias and type unknown). This override restores both. Remove it once generate-schema.js models parent-option inheritance. Verified against skills.ts at neonctl 4.11.0.",
-              "type": "boolean",
-              "alias": "y"
-            }
-          }
-        }
-      }
-    },
     "claim": {
       "commands": {
         "create": {

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -3512,6 +3512,7 @@
             "yes": {
               "type": "boolean",
               "describe": "Skip the confirm prompt",
+              "default": false,
               "alias": "y"
             }
           },


### PR DESCRIPTION
## Overview

yargs inherits a parent command's options into its subcommands, so `neon skills update`
accepts `-y` from the parent `skills` command. The schema generator parsed each builder on
its own and missed this, so `skills update`'s `yes` came out with no alias and an unknown
type, patched until now with a hand-written override.

The generator now backfills inherited fields onto the options a subcommand already declares,
without adding parent options it omits or overriding the subcommand's own fields. The
`skills update` override is now redundant and removed.

Testing: `npm run cli-docs -- check` passes (52/52), with new unit tests for the merge.

This pull request and its description were written by Isaac.
