### PR TITLE
Rewrite auth.md for provision-then-claim

### DIFF
--- a/public/auth.md
+++ b/public/auth.md
@@ -34,7 +34,8 @@ If `create` is not a command, use HTTP.
 `source` is your agent name, 1-100 characters. Replace `your-agent`. Request only services
 the app needs. `postgres`, `data_api`, and `auth` can be granted now. `functions`,
 `storage`, and `ai_gateway` return `granted: false` and `reason: "requires_claim"`. Do not
-retry those. If the app needs them, go to Claim.
+retry those. Finish provision with what was granted. If the app still needs a denied
+service, claim after you have `project.id` and an access token.
 
 ```http
 POST https://claimable.neon.tech/v1/agent/identity
@@ -107,28 +108,26 @@ An unused claim code dies in `expires_in` seconds (900 today). If they have not 
 Neon and the code expired, POST this endpoint again. Each POST cancels the previous unused
 code. Re-issue only while `project.expires_at` is still in the future.
 
-Opening `verification_uri_complete` does not freeze access. Keep using `database_url` until
-they continue from that page to Neon.
+Opening `verification_uri_complete` does not freeze access.
 
-Continuing to Neon starts the transfer: existing access tokens are revoked and
-`DATABASE_URL` is rotated. The project key and database password stay revoked. Do not restore
-the old `database_url`. Re-exchange the identity assertion with the same token POST as
-above. The new token has no project scopes. It can poll claim status and mint a replacement
-code if the transfer window expires. If that window expires before they accept, POST claim
-again.
-
-Poll every `interval` seconds with that new `access_token`:
+Start polling now, every `interval` seconds, with the current `access_token`:
 
 ```http
 GET https://claimable.neon.tech/v1/projects/<project_id>/claim
 Authorization: Bearer <access_token>
 ```
 
-`state` moves `pending` → `accepted` → `reconciled`. `accepted` is brief; the next poll is
-usually `reconciled`. Keep polling until `reconciled` is true. That status stays
-`reconciled` if you retry with the same token.
+```json
+{"state":"pending","expires_at":"<iso8601>","reconciled":false}
+```
 
-At `reconciled`, discard the identity assertion, access tokens, and pre-claim
+Stop when `reconciled` is `true`.
+
+If GET returns 401, re-exchange with the same token POST as above and keep polling. When they
+continue to Neon, `DATABASE_URL` is rotated. Do not restore the old `database_url`. If the
+transfer window expires before they accept, POST claim again.
+
+At `reconciled: true`, discard the identity assertion, access tokens, and pre-claim
 `database_url`. They no longer authorize project access. Auth and the Data API stay enabled
 and transfer with the project if they were granted. The human owns the project. You are
 done.

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,63 +1,40 @@
-# Claimable Neon for agents
+# Claimable Neon
 
-If you need a Neon account and the user is not around, provision a project now. A human claims it
-later if they want to keep it.
+You need a Neon project and no human is signed in. Provision now. A human claims it later
+if they want to keep it.
 
-Claimable Neon issues an identity assertion and credentials scoped to one project.
+This file is https://neon.com/auth.md.
 
-## Discover
+If `NEON_API_KEY` is set, use that account and stop. If `neon` is on `PATH`, run
+`neon profile list -o json`. A profile whose `account` is not `-` is an account; use it and
+stop. A `DEFAULT` row with `account: "-"` is not an account. Do not run `neon auth` on this
+path.
 
-Start at `llms.txt`, then this document. Do not guess `POST /v1/agent/identity`.
-
-```text
-https://neon.com/docs/llms.txt
-https://neon.com/auth.md
-https://neon.com/.well-known/oauth-authorization-server/claimable
-https://claimable.neon.tech/.well-known/oauth-protected-resource
-https://claimable.neon.tech/.well-known/jwks.json
-```
-
-`agent_auth.skill` is this file. `identity_endpoint` is where you register. `claim_endpoint`
-accepts `{"claim_token":"<identity_assertion>"}`. JWT `iss` is `https://neon.com/claimable`. Token
-`aud` / `resource` is `https://claimable.neon.tech/`. Request and response field names for the
-HTTP calls below also live at `https://claimable.neon.tech/auth.md`. If this file and that file
-disagree on a field, use that copy. Token exchange, JWKS, and project REST stay on
-`https://claimable.neon.tech`.
-
-## Install the Neon CLI
-
-The Neon CLI is the client. Do not start from the HTTP examples unless you are implementing a
-client. Install it. If `NEON_API_KEY` is set, or `neon profile list -o json`
-lists a profile whose `account` is not `-`, use that account and stop. A `DEFAULT` row with
-`account: "-"` and `file: "missing"` is not an account. If a command waits on a browser or
-authentication fails, stop and ask the user to sign in (`neon auth`) or mint an API key. Do not
-run `neon auth` on this path.
-
-If there is no account, declare services in `neon.ts`, and let the CLI register, store the identity
-assertion, and pull env.
+## Provision
 
 ```bash
 npm i -g neon@latest
-neon skills -s neon -s neon-postgres
 ```
 
-https://neon.com/docs/cli/install.md
-https://neon.com/docs/reference/neon-ts.md
+If `neon claim --help` lists `create`:
 
 ```bash
-neon claim create --service data-api --service auth --env-pull
+neon claim create --service data-api --service auth
 neon branches list
 ```
 
-If `neon claim` is not a command, or `neon claim --help` does not list `create`, use the HTTP
-below. The HTTP below is the protocol the CLI speaks.
+Drop `--service` flags the app does not need. Postgres is always included. The CLI writes
+`DATABASE_URL` (and granted service URLs) to `.env` or `.env.local`. Then skip to Claim when
+the human is ready.
 
-## Register anonymously
+If `create` is not a command, use HTTP.
 
-Request `postgres` and any optional services the app needs. `data_api` and `auth` are
-available before claim. `functions`, `storage`, and `ai_gateway` return a recorded
-`reason: "requires_claim"` decision. Calling a protected operation for one of those capabilities
-returns the `capability_requires_claim` error code.
+### Register
+
+`source` is your agent name, 1-100 characters. Replace `your-agent`. Request only services
+the app needs. `postgres`, `data_api`, and `auth` can be granted now. `functions`,
+`storage`, and `ai_gateway` return `granted: false` and `reason: "requires_claim"`. Do not
+retry those. If the app needs them, go to Claim.
 
 ```http
 POST https://claimable.neon.tech/v1/agent/identity
@@ -66,13 +43,20 @@ Content-Type: application/json
 {"type":"anonymous","capabilities":["postgres","data_api","auth"],"source":"your-agent"}
 ```
 
-The response contains:
+Keep:
 
 - `identity_assertion`: the durable secret. Store it like an API key.
-- `project.id`, `project.branch_id`, and `project.expires_at`.
-- One decision for every requested capability. Check `granted` before using a service.
+- `project.id`, `project.branch_id`, and `project.expires_at`. The unclaimed project dies at
+  `expires_at` (72 hours today).
+- One row per requested capability. Check `granted` before using a service.
 
-## Exchange for an access token
+Register returns 201 today. Treat any 2xx as success. Otherwise stop. Do not continue with
+missing fields.
+
+### Access token
+
+The assertion is issued by https://neon.com/claimable. Exchange it for a short-lived bearer
+token. There is no refresh token. Re-exchange the same assertion when the token expires.
 
 ```http
 POST https://claimable.neon.tech/v1/oauth2/token
@@ -81,27 +65,21 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<identity_assertion>&resource=https://claimable.neon.tech/
 ```
 
-The response contains a short-lived bearer `access_token` and no refresh token. Re-exchange the
-identity assertion when the access token expires.
+Keep `access_token`. Send it as `Authorization: Bearer <access_token>`.
 
-## Pull credentials
+### Credentials
+
+`project_id` is `project.id` from register.
 
 ```http
 GET https://claimable.neon.tech/v1/projects/<project_id>/credentials
 Authorization: Bearer <access_token>
 ```
 
-The response contains `database_url`, the project and branch IDs, `expires_at`, and credentials
-for granted services:
+Keep `database_url`. If granted: `services.data_api.url`, `services.auth.base_url`,
+`services.auth.jwks_url`. Use `database_url` with any Postgres client.
 
-- `services.data_api.url`
-- `services.auth.base_url`
-- `services.auth.jwks_url`
-
-## Use the project
-
-Use `database_url` with any Postgres client. Supported Neon Management API operations are
-available through the scoped proxy:
+Management API calls the proxy allows:
 
 ```http
 GET https://claimable.neon.tech/v1/projects/<project_id>/...
@@ -110,98 +88,56 @@ Authorization: Bearer <access_token>
 
 The project-scoped Neon API key stays inside Claimable Neon and is never returned.
 
-## Claim the project
+## Claim
 
-Metadata `claim_endpoint` is `POST /v1/agent/identity/claim` with `{"claim_token":"<identity_assertion>"}`.
-The HTTP below uses the access token instead. Both create the same claim code.
+Do not mint a claim URL until the human is ready to keep the project.
 
-Create a short-lived human claim code when the project is ready to keep:
+If the CLI created the project:
+
+```bash
+neon claim accept --no-open
+neon claim status
+```
+
+Report the printed verification URL.
+
+Otherwise HTTP. `project_id` is `project.id`. The access token is from the token call above.
 
 ```http
 POST https://claimable.neon.tech/v1/projects/<project_id>/claim
 Authorization: Bearer <access_token>
 ```
 
-The unclaimed project expires at `project.expires_at` (72 hours today). A claim code expires in
-`expires_in` seconds (900 today). If the unused code expires, POST this endpoint again. Each POST
-cancels the previous unused code and returns a new one. Re-issue only while `project.expires_at`
-is still in the future.
+Keep `verification_uri_complete`, `user_code`, `expires_in`, and `interval`. Give the human
+`verification_uri_complete`. They sign in to Neon, select a destination organization, and
+accept the transfer.
 
-Open the returned `verification_uri_complete`. Opening the URL does not freeze access. Continuing
-to Neon starts a transfer with a new `expires_in` window, revokes access tokens, and rotates
-`DATABASE_URL`. If that window expires before the human accepts, POST this endpoint again. The
-project key and database password stay revoked.
+An unused claim code dies in `expires_in` seconds (900 today). If they have not continued to
+Neon and the code expired, POST this endpoint again. Each POST cancels the previous unused
+code. Re-issue only while `project.expires_at` is still in the future.
 
-The human signs in to Neon, selects a destination organization, and accepts the transfer.
+Opening `verification_uri_complete` does not freeze access. Keep using `database_url` until
+they continue from that page to Neon.
 
-Continuing to Neon revokes existing access tokens. Re-exchange the identity assertion; while the
-claim is in progress, the new token has no project scopes and authorizes claim-status polling and
-a replacement claim code if the transfer window expires:
+Continuing to Neon starts the transfer: existing access tokens are revoked and
+`DATABASE_URL` is rotated. The project key and database password stay revoked. Do not restore
+the old `database_url`. Re-exchange the identity assertion with the same token POST as
+above. The new token has no project scopes. It can poll claim status and mint a replacement
+code if the transfer window expires. If that window expires before they accept, POST claim
+again.
 
-```http
-POST https://claimable.neon.tech/v1/oauth2/token
-Content-Type: application/x-www-form-urlencoded
-
-grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<identity_assertion>&resource=https://claimable.neon.tech/
-```
-
-Retain that access token and poll at the returned `interval`:
+Poll every `interval` seconds:
 
 ```http
 GET https://claimable.neon.tech/v1/projects/<project_id>/claim
 Authorization: Bearer <claim_status_access_token>
 ```
 
-The claim moves through `pending`, `accepted`, and `reconciled`. Stop using pre-claim
-credentials when the browser claim starts. At `reconciled`, the identity assertion, access
-tokens, project key, and database password no longer authorize project access. Auth and the
-Data API stay enabled and transfer with the project if they were enabled. The status endpoint
-keeps returning the terminal `reconciled` state when retried with the retained status token.
+`state` moves `pending` → `accepted` → `reconciled`. `accepted` is brief; the next poll is
+usually `reconciled`. Keep polling until `reconciled` is true. That status stays
+`reconciled` if you retry with the same token.
 
-## Add Auth or the Data API
-
-They stay off unless requested at create or enabled later. On the unclaimed project, `neon.ts`
-plus `neon deploy` enables them. After claim, the same config talks to Neon directly. Data API
-with the default auth provider requires Auth:
-
-```typescript
-import { defineConfig } from "@neon/config/v1";
-
-export default defineConfig({
-  auth: true,
-  dataApi: true,
-});
-```
-
-```bash
-neon deploy
-```
-
-An external JWKS is not accepted on the unclaimed project. After claim:
-
-```typescript
-dataApi: {
-  authProvider: "external",
-  jwksUrl: "https://example.com/.well-known/jwks.json",
-}
-```
-
-## Delete or revoke
-
-Delete an unclaimed project:
-
-```http
-DELETE https://claimable.neon.tech/v1/projects/<project_id>
-Authorization: Bearer <access_token>
-```
-
-Revoke an access token or identity assertion with `POST https://claimable.neon.tech/v1/oauth2/revoke`.
-
-## Handle errors
-
-Every error has an `error.code`, human-readable `error.message`, `error.origin`,
-`error.retryable`, and `error.request_id`. Use the code for control flow. Retry only when
-`error.retryable` is true.
-
-When `error.code` is `capability_requires_claim`, preserve the denied capability and give the
-human a claim link instead of retrying or silently omitting it.
+At `reconciled`, discard the identity assertion, access tokens, and pre-claim
+`database_url`. They no longer authorize project access. Auth and the Data API stay enabled
+and transfer with the project if they were granted. The human owns the project. You are
+done.

--- a/public/auth.md
+++ b/public/auth.md
@@ -14,7 +14,11 @@ path.
 
 ```bash
 npm i -g neon@latest
+neon skills -s neon -s neon-postgres
 ```
+
+The `neon` skill documents the claim flow in more detail. `neon-postgres` is for working
+with Lakebase Postgres after claim.
 
 If `neon claim --help` lists `create`:
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -79,15 +79,6 @@ Authorization: Bearer <access_token>
 Keep `database_url`. If granted: `services.data_api.url`, `services.auth.base_url`,
 `services.auth.jwks_url`. Use `database_url` with any Postgres client.
 
-Management API calls the proxy allows:
-
-```http
-GET https://claimable.neon.tech/v1/projects/<project_id>/...
-Authorization: Bearer <access_token>
-```
-
-The project-scoped Neon API key stays inside Claimable Neon and is never returned.
-
 ## Claim
 
 Do not mint a claim URL until the human is ready to keep the project.
@@ -96,10 +87,10 @@ If the CLI created the project:
 
 ```bash
 neon claim accept --no-open
-neon claim status
 ```
 
-Report the printed verification URL.
+Report the printed verification URL. Then run `neon claim status` until it reports
+reconciled.
 
 Otherwise HTTP. `project_id` is `project.id`. The access token is from the token call above.
 
@@ -126,11 +117,11 @@ above. The new token has no project scopes. It can poll claim status and mint a 
 code if the transfer window expires. If that window expires before they accept, POST claim
 again.
 
-Poll every `interval` seconds:
+Poll every `interval` seconds with that new `access_token`:
 
 ```http
 GET https://claimable.neon.tech/v1/projects/<project_id>/claim
-Authorization: Bearer <claim_status_access_token>
+Authorization: Bearer <access_token>
 ```
 
 `state` moves `pending` → `accepted` → `reconciled`. `accepted` is brief; the next poll is

--- a/public/auth.md
+++ b/public/auth.md
@@ -36,9 +36,7 @@ If `create` is not a command, use HTTP.
 ### Register
 
 `source` is your agent name, 1-100 characters. Replace `your-agent`. Request only services
-the app needs. `postgres`, `data_api`, and `auth` can be granted now. `functions`,
-`storage`, and `ai_gateway` return `granted: false` and `reason: "requires_claim"`. Do not
-retry those. Finish provision with what was granted. If the app still needs a denied
+the app needs. Finish provision with what was granted. If the app still needs a denied
 service, claim after you have `project.id` and an access token.
 
 ```http

--- a/public/auth.md
+++ b/public/auth.md
@@ -17,17 +17,20 @@ Install the CLI, `@neon/config`, and the skills:
 ```bash
 npm i -g neon@latest
 npm i @neon/config
-neon skills -s neon -s neon-postgres
+neon skills -y -s neon -s neon-postgres
 ```
 
-The `neon` skill documents the claim flow in more detail. `neon-postgres` is for working
-with Lakebase Postgres after claim.
+The `neon` skill is the Neon platform skill. `neon-postgres` is for working with Lakebase
+Postgres after claim.
+
+If you cannot run the CLI, or `neon claim --help` does not list `create`, skip to REST.
 
 ### neon.ts
 
-Write and commit `neon.ts`. Declare the services the app needs. `neon claim create` reads
-this file (walks up from the current directory). After claim, the same file is how you add
-Functions, Object Storage, and the AI Gateway. https://neon.com/docs/reference/neon-ts.md
+Write `neon.ts` and commit it with the app. Declare the services the app needs.
+`neon claim create` reads this file (walks up from the current directory). After claim, the
+same file is how you add Functions, Object Storage, and the AI Gateway.
+https://neon.com/docs/reference/neon-ts.md
 
 ```typescript
 import { defineConfig } from "@neon/config/v1";
@@ -37,8 +40,6 @@ export default defineConfig({
   dataApi: true,
 });
 ```
-
-If `neon claim --help` lists `create`:
 
 ```bash
 neon claim create
@@ -61,13 +62,9 @@ Same env write as above. Then skip to Claim when the human is ready.
 
 ### REST
 
-If you cannot run the CLI, or `create` is not a command, use HTTP.
-
-### Register
-
 `source` is your agent name, 1-100 characters. Replace `your-agent`. Request only services
 the app needs. Finish provision with what was granted. If the app still needs a denied
-service, claim after you have `project.id` and an access token.
+service, wait until the human is ready, then Claim.
 
 ```http
 POST https://claimable.neon.tech/v1/agent/identity

--- a/public/auth.md
+++ b/public/auth.md
@@ -12,26 +12,56 @@ path.
 
 ## Provision
 
+Install the CLI, `@neon/config`, and the skills:
+
 ```bash
 npm i -g neon@latest
+npm i @neon/config
 neon skills -s neon -s neon-postgres
 ```
 
 The `neon` skill documents the claim flow in more detail. `neon-postgres` is for working
 with Lakebase Postgres after claim.
 
+### neon.ts
+
+Write and commit `neon.ts`. Declare the services the app needs. `neon claim create` reads
+this file (walks up from the current directory). After claim, the same file is how you add
+Functions, Object Storage, and the AI Gateway. https://neon.com/docs/reference/neon-ts.md
+
+```typescript
+import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+});
+```
+
 If `neon claim --help` lists `create`:
 
 ```bash
-neon claim create --service data-api --service auth
+neon claim create
 neon branches list
 ```
 
-Drop `--service` flags the app does not need. Postgres is always included. The CLI writes
-`DATABASE_URL` (and granted service URLs) to `.env` or `.env.local`. Then skip to Claim when
-the human is ready.
+The CLI writes `DATABASE_URL` (and granted service URLs) to `.env` or `.env.local`. Then
+skip to Claim when the human is ready.
 
-If `create` is not a command, use HTTP.
+### CLI only
+
+If you cannot write `neon.ts`, pass `--service` instead. Drop flags the app does not
+need. Postgres is always included.
+
+```bash
+neon claim create --service data-api --service auth
+```
+
+Same env write as above. Then skip to Claim when the human is ready.
+
+### REST
+
+If you cannot run the CLI, or `create` is not a command, use HTTP.
 
 ### Register
 


### PR DESCRIPTION
## Problem

https://neon.com/auth.md is the file an agent fetches when it needs a Neon project and no human is signed in. Provision now. A human claims later if they want to keep it.

On `main`, skills install is interactive:

```bash
neon skills -s neon -s neon-postgres
```

`neon skills --help` (CLI 4.14.0) documents `-y` as "Skip prompts". Default is a picker. The agent waits.

The same file says to declare services in `neon.ts`, then the only `create` it shows is flags:

```bash
neon claim create --service data-api --service auth --env-pull
```

HTTP is introduced as the protocol the CLI speaks. Followed in order, the file hangs on skills, skips writing `neon.ts`, or implements REST first.

`neon.ts` is the committed config `neon claim create` already reads. After claim, the same file adds Functions, Object Storage and the AI Gateway. If provision never writes it, that path is missing.

## Diagnosis

Agents execute this file in order. The first working example is the path they take.

`neon claim create --help` on CLI 4.14.0 already has the `neon.ts` path:

```
--config
  Path to neon.ts. Defaults to walking up from the current directory

-s, --service
  Services to request for the claimable project. Postgres is always included.

--env-pull
  Write the provisioned DATABASE_URL and service URLs to a dotenv file [default: true]
```

`--service` is the flag fallback. REST is what to call when the CLI cannot run or `create` is missing. Skills already accept `-y`.

The file on `main` shows flags as the create command and HTTP as the protocol. `neon.ts` is a sentence with no file. The skip condition (`neon claim --help` does not list `create`) is already there; this change keeps it and adds "if you cannot run the CLI".

## The user-facing interface

If `NEON_API_KEY` is set, or `neon profile list -o json` has a profile whose `account` is not `-`, use that account and stop. A `DEFAULT` row with `account: "-"` is not an account. Do not run `neon auth` on this path.

### Provision

```bash
npm i -g neon@latest
npm i @neon/config
neon skills -y -s neon -s neon-postgres
```

The `neon` skill is the platform skill. `neon-postgres` is for Lakebase Postgres after claim.

If you cannot run the CLI, or `neon claim --help` does not list `create`, skip to REST.

Otherwise write `neon.ts` and commit it with the app. `neon claim create` reads it (walks up from the current directory):

```typescript
import { defineConfig } from "@neon/config/v1";

export default defineConfig({
  auth: true,
  dataApi: true,
});
```

```bash
neon claim create
neon branches list
```

The CLI writes `DATABASE_URL` (and granted service URLs) to `.env` or `.env.local`. Then skip to Claim when the human is ready.

If you cannot write `neon.ts`, pass `--service` instead. Drop flags the app does not need. Postgres is always included:

```bash
neon claim create --service data-api --service auth
```

Same env write. Then skip to Claim when the human is ready.

REST, only after the gate. `source` is the agent name, 1-100 characters. Request the services the app needs. Finish provision with what was granted. If the app still needs a denied service, wait until the human is ready, then Claim.

```http
POST https://claimable.neon.tech/v1/agent/identity
Content-Type: application/json

{"type":"anonymous","capabilities":["postgres","data_api","auth"],"source":"your-agent"}
```

Keep `identity_assertion` (durable secret), `project.id`, `project.branch_id` and `project.expires_at`. The unclaimed project dies at `expires_at` (72 hours today). One row per requested capability; check `granted` before using a service. Register returns 201 today. Treat any 2xx as success. Otherwise stop. Do not continue with missing fields.

```http
POST https://claimable.neon.tech/v1/oauth2/token
Content-Type: application/x-www-form-urlencoded

grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<identity_assertion>&resource=https://claimable.neon.tech/
```

Keep `access_token`. Send `Authorization: Bearer <access_token>`. No refresh token. Re-exchange the same assertion when the token expires.

```http
GET https://claimable.neon.tech/v1/projects/<project_id>/credentials
Authorization: Bearer <access_token>
```

`project_id` is `project.id` from register. Keep `database_url`. If granted: `services.data_api.url`, `services.auth.base_url`, `services.auth.jwks_url`. Use `database_url` with any Postgres client.

### Claim

Do not mint a claim URL until the human is ready to keep the project.

If the CLI created the project:

```bash
neon claim accept --no-open
```

`--open` defaults to true. `--no-open` prints the verification URL instead of opening a browser. Report that URL. Then run `neon claim status` until it reports reconciled.

Otherwise HTTP. Same `project_id` and `access_token` as provision:

```http
POST https://claimable.neon.tech/v1/projects/<project_id>/claim
Authorization: Bearer <access_token>
```

Keep `verification_uri_complete`, `user_code`, `expires_in` and `interval`. Give the human `verification_uri_complete`. They sign in to Neon, select a destination organization and accept the transfer.

An unused claim code dies in `expires_in` seconds (900 today). If they have not continued to Neon and the code expired, POST again. Each POST cancels the previous unused code. Re-issue only while `project.expires_at` is still in the future. Opening `verification_uri_complete` does not freeze access.

Start polling now, every `interval` seconds, with the current `access_token`:

```http
GET https://claimable.neon.tech/v1/projects/<project_id>/claim
Authorization: Bearer <access_token>
```

```json
{"state":"pending","expires_at":"<iso8601>","reconciled":false}
```

Stop when `reconciled` is `true`. If GET returns 401, re-exchange with the same token POST and keep polling. When they continue to Neon, `DATABASE_URL` is rotated. Do not restore the old `database_url`. If the transfer window expires before they accept, POST claim again.

At `reconciled: true`, discard the identity assertion, access tokens and pre-claim `database_url`. They no longer authorize project access. Auth and the Data API stay enabled and transfer with the project if they were granted. The human owns the project.

## Also in here

Only `public/auth.md` (https://neon.com/auth.md).

Removed from this file: discovery (`llms.txt`, well-known OAuth/JWKS URLs, `https://claimable.neon.tech/auth.md` as a field-name override), `--env-pull` on the create example, `neon deploy` to enable Auth / Data API on the unclaimed project, external JWKS `dataApi` after claim, `DELETE /v1/projects/<project_id>`, `POST /v1/oauth2/revoke`, the error object shape and `capability_requires_claim` as control flow.

`neon claim delete` remains in the CLI. https://neon.com/docs/reference/neon-ts.md remains the `neon.ts` reference.

## Verification

CLI 4.14.0 (`neon --version`):

- `neon claim --help` lists `create`, `accept` and `status`. The skip-to-REST gate is that listing for `create`.
- `neon claim create --help`: `--config` walks up for `neon.ts`; `--service` is the flag path; `--env-pull` defaults to true.
- `neon claim accept --help`: `--open` defaults to true, so `--no-open` is the agent invocation.
- `neon skills --help`: `-y` skips prompts; `-s` is repeatable. Help example: `neon skills -y -s neon -s neon-ai-gateway`.

Read `public/auth.md` against that help. The documented commands and flags exist.

Not verified:

- A live `POST` to `https://claimable.neon.tech/v1/agent/identity` (or token, credentials, claim) from this branch
- An agent following the file in a fresh repo: install, `neon skills -y -s neon -s neon-postgres`, `neon.ts`, `neon claim create`, then `accept --no-open` / `status`
- Which agent directories `neon skills -y` writes to in a real project folder
- Production fetch of https://neon.com/auth.md after deploy

No tests in the diff. Static file in `public/`.

## For your attention

- Merge publishes this file. The next fetch of https://neon.com/auth.md gets these instructions.
- The examples request Auth and the Data API. Postgres is implicit on CLI create. Functions, Object Storage and the AI Gateway are named as later work in the same `neon.ts`. REST does not list per-capability deny reasons.
- The REST skip is a help-text check for `create`. A CLI with `neon claim` and no `create` goes to REST.
- `neon skills -y` does not pass `--agent`. Install target is whatever the CLI detects.
- `npm i @neon/config` is unpinned. `neon` is `neon@latest`.
