### PR TITLE
docs: best AI agent frameworks in 2026 (with persistence in Postgres)

### DIFF
--- a/content/guides/best-agent-frameworks-2026.md
+++ b/content/guides/best-agent-frameworks-2026.md
@@ -1,0 +1,241 @@
+---
+title: 'The best AI agent frameworks in 2026, compared'
+subtitle: 'A database-first ranking of the top AI agent frameworks in 2026, covering where Mastra, LangGraph, CrewAI, the OpenAI Agents SDK, and Pydantic AI store agent memory and durable state on Postgres.'
+author: rishi-raj-jain
+enableTableOfContents: true
+createdAt: '2026-09-01T00:00:00.000Z'
+---
+
+In production, AI agents are expected to remember past sessions, resume reliably after crashes, and maintain a queryable audit trail. Without this, teams face failures like agents forgetting yesterday's tickets<sup><a href="#ref-1">[1]</a></sup> or looping endlessly, burning unexpected bills<sup><a href="#ref-2">[2]</a></sup>. Enter the fix: A durable state layer, Postgres.
+
+And this is where Neon comes in. It branches a [full copy of your database per agent run](/docs/introduction/branching) in milliseconds, and [scales to zero](/docs/introduction/scale-to-zero) between runs, so an idle agent's compute costs nothing ([yes, really](/docs/introduction/cost-optimization#compute-cu-hours)).
+
+This guide ranks popular AI agent frameworks by how they handle memory and durable state, and how well they fit serverless Postgres.
+
+## What do you need from an AI agent framework?
+
+At a minimum, a useful AI agent framework should:
+
+- Support **tool calling** so the agent can invoke functions, APIs, and other systems.
+- Stay **model-agnostic** so you can swap models without rewriting the agent.
+- Provide a **control-flow model** to express what happens in what order, whether that's a loop, a graph, or a crew of roles.
+- Keep some notion of **memory**, at least conversation history within a run.
+
+The strongest frameworks add:
+
+- **Durable execution:** When the process dies mid-run, the agent picks up from the last committed step instead of starting over or losing work.
+- **Long-term memory:** Recall that carries across sessions, backed by a database you can query and back up.
+- **Native MCP:** The [Model Context Protocol](https://modelcontextprotocol.io/) is now the common way to expose tools and context to agents.
+- **Evals and tracing:** You can measure whether the agent is getting better and see what it did when it fails.
+- **Serverless deploy:** The agent runs in the edge and serverless runtimes where modern apps run.
+
+Here's how some of the most popular AI agent frameworks compare:
+
+| Framework              | Language   | Architecture                          | Durable + resumable            | First-class long-term memory         | Native Postgres backend             |
+| :--------------------- | :--------- | :------------------------------------ | :----------------------------- | :----------------------------------- | :---------------------------------- |
+| **Mastra**             | TypeScript | Agents + workflows (suspend/resume)   | Yes                            | Yes, built in (working + semantic recall) | Yes, `@mastra/pg`               |
+| **LangGraph**          | Python, TypeScript | Graph (typed state)                   | Yes                            | Yes, via Store + LangMem             | Yes, `PostgresSaver`                |
+| **CrewAI**             | Python     | Crews (role-based) + Flows            | Partial (manual recovery)      | Yes, built in (local by default)     | Local ChromaDB/SQLite (not swappable) |
+| **OpenAI Agents SDK**  | Python, TypeScript     | Minimal model-driven loop             | External (Temporal/DBOS)       | History only (DIY long-term)         | Yes, `SQLAlchemySession`            |
+| **Pydantic AI**        | Python     | Type-safe agent (tools + structured output) | External (Temporal/DBOS/Prefect/Restate) | History only (DIY long-term)  | Yes, store history in Postgres      |
+
+## What's the best AI agent framework for stateful agents?
+
+### 1. Mastra
+
+[Mastra](https://mastra.ai) is an open-source TypeScript agent framework from the team that built Gatsby. It bundles the pieces a stateful agent needs into one package: [agents that call tools](https://mastra.ai/docs/workflows/agents-and-tools), workflows with [suspend and resume](https://mastra.ai/docs/workflows/suspend-and-resume), a [native memory system](https://mastra.ai/docs/memory/overview), [RAG](https://mastra.ai/reference/rag/overview), [evals](https://mastra.ai/docs/evals/overview), [tracing](https://mastra.ai/docs/observability/tracing/overview), and [native MCP support](https://mastra.ai/docs/connections/mcp), plus [a local playground](https://mastra.ai/docs/deployment/mastra-server) for iterating on all of it.
+
+In Mastra, there are two primitives: agents and workflows. Agents call tools and reason. Workflows chain `createStep` blocks with `.then`, and any step resumes from exactly where it left off.
+
+Memory is what makes Mastra fit stateful agents: working memory for persistent user facts, semantic recall by vector similarity, and conversation history, all organized by [resources and threads](https://mastra.ai/docs/memory/message-history#threads-and-resources).
+
+To persist memory in Mastra, point `@mastra/pg`'s `PostgresStore` and `PgVector` at a [Neon connection string](/docs/get-started/connect-neon#get-your-connection-string). For a full walkthrough, refer to [Mastra + Neon guide](/guides/mastra-neon).
+
+**Strengths:**
+
+- A fully TypeScript-native agent framework
+- A local Studio runs the agent and shows its tool calls and memory
+- Model routing spans many providers through a `provider/model` string
+- Evals and tracing come in the same package, no separate vendor needed
+- Built-in deployers to Vercel, Cloudflare, or Netlify
+
+<Admonition type="tip" title="Best for">
+TypeScript teams shipping stateful agents who want memory, workflows, evals, and tracing in one package, with Postgres-backed persistence.
+</Admonition>
+
+### 2. LangGraph
+
+[LangGraph](https://www.langchain.com/langgraph) is an open-source graph orchestration framework from the LangChain team. It enables you to model an agent as nodes and edges over a typed state object, making it the default choice when you need an explicit state machine. It's a mature option for control and recoverability, with production use presented by Uber, LinkedIn, and Replit.
+
+To understand LangGraph's model, think of a graph. Each node reads and writes a shared, typed state. Edges decide what to run next. Because that state is checkpointed, LangGraph gives you crash-surviving execution, time-travel debugging, and resumable runs.
+
+To persist state on Neon, point LangGraph's [`PostgresSaver`](https://reference.langchain.com/python/langgraph.checkpoint.postgres/PostgresSaver) checkpointer at a Neon connection string, then add the Store and LangMem for long-term memory across threads, as the [LangGraph + Neon guide](/guides/langgraph-neon) walks through end to end.
+
+**Strengths:**
+
+- Explicit graph with cycles and branching to enable agents to loop, retry, and take conditional paths
+- Subgraphs let you nest a whole agent as a reusable node inside a larger multi-agent graph
+- Checkpointers resume a crashed run from its last step
+- Time-travel debugging built in
+- Human-in-the-loop pauses built in
+
+<Admonition type="tip" title="Best for">
+Python teams that need explicit, durable, resumable execution: long-running or multi-agent workflows where losing state mid-run is unacceptable.
+</Admonition>
+
+### 3. CrewAI
+
+[CrewAI](https://crewai.com/) is role-based multi-agent orchestration in Python. You define a crew where each agent gets a persona, a set of tools, and a task, and the crew collaborates to get the job done.
+
+Using CrewAI is intuitive to assembling a team. You describe a researcher, a writer, and an editor, hand each one tools, and let them pass work between them.
+
+CrewAI also has Flows, an event-driven orchestration layer where `@start`, `@listen`, and `@router` decorators wire steps together, carry typed state across them, and branch on each step's result, so you can chain several crews into one controlled process.
+
+CrewAI's native memory can't be swapped for Postgres, so you can persist crew outputs and Flow state to Neon yourself using the [CrewAI + Composio + Neon guide](/guides/composio-crewai-neon).
+
+**Strengths:**
+
+- Intuitive role-based model where each agent gets a persona, its own tools, and a task
+- Fast from zero to a running multi-agent prototype
+- Strong for pipelines where the work is split across specialized roles
+- [100+ first-party tools](https://docs.crewai.com/concepts/tools) out of the box, like `SerperDevTool` for search, `ScrapeWebsiteTool`, and `PDFSearchTool`
+- MCP support to expose tools and context to the crew
+
+<Admonition type="tip" title="Best for">
+Setting up a role-based multi-agent prototype quickly, where a crew of personas clearly map to the work and you want to be running with minimal setup.
+</Admonition>
+
+### 4. OpenAI Agents SDK
+
+[OpenAI Agents SDK](https://developers.openai.com/api/docs/guides/agents) is OpenAI's own agent framework. Its primitives are agents, handoffs to pass work between agents, guardrails to check inputs and outputs, sessions to hold conversation history, and built-in tracing for each run. It's first-party, and while it began OpenAI-only, it now runs more than 100 models through LiteLLM.
+
+The SDK runs an agentic loop, where the model picks a tool, the SDK runs it, and the result flows back to the model until it decides the task is done. Function tools have their schemas generated and validated with Pydantic, MCP servers plug in as tools, and recent releases added [sandboxed execution](https://developers.openai.com/api/docs/guides/agents/sandboxes) together with a [human approval](https://developers.openai.com/api/docs/guides/agents/guardrails-approvals#pause-for-human-review) step before a tool runs.
+
+To persist conversation history, point a [`SQLAlchemySession`](https://openai.github.io/openai-agents-python/sessions#sqlalchemy-sessions) at a Neon connection string, and it creates its `agent_sessions` and `agent_messages` tables. To add long-term recall on `pgvector` and durability with Temporal or DBOS, refer to the [replayable AI agents guide](/guides/replayable-ai-agents).
+
+**Strengths:**
+
+- Running in just a few lines
+- Built-in tracing in the OpenAI dashboard (no separate vendor)
+- First-class voice and realtime agents
+- Guardrails as a first-class primitive
+- Minimal surface you can read and debug in a few lines
+
+<Admonition type="tip" title="Best for">
+Teams that want the thinnest possible agent loop from the model vendor, are happy on OpenAI models, and will bring their own durability and long-term memory on Postgres.
+</Admonition>
+
+### 5. Pydantic AI
+
+[Pydantic AI](https://pydantic.dev/docs/ai/overview/) is a type-safe, validation-first framework from the Pydantic team. If you want structured outputs, validated tool arguments, and a clean message-history model without heavy orchestration, this is the Python framework built around those guarantees.
+
+The framework ensures that a malformed field fails at the boundary, because it requires you to declare a typed output and typed tool arguments that are validated at runtime. It's model-agnostic and light on orchestration, which is why a team migrated a three-agent swarm from CrewAI for type safety at the database boundary<sup><a href="#ref-3">[3]</a></sup>.
+
+To persist state on Neon, serialize Pydantic AI's message history into a Neon table and pair it with DBOS for durable execution, as covered in the [Pydantic AI + DBOS + Neon guide](/guides/pydantic-ai-dbos-neon).
+
+**Strengths:**
+
+- Type-safe, validated tool args and outputs
+- Dependency injection to pass and swap deps like DB connections and config
+- First-party durable execution on Temporal, DBOS, or Prefect
+- Streaming with validated output, plus an optional Pydantic Graph for complex flows
+- Pydantic Logfire for OpenTelemetry tracing
+- Built by the Pydantic team, the validation layer under other agent SDKs
+
+<Admonition type="tip" title="Best for">
+Python teams already building on Pydantic who want validated inputs and outputs, and want to bring their own durable execution when a workflow needs it.
+</Admonition>
+
+## Which agent framework should you choose?
+
+- **Building in TypeScript and want memory, workflows, and tracing in one package?** Choose **Mastra**.
+- **On Python and need explicit, durable, resumable execution?** Choose **LangGraph**.
+- **Want the fastest role-based multi-agent prototype?** Choose **CrewAI**.
+- **Building on OpenAI models and want a thin, first-party agent framework?** Choose the **OpenAI Agents SDK**.
+- **Want a type-safe, validation-first Python agent framework?** Choose **Pydantic AI**.
+
+### Recommendations by team type
+
+#### For solo developers or side projects
+
+- **Mastra** for TypeScript builders who want memory, workflows, and a local Studio in one
+- **OpenAI Agents SDK** for Python devs who want an agent running in a few lines
+- **Pydantic AI** for Python devs who want type safety without much overhead
+
+#### For early-stage startups
+
+- **Mastra** for TypeScript teams, with Postgres-backed memory and easy serverless deploys
+- **LangGraph** for Python teams that need durable, resumable runs early
+- **CrewAI** when you need a role-based multi-agent prototype fast to validate the idea
+
+#### For scaling teams
+
+- **LangGraph** for checkpointer-backed crash recovery on long runs
+- **Pydantic AI** paired with DBOS or Temporal for durable execution
+- **Mastra** for scaling suspend and resume workflows on Postgres
+
+#### For enterprises
+
+- **LangGraph** for the strongest production track record, with Klarna, Uber, and LinkedIn
+- **OpenAI Agents SDK** for OpenAI-standardized shops wanting built-in tracing and guardrails
+- **Mastra** for TypeScript enterprises that want evals, tracing, and durable workflows in one stack
+
+## Frequently asked questions
+
+<Faq>
+
+<FaqItem question="What's the best TypeScript agent framework?">
+
+**Mastra** is the strongest TypeScript-native framework. It combines native memory, suspend-and-resume workflows, evals, and tracing in one package, with `@mastra/pg` making Postgres a drop-in backend.
+
+</FaqItem>
+
+<FaqItem question="What's the best Python agent framework?">
+
+**LangGraph** is the strongest Python-native framework. It provides durable, resumable execution with an explicit graph, checkpointer-backed crash recovery, and time-travel debugging, backed by the most enterprise production use in this set.
+
+</FaqItem>
+
+<FaqItem question="Where do AI agents store memory?">
+
+Increasingly in Postgres, through each framework's adapter. **Mastra** uses `@mastra/pg`, **LangGraph** uses `PostgresSaver`, the **OpenAI Agents SDK** uses `SQLAlchemySession`, and **Pydantic AI** stores serialized message history in Postgres tables. **CrewAI** is the exception: its native memory is local ChromaDB and SQLite, so you persist to Postgres yourself.
+
+</FaqItem>
+
+<FaqItem question="How do I give a LangGraph agent persistent memory?">
+
+Use the [PostgresSaver checkpointer](https://reference.langchain.com/python/langgraph.checkpoint.postgres/PostgresSaver) and point it at a Postgres connection string. It persists state after each step, so runs survive crashes and resume from the last checkpoint.
+
+</FaqItem>
+
+<FaqItem question="Can I use Neon as the backend for these frameworks?">
+
+Yes. All five persist to standard Postgres, including Neon's serverless Postgres. Neon's ability to [branch object storage and database in milliseconds](/docs/introduction/branching) makes it a good fit for agentic workloads.
+
+</FaqItem>
+
+<FaqItem question="Do I need a separate vector database for agent memory?">
+
+Often no. [pgvector](/docs/extensions/pgvector) covers RAG and semantic memory inside Postgres, so embedding-based recall and structured state share a single database. For many agent workloads that removes the need to run and sync a dedicated vector store.
+
+</FaqItem>
+
+<FaqItem question="Are AI agent frameworks free?">
+
+Yes. All five covered in this guide are free and open source. Your only unavoidable cost is model tokens, which is the same regardless of framework.
+
+</FaqItem>
+
+<FaqItem question="Which AI agent framework is cheapest to run?">
+
+Any of them, self-hosted with state on Postgres. Because the frameworks are free and tokens are fixed, the cheapest setup is one where you own the state layer instead of renting a managed platform. On Neon, [scale to zero](/docs/introduction/autoscaling) means an idle agent's memory database costs nearly nothing between runs, which keeps the bill low for bursty agent workloads.
+
+</FaqItem>
+
+</Faq>
+
+## References
+
+1. <a id="ref-1" target="_blank" href="https://www.reddit.com/r/AI_Agents/comments/1tlgz6o/after_6_months_of_running_ai_agents_in_production/">"After 6 months of running AI agents in production" (r/AI_Agents)</a>
+2. <a id="ref-2" target="_blank" href="https://www.reddit.com/r/AI_Agents/comments/1s4u5v4/90_of_ai_agent_projects_i_get_hired_for_dont_need/">"90% of AI agent projects I get hired for don't need agents at all" (r/AI_Agents)</a>
+3. <a id="ref-3" target="_blank" href="https://www.reddit.com/r/crewai/comments/1txl68g/we_built_the_same_3agent_swarm_in_crewai_and/">"We built the same 3-agent swarm in CrewAI and Pydantic AI" (r/crewai)</a>


### PR DESCRIPTION
Preview: https://neon-next-11xjoscfq-neondatabase.vercel.app/guides/best-agent-frameworks-2026

---

This guide compares the top AI agent frameworks in 2026, focusing on their memory handling and durable state management with Postgres. It includes detailed evaluations of Mastra, LangGraph, CrewAI, OpenAI Agents SDK, and Pydantic AI.

Heavily inspired from my previous work with PostHog: https://posthog.com/blog/cheapest-ai-observability-tools