### PR TITLE
docs: update 'new' tags across nav and pages

### DIFF
--- a/content/docs/ai-gateway/anthropic-messages.md
+++ b/content/docs/ai-gateway/anthropic-messages.md
@@ -1,12 +1,14 @@
 ---
 title: Anthropic Messages API
+tag: new
+tagTheme: green
 subtitle: Use the Anthropic SDK with Neon AI Gateway
 summary: >-
   The Anthropic Messages endpoint lets you use the Anthropic SDK with Neon AI
   Gateway by changing only the base URL. Supports streaming, prompt caching,
   and extended thinking on Claude models.
 enableTableOfContents: true
-updatedOn: '2026-08-06T17:43:14.909Z'
+updatedOn: '2026-09-01T16:04:17.197Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />

--- a/content/docs/ai/ai-grok-bot-plugin.md
+++ b/content/docs/ai/ai-grok-bot-plugin.md
@@ -1,5 +1,7 @@
 ---
 title: Grok Bot plugin for Neon
+tag: new
+tagTheme: green
 summary: >-
   Connect Neon to Grok Bot so you can create projects, work with branches and
   run SQL from chat.

--- a/content/docs/cli/ask.md
+++ b/content/docs/cli/ask.md
@@ -1,5 +1,7 @@
 ---
 title: 'Neon CLI command: ask'
+tag: new
+tagTheme: green
 subtitle: 'Ask the Neon assistant a question from the terminal'
 summary: >-
   The Neon CLI `ask` command sends a question to the Neon assistant and prints

--- a/content/docs/cli/claim.md
+++ b/content/docs/cli/claim.md
@@ -1,5 +1,7 @@
 ---
 title: 'Neon CLI command: claim'
+tag: new
+tagTheme: green
 subtitle: Create and claim a temporary Neon project without an account
 summary: >-
   The Neon CLI `claim` command (`neon claimable` is an alias) creates a

--- a/content/docs/cli/logs.md
+++ b/content/docs/cli/logs.md
@@ -1,5 +1,7 @@
 ---
 title: 'Neon CLI command: logs'
+tag: new
+tagTheme: green
 subtitle: Query the logs a branch's services emit
 summary: >-
   The Neon CLI `neon logs` command reads the logs a branch's services emit.
@@ -9,7 +11,7 @@ summary: >-
   LogQL, and list which fields and values a branch reports. Logs are in beta
   and available only in AWS US East (Ohio) (aws-us-east-2).
 enableTableOfContents: true
-updatedOn: '2026-08-26T13:16:52.511Z'
+updatedOn: '2026-09-01T16:04:17.197Z'
 ---
 
 <FeatureBeta />

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -1,5 +1,7 @@
 ---
 title: 'Neon CLI command: mcp'
+tag: new
+tagTheme: green
 subtitle: 'Install the Neon MCP Server into your coding agents'
 summary: >-
   The Neon CLI `mcp` command installs the [Neon MCP Server](/docs/ai/neon-mcp-server)

--- a/content/docs/cli/open.md
+++ b/content/docs/cli/open.md
@@ -1,5 +1,7 @@
 ---
 title: 'Neon CLI command: open'
+tag: new
+tagTheme: green
 subtitle: 'Open the linked project in the Neon Console in your browser'
 summary: >-
   The Neon CLI `open` command opens your linked project's dashboard in the Neon

--- a/content/docs/cli/plugins.md
+++ b/content/docs/cli/plugins.md
@@ -1,5 +1,7 @@
 ---
 title: 'Neon CLI command: plugins'
+tag: new
+tagTheme: green
 subtitle: 'Install the Neon plugin into coding agents that support plugin marketplaces'
 summary: >-
   The Neon CLI `plugins` command installs the `neon-postgres` plugin into

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -1,5 +1,7 @@
 ---
 title: 'Neon CLI command: skills'
+tag: new
+tagTheme: green
 subtitle: 'Install and update Neon agent skills in your coding agents'
 summary: >-
   The Neon CLI `skills` command installs [Neon agent skills](/docs/ai/agent-skills)
@@ -8,7 +10,7 @@ summary: >-
   agents and skip the prompts. Use `neon skills update` to refresh installed
   skills to their latest versions.
 enableTableOfContents: true
-updatedOn: '2026-08-28T19:48:06.838Z'
+updatedOn: '2026-09-01T16:04:17.197Z'
 ---
 
 The `skills` command installs [Neon agent skills](/docs/ai/agent-skills) into your coding agents, so tools like Cursor and Claude Code know how to work with Neon's Postgres, AI Gateway, Object Storage, and Functions.

--- a/content/docs/compute/functions/discord-bot.md
+++ b/content/docs/compute/functions/discord-bot.md
@@ -1,5 +1,7 @@
 ---
 title: How to host a Discord bot on Neon Functions
+tag: new
+tagTheme: green
 subtitle: Receive slash commands at a public function URL with no Gateway connection
 enableTableOfContents: true
 isDraft: false

--- a/content/docs/compute/functions/telegram-bot.md
+++ b/content/docs/compute/functions/telegram-bot.md
@@ -1,5 +1,7 @@
 ---
 title: How to host a Telegram bot on Neon Functions
+tag: new
+tagTheme: green
 subtitle: Receive Telegram messages, run bot commands and store data in Postgres
 enableTableOfContents: true
 isDraft: false

--- a/content/docs/compute/functions/whatsapp-bot.md
+++ b/content/docs/compute/functions/whatsapp-bot.md
@@ -1,5 +1,7 @@
 ---
 title: How to host a WhatsApp bot on Neon Functions
+tag: new
+tagTheme: green
 subtitle: Receive WhatsApp messages and reply through the Graph API
 enableTableOfContents: true
 isDraft: false

--- a/content/docs/guides/backup-restore.md
+++ b/content/docs/guides/backup-restore.md
@@ -9,10 +9,8 @@ summary: >-
   automated daily, weekly, or monthly backups. Snapshot storage is billed at
   $0.09/GB-month. Scheduled snapshots do not count toward the manual snapshot
   limit.
-tag: new
-tagTheme: green
 enableTableOfContents: true
-updatedOn: '2026-08-31T19:23:51.024Z'
+updatedOn: '2026-09-01T14:50:06.167Z'
 ---
 
 <Admonition type="note" title="Snapshots">

--- a/content/docs/guides/kotlin.md
+++ b/content/docs/guides/kotlin.md
@@ -1,5 +1,7 @@
 ---
 title: Connect a Kotlin application to Neon Postgres
+tag: new
+tagTheme: green
 subtitle: Learn how to run SQL queries in Neon from Kotlin using the PostgreSQL JDBC
   driver
 summary: >-
@@ -9,7 +11,7 @@ summary: >-
   and rollback. Also covers dotenv-kotlin for credential management. Focuses on
   raw JDBC without an ORM, unlike Micronaut or Hibernate guides.
 enableTableOfContents: true
-updatedOn: '2026-07-17T21:07:05.131Z'
+updatedOn: '2026-09-01T16:04:17.197Z'
 ---
 
 <CopyPrompt src="/prompts/kotlin-prompt.md"

--- a/content/docs/introduction/spending-notifications.md
+++ b/content/docs/introduction/spending-notifications.md
@@ -10,8 +10,6 @@ summary: >-
 redirectFrom:
   - /docs/introduction/spending-limit
 enableTableOfContents: true
-tag: new
-tagTheme: green
 ---
 
 <InfoBlock>

--- a/content/docs/manage/project-permissions-get-started.md
+++ b/content/docs/manage/project-permissions-get-started.md
@@ -1,5 +1,7 @@
 ---
 title: Get started with project permissions
+tag: new
+tagTheme: green
 subtitle: Scope each person and agent to the projects they need, in about five minutes
 summary: >-
   A worked example that takes a four-person team from everyone-sees-everything

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1079,8 +1079,6 @@
           slug: introduction/manage-billing
         - title: Spending notifications
           slug: introduction/spending-notifications
-          tag: new
-          tagTheme: green
         - title: Monitor billing
           slug: introduction/monitor-usage
         - title: Usage and cost calculations

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -93,6 +93,8 @@
               slug: guides/javascript
             - title: Kotlin
               slug: guides/kotlin
+              tag: new
+              tagTheme: green
             - title: Python
               slug: guides/python
             - title: Rust
@@ -836,10 +838,16 @@
           items:
             - title: Discord bot
               slug: compute/functions/discord-bot
+              tag: new
+              tagTheme: green
             - title: Telegram bot
               slug: compute/functions/telegram-bot
+              tag: new
+              tagTheme: green
             - title: WhatsApp bot
               slug: compute/functions/whatsapp-bot
+              tag: new
+              tagTheme: green
         - section: Reference
           items:
             - title: Runtime limits
@@ -890,6 +898,8 @@
               slug: ai-gateway/openai-responses
             - title: Anthropic Messages API
               slug: ai-gateway/anthropic-messages
+              tag: new
+              tagTheme: green
             - title: Gemini API
               slug: ai-gateway/gemini
         - section: Reference
@@ -914,6 +924,8 @@
               slug: manage/accounts
             - title: Permissions quickstart
               slug: manage/project-permissions-get-started
+              tag: new
+              tagTheme: green
             - title: User permissions
               slug: manage/user-permissions
             - title: Organizations
@@ -1119,6 +1131,8 @@
           items:
             - title: Claimable Neon
               slug: reference/claimable-neon
+              tag: new
+              tagTheme: green
         - section: Guides
           icon: book
           items:
@@ -1161,6 +1175,8 @@
                   slug: ai/ai-cursor-plugin
                 - title: Grok Bot plugin
                   slug: ai/ai-grok-bot-plugin
+                  tag: new
+                  tagTheme: green
                 - title: GitHub Copilot agents
                   slug: ai/ai-github-copilot-agents
             - section: Build AI agents
@@ -1215,14 +1231,24 @@
                   slug: cli/init
                 - title: ask
                   slug: cli/ask
+                  tag: new
+                  tagTheme: green
                 - title: mcp
                   slug: cli/mcp
+                  tag: new
+                  tagTheme: green
                 - title: skills
                   slug: cli/skills
+                  tag: new
+                  tagTheme: green
                 - title: plugins
                   slug: cli/plugins
+                  tag: new
+                  tagTheme: green
                 - title: claim
                   slug: cli/claim
+                  tag: new
+                  tagTheme: green
                 - title: bootstrap
                   slug: cli/bootstrap
                 - title: link
@@ -1235,6 +1261,8 @@
                   slug: cli/set-context
                 - title: open
                   slug: cli/open
+                  tag: new
+                  tagTheme: green
                 - title: me
                   slug: cli/me
                 - title: profile
@@ -1301,6 +1329,8 @@
                   slug: cli/inspect
                 - title: logs
                   slug: cli/logs
+                  tag: new
+                  tagTheme: green
         - section: API
           icon: api
           items:

--- a/content/docs/reference/claimable-neon.md
+++ b/content/docs/reference/claimable-neon.md
@@ -1,5 +1,7 @@
 ---
 title: Claimable Neon
+tag: new
+tagTheme: green
 subtitle: CLI, claim, and HTTP reference
 summary: >-
   If an agent needs a Neon account and the user is not around, provision a
@@ -10,7 +12,7 @@ redirectFrom:
   - /docs/reference/neon-launchpad
   - /docs/reference/instagres
   - /docs/reference/claimable-postgres
-updatedOn: '2026-08-26T18:00:00.000Z'
+updatedOn: '2026-09-01T16:04:17.197Z'
 ---
 
 If an agent needs a Neon account and the user is not around, it provisions a project now. A human claims it later if they want to keep it. The agent receives credentials scoped to one project, builds with standard Postgres tools, and hands over a claim link. Unclaimed projects expire in 72 hours (`project.expires_at`) and are capped at 100 MB storage and 1 GB transfer. Claim codes expire in 15 minutes (`expires_in`). Those are two clocks.
@@ -193,14 +195,14 @@ Only requested and granted services appear under `services`.
 
 ## Capabilities
 
-| Capability          | Available before claim | Environment variable          |
-| ------------------- | ---------------------- | ----------------------------- |
-| Postgres            | Yes                    | `DATABASE_URL`                |
+| Capability          | Available before claim                      | Environment variable          |
+| ------------------- | ------------------------------------------- | ----------------------------- |
+| Postgres            | Yes                                         | `DATABASE_URL`                |
 | Data API            | When requested, or later with `neon deploy` | `NEON_DATA_API_URL`           |
 | Managed Better Auth | When requested, or later with `neon deploy` | `NEON_AUTH_BASE_URL`          |
-| Functions           | No                     | Requires claiming the project |
-| Object Storage      | No                     | Requires claiming the project |
-| AI Gateway          | No                     | Requires claiming the project |
+| Functions           | No                                          | Requires claiming the project |
+| Object Storage      | No                                          | Requires claiming the project |
+| AI Gateway          | No                                          | Requires claiming the project |
 
 Registration records those as `{ granted: false, reason: "requires_claim" }`. A later protected operation returns `capability_requires_claim`. Preserve the denied capability and give the human a claim link; do not retry or drop it.
 
@@ -330,18 +332,18 @@ Use `error.code` for control flow and show `error.message` to the user. Retry on
 
 Common codes include:
 
-| Code                        | Meaning                                                      |
-| --------------------------- | ------------------------------------------------------------ |
-| `invalid_request`           | The request body or parameter is invalid                     |
-| `invalid_grant`             | The identity assertion cannot be exchanged. Discard it       |
-| `unauthorized`              | No credential was presented, or it did not verify            |
-| `token_expired`             | The access token expired. Re-exchange the identity assertion |
-| `scope_insufficient`        | The access token does not permit the operation               |
-| `capability_requires_claim` | The requested service or operation requires human ownership  |
+| Code                        | Meaning                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| `invalid_request`           | The request body or parameter is invalid                                         |
+| `invalid_grant`             | The identity assertion cannot be exchanged. Discard it                           |
+| `unauthorized`              | No credential was presented, or it did not verify                                |
+| `token_expired`             | The access token expired. Re-exchange the identity assertion                     |
+| `scope_insufficient`        | The access token does not permit the operation                                   |
+| `capability_requires_claim` | The requested service or operation requires human ownership                      |
 | `claim_in_progress`         | The transfer window is still live. Poll status; mint a new code after it expires |
-| `project_claimed`           | The project transferred. Discard the identity assertion      |
-| `project_expired`           | The unclaimed window closed. Discard the identity assertion  |
-| `upstream_error`            | A Neon API or service dependency failed                      |
+| `project_claimed`           | The project transferred. Discard the identity assertion                          |
+| `project_expired`           | The unclaimed window closed. Discard the identity assertion                      |
+| `upstream_error`            | A Neon API or service dependency failed                                          |
 
 ## Resources
 

--- a/content/docs/workflows/data-anonymization.md
+++ b/content/docs/workflows/data-anonymization.md
@@ -11,10 +11,8 @@ summary: >-
   and the branch is unavailable while anonymization runs.
 redirectFrom:
   - /docs/concepts/anonymized-data
-tag: new
-tagTheme: green
 enableTableOfContents: true
-updatedOn: '2026-08-18T10:29:02.410Z'
+updatedOn: '2026-09-01T14:50:06.167Z'
 ---
 
 <FeatureBeta />


### PR DESCRIPTION
Maintenance pass on `new` tags in the docs nav and page frontmatter.

## Removed stale `new` tags

- Spending notifications: `navigation.yaml` + page frontmatter (feature no longer new)
- Data anonymization: frontmatter-only tag (added 2025-07)
- Backup & restore: frontmatter-only tag (added 2025-05)

## Added `new` tags to pages merged in the past month

Frontmatter + matching `navigation.yaml` entry (`tag: new`, `tagTheme: green`) for:

- Compute Functions: WhatsApp bot, Telegram bot, Discord bot
- CLI: ask, claim, plugins, skills, mcp, open, logs
- Guides: Kotlin
- AI: Grok Bot plugin
- AI Gateway: Anthropic Messages API
- Reference: Claimable Neon
- Manage: Permissions quickstart

This pull request and its description were written by Isaac.