### PR TITLE
docs(ai-gateway): cross-reference beta limits from the overview pricing section

### DIFF
--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -59,6 +59,8 @@ AI Gateway pricing isn't finalized. Here's what to expect once it moves out of b
 
 We'll publish exact per-model rates on the [Neon pricing page](https://neon.com/pricing) and update this page before billing begins.
 
+Free inference doesn't mean unlimited requests. During the beta you can still hit two account-level limits: a per-minute token limit, and a daily spend cap that returns `429 Too Many Requests`. Both are covered on the models page under [Rate limits](/docs/ai-gateway/models#rate-limits) and [Pricing](/docs/ai-gateway/models#pricing).
+
 ## Starter templates
 
 Browse working examples at [build-on-neon.vercel.app](https://build-on-neon.vercel.app/). Two templates use AI Gateway:


### PR DESCRIPTION
LKB-17333

Doc-only fix from the docs-drift audit: the AI Gateway overview's Pricing section says inference is free during the beta, but never mentions the two account-level limits that can still reject a request. One paragraph, one file. No new facts are introduced, both limits are already documented on the models page.

**Not auto-merged — awaiting your review.**

## Change: cross-reference the beta limits from the Pricing section

**Before** (`content/docs/ai-gateway/overview.md`, end of `## Pricing`):

> We'll publish exact per-model rates on the [Neon pricing page](https://neon.com/pricing) and update this page before billing begins.

**After** — the same closing line, plus one paragraph:

> Free inference doesn't mean unlimited requests. During the beta you can still hit two account-level limits: a per-minute token limit, and a daily spend cap that returns `429 Too Many Requests`. Both are covered on the models page under [Rate limits](/docs/ai-gateway/models#rate-limits) and [Pricing](/docs/ai-gateway/models#pricing).

**Why the new text is right:** the models page already documents both limits and the response a user sees — a 200,000 tokens-per-minute account limit that returns `429 Too Many Requests`, and an account-level daily spend cap that returns `429` with error code `REQUEST_LIMIT_EXCEEDED` "even though inference itself isn't billed yet". A reader who lands on the overview's Pricing section sees only "free during the beta", with nothing to suggest a request can still be blocked while it's free.

## Files

| File                                    | Change                                                                                                         |
| --------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| `content/docs/ai-gateway/overview.md`   | Adds one paragraph at the end of `## Pricing` pointing at the models page's Rate limits and Pricing sections.   |

## How to verify

Text-only, no build or runtime behavior affected.

1. Open `/docs/ai-gateway/models#rate-limits` and `/docs/ai-gateway/models#pricing`. Both headings exist and state the two limits quoted above, so the new paragraph adds no fact that isn't already published.
2. Confirm both link targets resolve (each is an `##` heading on the models page).

## Scope / what's intentionally untouched

- No limit values are repeated on the overview page, so the numbers stay single-sourced on the models page.
- The three pricing bullets are unchanged. This only adds a pointer to the beta limits.
- The daily spend cap has no published value upstream, and this PR doesn't invent one.

Tracked in LKB-17333.
