### PR TITLE
docs: live-reload browser tabs on content edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,8 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "shiki": "^1.1.1",
         "tailwindcss": "^4.2.1",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.0",
+        "ws": "^7.5.11"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -18853,7 +18854,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "shiki": "^1.1.1",
     "tailwindcss": "^4.2.1",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "ws": "^7.5.11"
   }
 }

--- a/scripts/watch-content.mjs
+++ b/scripts/watch-content.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Live-reload watcher for docs, blog, and guide content.
+ * Watches the markdown content dirs and tells open browser tabs to reload when a
+ * content file changes.
+ * The browser side is a dev-only inline script in the root layout
+ * (src/app/layout.jsx) that connects to this WebSocket server.
+ * PORT must match the value in src/app/layout.jsx.
+ */
+import { watch } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ws from 'ws';
+
+const WebSocketServer = ws.WebSocketServer || ws.Server;
+
+const PORT = 3549;
+const DEBOUNCE_MS = 100;
+const WATCHED_EXTENSIONS = ['.md', '.mdx'];
+
+// Content areas to watch
+const WATCHED_DIRS = ['content/docs', 'content/blog', 'content/guides'];
+
+const rootDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const log = (message) => {
+  console.log(`[watch:content] ${message}`);
+};
+
+const wss = new WebSocketServer({ port: PORT });
+
+wss.on('listening', () => {
+  log(`watching ${WATCHED_DIRS.join(', ')} (${WATCHED_EXTENSIONS.join(', ')})`);
+  log(`ws://localhost:${PORT} ready, reloads open tabs on save`);
+});
+
+wss.on('error', (error) => {
+  // Never exit the process. This may be embedded in the dev server (see
+  // src/instrumentation.js), and exiting would take the dev server down with it.
+  if (error.code === 'EADDRINUSE') {
+    log(`port ${PORT} already in use, live reload disabled (another watcher running?).`);
+  } else {
+    log(`server error: ${error.message}`);
+  }
+});
+
+const broadcastReload = () => {
+  let sent = 0;
+  for (const client of wss.clients) {
+    if (client.readyState === client.OPEN) {
+      client.send('reload');
+      sent += 1;
+    }
+  }
+  return sent;
+};
+
+let timer = null;
+const onChange = (filename) => {
+  if (!filename || !WATCHED_EXTENSIONS.some((ext) => filename.endsWith(ext))) return;
+  clearTimeout(timer);
+  timer = setTimeout(() => {
+    const sent = broadcastReload();
+    log(`changed ${filename} → reloaded ${sent} tab(s)`);
+  }, DEBOUNCE_MS);
+};
+
+for (const dir of WATCHED_DIRS) {
+  const absDir = path.join(rootDir, dir);
+  try {
+    watch(absDir, { recursive: true }, (_event, filename) => onChange(filename));
+  } catch (error) {
+    log(`could not watch ${dir}: ${error.message}`);
+  }
+}

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -33,6 +33,12 @@ const RootLayout = ({ children }) => (
       {process.env.NODE_ENV === 'production' && (
         <Script strategy="afterInteractive" src="https://neonapi.io/cb.js" />
       )}
+      {/* Dev-only live reload for content edits */}
+      {process.env.NODE_ENV === 'development' && (
+        <Script id="content-live-reload" strategy="afterInteractive">
+          {`(function c(){try{var s=new WebSocket('ws://localhost:3549');s.onmessage=function(e){if(e.data==='reload')location.reload()};s.onclose=function(){setTimeout(c,1000)};s.onerror=function(){s.close()}}catch(e){setTimeout(c,1000)}})()`}
+        </Script>
+      )}
       <link rel="preconnect" href={LINKS.console} />
       <RiveWasm />
     </head>

--- a/src/instrumentation.js
+++ b/src/instrumentation.js
@@ -1,0 +1,14 @@
+const { join } = require('path');
+
+// Next.js calls register() once when the server process starts. We use it to
+// boot the content live-reload watcher in-process during development.
+//
+// Server-only, so no client-bundle impact. The import below is skipped unless
+// NODE_ENV === 'development' and is marked webpack/turbopack-ignore, so the
+// watcher and `ws` do not make it to the build.
+export async function register() {
+  if (process.env.NODE_ENV !== 'development') return;
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  const watcherUrl = join(import.meta.url, '..', '..', 'scripts', 'watch-content.mjs');
+  await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ watcherUrl);
+}


### PR DESCRIPTION
Adds a dev-only live-reload for content editing. A small WebSocket server watches the content/docs, content/blog, and content/guides markdown dirs and broadcasts a reload to open tabs whenever a .md or .mdx file is saved.

This helps me from manually reloading the guide everytime to see a change being reflected on the preview server.