### PR TITLE
docs: add eu-central-1 to backend region availability

### DIFF
--- a/content/api-docs/ai-gateway.md
+++ b/content/api-docs/ai-gateway.md
@@ -4,4 +4,4 @@ A `404` includes a `reason` field explaining why the gateway is unavailable.
 
 Authenticating to the gateway uses a scoped [credential](/docs/reference/api/credentials) with the `ai_gateway:invoke` scope, not your Neon API key.
 
-AI Gateway is in beta, requires a paid plan, and is available only in AWS US East (Ohio) (`aws-us-east-2`). See [AI Gateway](/docs/ai-gateway/overview) for supported models and [Chat completions](/docs/ai-gateway/chat-completions) for the request format.
+AI Gateway is in beta, requires a paid plan, and is currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [AI Gateway](/docs/ai-gateway/overview) for supported models and [Chat completions](/docs/ai-gateway/chat-completions) for the request format.

--- a/content/api-docs/buckets.md
+++ b/content/api-docs/buckets.md
@@ -4,4 +4,4 @@ These endpoints are served by your session, so they need no S3 credentials. For 
 
 You can also manage buckets from the CLI with [`neon buckets`](/docs/cli/buckets).
 
-Object Storage is in beta and available only in AWS US East (Ohio) (`aws-us-east-2`). See [Object Storage](/docs/storage/overview) for setup and [S3 compatibility](/docs/storage/s3-compatibility) for supported operations.
+Object Storage is in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Object Storage](/docs/storage/overview) for setup and [S3 compatibility](/docs/storage/s3-compatibility) for supported operations.

--- a/content/api-docs/functions.md
+++ b/content/api-docs/functions.md
@@ -6,4 +6,4 @@ Renaming acts only on a function the branch owns. A slug that's only inherited f
 
 You can also manage functions from the CLI with [`neon functions`](/docs/cli/functions).
 
-Functions are in beta and available only in AWS US East (Ohio) (`aws-us-east-2`). See [Neon Functions](/docs/compute/functions/overview) for the deployment workflow, [Environment variables](/docs/compute/functions/environment-variables) for what gets injected, and [Runtime limits](/docs/compute/functions/reference/runtime-limits) for timeouts and concurrency.
+Functions are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Neon Functions](/docs/compute/functions/overview) for the deployment workflow, [Environment variables](/docs/compute/functions/environment-variables) for what gets injected, and [Runtime limits](/docs/compute/functions/reference/runtime-limits) for timeouts and concurrency.

--- a/content/api-docs/storage.md
+++ b/content/api-docs/storage.md
@@ -4,4 +4,4 @@ A `404` means object storage isn't available for that branch, with a `reason` fi
 
 Neon Object Storage uses path-style addressing only, which is why `force_path_style` is returned. See [S3 compatibility](/docs/storage/s3-compatibility) for client configuration and [Buckets](/docs/reference/api/buckets) for the endpoints that read and write data, or manage buckets and objects from the CLI with [`neon buckets`](/docs/cli/buckets), which handles these S3 details for you.
 
-Object Storage is in beta and available only in AWS US East (Ohio) (`aws-us-east-2`).
+Object Storage is in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.

--- a/content/blog/posts/neon-backend-is-beta.md
+++ b/content/blog/posts/neon-backend-is-beta.md
@@ -140,6 +140,8 @@ These tools just achieved beta, meaning that they are not yet feature-complete. 
 
 All Neon projects in the us-east-2 region only. More regions will roll out progressively after beta.
 
+_Update: region availability has since expanded. See [Regions](/docs/introduction/regions) for current coverage._
+
 ### Which plans have access?
 
 Object Storage and Functions are available on all plans, including Free. AI Gateway is available on Launch and Scale plans only (paid plans), with no difference in AI Gateway pricing or model access between the two.

--- a/content/changelog/2026-08-07.md
+++ b/content/changelog/2026-08-07.md
@@ -19,6 +19,8 @@ Each service shows whether it's enabled on the branch, so the page doubles as a 
 
 <Admonition type="important" title="More regions for backend services coming soon">
 Object Storage, Functions, and the AI Gateway services are available only in **AWS US East (Ohio) (`aws-us-east-2`)**. More regions are coming soon.
+
+_Update: region availability has since expanded. See [Regions](/docs/introduction/regions) for current coverage._
 </Admonition>
 
 ## More models on the AI Gateway

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -23,7 +23,7 @@ Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s n
 
 ## Get access
 
-You need a project in the AWS us-east-2 region. Foundation model access requires a paid Neon plan, and it's enabled automatically once you're on one, no separate sign-up step needed.
+You need a project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. Foundation model access requires a paid Neon plan, and it's enabled automatically once you're on one, no separate sign-up step needed.
 
 ## Create a credential
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-08-26T10:59:34.509Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 ## Foundation model access
@@ -37,7 +37,7 @@ Open-weight models are available to every project right away. Frontier models fr
 
 Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets you call models from OpenAI, Google, and other providers using your Neon credential, without setting up separate provider accounts. Your existing OpenAI SDK works without code changes. Just point it at your branch endpoint.
 
-> AI Gateway is in beta and available only in **AWS US East (Ohio) (`aws-us-east-2`)**, so create your project there to use it. It requires a paid Neon plan. Inference is free for paid plans during beta. See [Pricing](#pricing) for what to expect when billing begins.
+> AI Gateway is in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Create your project in one of these regions to use it. Support is expanding toward all regions. It requires a paid Neon plan. Inference is free for paid plans during beta. See [Pricing](#pricing) for what to expect when billing begins.
 
 <Admonition type="important">
 Participation in this Beta is subject to our Terms of Service. Access is not available to users, organizations, or entities located in or operating from regions restricted by Anthropic's [Supported Regions Policy](https://www.anthropic.com/supported-countries). This restriction also applies to entities that are majority owned, directly or indirectly, by companies headquartered in unsupported regions.

--- a/content/docs/cli/logs.md
+++ b/content/docs/cli/logs.md
@@ -9,16 +9,17 @@ summary: >-
   are coming. Query records over a time
   window, filter by source, severity, or OpenTelemetry attributes, run raw
   LogQL, and list which fields and values a branch reports. Logs are in beta
-  and available only in AWS US East (Ohio) (aws-us-east-2).
+  and available in AWS US East (Ohio) (aws-us-east-2) and AWS Europe
+  (Frankfurt) (aws-eu-central-1).
 enableTableOfContents: true
-updatedOn: '2026-09-01T16:04:17.197Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 <FeatureBeta />
 
 The `logs` command reads the logs a branch's services emit. Today that covers Neon Functions and Object Storage; Postgres compute logs are coming. Query records over a time window, filter by source, severity, or OpenTelemetry attribute, and list which fields and values a branch reports so you can build precise filters.
 
-Logs are in beta and available only in **AWS US East (Ohio) (`aws-us-east-2`)**, so your project must be in that region to use them.
+Logs are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`), so your project must be in one of these regions to use them. Support is expanding toward all regions.
 
 Every subcommand resolves the project and branch from your [context](/docs/cli/set-context). Pass `--project-id` and `--branch` to target a specific branch instead.
 
@@ -101,4 +102,4 @@ curl "https://console.neon.tech/telemetry/v1/projects/$PROJECT_ID/branches/$BRAN
 
 The stream label is `entity_type` (not `--source`), so a LogQL selector reads `{entity_type="function"}`. This is a read-only subset, not a push endpoint or a complete Loki deployment. A Loki client that builds its own paths may need a different root: a Grafana data source, for example, appends `/loki/api/v1` to whatever URL it is given. Confirm the data-source URL against this base rather than pasting it verbatim.
 
-Like the CLI, this API reads logs only on branches in **AWS US East (Ohio) (`aws-us-east-2`)**, the only region where branch logs are available during the beta period. A branch in any other region returns `404`.
+Like the CLI, this API reads logs only on branches in a supported region: AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`) during the beta period. Support is expanding toward all regions. A branch in any other region returns `404`.

--- a/content/docs/compute/functions/discord-bot.md
+++ b/content/docs/compute/functions/discord-bot.md
@@ -19,7 +19,7 @@ Neon Functions are not the right primitive for a Discord Gateway bot yet. Gatewa
 
 ## Prerequisites
 
-- A Neon project in AWS US East (Ohio) (`aws-us-east-2`). Functions are available only in this region during beta. See [Get started with Neon Functions](/docs/compute/functions/get-started).
+- A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Get started with Neon Functions](/docs/compute/functions/get-started).
 - The [Neon CLI](/docs/cli), version 2.25.0 or later (`neon --version`). `neon bootstrap` needs that floor. Upgrade with `npm install -g neon@latest` if you're behind, then authenticate ([CLI auth](/docs/cli/auth)).
 - Node.js 24 (`node -v`). Deployed functions run on `nodejs24`. Get Started's Node.js 20+ is the platform floor; this template needs 24.
 - A Discord account.

--- a/content/docs/compute/functions/get-started.md
+++ b/content/docs/compute/functions/get-started.md
@@ -7,7 +7,7 @@ summary: >-
   with neon dev, and deploy with neon deploy. The function gets a public HTTPS
   URL with DATABASE_URL injected from the branch's Postgres database.
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -63,7 +63,7 @@ That's a deployed function in three commands. The rest of this guide builds a mo
 
 ## Prerequisites
 
-- A Neon project in AWS US East (Ohio) (`aws-us-east-2`), the only region where Functions are available during beta.
+- A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
 - The latest `neon`, installed and authenticated. Functions commands are new and change often, so upgrade before you start (`npm install -g neon@latest`).
 - Node.js 20 or later. Deployed functions run on Node.js 24, so use 24 locally for the closest match.
 

--- a/content/docs/compute/functions/overview.md
+++ b/content/docs/compute/functions/overview.md
@@ -8,7 +8,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/compute/functions/preview-access
-updatedOn: '2026-08-26T11:04:20.169Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 Neon Functions are serverless functions you deploy onto a Neon branch, so your backend code runs right next to your database. Use them to host an API, an AI agent, a real-time server, or a webhook handler without standing up separate infrastructure.
@@ -21,7 +21,7 @@ What makes Neon Functions different from lambda-style serverless?
 
 Functions run on Neon's own compute platform, the same infrastructure that runs your Postgres, so they sit in the same region as your data.
 
-> Functions are in beta and available only in **AWS US East (Ohio) (`aws-us-east-2`)**, so create your project there to use them. Functions are free to use during beta, subject to [usage limits](/docs/compute/functions/reference/runtime-limits), on any plan. See [plans and pricing](/docs/introduction/plans#functions) for the rates that apply when billing begins.
+> Functions are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Create your project in one of these regions to use them. Support is expanding toward all regions. Functions are free to use during beta, subject to [usage limits](/docs/compute/functions/reference/runtime-limits), on any plan. See [plans and pricing](/docs/introduction/plans#functions) for the rates that apply when billing begins.
 
 <Admonition type="important" title="JavaScript and TypeScript only">
 Neon Functions currently run JavaScript or TypeScript on the Node.js runtime. Deploy JS/TS handlers, or code that bundles to JS for Node.js 24. Other runtimes and language targets aren't supported during beta.

--- a/content/docs/compute/functions/telegram-bot.md
+++ b/content/docs/compute/functions/telegram-bot.md
@@ -19,7 +19,7 @@ This guide uses Telegram webhooks. It doesn't run a polling process with `getUpd
 
 ## Prerequisites
 
-- A Neon project in AWS US East (Ohio) (`aws-us-east-2`). Functions are available only in this region during beta. See [Get started with Neon Functions](/docs/compute/functions/get-started).
+- A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Get started with Neon Functions](/docs/compute/functions/get-started).
 - The latest [Neon CLI](/docs/cli), installed and authenticated. Upgrade with `npm install -g neon@latest` if needed, then see [CLI auth](/docs/cli/auth).
 - Node.js 24 (`node -v`). Deployed functions run on `nodejs24`.
 - A Telegram account.

--- a/content/docs/compute/functions/whatsapp-bot.md
+++ b/content/docs/compute/functions/whatsapp-bot.md
@@ -19,7 +19,7 @@ This example uses Meta's hosted WhatsApp Cloud API. It doesn't automate a person
 
 ## Prerequisites
 
-- A Neon project in AWS US East (Ohio) (`aws-us-east-2`). Functions are available only in this region during beta. See [Get started with Neon Functions](/docs/compute/functions/get-started).
+- A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. See [Get started with Neon Functions](/docs/compute/functions/get-started).
 - The latest [Neon CLI](/docs/cli), installed and authenticated. Upgrade with `npm install -g neon@latest`, then follow [CLI authentication](/docs/cli/auth).
 - Node.js 24 (`node -v`). Deployed functions run on `nodejs24`.
 - A Meta developer account.

--- a/content/docs/get-started/backend-beta.md
+++ b/content/docs/get-started/backend-beta.md
@@ -7,7 +7,7 @@ redirectFrom:
 ---
 
 <Admonition type="info" title="Beta">
-Functions, Object Storage, and the AI Gateway are in beta and not yet recommended for production workloads. They're available to every Neon account, no invite required, on new or existing projects in **AWS US East (Ohio) (`aws-us-east-2`)**.
+Functions, Object Storage, and the AI Gateway are in beta and not yet recommended for production workloads. They're available to every Neon account, no invite required, on new or existing projects in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
 
 Functions and Object Storage are free on any plan during the beta, subject to usage limits. The AI Gateway requires a paid plan (Launch or Scale), with inference free during the beta. Build something and help us refine them by sharing your feedback in Discord.
 </Admonition>
@@ -24,9 +24,9 @@ You declare all of it in one `neon.ts` file, and it branches together: fork a br
 
 ## Check your access
 
-To confirm access, go to [console.neon.tech](https://console.neon.tech), open a project in **US East (Ohio)**, and check the left navigation for **Object storage**, **Credentials**, **AI Gateway**, and **Functions**. For what AI Gateway costs once billing begins, see [AI Gateway pricing](/docs/ai-gateway/overview#pricing).
+To confirm access, go to [console.neon.tech](https://console.neon.tech), open a project in **US East (Ohio)** or **Europe (Frankfurt)**, and check the left navigation for **Object storage**, **Credentials**, **AI Gateway**, and **Functions**. For what AI Gateway costs once billing begins, see [AI Gateway pricing](/docs/ai-gateway/overview#pricing).
 
-Not seeing the services? The most common reason is region: the project isn't in `us-east-2`. Create a new project in **US East (Ohio)**, or switch to an existing one there. If AI Gateway is the only thing missing, check your plan, it requires Launch or Scale. If a service is still missing after that, post in [#neon-platform-beta](https://discord.com/channels/1176467419317940276/1525919714541437058) on Discord.
+Not seeing the services? The most common reason is region: the project isn't in a supported region. Create a new project in **US East (Ohio)** or **Europe (Frankfurt)**, or switch to an existing one there. If AI Gateway is the only thing missing, check your plan, it requires Launch or Scale. If a service is still missing after that, post in [#neon-platform-beta](https://discord.com/channels/1176467419317940276/1525919714541437058) on Discord.
 
 Using the CLI? Keep it current, the beta CLI updates frequently. Run `npm i -g neon@latest` before each session and before reporting a bug.
 

--- a/content/docs/get-started/backend-overview.md
+++ b/content/docs/get-started/backend-overview.md
@@ -38,7 +38,7 @@ Function  ──streams the answer──▶  Browser
 So when you see a `notes` table, an `attachments` bucket, or a `chat` function below, they're all parts of this same app. Postgres is the system of record for notes; Storage holds the files that are too big for a row; the Function is the long-running piece that handles a chat request; the AI Gateway is the single credential for the model call; and Auth decides whose notes a request may read.
 
 <Admonition type="info" title="Region and access requirements">
-Object Storage, Functions, and the AI Gateway are in beta and available only in **AWS US East (Ohio) (`aws-us-east-2`)**, on new or existing projects in that region, so use a project there to try them. Postgres and Managed Better Auth work in any region. The three new beta services are free to use during beta, subject to usage limits. The AI Gateway is only available on paid plans; the other two are on any plan.
+Object Storage, Functions, and the AI Gateway are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`), on new or existing projects in those regions, so use a project in one of them to try them. Support is expanding toward all regions. Postgres and Managed Better Auth work in any region. The three new beta services are free to use during beta, subject to usage limits. The AI Gateway is only available on paid plans; the other two are on any plan.
 </Admonition>
 
 ## The shape of a Neon backend
@@ -52,7 +52,7 @@ npm i -g neon
 neon auth
 ```
 
-Then create the project. Create it in `aws-us-east-2` so the beta services are available:
+Then create the project. Create it in `aws-us-east-2` or `aws-eu-central-1` so the beta services are available:
 
 ```bash
 neon link --project-name notes-app --region-id aws-us-east-2

--- a/content/docs/get-started/full-backend-quickstart.md
+++ b/content/docs/get-started/full-backend-quickstart.md
@@ -21,8 +21,8 @@ You'll need [Node.js 20.19+](https://nodejs.org/) and the [Neon CLI](/docs/cli/i
 npm i -g neon
 ```
 
-<Admonition type="important" title="Create your project in AWS US East (Ohio)">
-Object Storage, Functions, and the AI Gateway are in beta and available only in **AWS US East (Ohio) (`aws-us-east-2`)**, on new or existing projects in that region, so use a project there to follow this guide. Postgres works in any region. The three beta services are free to use during beta, subject to usage limits. The AI Gateway requires a paid plan; Object Storage and Functions work on any plan.
+<Admonition type="important" title="Create your project in a supported region">
+Object Storage, Functions, and the AI Gateway are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`), on new or existing projects in those regions, so use a project in one of them to follow this guide. Support is expanding toward all regions. Postgres works in any region. The three beta services are free to use during beta, subject to usage limits. The AI Gateway requires a paid plan; Object Storage and Functions work on any plan.
 </Admonition>
 
 <TwoColumnLayout>
@@ -32,7 +32,7 @@ Object Storage, Functions, and the AI Gateway are in beta and available only in 
 
 If you don't have a Neon account, sign up at [console.neon.tech](https://console.neon.tech/signup).
 
-Create your project in **AWS US East (Ohio)**. Any path below works; the rest of this guide uses the Neon CLI, which you'll also use in step 3 to link the project and pull its credentials automatically.
+Create your project in **AWS US East (Ohio)** or **AWS Europe (Frankfurt)**. Any path below works; the rest of this guide uses the Neon CLI, which you'll also use in step 3 to link the project and pull its credentials automatically.
 
 </TwoColumnLayout.Block>
 <TwoColumnLayout.Block>

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /docs/cloud/roadmap
   - /docs/conceptual-guides/roadmap
   - /docs/reference/roadmap
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 This roadmap describes what's in flight, what we delivered recently, and what's on the horizon.
@@ -90,7 +90,7 @@ We're accelerating work on improving and scaling the core database on Neon as we
 - **Debug Postgres from the CLI with `neon inspect db`**: Run read-only Postgres diagnostics (table sizes, bloat, unused indexes, long-running queries, locks, and more) straight from the Neon CLI, safe to hand to an agent. [Learn more](/docs/cli/inspect).
 - **Snapshots in the Neon CLI**: The new `neon snapshots` command group manages the full snapshot lifecycle (list, create, restore, and schedule) from your terminal. [Learn more](/docs/cli/snapshots).
 - **Query Functions and Storage logs from the Neon MCP server**: New read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools let your AI assistant investigate Functions and Object Storage failures without leaving your editor. [Learn more](/docs/ai/neon-mcp-server).
-- **Neon backend services in beta**: Object Storage, Functions, and AI Gateway have graduated from private preview to beta and are available to everyone in AWS US East (Ohio). Declare your whole backend in one `neon.ts` file and it branches with your data. [Read the announcement](/blog/neon-backend-is-beta).
+- **Neon backend services in beta**: Object Storage, Functions, and AI Gateway have graduated from private preview to beta and are available in AWS US East (Ohio) and AWS Europe (Frankfurt). Support is expanding toward all regions. Declare your whole backend in one `neon.ts` file and it branches with your data. [Read the announcement](/blog/neon-backend-is-beta).
 - **New TypeScript SDK for the Neon API**: `@neon/sdk` is a fetch-based, zero-dependency client that covers the full Neon Platform API, including the new backend services, and replaces `@neondatabase/api-client` as the recommended client. [Learn more](/docs/reference/typescript-sdk).
 - **Passkey support**: Sign in to Neon with a passkey using device biometrics or a security key. Passkeys satisfy organization-level 2FA requirements. [Learn more](/docs/manage/accounts#passkeys).
 - **Git-style diffs in the Neon CLI**: The new `neon diff` command shows schema changes between your current branch and any other branch, and the config commands now report their changes as a git diff. [Learn more](/docs/cli).

--- a/content/docs/reference/neon-ts.md
+++ b/content/docs/reference/neon-ts.md
@@ -9,7 +9,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/compute/functions/reference/neon-ts/
-updatedOn: '2026-08-31T17:10:44.328Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 `neon.ts` is a TypeScript config file you commit to your repository. It declares which Neon services exist on your project and how each branch is configured.
@@ -280,7 +280,7 @@ env.postgres.databaseUrl;
 ## Preview services
 
 <Admonition type="info" title="Beta">
-Functions, Storage, and AI Gateway are in beta and available only in AWS US East (Ohio) (`aws-us-east-2`), so create your project there to use them.
+Functions, Storage, and AI Gateway are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Create your project in one of these regions to use them. Support is expanding toward all regions.
 </Admonition>
 
 Preview services are declared under the `preview` block. All three are optional and independent:

--- a/content/docs/shared-content/mcp-tools.md
+++ b/content/docs/shared-content/mcp-tools.md
@@ -1,5 +1,5 @@
 ---
-updatedOn: '2026-08-24T20:23:46.738Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 ## Available tools
@@ -28,5 +28,5 @@ Schema tools accept schema-qualified table names, such as `crm.contacts`. An unq
 The `querying` category includes `inspect_database`, which runs the same 15 read-only checks as [`neon inspect db`](/docs/cli/inspect): relation and index sizes, unused indexes, sequential scans, active queries and locks, stalled queries running longer than 30 seconds, heavy and frequent statements, cache hit rate and working set, autovacuum and bloat, and replication state. Some checks need [`pg_stat_statements`](/docs/extensions/pg_stat_statements) or the [`neon`](/docs/extensions/neon) extension; the tool asks before suggesting `CREATE EXTENSION`.
 
 <Admonition type="note">
-The `observability` tools query [Neon Functions logs](/docs/compute/functions/logs) and [object storage logs](/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS `us-east-2` only. Log querying returns results only for projects in a supported region. Database diagnostics via `inspect_database` are under `querying`, not `observability`.
+The `observability` tools query [Neon Functions logs](/docs/compute/functions/logs) and [object storage logs](/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. Log querying returns results only for projects in a supported region. Database diagnostics via `inspect_database` are under `querying`, not `observability`.
 </Admonition>

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -21,7 +21,7 @@ Without the Neon CLI, run `npx skills add neondatabase/agent-skills -s neon -s n
 
 To follow this guide, you need:
 
-- A Neon project in the AWS `us-east-2` region
+- A Neon project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
 - The Neon CLI installed and authenticated if you use the recommended `neon.ts` flow
 - A Neon API key in `NEON_API_KEY` if you use the manual API flow
 
@@ -93,7 +93,7 @@ export AWS_ENDPOINT_URL_S3=https://br-winter-pond-aptw82ef.storage.c-2.us-east-2
 export AWS_REGION=us-east-2
 ```
 
-A `404` response means object storage is not available for that branch. There is no separate manual enable API call: use the recommended `neon.ts` flow above, or make sure your project is in the AWS `us-east-2` region.
+A `404` response means object storage is not available for that branch. There is no separate manual enable API call: use the recommended `neon.ts` flow above, or make sure your project is in a supported region: AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankfurt) (`aws-eu-central-1`).
 
 ## Create a credential
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,12 +7,12 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-08-26T10:59:34.509Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
 
-> During the beta, object storage is available in the **AWS us-east-2** region only and is free to use, subject to usage limits. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
+> During the beta, object storage is currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`), and is free to use, subject to usage limits. Support is expanding toward all regions. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
 
 - **Branches with your database.** Each branch has its own view of storage. Test file uploads and deletions in preview branches without touching production data.
 - **Standard S3 SDKs.** The AWS SDK for JavaScript, boto3, the AWS CLI, the [Files SDK](https://files-sdk.dev), and any other S3-compatible tool works out of the box.
@@ -55,7 +55,7 @@ neon bootstrap --template ai-sdk
 
 During the beta, the following usage limits apply:
 
-- **Region**: object storage is available in AWS us-east-2 only.
+- **Region**: object storage is available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
 - **Free storage**: the Free plan includes 5 GB, measured across your whole account rather than per project. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
 - **Object size**: objects can be up to 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload). [Contact support](/docs/introduction/support) if you need to store larger objects.
 - **Rate limiting**: requests may be throttled during heavy use, returning a `503 SlowDown` response. Back off and retry. See [Connection and performance errors](/docs/storage/troubleshooting#connection-and-performance-errors).

--- a/content/guides/clean-up-orphaned-s3-objects-neon-branching.md
+++ b/content/guides/clean-up-orphaned-s3-objects-neon-branching.md
@@ -4,7 +4,7 @@ subtitle: 'Practice a real orphan-cleanup job on a Neon branch before running it
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-08-26T00:00:00.000Z'
-updatedOn: '2026-08-27T18:38:44.047Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 If you're building an application that handles user files (avatars, invoices, PDF exports, or chat attachments), you run into the same two-part architecture every time: the files live in object storage, and the metadata lives in Postgres. A row in an `attachments` table stores an `object_key`, and that key points to a file in an S3 bucket.
@@ -28,7 +28,7 @@ The standard fix is a vacuum job: list every object in the bucket, load every `o
 Neon removes that trade-off with [Neon Object Storage](/docs/storage/overview). Buckets [branch with your database](/docs/storage/objects#object-branching), so creating a branch gives you an isolated copy of your data in both systems: the Postgres rows and the S3 objects. You can run the real vacuum, actual `DeleteObject` calls and all, against the branch, verify that rows and objects still agree, and only then run the same script against production with the safeguards described below.
 
 <Admonition type="info" title="Beta">
-Neon Object Storage is in beta and available only in the AWS `us-east-2` region. Create your project there to follow along.
+Neon Object Storage is in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions. Create your project in one of these regions to follow along.
 </Admonition>
 
 In this tutorial, you'll build a small demo app that simulates the drift problem, then write a vacuum job and test it on a Neon branch before promoting it to production. The workflow is identical for your own application: declare the bucket, measure drift with the checker, run the vacuum on a branch, and promote.
@@ -73,7 +73,7 @@ Link your local workspace to a Neon project:
 neon link
 ```
 
-You'll be prompted to select your organization, then a project. **Create a new project** named `postgres-s3-drift-demo` (or pick an existing one). Next, select a region. Choose **AWS US East 2 (Ohio)** (`aws-us-east-2`), as Neon Object Storage is currently available only in this region during beta. When asked which Neon services you require, select **Object Storage**. Finally, confirm that you want to manage your setup as code, which generates a `neon.ts` file in your project root:
+You'll be prompted to select your organization, then a project. **Create a new project** named `postgres-s3-drift-demo` (or pick an existing one). Next, select a region. Choose **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`); this guide uses US East (Ohio). Neon Object Storage is currently available in these regions during beta. Support is expanding toward all regions. When asked which Neon services you require, select **Object Storage**. Finally, confirm that you want to manage your setup as code, which generates a `neon.ts` file in your project root:
 
 ```text
 $ neon link

--- a/content/guides/discord-bot-on-neon-functions.md
+++ b/content/guides/discord-bot-on-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to build a Discord bot with AI chat and image generation us
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-06-28T00:00:00.000Z'
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 If you've spent any time on Discord, you've run into bots: moderation bots, music players, AI image generators like Midjourney, which started out as a Discord bot before becoming a standalone product. They all do the same basic thing under the hood: listen for a command and respond, whether that's a one-line reply or a fully generated image.
@@ -74,7 +74,7 @@ neon link
 Follow the prompts to select your organization and create a new project:
 
 <Admonition type="note">
-Ensure you select the **AWS US East 2 (Ohio)** region when creating your Neon project, as Neon Functions are currently only available in this region during Beta. After linking, choose “yes” when prompted to manage the setup as code to automatically generate a `neon.ts` file for your project.
+Select **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`) when creating your Neon project; this guide uses US East (Ohio). Neon Functions are currently available in these regions during beta. Support is expanding toward all regions. After linking, choose “yes” when prompted to manage the setup as code to automatically generate a `neon.ts` file for your project.
 </Admonition>
 
 ```bash

--- a/content/guides/durable-workflow-on-neon-functions.md
+++ b/content/guides/durable-workflow-on-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to orchestrate reliable, long-running workflows with Innges
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-07-25T00:00:00.000Z'
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 If you're building modern web applications, you inevitably run into work that shouldn't or can't happen inside a single HTTP request-response cycle. Whether it's running multi-step AI enrichment pipelines, orchestrating customer onboarding sequences, processing background uploads, or handling third-party webhooks, background work is a core requirement of production backends.
@@ -106,7 +106,7 @@ Link your local workspace to a Neon project:
 neon link
 ```
 
-You'll be prompted to select your organization, then a project. Create a new one or pick an existing project. Choose the **AWS US East 2 (Ohio)** (`aws-us-east-2`) region, since Neon Functions are available only there during beta.
+You'll be prompted to select your organization, then a project. Create a new one or pick an existing project. Choose **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`); this guide uses US East (Ohio). Neon Functions are currently available in these regions during beta. Support is expanding toward all regions.
 
 Next, install the required dependencies:
 
@@ -131,7 +131,7 @@ neon link
 Select your organization and choose to create a new project named `neon-inngest-demo`.
 
 <Admonition type="note">
-Ensure you select the **AWS US East 2 (Ohio)** region (`aws-us-east-2`) when creating your Neon project, as Neon Functions are currently available in this region during beta. Select **Yes** when prompted to manage your setup as code (`neon.ts`).
+Select **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`) when creating your Neon project; this guide uses US East (Ohio). Neon Functions are currently available in these regions during beta. Support is expanding toward all regions. Select **Yes** when prompted to manage your setup as code (`neon.ts`).
 </Admonition>
 
 A `.env.local` file should be created automatically in your project root with your Neon project details, including `DATABASE_URL` and other Neon-specific variables.

--- a/content/guides/image-processing-api-neon-functions.md
+++ b/content/guides/image-processing-api-neon-functions.md
@@ -66,7 +66,7 @@ Link your local workspace to a Neon project:
 neon link
 ```
 
-You'll be prompted to select your organization, then a project. **Create a new project** named `image-api` (or pick an existing one). Next, select a region. Choose **AWS US East 2 (Ohio)** (`aws-us-east-2`), as Neon Functions are currently available only in this region during beta. When asked which Neon services you require, select **Functions** and **AI Gateway**. Finally, confirm that you want to manage your setup as code, which generates a `neon.ts` file in your project root:
+You'll be prompted to select your organization, then a project. **Create a new project** named `image-api` (or pick an existing one). Next, select a region. Choose **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`); this guide uses US East (Ohio). Neon Functions are currently available in these regions during beta. Support is expanding toward all regions. When asked which Neon services you require, select **Functions** and **AI Gateway**. Finally, confirm that you want to manage your setup as code, which generates a `neon.ts` file in your project root:
 
 ```text
 $ neon link

--- a/content/guides/llm-proxy-neon-functions.md
+++ b/content/guides/llm-proxy-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to build a secure LLM proxy backend that authenticates requ
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-07-22T00:00:00.000Z'
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 If you’re building a web application that uses large language models (LLMs), you need a secure way to handle requests from the frontend to the model endpoints. Whether it’s a chat interface or a content generation tool, the frontend needs to reach a model endpoint. But exposing LLM API keys directly to the browser is a serious security risk. Secret keys can leak through browser DevTools or network logs. Without server-side controls, there’s also nothing stopping a user from sending unlimited requests, driving up costs, or bypassing access restrictions entirely.
@@ -77,7 +77,7 @@ neon link
 You will be prompted to select your organization. After selecting your organization, choose an existing Neon project if you already have one, or create a new project named `llm-proxy-demo`.
 
 <Admonition type="note">
-Ensure you select the **AWS US East 2 (Ohio)** region when creating your Neon project, as Neon Functions are currently only available in this region during Beta.
+Select **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`) when creating your Neon project; this guide uses US East (Ohio). Neon Functions are currently available in these regions during beta. Support is expanding toward all regions.
 </Admonition>
 
 ```bash

--- a/content/guides/neon-functions-github-actions.md
+++ b/content/guides/neon-functions-github-actions.md
@@ -4,7 +4,7 @@ subtitle: 'Set up CI/CD for Neon Functions: deploy to production on merge and cr
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-08-06T00:00:00.000Z'
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 [Neon Functions](/docs/compute/functions/overview) are long-running serverless functions you deploy onto a Neon branch, so your backend runs right next to your Postgres database. Each branch runs its own function at its own URL against its own database state, with `DATABASE_URL` injected automatically. That makes them a natural fit for a workflow where every environment gets its own isolated function.
@@ -23,7 +23,7 @@ You'll set up that automation with GitHub Actions and build a small API on Neon 
 Because the pipeline is just the [Neon CLI](/docs/cli) running in a CI job, the same recipe works in GitLab CI, CircleCI, Azure DevOps, or any other CI/CD system. The last section shows how to adapt it.
 
 <Admonition type="note" title="Neon Functions are in beta">
-Functions are currently available only in the **AWS US East (Ohio)** (`aws-us-east-2`) region, so create your Neon project there to follow along. Functions run JavaScript or TypeScript on the Node.js 24 runtime.
+Functions are currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`), so create your Neon project in one of these regions to follow along. Support is expanding toward all regions. Functions run JavaScript or TypeScript on the Node.js 24 runtime.
 </Admonition>
 
 ## Prerequisites
@@ -58,7 +58,7 @@ Link your local workspace to a Neon project:
 neon link
 ```
 
-You'll be prompted to select your organization, then a project. **Create a new project** named `neon-functions-api` (or pick an existing one). Next, select a region. Choose **AWS US East 2 (Ohio)** (`aws-us-east-2`), because Neon Functions are currently available only in this region during beta. When asked which Neon services you require, select **Functions**. Finally, confirm that you want to manage your setup as code, which generates a `neon.ts` file in your project root:
+You'll be prompted to select your organization, then a project. **Create a new project** named `neon-functions-api` (or pick an existing one). Next, select a region. Choose **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`); this guide uses US East (Ohio). Neon Functions are currently available in these regions during beta. Support is expanding toward all regions. When asked which Neon services you require, select **Functions**. Finally, confirm that you want to manage your setup as code, which generates a `neon.ts` file in your project root:
 
 ```text
 $ neon link

--- a/content/guides/neon-ts-demo.md
+++ b/content/guides/neon-ts-demo.md
@@ -4,7 +4,7 @@ subtitle: Use Neon's native TypeScript configuration to provision services, mana
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-06-24T00:00:00.000Z'
-updatedOn: '2026-07-15T00:08:00.682Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 ---
 
 [`neon.ts`](/docs/reference/neon-ts) is Neon's native **Infrastructure-as-Code (IaC)** file designed for full-stack TypeScript projects. Unlike traditional IaC tools such as [Terraform](/docs/reference/terraform), [Pulumi](/guides/neon-pulumi), or [OpenTofu](/guides/opentofu-neon), which require learning a new DSL, managing complex state files, and wiring outputs into your application by hand, `neon.ts` is integrated into your local development loop. It provisions infrastructure through the [Neon CLI (`neon`)](/docs/cli), syncs connection strings directly into `.env.local`, and validates those variables inside your application code with strict TypeScript typing.
@@ -359,7 +359,7 @@ preview: {
 
 Running `neon deploy` will provision the buckets and deploy the functions, and `parseEnv` will automatically type your `env.aiGateway` and `env.preview.buckets` variables. For local development, you can run `neon dev` to hot-reload your functions against your linked branch.
 
-_Neon Functions and Storage are in beta and available only in AWS US East (Ohio) (`aws-us-east-2`), so create your project there to use them._
+_Neon Functions and Storage are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Create your project in one of these regions to use them. Support is expanding toward all regions._
 
 ## Conclusion
 

--- a/content/guides/sentry-neon-functions.md
+++ b/content/guides/sentry-neon-functions.md
@@ -4,7 +4,7 @@ subtitle: 'Learn how to add error tracking, structured logs, and request tracing
 author: dhanush-reddy
 enableTableOfContents: true
 createdAt: '2026-08-05T00:00:00.000Z'
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T15:10:53.712Z'
 canonical: 'https://sentry.io/cookbook/monitor-neon-functions-sentry/'
 ---
 
@@ -65,7 +65,7 @@ Link your local workspace to a Neon project:
 neon link
 ```
 
-You’ll be prompted to select your organization. Once chosen, either pick an existing Neon project or create a new one named `neon-sentry-demo`. Next, select a region. Choose **AWS US East 2 (Ohio)** (`aws-us-east-2`), as Neon Functions are currently available only in this region during beta. When asked which Neon services you require, select **Functions**. Finally, confirm that you want to manage your setup as code; this will generate a `neon.ts` file in the root of your project.
+You’ll be prompted to select your organization. Once chosen, either pick an existing Neon project or create a new one named `neon-sentry-demo`. Next, select a region. Choose **AWS US East (Ohio)** (`aws-us-east-2`) or **AWS Europe (Frankfurt)** (`aws-eu-central-1`); this guide uses US East (Ohio). Neon Functions are currently available in these regions during beta. Support is expanding toward all regions. When asked which Neon services you require, select **Functions**. Finally, confirm that you want to manage your setup as code; this will generate a `neon.ts` file in the root of your project.
 
 ```text
 $ neon link

--- a/public/prompts/neon-backend.md
+++ b/public/prompts/neon-backend.md
@@ -1,6 +1,6 @@
 Get this project set up on Neon so I can build a backend on it. Work through it with the Neon CLI; don't rely on interactive pickers.
 
-First, ask me in one message (don't guess or pick a default): which org, an existing `aws-us-east-2` project to reuse or a name to create a new one there, and a one-line description of what I'm building. Neon's backend services (Functions, Object Storage, and the AI Gateway) are only available in `aws-us-east-2` during beta.
+First, ask me in one message (don't guess or pick a default): which org, an existing project in a supported region (`aws-us-east-2` or `aws-eu-central-1`) to reuse or a name to create a new one, and a one-line description of what I'm building. Neon's backend services (Functions, Object Storage, and the AI Gateway) are available in `aws-us-east-2` and `aws-eu-central-1` during beta. Support is expanding toward all regions.
 
 Then set up the tooling and connect:
 

--- a/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
+++ b/src/scripts/__snapshots__/process-md-for-llms.test.js.snap
@@ -45,7 +45,7 @@ Schema tools accept schema-qualified table names, such as \`crm.contacts\`. An u
 
 The \`querying\` category includes \`inspect_database\`, which runs the same 15 read-only checks as [\`neon inspect db\`](https://neon.com/docs/cli/inspect): relation and index sizes, unused indexes, sequential scans, active queries and locks, stalled queries running longer than 30 seconds, heavy and frequent statements, cache hit rate and working set, autovacuum and bloat, and replication state. Some checks need [\`pg_stat_statements\`](https://neon.com/docs/extensions/pg_stat_statements) or the [\`neon\`](https://neon.com/docs/extensions/neon) extension; the tool asks before suggesting \`CREATE EXTENSION\`.
 
-**Note:** The \`observability\` tools query [Neon Functions logs](https://neon.com/docs/compute/functions/logs) and [object storage logs](https://neon.com/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS \`us-east-2\` only. Log querying returns results only for projects in a supported region. Database diagnostics via \`inspect_database\` are under \`querying\`, not \`observability\`.
+**Note:** The \`observability\` tools query [Neon Functions logs](https://neon.com/docs/compute/functions/logs) and [object storage logs](https://neon.com/docs/storage/logs), which are part of the Neon backend beta, currently available in AWS US East (Ohio) (\`aws-us-east-2\`) and AWS Europe (Frankfurt) (\`aws-eu-central-1\`). Support is expanding toward all regions. Log querying returns results only for projects in a supported region. Database diagnostics via \`inspect_database\` are under \`querying\`, not \`observability\`.
 
 ### LinkAPIKey
 


### PR DESCRIPTION
## Overview

Neon's backend beta services (Functions, Object Storage, AI Gateway, and logs) now run in AWS Europe (Frankfurt) as well as AWS US East (Ohio). This updates every place the docs stated the services were available only in us-east-2 to name both regions, and unifies the phrasing across pages.

Scope is prose and availability statements across docs, guides, API references, and the backend setup prompt. Example commands, hostnames, and connection strings stay on us-east-2 so walkthroughs remain internally consistent. The launch changelog and announcement blog keep their original wording with a dated pointer to the current region list.

The vendored agent-skill copies under public/docs/ai/skills/ still say us-east-2; those are synced from neondatabase/agent-skills and will be updated upstream and re-synced separately.

This pull request and its description were written by Isaac.
