### PR TITLE
docs: refresh Neon CLI to 4.14.0 (checkout --env, env pull)

### DIFF
--- a/content/docs/cli/checkout.md
+++ b/content/docs/cli/checkout.md
@@ -6,7 +6,7 @@ summary: >-
   active branch in your local context, so subsequent commands target that
   branch without specifying `--branch` on every command.
 enableTableOfContents: true
-updatedOn: '2026-08-11T18:35:41.335Z'
+updatedOn: '2026-09-02T04:08:12.679Z'
 redirectFrom:
   - /docs/reference/cli-checkout
 ---
@@ -26,6 +26,8 @@ The branch argument is optional. Run `neon checkout` with no branch in an intera
 <CliOptions command="checkout" />
 
 By default, `checkout` pulls environment variables into a `.env` file after checking out the branch; use `--no-env-pull` to skip this.
+
+When `checkout` creates a branch from a [`neon.ts`](/docs/reference/neon-ts) policy, it applies that policy as part of the checkout. Pass `--env <file>` to load Function env from `<file>` first, so the `process.env` values your `neon.ts` reads resolve during that apply. It's ignored when you check out an existing branch, which never re-applies the policy.
 
 ## Branch ID vs name
 

--- a/content/docs/cli/checkout.md
+++ b/content/docs/cli/checkout.md
@@ -6,7 +6,7 @@ summary: >-
   active branch in your local context, so subsequent commands target that
   branch without specifying `--branch` on every command.
 enableTableOfContents: true
-updatedOn: '2026-09-02T04:08:12.679Z'
+updatedOn: '2026-09-02T13:05:14.252Z'
 redirectFrom:
   - /docs/reference/cli-checkout
 ---
@@ -27,7 +27,7 @@ The branch argument is optional. Run `neon checkout` with no branch in an intera
 
 By default, `checkout` pulls environment variables into a `.env` file after checking out the branch; use `--no-env-pull` to skip this.
 
-When `checkout` creates a branch from a [`neon.ts`](/docs/reference/neon-ts) policy, it applies that policy as part of the checkout. Pass `--env <file>` to load Function env from `<file>` first, so the `process.env` values your `neon.ts` reads resolve during that apply. It's ignored when you check out an existing branch, which never re-applies the policy.
+Creating a branch from a [`neon.ts`](/docs/reference/neon-ts) policy evaluates that policy, resolving any `process.env` values it references (such as a function's secrets) from your environment. Pass `--env <file>` to load those values from `<file>` first, so they resolve during the checkout. Checking out an existing branch doesn't re-evaluate the policy, so `--env` is ignored there.
 
 ## Branch ID vs name
 

--- a/content/docs/cli/env.md
+++ b/content/docs/cli/env.md
@@ -21,6 +21,10 @@ Writes the branch's Neon environment variables to a local `.env` file.
 
 `neon env pull` works with or without a [`neon.ts`](/docs/reference/neon-ts) configuration file. Without one, it writes the branch's core variables (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`). With a `neon.ts`, it also writes credentials for each service you declare (Managed Better Auth, Data API, AI Gateway, Object Storage).
 
+When your `neon.ts` declares functions, `neon env pull` also writes each one's invocation URL as `NEON_FUNCTION_<SLUG>_BASE_URL` (for example, `NEON_FUNCTION_DISCORD_BASE_URL`). The URL is derived from the branch, so the function doesn't have to be deployed yet; the value is the address it will answer at once you deploy it to that branch. Scoping the pull with `--service functions` instead writes URLs only for functions that are already deployed, so a declared-but-undeployed function appears in the default `neon.ts` pull but not with `--service functions`.
+
+Unset function env vars don't block a pull. If a declared function reads a `process.env.*` value that isn't set, `neon env pull` (and the pull that [`neon link`](/docs/cli/link) and [`neon checkout`](/docs/cli/checkout) run) skips that value and writes everything else instead of failing. The commands that actually build or run your functions still require every declared value: `neon deploy`, `neon dev`, and `neon-env run`.
+
 <CliUsage command="env pull" />
 
 <CliOptions command="env pull" />
@@ -37,7 +41,7 @@ Pull a specific branch into a specific file:
 neon env pull --branch preview --file .env.preview
 ```
 
-Pull only the variables for the services you name, ignoring `neon.ts`. Repeat `--service` or comma-separate the values (`postgres`, `auth`, `data-api`, `object-storage`, `ai-gateway`):
+Pull only the variables for the services you name, ignoring `neon.ts`. Repeat `--service` or comma-separate the values (`postgres`, `auth`, `data-api`, `functions`, `object-storage`, `ai-gateway`):
 
 ```bash
 neon env pull --service ai-gateway --service postgres

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -165,6 +165,24 @@ function resolveSpecObject(expr, consts) {
       return resolveSpecObject(prop.initializer, consts);
     }
   }
+  // Dot access into a resolvable const object, e.g. `envFlag.env` where
+  // `envFlag = { env: { type, describe } }` is pooled in `consts`. Mirrors the
+  // bracket-access branch above; needed because checkout.ts redefines its `env`
+  // option as `{ ...envFlag.env, describe: envFlag.env.describe + '…' }`, so both
+  // the inner spread and the describe concat resolve through this.
+  if (
+    ts.isPropertyAccessExpression(e) &&
+    ts.isIdentifier(e.expression) &&
+    consts &&
+    consts.has(e.expression.text)
+  ) {
+    const container = consts.get(e.expression.text);
+    if (!ts.isObjectLiteralExpression(container)) return undefined;
+    const prop = getProp(container, e.name.text);
+    if (prop && ts.isPropertyAssignment(prop)) {
+      return resolveSpecObject(prop.initializer, consts);
+    }
+  }
   return undefined;
 }
 

--- a/scripts/docs-checks/neonctl/overrides.json
+++ b/scripts/docs-checks/neonctl/overrides.json
@@ -35,9 +35,9 @@
         "pull": {
           "options": {
             "service": {
-              "_comment": "Built by the servicesOption() factory in neon_services.ts (see config init services override). type and describe verified against `neon env pull --help` at neonctl 3.1.0.",
+              "_comment": "Built by the servicesOption() factory in neon_services.ts (see config init services override). type and describe verified against env_services.ts (ENV_PULL_SERVICES = NEON_SERVICES) at neonctl 4.14.0, which added `functions` to the service list.",
               "type": "array",
-              "describe": "Pull only these services' variables: postgres, auth, data-api, object-storage, ai-gateway. Repeat the flag or comma-separate. Overrides neon.ts, and prunes only within the services you name."
+              "describe": "Pull only these services' variables: postgres, auth, data-api, functions, object-storage, ai-gateway. Repeat the flag or comma-separate. Overrides neon.ts, and prunes only within the services you name."
             }
           }
         }

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.13.0",
+  "neonctlVersion": "4.14.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -917,6 +917,10 @@
         }
       ],
       "options": {
+        "env": {
+          "type": "string",
+          "describe": "Path to a .env file to load into the environment before evaluating neon.ts so Function env values resolve from it. Existing env vars are not overridden. Function env values that read process.env must be set in this file or the environment. Used when this checkout creates a branch from neon.ts; ignored for an existing branch."
+        },
         "env-pull": {
           "type": "boolean",
           "describe": "Pull the branch's Neon env vars (DATABASE_URL, ...) into a local .env after checkout. On by default; use --no-env-pull to skip, for example when injecting env at runtime with `neon-env run` (from `@neon/env`) or `neon dev`.",
@@ -934,6 +938,10 @@
         {
           "command": "$0 checkout br-cool-snow-12345678 --project-id project-id-123",
           "description": "Pin a branch by id for an explicit project"
+        },
+        {
+          "command": "$0 checkout feat --env .env.local",
+          "description": "Create feat from neon.ts, loading Function env from .env.local first"
         },
         {
           "command": "$0 checkout main",
@@ -1082,7 +1090,7 @@
             },
             "env": {
               "type": "string",
-              "describe": "Path to a .env file to load into the environment before evaluating neon.ts (so function env values resolve from it). Existing env vars are not overridden."
+              "describe": "Path to a .env file to load into the environment before evaluating neon.ts so Function env values resolve from it. Existing env vars are not overridden. Function env values that read process.env must be set in this file or the environment."
             },
             "env-pull": {
               "type": "boolean",
@@ -1131,7 +1139,7 @@
             },
             "env": {
               "type": "string",
-              "describe": "Path to a .env file to load into the environment before evaluating neon.ts (so function env values resolve from it). Existing env vars are not overridden."
+              "describe": "Path to a .env file to load into the environment before evaluating neon.ts so Function env values resolve from it. Existing env vars are not overridden. Function env values that read process.env must be set in this file or the environment."
             }
           },
           "commands": {},
@@ -1507,7 +1515,7 @@
         },
         "env": {
           "type": "string",
-          "describe": "Path to a .env file to load into the environment before evaluating neon.ts (so function env values resolve from it). Existing env vars are not overridden."
+          "describe": "Path to a .env file to load into the environment before evaluating neon.ts so Function env values resolve from it. Existing env vars are not overridden. Function env values that read process.env must be set in this file or the environment."
         },
         "env-pull": {
           "type": "boolean",
@@ -1635,7 +1643,7 @@
             },
             "service": {
               "type": "array",
-              "describe": "Pull only these services' variables: postgres, auth, data-api, object-storage, ai-gateway. Repeat the flag or comma-separate. Overrides neon.ts, and prunes only within the services you name."
+              "describe": "Pull only these services' variables: postgres, auth, data-api, functions, object-storage, ai-gateway. Repeat the flag or comma-separate. Overrides neon.ts, and prunes only within the services you name."
             }
           },
           "commands": {},
@@ -1660,6 +1668,14 @@
             {
               "command": "$0 env pull -s auth -e DATABASE_URL",
               "description": "Pull all Auth variables plus DATABASE_URL"
+            },
+            {
+              "command": "$0 env pull -s functions",
+              "description": "Pull NEON_FUNCTION_<SLUG>_BASE_URL for every deployed function"
+            },
+            {
+              "command": "$0 env pull -e NEON_FUNCTION_HELLO_BASE_URL",
+              "description": "Write that function's production invocation URL (no deploy required)"
             }
           ],
           "usage": "$0 env pull [options]"


### PR DESCRIPTION
Refresh the committed CLI schema to Neon CLI 4.14.0 and document its env-related changes.

- schema: bump to 4.14.0; the new `neon checkout --env` option now resolves from source.
- generate-schema.js: teach the option-spec parser to resolve dot-access into pooled consts
  (`envFlag.env`), so `checkout --env` gets its type and describe without a manual override.
- overrides.json: add `functions` to the `env pull --service` values (new in 4.14.0).
- env.md: document that `env pull` writes `NEON_FUNCTION_<SLUG>_BASE_URL` for declared
  functions (deployed or not), that `--service functions` covers only deployed functions,
  and that pull no longer fails on unset function env (deploy and dev still require it).
- checkout.md: document `--env` for loading Function env during create-apply.

This pull request and its description were written by Isaac.