### PR TITLE
feat: server-render JSON-LD with enriched Organization schema

### DIFF
--- a/src/components/shared/json-ld/json-ld.jsx
+++ b/src/components/shared/json-ld/json-ld.jsx
@@ -1,13 +1,13 @@
-import Script from 'next/script';
 import PropTypes from 'prop-types';
 
+// Server-rendered JSON-LD. A plain <script> (not next/script) so the structured
+// data is present in the initial HTML for crawlers that do not execute JS.
+// Matches the inline pattern used by the docs/guides/blog pages.
 const JsonLd = ({ data, id }) => (
-  <Script
+  <script
     id={id || 'json-ld'}
     type="application/ld+json"
-    dangerouslySetInnerHTML={{
-      __html: JSON.stringify(data, null, 2),
-    }}
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
   />
 );
 

--- a/src/components/shared/json-ld/json-ld.test.jsx
+++ b/src/components/shared/json-ld/json-ld.test.jsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+
+import JsonLd from './json-ld';
+
+describe('JsonLd', () => {
+  it('renders a server-side <script type="application/ld+json"> with the data', () => {
+    const data = { '@context': 'https://schema.org', '@type': 'Organization', name: 'Neon' };
+    const html = renderToStaticMarkup(<JsonLd data={data} id="org-schema" />);
+
+    expect(html).toContain('<script');
+    expect(html).toContain('type="application/ld+json"');
+    expect(html).toContain('id="org-schema"');
+    // The JSON payload is present in the static (no-JS) markup
+    expect(html).toContain('"@type":"Organization"');
+    expect(html).toContain('Neon');
+  });
+
+  it('falls back to id="json-ld" when no id prop is given', () => {
+    const html = renderToStaticMarkup(<JsonLd data={{ a: 1 }} />);
+    expect(html).toContain('id="json-ld"');
+  });
+});

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -1,8 +1,26 @@
-const SITE_URL = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL;
+import LINKS from 'constants/links';
+import SEO_DATA from 'constants/seo-data';
+
+const SITE_URL = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://neon.com';
 
 export const generateOrganizationSchema = () => ({
   '@context': 'https://schema.org',
   '@type': 'Organization',
-  name: 'Neon Serverless Postgres',
+  name: 'Neon',
+  alternateName: 'Neon Serverless Postgres',
+  legalName: 'Neon, LLC',
   url: SITE_URL,
+  description: SEO_DATA.index.description,
+  logo: `${SITE_URL}/brand/neon-logo-light-color.svg`,
+  sameAs: [LINKS.github, LINKS.twitter, LINKS.linkedin, LINKS.youtube, LINKS.discord],
+  parentOrganization: {
+    '@type': 'Organization',
+    name: 'Databricks, Inc.',
+    url: 'https://www.databricks.com',
+  },
+  contactPoint: {
+    '@type': 'ContactPoint',
+    contactType: 'sales',
+    url: `${SITE_URL}${LINKS.contactSales}`,
+  },
 });

--- a/src/lib/schema.test.js
+++ b/src/lib/schema.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_DEFAULT_SITE_URL = 'https://neon.com';
+});
+
+describe('generateOrganizationSchema', () => {
+  it('returns a complete Organization node (no postal address)', async () => {
+    const { generateOrganizationSchema } = await import('./schema');
+    const s = generateOrganizationSchema();
+
+    expect(s['@context']).toBe('https://schema.org');
+    expect(s['@type']).toBe('Organization');
+    expect(s.name).toBe('Neon');
+    expect(s.alternateName).toBe('Neon Serverless Postgres');
+    expect(s.legalName).toBe('Neon, LLC');
+    expect(s.url).toBe('https://neon.com');
+    expect(s.description).toBeTruthy();
+    expect(s.logo).toMatch(/^https?:\/\//);
+    expect(Array.isArray(s.sameAs)).toBe(true);
+    expect(s.sameAs.length).toBeGreaterThanOrEqual(3);
+    expect(s.parentOrganization?.name).toMatch(/Databricks/i);
+    expect(s.contactPoint?.['@type']).toBe('ContactPoint');
+    expect(s.contactPoint?.contactType).toBeTruthy();
+    // Product decision: no PostalAddress
+    expect(s.address).toBeUndefined();
+  });
+
+  it('produces JSON-serialisable output', async () => {
+    const { generateOrganizationSchema } = await import('./schema');
+    expect(() => JSON.stringify(generateOrganizationSchema())).not.toThrow();
+  });
+});


### PR DESCRIPTION
neon.com's Organization JSON-LD was injected client-side via next/script, so it never appeared in the server HTML that non-JavaScript crawlers and AI agents read. This renders it as a plain inline script, and fills out the Organization node, which previously had only name and url.

The schema now includes the brand name, legal name (Neon, LLC), parent company (Databricks, Inc.), logo, description, a sales contact point, and the company's social profiles pulled from the shared LINKS constants.

Verified against a local build: the Organization block is present in the raw HTML of /, /home, and /mts with no JavaScript. Unit tests cover the server-rendered script tag and the schema shape. The existing social URLs in LINKS are reused as-is; correcting the stale ones is left to a separate issue.

This pull request and its description were written by Isaac.