### PR TITLE
chore: exclude .claude worktrees from vitest test discovery

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    exclude: [...configDefaults.exclude, 'tests/critical-flows/**'],
+    exclude: [...configDefaults.exclude, 'tests/critical-flows/**', '**/.claude/**'],
     globals: true,
     setupFiles: ['./vitest.setup.js'],
   },


### PR DESCRIPTION
## Overview

Vitest ran the duplicate test files inside Claude Code's in-repo worktrees (`.claude/worktrees/`),
because its `exclude` list didn't cover `.claude`. Those copies ran alongside the real suite and
collided on a shared worker, producing spurious failures that blocked the `pre-push` hook. This adds
`**/.claude/**` to the vitest `exclude`, matching what eslint and prettier already ignore, so anyone
using Claude worktrees on this repo gets a clean test run.

Verified: `npm run test:unit:run` goes from 12 spurious failures to a clean pass (49 files, 811 tests).

This pull request and its description were written by Isaac.
