### PR TITLE
docs: reorganize Neon Functions nav and publish bot guides

### DIFF
--- a/content/docs/compute/functions/discord-bot.md
+++ b/content/docs/compute/functions/discord-bot.md
@@ -2,7 +2,7 @@
 title: How to host a Discord bot on Neon Functions
 subtitle: Receive slash commands at a public function URL with no Gateway connection
 enableTableOfContents: true
-isDraft: true
+isDraft: false
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />

--- a/content/docs/compute/functions/telegram-bot.md
+++ b/content/docs/compute/functions/telegram-bot.md
@@ -2,7 +2,7 @@
 title: How to host a Telegram bot on Neon Functions
 subtitle: Receive Telegram messages, run bot commands and store data in Postgres
 enableTableOfContents: true
-isDraft: true
+isDraft: false
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />

--- a/content/docs/compute/functions/whatsapp-bot.md
+++ b/content/docs/compute/functions/whatsapp-bot.md
@@ -2,7 +2,7 @@
 title: How to host a WhatsApp bot on Neon Functions
 subtitle: Receive WhatsApp messages and reply through the Graph API
 enableTableOfContents: true
-isDraft: true
+isDraft: false
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -806,18 +806,20 @@
           slug: compute/functions/environment-variables
         - title: Authentication
           slug: compute/functions/authentication
-        - section: Guides
+        - section: Use cases
           items:
-            - title: WhatsApp bot
-              slug: compute/functions/whatsapp-bot
-            - title: Telegram bot
-              slug: compute/functions/telegram-bot
-            - title: Discord bot
-              slug: compute/functions/discord-bot
             - title: AI agents
               slug: compute/functions/agents
             - title: WebSockets and SSE
               slug: compute/functions/websockets
+        - section: Example apps
+          items:
+            - title: Discord bot
+              slug: compute/functions/discord-bot
+            - title: Telegram bot
+              slug: compute/functions/telegram-bot
+            - title: WhatsApp bot
+              slug: compute/functions/whatsapp-bot
         - section: Reference
           items:
             - title: Runtime limits


### PR DESCRIPTION
## Changes

- Split the Neon Functions `Guides` nav section into two: **Use cases** (AI agents, WebSockets and SSE) and **Example apps** (Discord, Telegram, WhatsApp bots).
- Set `isDraft: false` on the three merged bot guides (`discord-bot`, `telegram-bot`, `whatsapp-bot`) so they publish in production.

## Notes

- `Example apps` is intended to grow as walkthroughs for the other `neon bootstrap` templates land.
- Follow-up: the new `compute/functions/discord-bot` overlaps the existing `guides/discord-bot-on-neon-functions`; the Discord duplication still needs resolving.

This pull request and its description were written by Isaac.