### PR TITLE
docs: improve and align the Neon Functions bot guides

### DIFF
--- a/content/docs/compute/functions/discord-bot.md
+++ b/content/docs/compute/functions/discord-bot.md
@@ -3,7 +3,12 @@ title: How to host a Discord bot on Neon Functions
 tag: new
 tagTheme: green
 subtitle: Receive slash commands at a public function URL with no Gateway connection
+summary: >-
+  Host a Discord interactions bot on Neon Functions. Receive slash commands over HTTP at a
+  public function URL, verify Discord's Ed25519 request signatures, and store data in Postgres
+  on the same branch.
 enableTableOfContents: true
+updatedOn: '2026-09-02T23:13:13.838Z'
 isDraft: false
 ---
 
@@ -20,12 +25,12 @@ Neon Functions are not the right primitive for a Discord Gateway bot yet. Gatewa
 ## Prerequisites
 
 - A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Get started with Neon Functions](/docs/compute/functions/get-started).
-- The [Neon CLI](/docs/cli), version 2.25.0 or later (`neon --version`). `neon bootstrap` needs that floor. Upgrade with `npm install -g neon@latest` if you're behind, then authenticate ([CLI auth](/docs/cli/auth)).
-- Node.js 24 (`node -v`). Deployed functions run on `nodejs24`. Get Started's Node.js 20+ is the platform floor; this template needs 24.
+- The latest [Neon CLI](/docs/cli), installed and authenticated. Upgrade with `npm install -g neon@latest`, then see [CLI auth](/docs/cli/auth).
+- Node.js 24 (`node -v`). Deployed functions run on `nodejs24`, so 24 locally is the closest match. Node.js 20+ works.
 - A Discord account.
 - A Discord server you own. Create one if you need to. You often can't add a bot to someone else's server.
 
-This guide's commands are the `pnpm` forms from the template README. The template ships `package-lock.json` and no `pnpm-lock.yaml`, so `neon bootstrap` may use npm. `npm run <script>` runs the same script names.
+This guide uses npm commands, matching the template.
 
 ## Create a Discord application
 
@@ -33,11 +38,11 @@ Open the [Discord Developer Portal](https://discord.com/developers/applications)
 
 ![Discord Developer Portal New Application modal](/docs/compute/functions/discord-new-application.png)
 
-On **General Information**, copy the **Application ID** and **Public Key**. Stash them somewhere local. They go into `.env` after you scaffold the project.
+On **General Information**, copy the **Application ID** and **Public Key**. Stash them somewhere local. They go into `.env.local` after you scaffold the project.
 
 ![Discord General Information showing Application ID and Public Key](/docs/compute/functions/discord-general-information.png)
 
-Open the **Bot** tab and click **Reset Token**. Copy the token. Discord shows it once. Resetting invalidates any previous token, so if this app already had one, update `.env` after you create it.
+Open the **Bot** tab and click **Reset Token**. Copy the token. Discord shows it once. Resetting invalidates any previous token, so if this app already had one, update `.env.local` after you create it.
 
 ![Discord Bot tab showing the Reset Token button](/docs/compute/functions/discord-bot-token.png)
 
@@ -45,7 +50,7 @@ Open the **Bot** tab and click **Reset Token**. Copy the token. Discord shows it
 Treat the bot token like a password. Anyone who has it can act as your bot. Never commit it or paste it into screenshots, tickets or chat.
 </Admonition>
 
-The public key is what the function uses to verify that a POST really came from Discord. The application ID and bot token are what `pnpm register:commands` uses to declare slash commands. `/help` uses the token at request time for command mentions.
+The public key is what the function uses to verify that a POST really came from Discord. The application ID and bot token are what `npm run register:commands` uses to declare slash commands. `/help` uses the token at request time for command mentions.
 
 ### Invite the bot to a test server
 
@@ -67,10 +72,10 @@ Slash commands show up after you [register them](#register-slash-commands).
 
 ## Scaffold the project
 
-`neon bootstrap` copies the HTTP example into an empty directory, can install dependencies and can [link](/docs/cli/link) a Neon project. The template id is `discord-bot-http`:
+`neon bootstrap` copies the HTTP example into an empty directory and prompts you to install dependencies and set up the project. Accept the prompts. Pass `--no-link` to skip linking for now; you'll [link](/docs/cli/link) in the next step, after creating `.env.local`, so Neon writes its variables straight into that file. The template id is `discord-bot-http`:
 
 ```bash
-neon bootstrap my-discord-bot --template discord-bot-http
+neon bootstrap my-discord-bot --template discord-bot-http --no-link
 cd my-discord-bot
 ```
 
@@ -90,9 +95,9 @@ export default defineConfig({
         name: "Discord interactions",
         source: "./functions/discord.ts",
         env: {
-          DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY,
-          DISCORD_APPLICATION_ID: process.env.DISCORD_APPLICATION_ID,
-          DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN,
+          DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY!,
+          DISCORD_APPLICATION_ID: process.env.DISCORD_APPLICATION_ID!,
+          DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN!,
           ...(process.env.DISCORD_GUILD_ID ? { DISCORD_GUILD_ID: process.env.DISCORD_GUILD_ID } : {}),
         },
         dev: {
@@ -106,90 +111,95 @@ export default defineConfig({
 
 The key `discord` is the function slug. It's permanent after the first deploy and appears in CLI commands and the invocation URL. See the [neon.ts reference](/docs/reference/neon-ts).
 
-This walkthrough is deploy-only. Discord needs a public HTTPS URL, so we don't use `pnpm dev` here. The scaffold still sets `dev.port` to `8787` to match the template.
+This walkthrough is deploy-only. Discord needs a public HTTPS URL, so we don't use `npm run dev` here. The scaffold still sets `dev.port` to `8787` to match the template.
 
 ## Add Discord secrets
 
-Template scripts read `.env` (`neon deploy --env .env` and `node --env-file=.env`). Don't copy `.env.example` over a `.env` that `neon bootstrap` or `neon link` already wrote. That can wipe `DATABASE_URL`. If `.env` exists, add the Discord keys to it. If it doesn't, copy `.env.example` to `.env`.
+Template scripts read `.env.local` (for example `neon deploy --env .env.local` and `node --env-file=.env.local`), the same convention as Next.js and `vercel env pull`. Bootstrap scaffolds a `.env.example` but no `.env.local` yet. Copy the example first, then link so Neon merges the branch's variables into it:
 
-```env filename=".env"
-DISCORD_PUBLIC_KEY=
-DISCORD_APPLICATION_ID=
-DISCORD_BOT_TOKEN=
+```bash
+cp .env.example .env.local
+neon link
+```
+
+Linking merges `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, and `NEON_FUNCTION_DISCORD_BASE_URL` (your function's public URL, ready before you deploy) into `.env.local`, leaving the Discord keys untouched. Uncomment and fill the three required `DISCORD_*` keys:
+
+```env filename=".env.local"
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# DISCORD_PUBLIC_KEY=
+# DISCORD_APPLICATION_ID=
+# DISCORD_BOT_TOKEN=
+
+# Optional: your test server's ID for fast guild commands; blank registers global commands.
 DISCORD_GUILD_ID=
 
-# Set automatically by Neon when running `pnpm deploy`.
+# Written into `.env.local` by `neon link`.
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=
+NEON_FUNCTION_DISCORD_BASE_URL=
 ```
 
-Fill in the four `DISCORD_*` values you stashed. For this guide, set `DISCORD_GUILD_ID` to your test server. In Discord, turn on Developer Mode (User Settings → App Settings → Advanced), right-click the server name in the sidebar and click **Copy Server ID**. A guild is a Discord server.
+For this guide, also set `DISCORD_GUILD_ID` to your test server. In Discord, turn on Developer Mode (User Settings → App Settings → Advanced), right-click the server name in the sidebar and click **Copy Server ID**. A guild is a Discord server.
 
-Don't set `NEON_BRANCH`, `DATABASE_URL` or `DATABASE_URL_UNPOOLED`. Neon writes them on deploy. See [Environment variables](/docs/compute/functions/environment-variables).
+Leave the pulled `NEON_*` and `DATABASE_URL*` values as written. See [Environment variables](/docs/compute/functions/environment-variables).
 
 If you omit `DISCORD_GUILD_ID`, the register script creates global commands, which can take up to an hour to show up. Skip that until you want a production-wide install.
 
 ## Deploy the function
 
-If you used `neon bootstrap` and let it install dependencies, skip that step. If you cloned by hand, install first (`pnpm install` as in the README, or `npm install` from the lockfile).
+If you used `neon bootstrap` and let it install dependencies, skip that step. If you cloned by hand, run `npm install` first.
 
-`pnpm deploy` (or `npm run deploy`) runs `neon deploy --env .env`, which evaluates `neon.ts` with your Discord secrets in `process.env`:
+`npm run deploy` runs `neon deploy --env .env.local`, which evaluates `neon.ts` with your Discord secrets in `process.env`:
 
 ```bash
-pnpm deploy
+npm run deploy
 ```
 
-or `npm run deploy`.
+The CLI applies the `neon.ts` policy, bundles the function and waits until that apply finishes. You'll see `Applied changes` and a **Function URLs** list. If the command fails, check [function logs](/docs/compute/functions/logs). Flags are in [Deploy and manage functions](/docs/compute/functions/deploy).
 
-The CLI applies the `neon.ts` policy, bundles the function and waits until that apply finishes. You'll see `Applied changes` and a **Function URLs** list. That list prints the `discord` origin: a URL with a trailing slash and no path. Pasting that origin into Discord fails the handshake. Copy the `discord` URL, strip the trailing slash and append `/api/interactions`. That's the value you paste into the Developer Portal. If the command fails, check [function logs](/docs/compute/functions/logs). Flags are in [Deploy and manage functions](/docs/compute/functions/deploy).
-
-Deployed env is a snapshot of `.env` at apply time. After you fix Discord keys (or if you deployed before filling them in), run `pnpm deploy` again.
-
-The URL looks like:
-
-```text shouldWrap
-https://br-cool-darkness-123456-discord.compute.c-1.us-east-2.aws.neon.tech/api/interactions
-```
-
-Your cell (`c-1`, `c-3`, …) will differ.
-
-If you need the origin again later, `pnpm endpoint` (or `npm run endpoint`) runs `neon functions get discord`. The default table columns are **Slug**, **Name**, **Invocation Url** and **Created At**. Copy **Invocation Url**, strip a trailing slash if there is one, then append `/api/interactions`. Pass `-o yaml` or `-o json` if you want the `invocation_url` key instead of the table.
+Deployed env is a snapshot of `.env.local` at apply time. Run `npm run deploy` again after any change to `.env.local`.
 
 ## Set the Interactions Endpoint URL
 
-In the Developer Portal, open **General Information**. Paste the Neon URL (including `/api/interactions`) into **Interactions Endpoint URL** and save.
+Your interactions endpoint is `NEON_FUNCTION_DISCORD_BASE_URL` (from `.env.local`) with `/api/interactions` appended:
+
+```text shouldWrap
+https://br-cool-darkness-123456-discord.compute.us-east-2.aws.neon.tech/api/interactions
+```
+
+Your URL will differ. Use the exact `NEON_FUNCTION_DISCORD_BASE_URL` value from `.env.local`, with `/api/interactions` appended; the host is specific to your branch.
+
+In the Developer Portal, open **General Information**. Paste that URL into **Interactions Endpoint URL** and save.
 
 Discord immediately POSTs a `PING` (`type: 1`). The handler verifies the signature and returns a `PONG`. If that handshake succeeds, Discord saves the URL (the Developer Portal shows a green success message).
 
-If save fails, retry once. Confirm the public key in `.env` matches General Information, you redeployed after editing `.env` and the path ends with `/api/interactions`. Then open or curl the function URL (the origin from Function URLs, or that URL plus `/api/interactions`). GET returns JSON with these keys:
+If save fails, retry once. Confirm the public key in `.env.local` matches General Information, you redeployed after editing `.env.local` and the path ends with `/api/interactions`. Then open or curl the function URL (`NEON_FUNCTION_DISCORD_BASE_URL`, or that URL plus `/api/interactions`). GET returns JSON with these keys:
 
 ```json
 {
   "ok": true,
   "service": "discord-interactions",
   "interactionsPath": "/api/interactions",
-  "interactionsUrl": "https://br-cool-darkness-123456-discord.compute.c-1.us-east-2.aws.neon.tech/api/interactions"
+  "interactionsUrl": "https://br-cool-darkness-123456-discord.compute.us-east-2.aws.neon.tech/api/interactions"
 }
 ```
 
-`ok: true` only proves the isolate is up and `interactionsUrl` is the value you paste. GET does not use the public key. A wrong key or a stale deploy still fails Discord's `PING`. Confirm `interactionsUrl` matches what you paste, then check [function logs](/docs/compute/functions/logs). Signature failures show up there. Fix `.env` and redeploy. The first PING can miss a cold start.
+`ok: true` proves the isolate is up, and `interactionsUrl` echoes the public endpoint you paste into Discord, so it should match the URL you saved. GET does not use the public key, so a wrong key or a stale deploy still fails Discord's `PING`. Check [function logs](/docs/compute/functions/logs); signature failures show up there. Fix `.env.local` and redeploy. The first PING can miss a cold start.
 
 ## Register slash commands
 
 Discord doesn't read commands from your handler. Register them once with the Discord API:
 
 ```bash
-pnpm register:commands
+npm run register:commands
 ```
-
-or `npm run register:commands`.
 
 That compiles `scripts/registerCommands.ts` and calls Discord's HTTP API with your bot token. It runs locally. It isn't part of the Neon Function. On success it prints the registered command list as JSON.
 
 The hosted function still needs `DISCORD_BOT_TOKEN`, `DISCORD_APPLICATION_ID` and `DISCORD_PUBLIC_KEY` in the deployed env. `/help` uses the token at request time for command mentions. The public key is for request verification.
 
-If it throws, check that `.env` exists and the token is set (Discord returns 401 for a bad token). A wrong `DISCORD_GUILD_ID`, or a bot that isn't in that server, fails with an unknown guild error.
+If it throws, check that `.env.local` exists and the token is set (Discord returns `401 Unauthorized` for a bad token). If the bot isn't in the target server, Discord returns `403 Missing Access`; invite it first (see [Invite the bot to a test server](#invite-the-bot-to-a-test-server)). A wrong `DISCORD_GUILD_ID` returns `404 Unknown Guild`.
 
 With `DISCORD_GUILD_ID` set, the script registers guild commands on that server.
 
@@ -209,8 +219,8 @@ If nothing appears, or Discord says "The application did not respond":
 
 - The bot is in the server with the `applications.commands` scope.
 - Discord saved the Interactions Endpoint URL after a successful PING/PONG.
-- `pnpm deploy` finished (redeploy after any `.env` change).
-- `pnpm register:commands` printed JSON (then you restarted Discord).
+- `npm run deploy` finished (redeploy after any `.env.local` change).
+- `npm run register:commands` printed JSON (then you restarted Discord).
 - `DISCORD_GUILD_ID` is this server.
 - Check [function logs](/docs/compute/functions/logs) for a failed PING or a slow cold start. Try `/ping` again once the branch is warm.
 
@@ -292,7 +302,7 @@ The template already implements more than `/ping`:
 
 - `/info` and `/help`: [Components v2](https://discord.com/developers/docs/components/overview) panels (Discord's newer message layout) with runtime details and slash-command mentions.
 - `/buttons`: Components v2 buttons (primary, secondary, success and danger).
-- `/name` and `/profile`: Postgres via Drizzle (`profiles` and `command_usage` tables). After the project is linked and deployed so `DATABASE_URL` exists, run `pnpm db:push` once. If you skip that, those commands reply that they could not reach the Neon database. On a cold branch they can also fall back to a warming-up reply; run the command again once the branch is warm.
+- `/name` and `/profile`: Postgres via Drizzle (`profiles` and `command_usage` tables). After the project is linked and deployed so `DATABASE_URL` exists, run `npm run db:push` once. If you skip that, those commands reply that they could not reach the Neon database. On a cold branch they can also fall back to a warming-up reply; run the command again once the branch is warm.
 
 To add LLM chat and image generation, see the [Community Guide](/guides/discord-bot-on-neon-functions). That's a separate from-scratch walkthrough.
 

--- a/content/docs/compute/functions/telegram-bot.md
+++ b/content/docs/compute/functions/telegram-bot.md
@@ -3,7 +3,11 @@ title: How to host a Telegram bot on Neon Functions
 tag: new
 tagTheme: green
 subtitle: Receive Telegram messages, run bot commands and store data in Postgres
+summary: >-
+  Host a Telegram bot on Neon Functions. Receive webhook updates, run bot commands, verify the
+  webhook secret token, and store data in Postgres on the same branch.
 enableTableOfContents: true
+updatedOn: '2026-09-02T23:13:13.838Z'
 isDraft: false
 ---
 
@@ -20,11 +24,11 @@ This guide uses Telegram webhooks. It doesn't run a polling process with `getUpd
 ## Prerequisites
 
 - A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Get started with Neon Functions](/docs/compute/functions/get-started).
-- The latest [Neon CLI](/docs/cli), installed and authenticated. Upgrade with `npm install -g neon@latest` if needed, then see [CLI auth](/docs/cli/auth).
-- Node.js 24 (`node -v`). Deployed functions run on `nodejs24`.
+- The latest [Neon CLI](/docs/cli), installed and authenticated. Upgrade with `npm install -g neon@latest`, then see [CLI auth](/docs/cli/auth).
+- Node.js 24 (`node -v`). Deployed functions run on `nodejs24`, so 24 locally is the closest match. Node.js 20+ works.
 - A Telegram account.
 
-The template uses npm. Its scripts load Telegram values from `.env`.
+The template uses npm. Its scripts load Telegram values from `.env.local`, the same convention as Next.js and `vercel env pull`.
 
 ## Create a Telegram bot
 
@@ -40,14 +44,12 @@ For more BotFather options, see [Creating a new bot](https://core.telegram.org/b
 
 ## Scaffold the project
 
-In an interactive terminal, `neon bootstrap` copies the Telegram example into a new directory, then prompts you to install dependencies and [link](/docs/cli/link) a Neon project. The template ID is `telegram-bot-http`:
+`neon bootstrap` copies the Telegram example into a new directory and prompts you to install dependencies and set up the project. Accept the prompts. Pass `--no-link` to skip linking for now; you'll [link](/docs/cli/link) in the next step, after creating `.env.local`, so Neon writes its variables straight into that file. The template ID is `telegram-bot-http`:
 
 ```bash
-neon bootstrap my-telegram-bot --template telegram-bot-http
+neon bootstrap my-telegram-bot --template telegram-bot-http --no-link
 cd my-telegram-bot
 ```
-
-Accept both prompts. If you skip either, run `npm install` and `neon link` before continuing.
 
 See [`neon bootstrap`](/docs/cli/bootstrap) for flags. Later commands in this guide assume you're in that directory.
 
@@ -83,12 +85,14 @@ This walkthrough deploys the function before connecting Telegram. Telegram requi
 
 ## Add Telegram secrets
 
-Don't overwrite an existing `.env`; doing so can remove `DATABASE_URL`. If `.env` doesn't exist, copy the template. Then pull the linked branch's Neon variables into the same file:
+Bootstrap scaffolds a `.env.example` but no `.env.local`. Copy the example first, then link so Neon merges the branch's variables into it:
 
 ```bash
-cp .env.example .env
-neon env pull --file .env
+cp .env.example .env.local
+neon link
 ```
+
+Linking merges `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, and `NEON_FUNCTION_TELEGRAM_BASE_URL` (your function's public URL, ready before you deploy) into `.env.local`, leaving the Telegram keys untouched.
 
 Generate a webhook secret:
 
@@ -96,22 +100,26 @@ Generate a webhook secret:
 openssl rand -hex 32
 ```
 
-Add the BotFather token and generated secret to `.env`. Leave `TELEGRAM_WEBHOOK_URL` empty until you deploy:
+Uncomment and set `TELEGRAM_BOT_TOKEN` (the BotFather token) and `TELEGRAM_WEBHOOK_SECRET` (the value you just generated). Leave `TELEGRAM_WEBHOOK_URL` empty until you deploy:
 
-```env filename=".env"
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_WEBHOOK_SECRET=
+```env filename=".env.local"
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_WEBHOOK_SECRET=
+
+# Local only, used by the set:webhook script. Set after you deploy.
 TELEGRAM_WEBHOOK_URL=
 
-# Written locally by `neon env pull`; injected into deployed functions by Neon.
+# Written into `.env.local` by `neon link`.
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=
+NEON_FUNCTION_TELEGRAM_BASE_URL=
 ```
 
 The webhook secret can contain 1 to 256 characters from `A-Z`, `a-z`, `0-9`, `_` and `-`. The `openssl` command above produces a valid value.
 
-Don't edit `NEON_BRANCH`, `DATABASE_URL` or `DATABASE_URL_UNPOOLED`. Refresh them with `neon env pull --file .env`. See [Environment variables](/docs/compute/functions/environment-variables).
+Leave the pulled `NEON_*` and `DATABASE_URL*` values as written. See [Environment variables](/docs/compute/functions/environment-variables).
 
 Only the local webhook setup script reads `TELEGRAM_WEBHOOK_URL`. Neon doesn't pass it to the function.
 
@@ -119,36 +127,20 @@ Only the local webhook setup script reads `TELEGRAM_WEBHOOK_URL`. Neon doesn't p
 
 If `neon bootstrap` installed dependencies, you can deploy now. If you copied the source by hand, run `npm install` first.
 
-The `deploy` script runs `neon deploy --env .env`, which evaluates `neon.ts` with your Telegram secrets in `process.env`:
+The `deploy` script runs `neon deploy --env .env.local`, which evaluates `neon.ts` with your Telegram secrets in `process.env`:
 
 ```bash
 npm run deploy
 ```
 
-The CLI applies the `neon.ts` policy, bundles the function and waits for the deployment to finish. You'll see `Applied changes` and a **Function URLs** list. Copy the `telegram` URL.
-
-The URL looks like:
-
-```text shouldWrap
-https://br-cool-darkness-123456-telegram.compute.c-1.us-east-2.aws.neon.tech/
-```
-
-Your cell (`c-1`, `c-3`, …) will differ.
-
-If you need the URL later, run:
-
-```bash
-npm run endpoint
-```
-
-This runs `neon functions get telegram`. Copy **Invocation Url** from the output.
+The CLI applies the `neon.ts` policy, bundles the function and waits for the deployment to finish. You'll see `Applied changes` and a **Function URLs** list. If the deployment fails, check [function logs](/docs/compute/functions/logs) and [Deploy and manage functions](/docs/compute/functions/deploy).
 
 ## Set the webhook
 
-Telegram sends updates to `/api/webhook`. Remove the trailing slash from the function URL, append `/api/webhook` and add the full URL to `.env`:
+Telegram sends updates to `/api/webhook`. Your webhook URL is `NEON_FUNCTION_TELEGRAM_BASE_URL` (from `.env.local`) with `/api/webhook` appended. Set `TELEGRAM_WEBHOOK_URL` to it:
 
-```env filename=".env"
-TELEGRAM_WEBHOOK_URL=https://br-cool-darkness-123456-telegram.compute.c-1.us-east-2.aws.neon.tech/api/webhook
+```env filename=".env.local"
+TELEGRAM_WEBHOOK_URL=https://br-cool-darkness-123456-telegram.compute.us-east-2.aws.neon.tech/api/webhook
 ```
 
 Register that URL and your webhook secret with Telegram:
@@ -170,11 +162,11 @@ Open the webhook URL in a browser to check that the function is available. A GET
   "ok": true,
   "service": "telegram-webhook",
   "webhookPath": "/api/webhook",
-  "webhookUrl": "https://br-cool-darkness-123456-telegram.compute.c-1.us-east-2.aws.neon.tech/api/webhook"
+  "webhookUrl": "https://br-cool-darkness-123456-telegram.compute.us-east-2.aws.neon.tech/api/webhook"
 }
 ```
 
-`ok: true` confirms only that the function is reachable at that URL. It doesn't verify the webhook secret or confirm webhook registration. A `true` result from `npm run set:webhook` confirms registration. Sending `/ping` verifies end-to-end delivery.
+`ok: true` confirms only that the function is reachable at that URL. `webhookUrl` echoes the public URL you requested; registering it with Telegram is still a separate step (`npm run set:webhook`). This GET doesn't verify the webhook secret or confirm webhook registration. A `true` result from `npm run set:webhook` confirms registration. Sending `/ping` verifies end-to-end delivery.
 
 ## Register bot commands
 
@@ -192,7 +184,7 @@ Run this command again after you change the command list.
 
 Open the bot link that BotFather gave you. If Telegram shows a **Start** button, click it. Then send `/ping`. The bot replies with `Pong` and an estimated webhook latency.
 
-If Telegram replies with `Unknown command` after you click **Start**, send `/ping`. The template doesn't register a `/start` command.
+The template doesn't register a `/start` command, so tapping **Start** may return `Unknown command`. Send `/ping` instead.
 
 If the bot doesn't reply:
 
@@ -230,7 +222,7 @@ The template includes more than `/ping`:
 
 The template stores Telegram user IDs, display names and usage counts in the `profiles` and `command_usage` tables. Usage tracking is best-effort and doesn't block replies.
 
-After `neon env pull --file .env` writes `DATABASE_URL`, create the tables:
+`neon link` wrote `DATABASE_URL` into `.env.local`, so create the tables any time after that:
 
 ```bash
 npm run db:push

--- a/content/docs/compute/functions/whatsapp-bot.md
+++ b/content/docs/compute/functions/whatsapp-bot.md
@@ -3,7 +3,11 @@ title: How to host a WhatsApp bot on Neon Functions
 tag: new
 tagTheme: green
 subtitle: Receive WhatsApp messages and reply through the Graph API
+summary: >-
+  Host a WhatsApp bot on Neon Functions. Receive WhatsApp Cloud API webhooks, verify Meta's
+  request signatures, reply through the Graph API, and store data in Postgres on the same branch.
 enableTableOfContents: true
+updatedOn: '2026-09-02T23:13:13.838Z'
 isDraft: false
 ---
 
@@ -20,8 +24,8 @@ This example uses Meta's hosted WhatsApp Cloud API. It doesn't automate a person
 ## Prerequisites
 
 - A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Get started with Neon Functions](/docs/compute/functions/get-started).
-- The latest [Neon CLI](/docs/cli), installed and authenticated. Upgrade with `npm install -g neon@latest`, then follow [CLI authentication](/docs/cli/auth).
-- Node.js 24 (`node -v`). Deployed functions run on `nodejs24`.
+- The latest [Neon CLI](/docs/cli), installed and authenticated. Upgrade with `npm install -g neon@latest`, then see [CLI auth](/docs/cli/auth).
+- Node.js 24 (`node -v`). Deployed functions run on `nodejs24`, so 24 locally is the closest match. Node.js 20+ works.
 - A Meta developer account.
 - A Meta app connected to a WhatsApp Business Account, with a Cloud API phone number and a test recipient. Meta's get started flow can create test resources for you.
 
@@ -63,10 +67,10 @@ Treat the access token, app secret and webhook verify token like passwords. Neve
 
 ## Scaffold the project
 
-`neon bootstrap` copies the WhatsApp HTTP example into a new directory, installs its dependencies and links a Neon project. The template ID is `whatsapp-bot-http`:
+`neon bootstrap` copies the WhatsApp HTTP example into a new directory and prompts you to install dependencies and set up the project. Accept the prompts. Pass `--no-link` to skip linking for now; you'll [link](/docs/cli/link) in the next step, after creating `.env.local`, so Neon writes its variables straight into that file. The template ID is `whatsapp-bot-http`:
 
 ```bash
-neon bootstrap my-whatsapp-bot --template whatsapp-bot-http
+neon bootstrap my-whatsapp-bot --template whatsapp-bot-http --no-link
 cd my-whatsapp-bot
 ```
 
@@ -104,61 +108,62 @@ Deploy the function before connecting Meta. Meta needs a public HTTPS callback U
 
 ## Add WhatsApp secrets
 
-The deploy script runs `neon deploy --env .env` to read `.env`. Don't replace a `.env` created by `neon bootstrap` because it can contain database variables for the linked project. Add the WhatsApp keys to the existing file. If the file doesn't exist, copy `.env.example` to `.env`.
+The deploy script runs `neon deploy --env .env.local`, the same convention as Next.js and `vercel env pull`. Bootstrap scaffolds a `.env.example` but no `.env.local`. Copy the example first, then link so Neon merges the branch's variables into it:
 
-```env filename=".env"
-WHATSAPP_ACCESS_TOKEN=
-WHATSAPP_PHONE_NUMBER_ID=
-WHATSAPP_VERIFY_TOKEN=
-WHATSAPP_APP_SECRET=
+```bash
+cp .env.example .env.local
+neon link
+```
 
-# Set automatically by Neon when running `neon deploy`.
+Linking merges `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, and `NEON_FUNCTION_WHATSAPP_BASE_URL` (your function's public URL, ready before you deploy) into `.env.local`, leaving the WhatsApp keys untouched. Uncomment and add them:
+
+```env filename=".env.local"
+# Required. Add real values before deploying; a missing key throws at deploy, an empty one uploads "".
+# WHATSAPP_ACCESS_TOKEN=
+# WHATSAPP_PHONE_NUMBER_ID=
+# WHATSAPP_VERIFY_TOKEN=
+# WHATSAPP_APP_SECRET=
+
+# Written into `.env.local` by `neon link`.
 NEON_BRANCH=
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=
+NEON_FUNCTION_WHATSAPP_BASE_URL=
 ```
 
 Set `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID` and `WHATSAPP_APP_SECRET` to the values from Meta. Set `WHATSAPP_VERIFY_TOKEN` to the random value you generated.
 
-Leave the Neon variables as written by `neon bootstrap`. Neon also injects them into the deployed function. See [Environment variables](/docs/compute/functions/environment-variables).
-
-## Apply the database schema
-
-The `/name` and `/profile` commands use the `profiles` and `command_usage` tables. Apply the included Drizzle schema to the linked Neon database:
-
-```bash
-npm run db:push
-```
-
-You can deploy and test `/ping` without these tables, but the database-backed commands will return an error until you apply the schema.
+Leave the pulled `NEON_*` and `DATABASE_URL*` values as written. Neon also injects them into the deployed function. See [Environment variables](/docs/compute/functions/environment-variables).
 
 ## Deploy the function
 
-Deploy the function with the WhatsApp secrets from `.env`:
+Deploy the function with the WhatsApp secrets from `.env.local`:
 
 ```bash
 npm run deploy
 ```
 
-The script runs `neon deploy --env .env`. The CLI evaluates `neon.ts`, bundles the handler and waits for the deployment to finish. If the deployment fails, check [function logs](/docs/compute/functions/logs) and [Deploy and manage functions](/docs/compute/functions/deploy).
+The script runs `neon deploy --env .env.local`. The CLI evaluates `neon.ts`, bundles the handler and waits for the deployment to finish. If the deployment fails, check [function logs](/docs/compute/functions/logs) and [Deploy and manage functions](/docs/compute/functions/deploy).
 
-Copy the `whatsapp` invocation URL from the deployment output. Remove its trailing slash, then append `/api/webhook`. The complete callback URL looks like:
+Your callback URL is `NEON_FUNCTION_WHATSAPP_BASE_URL` (from `.env.local`) with `/api/webhook` appended:
 
 ```text shouldWrap
-https://br-cool-darkness-123456-whatsapp.compute.c-1.us-east-2.aws.neon.tech/api/webhook
+https://br-cool-darkness-123456-whatsapp.compute.us-east-2.aws.neon.tech/api/webhook
 ```
 
-Your branch name, endpoint ID and cell will differ.
+Your URL will differ. Use the exact `NEON_FUNCTION_WHATSAPP_BASE_URL` value from `.env.local`, with `/api/webhook` appended; the host is specific to your branch.
 
-To get the invocation URL again, run:
+Deployed environment variables are a snapshot of `.env.local` at deployment time. Run `npm run deploy` again after changing any WhatsApp value.
+
+## Apply the database schema
+
+The `/name` and `/profile` commands use the `profiles` and `command_usage` tables. `neon link` wrote `DATABASE_URL` into `.env.local`, so apply the included Drizzle schema to the linked Neon database:
 
 ```bash
-npm run endpoint
+npm run db:push
 ```
 
-This script runs `neon functions get whatsapp`. Append `/api/webhook` to the returned invocation URL.
-
-Deployed environment variables are a snapshot of `.env` at deployment time. Run `npm run deploy` again after changing any WhatsApp value.
+You can test `/ping` without these tables, but the database-backed commands return an error until you apply the schema.
 
 ## Configure the webhook
 
@@ -177,7 +182,7 @@ If verification fails:
 
 - Confirm that the callback URL ends in `/api/webhook`.
 - Confirm that Meta's verify token exactly matches `WHATSAPP_VERIFY_TOKEN`.
-- Redeploy after editing `.env`.
+- Redeploy after editing `.env.local`.
 - Check [function logs](/docs/compute/functions/logs).
 
 Opening the callback URL directly in a browser returns `403 invalid verify token`. That's expected because a normal browser request doesn't contain Meta's verification query parameters.
@@ -194,7 +199,7 @@ If the bot doesn't reply:
 - Confirm that you sent the message to the phone number associated with `WHATSAPP_PHONE_NUMBER_ID`.
 - Check whether a temporary `WHATSAPP_ACCESS_TOKEN` expired.
 - Confirm that `WHATSAPP_APP_SECRET` matches the Meta app. A mismatch causes POST signature verification to return `401`.
-- Redeploy after changing `.env`, then check [function logs](/docs/compute/functions/logs).
+- Redeploy after changing `.env.local`, then check [function logs](/docs/compute/functions/logs).
 
 ## How it works
 


### PR DESCRIPTION
## Overview

Improves the three Neon Functions bot guides (Discord, Telegram, WhatsApp) after testing each
end-to-end against a live Neon project on Neon CLI 4.14. The guides now:

- Standardize on npm (pnpm's built-in `deploy` shadows the package script).
- Scaffold with `neon bootstrap --no-link`, then `cp .env.example .env` and `neon link`, so the
  Neon variables pull straight into `.env` with no stray `.env.local`.
- Read the function URL from `NEON_FUNCTION_<SLUG>_BASE_URL` (written by `neon link` before you
  deploy) instead of copying it from the deploy output. Its host tracks your branch, so the
  guides use the value rather than a fixed URL shape.
- Keep the `neon.ts` snippets in line with the templates, add `summary` and `updatedOn`
  frontmatter, and align prerequisites, scaffold steps, and command-registration troubleshooting.

## Depends on

neondatabase/examples#257, which comments out the required keys in each bot's `.env.example` so
`cp .env.example .env` then deploy fails loud until you set them. These guides document that
flow, so land #257 first or together.

## Testing

Verified end-to-end on a live Neon project in aws-us-east-2, including a working Discord bot:
command registration, the Interactions Endpoint PING/PONG handshake, and a live /ping.

This pull request and its description were written by Isaac.
