### PR TITLE
docs: document neon ask and functions --no-bundle (Neon CLI 4.13.0)

### DIFF
--- a/content/docs/cli/ask.md
+++ b/content/docs/cli/ask.md
@@ -1,0 +1,40 @@
+---
+title: 'Neon CLI command: ask'
+subtitle: 'Ask the Neon assistant a question from the terminal'
+summary: >-
+  The Neon CLI `ask` command sends a question to the Neon assistant and prints
+  the answer in your terminal. It answers from Neon's documentation and needs no
+  login; use `--output json` for machine-readable output when scripting or
+  calling it from an agent.
+enableTableOfContents: true
+---
+
+The `ask` command sends a question to the Neon assistant and prints the answer to your terminal: `neon ask --prompt "<question>"`. The assistant answers from Neon's documentation, so keep questions scoped to Neon and Lakebase Postgres rather than general chat. No login is required, and it doesn't touch your projects or account.
+
+The answer is natural-language text, not structured data. By default it streams as markdown, use `--output json` to get the answer back as a single `text` field you can parse.
+
+## Usage
+
+<CliUsage command="ask" />
+
+Pass your question with `--prompt`. It's the only required option.
+
+## Options
+
+<CliOptions command="ask" />
+
+`--output json` and `--output yaml` both return the full answer at once as a single `text` field, instead of streaming markdown.
+
+## Examples
+
+Ask a question:
+
+```bash
+neon ask --prompt "How do schema-only branches work?"
+```
+
+Get the answer as JSON so you can process it in a script:
+
+```bash
+neon ask --prompt "What is a Neon project?" --output json
+```

--- a/content/docs/cli/functions.md
+++ b/content/docs/cli/functions.md
@@ -28,6 +28,8 @@ Deploys a function from a local directory or entry file. The `<slug>` is the per
 
 By default, `deploy` waits until the deployment finishes building (`--wait=true`), which is the predictable path for scripts and CI. Use `--no-wait` to return immediately after triggering the deployment.
 
+By default, `deploy` bundles your `--src` with esbuild before uploading. Pass `--no-bundle` to skip bundling and deploy a prebuilt source instead: the directory root (or the file you point at) must be named or contain `index.mjs` or `index.js`. This is useful when you run your own build step and want to ship the output as-is.
+
 Deploy a function from an entry file:
 
 ```bash

--- a/content/docs/compute/functions/deploy.md
+++ b/content/docs/compute/functions/deploy.md
@@ -6,7 +6,7 @@ summary: >-
   deploy, or the Neon API, including flags, deployment states, and slug rules.
   Also covers checking status, listing functions, and deleting them.
 enableTableOfContents: true
-updatedOn: '2026-07-16T00:24:48.901Z'
+updatedOn: '2026-08-31T17:10:44.328Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -41,19 +41,20 @@ To deploy one function directly, without a `neon.ts` config:
 neon functions deploy <slug> [--src <dir-or-entry-file>] [--env KEY=VALUE] [--wait]
 ```
 
-The CLI bundles with esbuild, zips the output, and uploads it. The first deploy creates the function; subsequent deploys update it. See the [neon functions reference](/docs/cli/functions) for the full command surface.
+By default, the CLI bundles your source with esbuild, zips the output, and uploads it. Pass `--no-bundle` to skip esbuild and ship a prebuilt source as-is. The first deploy creates the function; subsequent deploys update it. See the [neon functions reference](/docs/cli/functions) for the full command surface.
 
 <Admonition type="note" title="esbuild not found">
 The `neon` CLI ships `esbuild` for most platforms. If bundling fails with an `esbuild not found` error, install it (`npm install -g esbuild`) or set `NEON_ESBUILD_PATH` to an esbuild binary. `NEON_ESBUILD_PATH` is read by the CLI's own bundler, not by `buildFunctionBundle` in [`@neon/config-runtime`](/docs/reference/config-runtime#function-bundling); when calling that package directly, pass a custom `bundleFunction` instead.
 </Admonition>
 
-| Flag              | Default       | Description                                                                                                                                   |
-| ----------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--src`           | (none)        | Function source: a directory containing `index.ts`, `index.mjs`, or `index.js`, or a path to the entry file                                   |
-| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neon deploy --env` |
-| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                          |
-| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                              |
-| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                          |
+| Flag              | Default       | Description                                                                                                                                                                                              |
+| ----------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--src`           | (none)        | Function source: a directory containing `index.ts`, `index.js`, or `index.mjs` (the first match is the entry), or a path to the entry file                                                               |
+| `--env KEY=VALUE` | (none)        | Set an environment variable. Repeatable. Stored with the deployment. Takes `KEY=VALUE` pairs, not a `.env` file path like `neon deploy --env`                                                            |
+| `--runtime`       | `nodejs24`    | Function runtime. `nodejs24` is the only valid value                                                                                                                                                     |
+| `--branch`        | linked branch | Target branch. Defaults to the branch in `.neon`                                                                                                                                                         |
+| `--wait`          | `true`        | Poll until `completed` or `failed`, up to 10 minutes                                                                                                                                                     |
+| `--no-bundle`     | off (bundles) | Skip esbuild and zip a prebuilt source as-is. The directory root, or the file you point at, must be `index.mjs` or `index.js` (TypeScript can't ship unbundled). Use it when you run your own build step |
 
 **Examples:**
 

--- a/content/docs/introduction/support.md
+++ b/content/docs/introduction/support.md
@@ -7,7 +7,7 @@ summary: >-
   options aligned with Databricks Support. Use this page to find which
   channels your plan includes and review the general support policy.
 enableTableOfContents: true
-updatedOn: '2026-06-30T18:26:43.964Z'
+updatedOn: '2026-08-31T17:10:44.328Z'
 ---
 
 This page outlines Neon's support plans, available channels, and policies. To learn how to access support, please refer to the [Support channels](#support-channels) section. Identify the channels available to you based on your plan and follow the links to navigate to the relevant information.
@@ -60,6 +60,7 @@ Neon AI chat assistance is available to all Neon users. You can access it from t
 - **Neon Console**: Open the Help menu (`?`) in the top right corner and select **Support**. This opens the **Neon AI Assistant** so you can ask questions about Neon.
 - **Neon documentation**: Toggle **Ask Neon AI** on the [Neon documentation](/docs/introduction) site
 - **Discord**: Join the **#gpt-help** channel on the [Neon Discord server](https://discord.gg/92vNTzKDGp)
+- **Neon CLI**: Run [`neon ask`](/docs/cli/ask) to ask questions about Neon from your terminal
 
 Neon AI Chat assistants are updated regularly and built on various sources including the Neon documentation, the Neon website, the Neon API, and Neon GitHub repositories.
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1214,6 +1214,8 @@
                   slug: cli/auth
                 - title: init
                   slug: cli/init
+                - title: ask
+                  slug: cli/ask
                 - title: mcp
                   slug: cli/mcp
                 - title: skills

--- a/content/docs/reference/neon-ts.md
+++ b/content/docs/reference/neon-ts.md
@@ -9,7 +9,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/compute/functions/reference/neon-ts/
-updatedOn: '2026-08-19T00:03:14.837Z'
+updatedOn: '2026-08-31T17:10:44.328Z'
 ---
 
 `neon.ts` is a TypeScript config file you commit to your repository. It declares which Neon services exist on your project and how each branch is configured.
@@ -302,6 +302,7 @@ preview: {
       name: string,       // display name shown in neon functions list and the console
       source: string,     // path to entry file, relative to neon.ts
       env?: Record<string, string>,
+      bundler?: "esbuild" | "none",  // default "esbuild"; "none" ships a prebuilt source as-is
       dev?: {
         port?: number,    // local port for neon dev; fails if taken; auto-assigned if omitted
       },
@@ -321,6 +322,8 @@ env: {
 ```
 
 Use `neon deploy --env .env.production` to load a `.env` file before evaluation. For typed access to these variables inside your function at runtime, see [Environment variables](/docs/compute/functions/environment-variables).
+
+`bundler` controls how `source` becomes the deployed archive. The default, `"esbuild"`, bundles your source (TypeScript is compiled here). Set `"none"` to ship a prebuilt directory or file as-is, in which case the entry must be named `index.mjs` or `index.js`. This is the config form of the CLI's [`--no-bundle`](/docs/compute/functions/deploy#deploy-with-neon-functions-deploy) flag.
 
 `dev` settings apply only to `neon dev` and never affect deploy.
 

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.11.0",
+  "neonctlVersion": "4.13.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -219,6 +219,31 @@
       },
       "describe": "Manage API keys",
       "usage": "$0 api-keys <sub-command> [options]"
+    },
+    "ask": {
+      "aliases": [],
+      "positionals": [],
+      "options": {
+        "prompt": {
+          "type": "string",
+          "describe": "The question to ask",
+          "required": true
+        },
+        "url": {
+          "type": "string",
+          "describe": "Override the assistant URL",
+          "hidden": true
+        }
+      },
+      "commands": {},
+      "describe": "Ask a question about Neon",
+      "usage": "$0 ask --prompt <question>",
+      "examples": [
+        {
+          "command": "$0 ask --prompt \"How do schema-only branches work?\"",
+          "description": ""
+        }
+      ]
     },
     "auth": {
       "aliases": [
@@ -1686,6 +1711,11 @@
             }
           ],
           "options": {
+            "bundle": {
+              "type": "boolean",
+              "describe": "Bundle --src with esbuild. Use --no-bundle to zip a prebuilt directory (root must contain index.mjs or index.js) or a file of that name.",
+              "default": true
+            },
             "entry": {
               "type": "string",
               "hidden": true
@@ -1707,7 +1737,7 @@
             },
             "src": {
               "type": "string",
-              "describe": "Function source: a directory containing index.ts, index.mjs, or index.js, or a path to the entry file"
+              "describe": "Function source: a directory containing index.ts, index.js, or index.mjs (first file match is the entry), or a path to the entry file"
             },
             "wait": {
               "type": "boolean",
@@ -2989,7 +3019,9 @@
       "usage": "$0 orgs <sub-command> [options]"
     },
     "plugins": {
-      "aliases": [],
+      "aliases": [
+        "plugin"
+      ],
       "positionals": [],
       "options": {
         "agent": {
@@ -3473,7 +3505,9 @@
       "usage": "$0 set-context [options]"
     },
     "skills": {
-      "aliases": [],
+      "aliases": [
+        "skill"
+      ],
       "positionals": [],
       "options": {
         "agent": {

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -52,6 +52,7 @@ const GROUP_OF = {
   skills: 'setup',
   plugins: 'setup',
   claim: 'setup',
+  ask: 'setup',
 };
 
 // Commands documented as a section of another command's page instead of a

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -38,6 +38,10 @@ const META = {
     examples: ['neon open'],
   },
   me: { desc: 'Show the authenticated user.', examples: ['neon me'] },
+  ask: {
+    desc: 'Ask the Neon assistant a question from the terminal.',
+    examples: ['neon ask --prompt "How do schema-only branches work?"'],
+  },
   mcp: {
     desc: 'Install the Neon MCP server into your coding agents.',
     examples: ['neon mcp', 'neon mcp -y'],


### PR DESCRIPTION
## Overview

Refreshes the generated Neon CLI reference to 4.13.0. Two user-facing additions land in this release: the neon ask command, which sends a question to the Neon assistant and prints the answer in your terminal, and a --no-bundle flag on functions deploy that ships a prebuilt source instead of running esbuild.

Alongside the generated schema, this adds the neon ask reference page and its nav and overview entries, documents --no-bundle in both the CLI reference and the Functions deploy guide, adds the matching neon.ts bundler field to the neon.ts reference, and corrects a stale entry-file search order in the deploy guide. It also lists neon ask as a way to reach Neon AI chat assistance on the support page.

Verified neon ask live against the 4.13.0 binary. Both bundle modes were deployed and invoked end-to-end on a throwaway branch (--no-bundle with a prebuilt index.mjs, and the default esbuild path from a .ts source), and the neon.ts bundler: "none" field was confirmed against @neon/config 1.1.0. The CLI docs coverage suite passes (52/52).

This pull request and its description were written by Isaac.
