### PR TITLE
chore: update topbar to promote autoscaling Lakebase Postgres post

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'A deep dive on the lakebase storage: S3 + WAL for the era of agents'
+text: 'The average Neon production DB resizes every 81 seconds - a deep dive on how our autoscaling is built:'
 link:
-  url: 'https://neon.com/blog/wal-s3-lakebase-storage-for-the-era-of-agents'
+  url: 'https://neon.com/blog/autoscaling-lakebase-postgres'
   target: '_blank'

--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'The average Neon production DB resizes every 81 seconds - a deep dive on how our autoscaling is built:'
+text: 'The average Neon production DB resizes every 81 seconds. Here's a deep dive on how our autoscaling is built'
 link:
   url: 'https://neon.com/blog/autoscaling-lakebase-postgres'
   target: '_blank'


### PR DESCRIPTION


- Updates the site topbar announcement to: "The average Neon production DB resizes every 81 seconds - a deep dive on how our autoscaling is built:"
- Links to https://neon.com/blog/autoscaling-lakebase-postgres
