### PR TITLE
fix: run OG image routes on the Node.js runtime

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,22 @@ const defaultConfig = {
   },
   outputFileTracingIncludes: {
     '*': ['./public/**/*.svg', './public/**/*.md'],
+    // OG image routes run on the Node.js runtime and read these assets from disk at
+    // request time, so they must be traced into the serverless bundle. The fonts live
+    // under src/ (not traced by default) and the images are otherwise dropped by the
+    // ./public/** exclude above.
+    '/api/og': [
+      './src/fonts/esbuild/ESBuild-Medium.ttf',
+      './src/fonts/inter/Inter-Regular.ttf',
+      './public/images/og-image/logo.png',
+      './public/images/og-image/background.png',
+    ],
+    '/docs/og': [
+      './src/fonts/geist-mono/GeistMono-Regular.ttf',
+      './src/fonts/inter/Inter-Regular.ttf',
+      './public/images/og-image/logo.png',
+      './public/images/og-image/docs-background.jpg',
+    ],
   },
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/src/app/(docs)/docs/og/route.jsx
+++ b/src/app/(docs)/docs/og/route.jsx
@@ -1,8 +1,5 @@
 import { ImageResponse } from 'next/og';
 
-export const runtime = 'edge';
-export const preferredRegion = 'auto';
-
 export async function GET(request) {
   const fontBreadcrumbs = fetch(
     new URL('../../../../fonts/geist-mono/GeistMono-Regular.ttf', import.meta.url)

--- a/src/app/(docs)/docs/og/route.jsx
+++ b/src/app/(docs)/docs/og/route.jsx
@@ -1,25 +1,18 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import { ImageResponse } from 'next/og';
 
 export async function GET(request) {
-  const fontBreadcrumbs = fetch(
-    new URL('../../../../fonts/geist-mono/GeistMono-Regular.ttf', import.meta.url)
-  ).then((res) => res.arrayBuffer());
-  const fontTitle = fetch(
-    new URL('../../../../fonts/inter/Inter-Regular.ttf', import.meta.url)
-  ).then((res) => res.arrayBuffer());
-  const logo = fetch(
-    new URL('../../../../../public/images/og-image/logo.png', import.meta.url)
-  ).then((res) => res.arrayBuffer());
-  const background = fetch(
-    new URL('../../../../../public/images/og-image/docs-background.jpg', import.meta.url)
-  ).then((res) => res.arrayBuffer());
-
-  const [fontDataBreadcrumbs, fontDataTitle, logoData, backgroundData] = await Promise.all([
-    fontBreadcrumbs,
-    fontTitle,
-    logo,
-    background,
+  const [fontDataBreadcrumbs, fontDataTitle, logoBuffer, backgroundBuffer] = await Promise.all([
+    readFile(join(process.cwd(), 'src', 'fonts', 'geist-mono', 'GeistMono-Regular.ttf')),
+    readFile(join(process.cwd(), 'src', 'fonts', 'inter', 'Inter-Regular.ttf')),
+    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'logo.png')),
+    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'docs-background.jpg')),
   ]);
+
+  const logoData = `data:image/png;base64,${logoBuffer.toString('base64')}`;
+  const backgroundData = `data:image/jpeg;base64,${backgroundBuffer.toString('base64')}`;
 
   try {
     const { searchParams } = request.nextUrl;

--- a/src/app/(docs)/docs/og/route.jsx
+++ b/src/app/(docs)/docs/og/route.jsx
@@ -3,18 +3,21 @@ import { join } from 'node:path';
 
 import { ImageResponse } from 'next/og';
 
+// Load fonts and images once per instance rather than on every request.
+const assets = Promise.all([
+  readFile(join(process.cwd(), 'src', 'fonts', 'geist-mono', 'GeistMono-Regular.ttf')),
+  readFile(join(process.cwd(), 'src', 'fonts', 'inter', 'Inter-Regular.ttf')),
+  readFile(join(process.cwd(), 'public', 'images', 'og-image', 'logo.png')),
+  readFile(join(process.cwd(), 'public', 'images', 'og-image', 'docs-background.jpg')),
+]);
+
 export async function GET(request) {
-  const [fontDataBreadcrumbs, fontDataTitle, logoBuffer, backgroundBuffer] = await Promise.all([
-    readFile(join(process.cwd(), 'src', 'fonts', 'geist-mono', 'GeistMono-Regular.ttf')),
-    readFile(join(process.cwd(), 'src', 'fonts', 'inter', 'Inter-Regular.ttf')),
-    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'logo.png')),
-    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'docs-background.jpg')),
-  ]);
-
-  const logoData = `data:image/png;base64,${logoBuffer.toString('base64')}`;
-  const backgroundData = `data:image/jpeg;base64,${backgroundBuffer.toString('base64')}`;
-
   try {
+    const [fontDataBreadcrumbs, fontDataTitle, logoBuffer, backgroundBuffer] = await assets;
+
+    const logoData = `data:image/png;base64,${logoBuffer.toString('base64')}`;
+    const backgroundData = `data:image/jpeg;base64,${backgroundBuffer.toString('base64')}`;
+
     const { searchParams } = request.nextUrl;
 
     const hasLogo = searchParams.get('show-logo') !== 'false';

--- a/src/app/api/og/route.jsx
+++ b/src/app/api/og/route.jsx
@@ -1,25 +1,18 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import { ImageResponse } from 'next/og';
 
 export async function GET(request) {
-  const fontTitle = fetch(
-    new URL('../../../fonts/esbuild/ESBuild-Medium.ttf', import.meta.url)
-  ).then((res) => res.arrayBuffer());
-  const fontText = fetch(new URL('../../../fonts/inter/Inter-Regular.ttf', import.meta.url)).then(
-    (res) => res.arrayBuffer()
-  );
-  const logo = fetch(new URL('../../../../public/images/og-image/logo.png', import.meta.url)).then(
-    (res) => res.arrayBuffer()
-  );
-  const background = fetch(
-    new URL('../../../../public/images/og-image/background.png', import.meta.url)
-  ).then((res) => res.arrayBuffer());
-
-  const [fontDataEsbuild, fontDataInter, logoData, backgroundData] = await Promise.all([
-    fontTitle,
-    fontText,
-    logo,
-    background,
+  const [fontDataEsbuild, fontDataInter, logoBuffer, backgroundBuffer] = await Promise.all([
+    readFile(join(process.cwd(), 'src', 'fonts', 'esbuild', 'ESBuild-Medium.ttf')),
+    readFile(join(process.cwd(), 'src', 'fonts', 'inter', 'Inter-Regular.ttf')),
+    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'logo.png')),
+    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'background.png')),
   ]);
+
+  const logoData = `data:image/png;base64,${logoBuffer.toString('base64')}`;
+  const backgroundData = `data:image/png;base64,${backgroundBuffer.toString('base64')}`;
 
   try {
     const { searchParams } = request.nextUrl;

--- a/src/app/api/og/route.jsx
+++ b/src/app/api/og/route.jsx
@@ -1,8 +1,5 @@
 import { ImageResponse } from 'next/og';
 
-export const runtime = 'edge';
-export const preferredRegion = 'auto';
-
 export async function GET(request) {
   const fontTitle = fetch(
     new URL('../../../fonts/esbuild/ESBuild-Medium.ttf', import.meta.url)

--- a/src/app/api/og/route.jsx
+++ b/src/app/api/og/route.jsx
@@ -3,18 +3,21 @@ import { join } from 'node:path';
 
 import { ImageResponse } from 'next/og';
 
+// Load fonts and images once per instance rather than on every request.
+const assets = Promise.all([
+  readFile(join(process.cwd(), 'src', 'fonts', 'esbuild', 'ESBuild-Medium.ttf')),
+  readFile(join(process.cwd(), 'src', 'fonts', 'inter', 'Inter-Regular.ttf')),
+  readFile(join(process.cwd(), 'public', 'images', 'og-image', 'logo.png')),
+  readFile(join(process.cwd(), 'public', 'images', 'og-image', 'background.png')),
+]);
+
 export async function GET(request) {
-  const [fontDataEsbuild, fontDataInter, logoBuffer, backgroundBuffer] = await Promise.all([
-    readFile(join(process.cwd(), 'src', 'fonts', 'esbuild', 'ESBuild-Medium.ttf')),
-    readFile(join(process.cwd(), 'src', 'fonts', 'inter', 'Inter-Regular.ttf')),
-    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'logo.png')),
-    readFile(join(process.cwd(), 'public', 'images', 'og-image', 'background.png')),
-  ]);
-
-  const logoData = `data:image/png;base64,${logoBuffer.toString('base64')}`;
-  const backgroundData = `data:image/png;base64,${backgroundBuffer.toString('base64')}`;
-
   try {
+    const [fontDataEsbuild, fontDataInter, logoBuffer, backgroundBuffer] = await assets;
+
+    const logoData = `data:image/png;base64,${logoBuffer.toString('base64')}`;
+    const backgroundData = `data:image/png;base64,${backgroundBuffer.toString('base64')}`;
+
     const { searchParams } = request.nextUrl;
     const title = searchParams.get('title');
     const hasTitle = searchParams.has('title');

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -13,8 +13,6 @@ import { inter, esbuild } from './fonts';
 import { HomepageVisitProvider } from './homepage-visit-context';
 import ThemeProvider from './theme-provider';
 
-export const preferredRegion = 'edge';
-
 export const viewport = {
   width: 'device-width',
   initialScale: 1,


### PR DESCRIPTION
Removes the `runtime = 'edge'` and `preferredRegion = 'auto'` exports from both OG image routes so they run on the default Node.js runtime instead of Edge as per the official Next.js recommendation: https://nextjs.org/docs/app/api-reference/adapters/invoking-entrypoints#edge-runtime-runtime-edge-deprecated.

<img width="524" height="120" alt="Screenshot 2026-09-02 at 5 22 12 PM" src="https://github.com/user-attachments/assets/57092806-5558-4acb-8b76-c54a2b43ad6b" />