### PR TITLE
fix: mount Inkeep modals only when opened so dev works without Inkeep keys

### DIFF
--- a/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
+++ b/src/components/shared/inkeep-trigger/inkeep-trigger.jsx
@@ -114,8 +114,8 @@ const InkeepTrigger = ({ className = null, isNotFoundPage = false }) => {
       {!isNotFoundPage && (
         <InkeepAIButton className="shrink-0" handleClick={() => setIsChatOpen(true)} />
       )}
-      <InkeepModalSearch {...searchModalProps} />
-      <InkeepModalChat {...chatModalProps} />
+      {isSearchOpen && <InkeepModalSearch {...searchModalProps} />}
+      {isChatOpen && <InkeepModalChat {...chatModalProps} />}
     </div>
   );
 };


### PR DESCRIPTION
While previewing a new guide on the local dev server, every page threw a client-side Next.js error. The Inkeep trigger rendered both modal components unconditionally, so `@inkeep/cxkit-react` tried to initialize on load using API credentials from env vars. Without those keys set locally, the widget threw during client-side rendering and Next.js showed an error overlay.

<img width="1512" height="907" alt="Screenshot 2026-09-02 at 12 28 56 AM" src="https://github.com/user-attachments/assets/f504364d-bd5d-4daf-a1c0-9db9ef9d7311" />


This change renders `InkeepModalSearch` and `InkeepModalChat` only when their open state is true, so the widget initializes on a click instead.