### PR TITLE
docs(experiment): prompt-forward Next.js quickstart (prototype #1)

### DIFF
--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,7 +7,7 @@ summary: >-
   them. Includes the key files to expect (schema, client, and page), and
   follow-up prompts for sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-05T19:04:43.372Z'
+updatedOn: '2026-09-05T19:08:01.333Z'
 ---
 
 Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres. Your agent uses the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) to create the table, run the SQL, and seed the data, so you watch it work instead of copy-pasting code.
@@ -16,7 +16,7 @@ Connect your AI coding agent to Neon once, send it one prompt, and you'll have a
 
 ## Connect your agent to Neon
 
-In your terminal, connect Neon to your app. Starting fresh? Run all three lines. Already have a Next.js app? Skip the first two and run `npx neon@latest init` in it.
+In your terminal, create your app and connect Neon:
 
 ```bash filename="Terminal"
 npx create-next-app@latest notes-app --yes --app

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -1,192 +1,53 @@
 ---
 title: Get started with your AI agent
-subtitle: Prompt your AI coding agent to build a working Next.js app on Neon Postgres
+subtitle: Prompt your AI coding agent to build a Next.js app on Neon
 summary: >-
-  A prompt-forward quickstart. Connect your AI coding assistant to Neon with the
-  Neon CLI and MCP server, then send one prompt that creates a table, seeds it
-  with sample rows, and adds a page that renders them. Includes the unattended
-  CLI sequence an autonomous agent can run start to finish, the files and output
-  to expect, and follow-up prompts for auth, Object Storage, Functions, and the
-  AI Gateway.
+  Connect your AI coding assistant to Neon with one command, then send a single
+  prompt that creates a table, seeds sample rows, and adds a page that lists
+  them. Includes the schema and page to expect, and follow-up prompts for
+  sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-02T19:06:46.133Z'
+updatedOn: '2026-09-02T20:30:02.851Z'
 ---
 
-Set up Neon and build on it without leaving your editor. Every step on this page is a prompt or a command you can hand to an AI coding assistant: you connect the agent to Neon once, then send it a single prompt that creates a table, seeds sample rows, and adds a page that displays them. You end up with a running Next.js app, not just a proven connection.
+Set up Neon and build on it without leaving your editor. Connect your agent once, then send it a single prompt: it creates a table, seeds a few rows, and adds a page that shows them. You end up with a running Next.js app, not just a connection.
 
-Two paths, so pick the one that matches how you work. This page is the prompt-forward path, where your agent writes the code. [Build a full backend](/docs/get-started/full-backend-quickstart) is the read-and-understand path, where you write every line yourself and the page explains each one. New to the platform? The [backend overview](/docs/get-started/backend-overview) shows how Postgres, Managed Better Auth, Object Storage, Functions, and the AI Gateway fit together.
-
-This page is an experiment in prompt-forward documentation. Every command below was checked against the Neon CLI 4.14.0 command and help semantics on 2026-09-02, and pins that version so the flags stay valid. That check covers the flags and their documented behavior, not an end-to-end live run.
-
-## Before you start
-
-You'll need:
-
-- [Node.js 20+](https://nodejs.org/). Use Node.js 22.20+ if you install [agent skills](/docs/cli/skills) directly, which run through `npx`.
-- [`jq`](https://jqlang.github.io/jq/), which the setup sequence uses to read IDs out of JSON output.
-- A supported AI coding assistant, such as Cursor or Claude Code (see [supported clients](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp)).
-- A Neon account. Sign up at [console.neon.tech](https://console.neon.tech/signup).
-
-To install or upgrade the CLI globally, run `npm install -g neon@latest`. The commands below call `npx neon@4.14.0` instead, so they don't depend on what you have installed.
+Prefer to write every line yourself? [Build a full backend](/docs/get-started/full-backend-quickstart) is the hands-on tutorial that explains each step.
 
 ## Connect your agent to Neon
 
-Your agent needs two things: the [Neon MCP server](/docs/ai/neon-mcp-server) plus [agent skills](/docs/ai/agent-skills), and a linked Neon project with a `DATABASE_URL` in your env file. The `neon plugins` command installs the first, and `neon link` does the second.
-
-### The unattended sequence
-
-This is the canonical setup. It runs start to finish with no terminal input, so an agent or a CI job can lift the whole block and run it as is:
-
-```bash shouldWrap filename="Unattended setup, Neon CLI 4.14.0"
-# Precondition: NEON_API_KEY is the unattended login. There is no non-interactive
-# `neon auth`, so without this variable sign-in opens a browser and the run stalls.
-# Create a key in the Neon Console, under API keys. The line below asserts the key
-# is already exported and exits with a message if it isn't. It never prints the key.
-: "${NEON_API_KEY:?Set NEON_API_KEY to a Neon API key before running. Create one in the Neon Console, under API keys}"
-
-# Optional safety belt: turns any prompt that does slip through into an immediate
-# error instead of a wait that never ends.
-export CI=true
-
-# 1. Pick the organization to create the project in. This takes the first one the
-#    key can see, which is the only one on most accounts. If you belong to several,
-#    run `npx neon@4.14.0 orgs list` and set ORG_ID to the one you want instead.
-ORG_ID=$(npx neon@4.14.0 orgs list --output json | jq -r '.[0].id')
-
-# 2. Create the project and capture its ID. --no-secrets keeps the connection
-#    string out of the log, which matters when an agent or CI job is capturing it.
-PROJECT_ID=$(npx neon@4.14.0 projects create --name my-app --region-id aws-us-east-2 --org-id "$ORG_ID" --no-secrets --output json | jq -r '.project.id')
-
-# 3. Link this directory to the project. `link` needs --project-id here: --yes only
-#    skips the "already linked" confirmation, so on its own it still asks which
-#    project to use. Linking writes the org and project IDs to a .neon file, so
-#    later commands and prompts can read the project ID back from there. It also
-#    pulls DATABASE_URL and the other Neon variables into .env, or into .env.local
-#    if no .env exists.
-npx neon@4.14.0 link --project-id "$PROJECT_ID" --yes
-
-# 4. Install the Neon plugin, which bundles the skills and MCP access, into your
-#    agent. Naming the agent skips the picker. Set AGENT_ID to the agent you use:
-#    claude-code, cursor, codex, vscode, and others are supported.
-AGENT_ID=claude-code
-npx neon@4.14.0 plugins --agent "$AGENT_ID" -y
-
-# 5. Optional: scaffold a neon.ts config, ready for other Neon services later.
-npx neon@4.14.0 config init --services none
-```
-
-Two requirements make the difference between a clean run and a hang: `NEON_API_KEY` has to be exported, and `link` has to be given a `--project-id`. There's no separate `neon env pull` step because `link` pulls the env vars itself. Run [`neon env pull --file .env.local`](/docs/cli/env) only if you need the variables in a specific file.
-
-<Admonition type="important" title="neon init -y is not the non-interactive form">
-`neon init` orchestrates these same commands, but it forwards no project identity to `link`, so `link` still asks which project to use unless the directory is already linked. In a pseudo-terminal, which is what most agent harnesses allocate, that question waits forever, and `init` has already written agent config to disk by then. Use the explicit sequence above whenever nobody is there to answer. This is drawn from how 4.14.0 orchestrates those commands and from the CLI's own help for `link --yes`, which says it still asks for a project unless one is already linked, rather than from an observed end-to-end run.
-</Admonition>
-
-### Or one command, if you're at a terminal
-
-When you're running the setup yourself, one command covers it:
+Run this once. It installs the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) for your editor, links a Neon project, and writes your `DATABASE_URL` into your env file:
 
 ```bash
-npx neon@4.14.0 init
+npx neon@latest init
 ```
 
-`neon init` is interactive. It asks how your coding agents should get Neon (a plugin, or skills and the MCP server), links a Neon project, and writes a `neon.ts` config. In an empty directory it scaffolds a starter template first. See the [`neon init` reference](/docs/cli/init) for the full flow.
+Pick how your agent gets Neon (a plugin, or skills and MCP) and which project to use. In an empty folder, `neon init` scaffolds a starter app first. That's it. Your agent now has everything it needs.
 
-If you only want the MCP server, run [`npx neon@4.14.0 mcp`](/docs/cli/mcp). If you only want agent skills, run [`npx neon@4.14.0 skills`](/docs/cli/skills).
+<Admonition type="note">
+Automating this with no one at the keyboard (CI, an autonomous agent)? `neon init` is interactive, so use the [non-interactive setup sequence](/docs/cli/init#run-it-non-interactively) instead.
+</Admonition>
 
-## Build the app with one prompt
+## Build your app with one prompt
 
-Paste this into your editor's AI chat. It works in a fresh directory and in an existing Next.js app:
+Paste this into your editor's AI chat:
 
 ```text shouldWrap filename="AI assistant prompt"
-Build me a working Next.js page backed by Neon Postgres, and use the Neon skills and MCP server you have installed.
-
-Set up:
-
-1. Decide whether a Next.js app already exists here. Check for a `package.json` that lists Next.js as a dependency, not whether the directory has files in it: the Neon setup already wrote a `.neon` file and an env file, so even a brand new project looks non-empty. If Next.js isn't installed, scaffold a new Next.js app in this directory (App Router, TypeScript) and leave the existing `.neon` and env files in place. If it is installed, add to that app instead of replacing it.
-2. Confirm Neon is connected. Read `projectId` from the `.neon` file in this directory and use that ID whenever a Neon CLI command needs one. If there's no `.neon` file, the unattended setup sequence from this page hasn't run here, so run that first: it creates a project, captures the ID, and links this directory. Then check that DATABASE_URL is in my env file. Never print connection strings or other secrets back to me.
-3. Install `drizzle-orm`, `@neondatabase/serverless`, and `@next/env`, plus `drizzle-kit` and `tsx` as dev dependencies. Install `@next/env` explicitly rather than relying on it arriving with Next.js, because the Drizzle config and the seed script both import `loadEnvConfig` from it.
-
-Then build:
-
-4. Define a `notes` table with Drizzle: a bigint identity primary key, `title` (text, not null, and unique so the seed can skip rows it already inserted), `body` (text, not null), and `created_at` (timestamptz, not null, defaults to now).
-5. Add a `drizzle.config.ts`. `drizzle-kit` is a standalone CLI and does not read `.env.local` on its own, so load the env first with `loadEnvConfig` from `@next/env`.
-6. Apply the schema with `npx drizzle-kit push`.
-7. Seed 5 sample notes from a script at `lib/db/seed.ts`, and make it idempotent: one insert with `onConflictDoNothing` targeting the unique `title`, so rerunning it leaves the count at 5 instead of inserting duplicates. Call `loadEnvConfig` in the script and build its own Drizzle client there. Don't import the shared client, because that module reads DATABASE_URL when it loads, before the env is in place. Add an `npm run db:seed` script that runs it with `tsx`.
-8. Add a `/notes` page as a Server Component that queries the notes through Drizzle and renders them newest first. Set `export const dynamic = 'force-dynamic'` so Next.js does not statically cache the page.
-9. Prove it works. Run `npm run db:seed`, then `npm run build`, then start the dev server and fetch http://localhost:3000/notes. Show me the rows you actually got back, not "setup complete". Then give me commands I can rerun myself, such as `npm run db:seed` followed by `npx neon@4.14.0 psql -- -c "select count(*) from notes"`.
-
-If any step fails, show me the error and what you tried. Don't route around it silently.
+Build me a working notes app backed by Neon Postgres, using the Neon skills and MCP server you have. Use Drizzle with @neondatabase/serverless. Create a notes table (title, body, created_at), seed 5 example rows, and add a /notes page, a Server Component, that lists them newest first. Then run it and show me the actual rows, not "done". If anything fails, show me the error instead of working around it.
 ```
 
 ## What you'll get
 
-Use this section to check the agent's work. If you're an agent reading this page, treat it as the spec for step 4 onward.
-
-Paths depend on the scaffold, so `src/`-prefixed variants are fine:
-
-```text filename="Files you should end up with"
-.env.local             DATABASE_URL and other Neon vars, written by `neon link`
-.neon                  org, project, and branch context, written by `neon link`
-drizzle.config.ts      points drizzle-kit at DATABASE_URL
-lib/db/schema.ts       the notes table
-lib/db/client.ts       Drizzle client over @neondatabase/serverless
-lib/db/seed.ts         idempotent seed for the 5 sample notes
-app/notes/page.tsx     Server Component that renders the rows
-```
-
-The table definition, the client, the seed, and the page:
+Your agent writes the schema, a Drizzle client, and the page. The two files that matter:
 
 ```typescript filename="lib/db/schema.ts"
 import { bigint, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 export const notes = pgTable('notes', {
   id: bigint('id', { mode: 'number' }).primaryKey().generatedByDefaultAsIdentity(),
-  title: text('title').notNull().unique(),
+  title: text('title').notNull(),
   body: text('body').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-});
-```
-
-```typescript filename="lib/db/client.ts"
-import { neon } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-http';
-
-import * as schema from './schema';
-
-const sql = neon(process.env.DATABASE_URL!);
-export const db = drizzle(sql, { schema });
-```
-
-The seed builds its own client instead of importing `lib/db/client.ts`, because that module reads `DATABASE_URL` at import time, before `loadEnvConfig` has run:
-
-```typescript filename="lib/db/seed.ts"
-import { neon } from '@neondatabase/serverless';
-import { loadEnvConfig } from '@next/env';
-import { drizzle } from 'drizzle-orm/neon-http';
-
-import { notes } from './schema';
-
-loadEnvConfig(process.cwd());
-
-const sampleNotes = [
-  { title: 'Welcome to Neon', body: 'This row came from the seed script.' },
-  { title: 'Branching', body: 'Copy the whole database in seconds.' },
-  { title: 'Autoscaling', body: 'Compute follows your traffic.' },
-  { title: 'Scale to zero', body: 'Idle computes suspend, so you stop paying for them.' },
-  { title: 'Serverless driver', body: 'Query Postgres over HTTP from the edge.' },
-];
-
-async function seed() {
-  const db = drizzle(neon(process.env.DATABASE_URL!));
-
-  await db.insert(notes).values(sampleNotes).onConflictDoNothing({ target: notes.title });
-
-  console.log(`Seeded ${sampleNotes.length} notes`);
-}
-
-seed().catch((error) => {
-  console.error(error);
-  process.exit(1);
 });
 ```
 
@@ -199,7 +60,7 @@ import { notes } from '@/lib/db/schema';
 export const dynamic = 'force-dynamic';
 
 export default async function NotesPage() {
-  const rows = await db.select().from(notes).orderBy(desc(notes.createdAt)).limit(10);
+  const rows = await db.select().from(notes).orderBy(desc(notes.createdAt));
 
   return (
     <ul>
@@ -214,62 +75,32 @@ export default async function NotesPage() {
 }
 ```
 
-Then verify it yourself. Push the schema, seed, build, and count the rows:
+## Run it
 
-```bash filename="Terminal"
-npx drizzle-kit push
-npm run db:seed
-npm run build
-npx neon@4.14.0 psql -- -c "select count(*) from notes"
+```bash
+npm run dev
 ```
 
-```text filename="Output"
- count
--------
-     5
-(1 row)
+Open [localhost:3000/notes](http://localhost:3000/notes) and you'll see your seeded notes, newest first. You can also open the table in the [Neon Console](https://console.neon.tech).
+
+## Keep building
+
+Each prompt below adds one capability to the app you just built. Send them one at a time.
+
+```text shouldWrap filename="Prompt: add sign-in"
+Add Managed Better Auth so each note belongs to a signed-in user: add a user_id to notes, scope every query to the current user, and add sign-in and sign-out. Follow https://neon.com/docs/auth/authentication-flow.md, since this API is in beta.
 ```
 
-Rerun `npm run db:seed` as often as you like. Because the insert skips conflicts on `title`, the count stays at 5.
-
-With `npm run dev` running, `http://localhost:3000/notes` lists the 5 seeded notes, newest first. You can also open the table in the [Neon Console](https://console.neon.tech).
-
-## Next steps
-
-Keep prompting. Each block below adds one capability to the app you just built. Send them one at a time and let the agent verify each before you move on.
-
-<Admonition type="note" title="Region support for the beta services">
-Object Storage, Functions, and the AI Gateway are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). The setup sequence above creates the project in `aws-us-east-2` for that reason. Postgres works in any region.
-</Admonition>
-
-Add authentication, so notes belong to a signed-in user:
-
-```text shouldWrap filename="Prompt: add auth"
-Add Managed Better Auth to this app so notes belong to a signed-in user. Declare auth in neon.ts, run `npx neon@4.14.0 deploy` to provision it, then `npx neon@4.14.0 env pull` to pull the new credentials. Add a `user_id` column to the notes table, scope every query to the signed-in user, and add sign-in and sign-out. Then prove it: sign in as a test user, create a note, and show me that a second user cannot see it. Follow https://neon.com/docs/auth/authentication-flow.md rather than your training data, since this API is in beta and changes often.
+```text shouldWrap filename="Prompt: add image uploads"
+Let each note carry an image using Neon Object Storage. Store the object key on the row, never the bytes, add an upload control, and render each image. Follow https://neon.com/docs/storage/get-started.md.
 ```
 
-Add file uploads, with the object key on the row:
-
-```text shouldWrap filename="Prompt: add file storage"
-Let each note carry an image. Declare Object Storage in neon.ts, run `npx neon@4.14.0 deploy`, then `npx neon@4.14.0 env pull`. Store the object key on the notes row, never the bytes. Add an upload control to the notes page and render each image from its key. Then prove it: upload a file, show me the stored key, and fetch the object back. Follow https://neon.com/docs/storage/get-started.md for the current package and config syntax.
+```text shouldWrap filename="Prompt: add AI summaries"
+Add a one-line AI summary to each note using the Neon AI Gateway, stored in a summary column. Pick a current model from the catalog. Follow https://neon.com/docs/ai-gateway/models.md.
 ```
-
-Call a model through one credential:
-
-```text shouldWrap filename="Prompt: add AI"
-Generate a one-line summary for each note using the Neon AI Gateway, and store it in a `summary` column. Declare the AI gateway in neon.ts, run `npx neon@4.14.0 deploy`, then `npx neon@4.14.0 env pull`. Pick a current text model from the catalog rather than guessing an ID. Then prove it: summarize the seeded notes and show me the generated text. Follow https://neon.com/docs/ai-gateway/models.md for endpoints, model IDs, and modality.
-```
-
-Move that long-running call into a Function:
-
-```text shouldWrap filename="Prompt: add a function"
-Move the summarization call into a Neon Function so it runs on compute next to the database instead of in a route handler, and stream the result back. Declare the function in neon.ts, run `npx neon@4.14.0 deploy`, then `npx neon@4.14.0 env pull`. Inside the function, connect with a `pg` Pool opened once at module scope; don't use `@neondatabase/serverless` there, since it's built for short-lived per-request work. Then prove it: call the function endpoint and show me the response. Follow https://neon.com/docs/compute/functions/get-started.md for the injected env var names and connection guidance.
-```
-
-Branch the whole backend to try any of these in isolation:
 
 ```text shouldWrap filename="Prompt: work on a branch"
-Create a Neon branch for this work and switch to it: `npx neon@4.14.0 branches create --name my-feature`, then `npx neon@4.14.0 checkout my-feature`. Always name the branch, since a bare `checkout` prompts interactively. Confirm which branch my env file now points at, and tell me how to switch back.
+Create a Neon branch so I can try changes in isolation, then switch to it: npx neon@latest branches create --name my-feature, then neon checkout my-feature.
 ```
 
 <NeedHelp/>

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -1,81 +1,230 @@
 ---
 title: Get started with your AI agent
-subtitle: Set up Neon in your project using your AI coding assistant
+subtitle: Prompt your AI coding agent to build a working Next.js app on Neon Postgres
 summary: >-
-  Set up Neon for your project with your AI coding assistant. Let your agent
-  install the Neon tooling and connect your project, or run `neon init`
-  yourself in a terminal, then ask your agent to get started.
+  A prompt-forward quickstart. Connect your AI coding assistant to Neon with the
+  Neon CLI and MCP server, then send one prompt that creates a table, seeds it
+  with sample rows, and adds a page that renders them. Includes the unattended
+  CLI sequence an autonomous agent can run start to finish, the files and output
+  to expect, and follow-up prompts for auth, Object Storage, Functions, and the
+  AI Gateway.
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-02T18:49:35.200Z'
 ---
 
-Set up Neon for your project without leaving your editor. You have two options: let your AI coding assistant install the Neon tooling and connect your project for you, or run `neon init` yourself in a terminal and then hand off to your agent. Either way, your agent ends up with the [agent skills](/docs/ai/agent-skills) and [Neon MCP server](/docs/ai/neon-mcp-server) it needs to create a Neon project, connect your app, and use Neon features as you build.
+Set up Neon and build on it without leaving your editor. Every step on this page is a prompt or a command you can hand to an AI coding assistant: you connect the agent to Neon once, then send it a single prompt that creates a table, seeds sample rows, and adds a page that displays them. You end up with a running Next.js app, not just a proven connection.
 
-New to the platform? The [backend overview](/docs/get-started/backend-overview) shows how Postgres, Managed Better Auth, Object Storage, Functions, and the AI Gateway fit together. For a hands-on walkthrough, see [Build a full backend](/docs/get-started/full-backend-quickstart).
+Two paths, so pick the one that matches how you work. This page is the prompt-forward path, where your agent writes the code. [Build a full backend](/docs/get-started/full-backend-quickstart) is the read-and-understand path, where you write every line yourself and the page explains each one. New to the platform? The [backend overview](/docs/get-started/backend-overview) shows how Postgres, Managed Better Auth, Object Storage, Functions, and the AI Gateway fit together.
+
+This page is an experiment in prompt-forward documentation. The commands and prompts below were verified against Neon CLI 4.14.0 on 2026-09-02, and they pin that version so the steps reproduce exactly.
 
 ## Before you start
 
 You'll need:
 
-- [Node.js 20+](https://nodejs.org/)
-- A supported AI coding assistant, such as Cursor or Claude Code (see [supported clients](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp))
+- [Node.js 20+](https://nodejs.org/). Use Node.js 22.20+ if you install [agent skills](/docs/cli/skills) directly, which run through `npx`.
+- A supported AI coding assistant, such as Cursor or Claude Code (see [supported clients](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp)).
+- A Neon account. Sign up at [console.neon.tech](https://console.neon.tech/signup).
 
-## Let your agent set it up
+To install or upgrade the CLI globally, run `npm install -g neon@latest`. The commands below call `npx neon@4.14.0` instead, so they don't depend on what you have installed.
 
-The fastest path is to let your agent do the whole setup, from installing the tooling to proving the connection works. Paste this prompt into your editor's AI chat:
+## Connect your agent to Neon
 
-```text shouldWrap filename="AI assistant prompt"
-Help me get set up with Neon, based on my project:
+Your agent needs two things: the [Neon MCP server](/docs/ai/neon-mcp-server) plus [agent skills](/docs/ai/agent-skills), and a linked Neon project with a `DATABASE_URL` in your env file. The `neon plugins` command installs the first, and `neon link` does the second.
 
-1. Install or upgrade the Neon CLI: `npm install -g neon@latest`.
-2. Install the Neon agent tooling for your editor, replacing `<agent>` with your editor id (for example `cursor`, `claude-code`, or `codex`): run `neon plugins --agent <agent>` (recommended, installs the Neon plugin), or `neon skills --agent <agent> -s neon -s neon-postgres`. If sign-in opens a browser, ask me to confirm before continuing, and never print secrets.
-3. Using the installed Neon skill, create a Neon project (or connect an existing one), link it, and pull my DATABASE_URL into my env file. Add a Postgres driver for my stack.
-4. Prove it works: run a real query and show me the result, not just "setup complete." Give me a command to re-check it myself (e.g. `neon psql`).
-5. Then suggest next steps, such as a schema or migrations, branching for previews, or Neon's other services (Object Storage, Functions, Managed Better Auth, AI Gateway).
+### The unattended sequence
+
+This is the canonical setup. It runs start to finish with no terminal input, so an agent or a CI job can lift the whole block and run it:
+
+```bash shouldWrap filename="Unattended setup, Neon CLI 4.14.0"
+# Precondition: NEON_API_KEY is the unattended login. There is no non-interactive
+# `neon auth`; without this variable, sign-in opens a browser and the run stalls.
+# Create a key in the Neon Console under API keys.
+export NEON_API_KEY=napi_...
+
+# Optional safety belt: turns any prompt that does slip through into an immediate
+# error instead of a wait that never ends.
+export CI=true
+
+# 1. List the organizations you can create a project in, and copy the ID you want.
+npx neon@4.14.0 orgs list --output json
+
+# 2. Create the project. --no-secrets keeps the connection string out of the log.
+#    Read the project ID from .project.id in the JSON output.
+npx neon@4.14.0 projects create --name my-app --region-id aws-us-east-2 --org-id <org-id> --no-secrets --output json
+
+# 3. Link this directory to the project. `link` needs --project-id here: with only
+#    --yes it still asks which project to use. Linking also pulls DATABASE_URL and
+#    the other Neon variables into .env, or .env.local if no .env exists.
+npx neon@4.14.0 link --project-id <project-id> --yes
+
+# 4. Install the Neon plugin, which bundles the skills and MCP access, into your
+#    agent. Naming the agent skips the picker. Swap claude-code for your own agent
+#    id: cursor, codex, vscode, and others are supported.
+npx neon@4.14.0 plugins --agent claude-code -y
+
+# 5. Optional: scaffold a neon.ts config, ready for other Neon services later.
+npx neon@4.14.0 config init --services none
 ```
 
-Your agent installs the Neon CLI and tooling and does the setup for you, so there's no switching between the terminal and the chat. It:
+Two requirements make the difference between a clean run and a hang: `NEON_API_KEY` has to be exported, and `link` has to be given a `--project-id`. There's no separate `neon env pull` step because `link` pulls the env vars itself. Run [`neon env pull --file .env.local`](/docs/cli/env) only if you need the variables in a specific file.
 
-- Installs either the Neon plugin, or [agent skills](/docs/ai/agent-skills) and the [Neon MCP server](/docs/ai/neon-mcp-server), for your editor, and signs you in (finish the browser step if it prompts)
-- Creates or connects a Neon project, writes your `DATABASE_URL` into your env file, and adds a Postgres driver for your stack
-- Uses the connection and shows you a real result so you can see it's working
+<Admonition type="important" title="neon init -y is not the non-interactive form">
+`neon init` orchestrates these same commands, but it forwards no project identity to `link`, so `link` still asks which project to use unless the directory is already linked. In a pseudo-terminal, which is what most agent harnesses allocate, that question waits forever, and `init` has already written agent config to disk by then. Use the explicit sequence above whenever nobody is there to answer.
+</Admonition>
 
-To confirm it yourself, run the command the agent gives you (e.g., `neon psql`), or open your project in the [Neon Console](https://console.neon.tech).
+### Or one command, if you're at a terminal
 
-## Prefer to run it yourself?
-
-You can run the setup manually and then hand off to your agent.
-
-<Steps>
-
-## Run the init command
-
-From your project root, run:
+When you're running the setup yourself, one command covers it:
 
 ```bash
-npx neon@latest init
+npx neon@4.14.0 init
 ```
 
-`neon init` is interactive, so run it in a terminal. It asks how your coding agents should get Neon (either a plugin, or skills and the MCP server), links a Neon project, and writes a `neon.ts` config. In an empty directory, it scaffolds a starter template first. For the full flow, and a non-interactive setup for agents and CI, see the [`neon init` reference](/docs/cli/init).
+`neon init` is interactive. It asks how your coding agents should get Neon (a plugin, or skills and the MCP server), links a Neon project, and writes a `neon.ts` config. In an empty directory it scaffolds a starter template first. See the [`neon init` reference](/docs/cli/init) for the full flow.
 
-If you only want the MCP server, without the skills or plugin, run [`npx neon@latest mcp`](/docs/cli/mcp) instead. If you only want agent skills, run [`npx neon@latest skills`](/docs/cli/skills).
+If you only want the MCP server, run [`npx neon@4.14.0 mcp`](/docs/cli/mcp). If you only want agent skills, run [`npx neon@4.14.0 skills`](/docs/cli/skills).
 
-## Tell your agent
+## Build the app with one prompt
 
-In your editor's AI chat, send:
+Paste this into your editor's AI chat. It works in an empty directory and in an existing Next.js app:
 
-```text
-Get started with Neon
+```text shouldWrap filename="AI assistant prompt"
+Build me a working Next.js page backed by Neon Postgres, and use the Neon skills and MCP server you have installed.
+
+Set up:
+
+1. If this directory is empty, scaffold a Next.js app here first (App Router, TypeScript). If it already holds a Next.js app, add to that app instead of replacing it.
+2. Confirm Neon is connected: if there's no `.neon` file, run `npx neon@4.14.0 link --project-id <project-id> --yes`, then check that DATABASE_URL is in my env file. Never print connection strings or other secrets back to me.
+3. Install `drizzle-orm` and `@neondatabase/serverless`, plus `drizzle-kit` as a dev dependency.
+
+Then build:
+
+4. Define a `notes` table with Drizzle: a bigint identity primary key, `title` (text, not null), `body` (text, not null), and `created_at` (timestamptz, not null, defaults to now).
+5. Add a `drizzle.config.ts`. `drizzle-kit` is a standalone CLI and does not read `.env.local` on its own, so load the env first with `loadEnvConfig` from `@next/env`.
+6. Apply the schema with `npx drizzle-kit push`.
+7. Seed 5 sample notes.
+8. Add a `/notes` page as a Server Component that queries the notes through Drizzle and renders them newest first. Set `export const dynamic = 'force-dynamic'` so Next.js does not statically cache the page.
+9. Prove it works. Run `npm run build`, start the dev server, and fetch http://localhost:3000/notes. Show me the rows you actually got back, not "setup complete". Then give me a command I can rerun myself, such as `npx neon@4.14.0 psql -- -c "select count(*) from notes"`.
+
+If any step fails, show me the error and what you tried. Don't route around it silently.
 ```
 
-Your agent reads the installed skill to create or connect a Neon project, pull your `DATABASE_URL` into your env file, add a Postgres driver, and run a real query to confirm the connection. The exact flow depends on your project.
+## What you'll get
 
-</Steps>
+Use this section to check the agent's work. If you're an agent reading this page, treat it as the spec for step 4 onward.
 
-## What's next
+Paths depend on the scaffold, so `src/`-prefixed variants are fine:
 
-- [How a Neon backend fits together](/docs/get-started/backend-overview)
-- [Build a full backend with Next.js and Neon](/docs/get-started/full-backend-quickstart)
-- [About branching](/docs/introduction/branching)
+```text filename="Files you should end up with"
+.env.local             DATABASE_URL and other Neon vars, written by `neon link`
+.neon                  org, project, and branch context, written by `neon link`
+drizzle.config.ts      points drizzle-kit at DATABASE_URL
+lib/db/schema.ts       the notes table
+lib/db/client.ts       Drizzle client over @neondatabase/serverless
+app/notes/page.tsx     Server Component that renders the rows
+```
+
+The table definition, the client, and the page:
+
+```typescript filename="lib/db/schema.ts"
+import { bigint, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const notes = pgTable('notes', {
+  id: bigint('id', { mode: 'number' }).primaryKey().generatedByDefaultAsIdentity(),
+  title: text('title').notNull(),
+  body: text('body').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+```
+
+```typescript filename="lib/db/client.ts"
+import { neon } from '@neondatabase/serverless';
+import { drizzle } from 'drizzle-orm/neon-http';
+
+import * as schema from './schema';
+
+const sql = neon(process.env.DATABASE_URL!);
+export const db = drizzle(sql, { schema });
+```
+
+```tsx filename="app/notes/page.tsx"
+import { desc } from 'drizzle-orm';
+
+import { db } from '@/lib/db/client';
+import { notes } from '@/lib/db/schema';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NotesPage() {
+  const rows = await db.select().from(notes).orderBy(desc(notes.createdAt)).limit(10);
+
+  return (
+    <ul>
+      {rows.map((note) => (
+        <li key={note.id}>
+          <strong>{note.title}</strong>
+          <p>{note.body}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Then verify it yourself. The schema push, the build, and the row count:
+
+```bash filename="Terminal"
+npx drizzle-kit push
+npm run build
+npx neon@4.14.0 psql -- -c "select count(*) from notes"
+```
+
+```text filename="Output"
+ count
+-------
+     5
+(1 row)
+```
+
+With `npm run dev` running, `http://localhost:3000/notes` lists the 5 seeded notes, newest first. You can also open the table in the [Neon Console](https://console.neon.tech).
+
+## Next steps
+
+Keep prompting. Each block below adds one capability to the app you just built. Send them one at a time and let the agent verify each before you move on.
+
+<Admonition type="note" title="Region support for the beta services">
+Object Storage, Functions, and the AI Gateway are in beta and currently available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). The setup sequence above creates the project in `aws-us-east-2` for that reason. Postgres works in any region.
+</Admonition>
+
+Add authentication, so notes belong to a signed-in user:
+
+```text shouldWrap filename="Prompt: add auth"
+Add Managed Better Auth to this app so notes belong to a signed-in user. Declare auth in neon.ts, run `npx neon@4.14.0 deploy` to provision it, then `npx neon@4.14.0 env pull` to pull the new credentials. Add a `user_id` column to the notes table, scope every query to the signed-in user, and add sign-in and sign-out. Then prove it: sign in as a test user, create a note, and show me that a second user cannot see it. Follow https://neon.com/docs/auth/authentication-flow.md rather than your training data, since this API is in beta and changes often.
+```
+
+Add file uploads, with the object key on the row:
+
+```text shouldWrap filename="Prompt: add file storage"
+Let each note carry an image. Declare Object Storage in neon.ts, run `npx neon@4.14.0 deploy`, then `npx neon@4.14.0 env pull`. Store the object key on the notes row, never the bytes. Add an upload control to the notes page and render each image from its key. Then prove it: upload a file, show me the stored key, and fetch the object back. Follow https://neon.com/docs/storage/get-started.md for the current package and config syntax.
+```
+
+Call a model through one credential:
+
+```text shouldWrap filename="Prompt: add AI"
+Generate a one-line summary for each note using the Neon AI Gateway, and store it in a `summary` column. Declare the AI gateway in neon.ts, run `npx neon@4.14.0 deploy`, then `npx neon@4.14.0 env pull`. Pick a current text model from the catalog rather than guessing an ID. Then prove it: summarize the seeded notes and show me the generated text. Follow https://neon.com/docs/ai-gateway/models.md for endpoints, model IDs, and modality.
+```
+
+Move that long-running call into a Function:
+
+```text shouldWrap filename="Prompt: add a function"
+Move the summarization call into a Neon Function so it runs on compute next to the database instead of in a route handler, and stream the result back. Declare the function in neon.ts, run `npx neon@4.14.0 deploy`, then `npx neon@4.14.0 env pull`. Inside the function, connect with a `pg` Pool opened once at module scope; don't use `@neondatabase/serverless` there, since it's built for short-lived per-request work. Then prove it: call the function endpoint and show me the response. Follow https://neon.com/docs/compute/functions/get-started.md for the injected env var names and connection guidance.
+```
+
+Branch the whole backend to try any of these in isolation:
+
+```text shouldWrap filename="Prompt: work on a branch"
+Create a Neon branch for this work and switch to it: `npx neon@4.14.0 branches create --name my-feature`, then `npx neon@4.14.0 checkout my-feature`. Always name the branch, since a bare `checkout` prompts interactively. Confirm which branch my env file now points at, and tell me how to switch back.
+```
 
 <NeedHelp/>

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,7 +7,7 @@ summary: >-
   them. Includes the three files to expect (schema, client, and page), and
   follow-up prompts for sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-04T18:56:19.179Z'
+updatedOn: '2026-09-05T17:43:23.709Z'
 ---
 
 Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres. Your agent uses the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) to create the table, run the SQL, and seed the data, so you watch it work instead of copy-pasting code.
@@ -31,19 +31,6 @@ npx neon@latest env pull
 ```
 
 If the directory was already linked, `init` skips the pull, so this step makes sure `DATABASE_URL` is in place before the build. Rerun it any time to refresh the values.
-
-<Admonition type="note">
-`neon init` still prompts for sign-in and which project to link, even with `-y` or `--agent`, so it isn't hands-off. For unattended or CI use, script the explicit commands with a project ID and `NEON_API_KEY` instead:
-
-```bash
-npx neon@latest link --project-id <project-id> -y
-npx neon@latest config init --services none
-npx neon@latest env pull
-```
-
-This connects the database but does not install the agent's Neon tooling, so it assumes [agent skills](/docs/ai/agent-skills) and the [Neon MCP server](/docs/ai/neon-mcp-server) are already set up; if not, install them first.
-
-</Admonition>
 
 ## Build your app with one prompt
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,7 +7,7 @@ summary: >-
   them. Includes the key files to expect (schema, client, and page), and
   follow-up prompts for sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-05T19:08:01.333Z'
+updatedOn: '2026-09-05T20:05:57.307Z'
 ---
 
 Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres. Your agent uses the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) to create the table, run the SQL, and seed the data, so you watch it work instead of copy-pasting code.
@@ -16,7 +16,7 @@ Connect your AI coding agent to Neon once, send it one prompt, and you'll have a
 
 ## Connect your agent to Neon
 
-In your terminal, create your app and connect Neon:
+Run these in your terminal to create your app and connect Neon (you'll sign in to Neon when prompted):
 
 ```bash filename="Terminal"
 npx create-next-app@latest notes-app --yes --app

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -4,10 +4,10 @@ subtitle: Prompt your AI coding agent to build a Next.js app on Neon
 summary: >-
   Connect your AI coding assistant to Neon with one command, then send a single
   prompt that creates a table, seeds sample rows, and adds a page that lists
-  them. Includes the three files to expect (schema, client, and page), and
+  them. Includes the key files to expect (schema, client, and page), and
   follow-up prompts for sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-05T17:43:23.709Z'
+updatedOn: '2026-09-05T19:04:43.372Z'
 ---
 
 Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres. Your agent uses the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) to create the table, run the SQL, and seed the data, so you watch it work instead of copy-pasting code.
@@ -16,9 +16,11 @@ Connect your AI coding agent to Neon once, send it one prompt, and you'll have a
 
 ## Connect your agent to Neon
 
-Already have a Next.js app? Run this in it. Starting fresh? Create one with `npx create-next-app@latest` first.
+In your terminal, connect Neon to your app. Starting fresh? Run all three lines. Already have a Next.js app? Skip the first two and run `npx neon@latest init` in it.
 
-```bash
+```bash filename="Terminal"
+npx create-next-app@latest notes-app --yes --app
+cd notes-app
 npx neon@latest init
 ```
 
@@ -26,7 +28,7 @@ npx neon@latest init
 
 Then pull the connection details into your env file:
 
-```bash
+```bash filename="Terminal"
 npx neon@latest env pull
 ```
 
@@ -34,15 +36,15 @@ If the directory was already linked, `init` skips the pull, so this step makes s
 
 ## Build your app with one prompt
 
-Paste this into your editor's AI chat:
+In your AI agent's chat, paste:
 
 ```text shouldWrap filename="AI assistant prompt"
-Build me a working notes app backed by Neon Postgres, using the Neon skills and MCP server you have. Use Drizzle with @neondatabase/serverless. Create a notes table (title, body, created_at), seed 5 example rows, and add a /notes page, a Server Component, that lists them newest first. Then run it and show me the actual rows, not "done". If anything fails, show me the error instead of working around it.
+In this Next.js App Router project, build me a working notes app backed by Neon Postgres, using the Neon skills and MCP server you have. Use Drizzle with @neondatabase/serverless. Create a notes table (title, body, created_at), seed 5 example rows, and add a /notes page, a Server Component, that lists them newest first. Then run it and show me the actual rows, not "done". If anything fails, show me the error instead of working around it.
 ```
 
 ## What you'll get
 
-Your agent writes these three files and uses Neon's MCP tools to create the `notes` table and seed it. You review the result, not every step.
+Your agent writes these key files and uses Neon's MCP tools to create the `notes` table and seed it. It may add others too, such as `drizzle.config.ts` or route files. You review the result, not every step.
 
 ```typescript filename="lib/db/schema.ts"
 import { bigint, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
@@ -104,7 +106,7 @@ Open [localhost:3000/notes](http://localhost:3000/notes) and you'll see your see
 Each prompt below adds one capability to the app you just built. Send them one at a time. Object Storage and the AI Gateway are in beta and run in select regions, so if a prompt reports one isn't available, create your project in a supported region such as `aws-us-east-2` (Ohio) or `aws-eu-central-1` (Frankfurt).
 
 ```text shouldWrap filename="Prompt: add sign-in"
-Add Managed Better Auth so each note belongs to a signed-in user: add a user_id to notes, scope every query to the current user, and add sign-in and sign-out. Follow https://neon.com/docs/auth/authentication-flow.md, since this API is in beta.
+Add Managed Better Auth so each note belongs to a signed-in user: add a user_id to notes, scope every query to the current user, and add sign-in and sign-out. Follow https://neon.com/docs/auth/quick-start/nextjs-api-only.md, since this API is in beta.
 ```
 
 ```text shouldWrap filename="Prompt: add image uploads"
@@ -112,7 +114,7 @@ Let each note carry an image using Neon Object Storage. Store the object key on 
 ```
 
 ```text shouldWrap filename="Prompt: add AI summaries"
-Add a one-line AI summary to each note using the Neon AI Gateway, stored in a summary column. Pick a current model from the catalog. Follow https://neon.com/docs/ai-gateway/models.md.
+Add a one-line AI summary to each note using the Neon AI Gateway, stored in a summary column. Pick a current model from the catalog. Follow https://neon.com/docs/ai-gateway/models.md. The AI Gateway needs a paid Neon plan (Launch or Scale), so if the request is rejected, tell me to upgrade rather than working around it.
 ```
 
 ```text shouldWrap filename="Prompt: work on a branch"

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -9,20 +9,21 @@ summary: >-
   to expect, and follow-up prompts for auth, Object Storage, Functions, and the
   AI Gateway.
 enableTableOfContents: true
-updatedOn: '2026-09-02T18:49:35.200Z'
+updatedOn: '2026-09-02T19:06:46.133Z'
 ---
 
 Set up Neon and build on it without leaving your editor. Every step on this page is a prompt or a command you can hand to an AI coding assistant: you connect the agent to Neon once, then send it a single prompt that creates a table, seeds sample rows, and adds a page that displays them. You end up with a running Next.js app, not just a proven connection.
 
 Two paths, so pick the one that matches how you work. This page is the prompt-forward path, where your agent writes the code. [Build a full backend](/docs/get-started/full-backend-quickstart) is the read-and-understand path, where you write every line yourself and the page explains each one. New to the platform? The [backend overview](/docs/get-started/backend-overview) shows how Postgres, Managed Better Auth, Object Storage, Functions, and the AI Gateway fit together.
 
-This page is an experiment in prompt-forward documentation. The commands and prompts below were verified against Neon CLI 4.14.0 on 2026-09-02, and they pin that version so the steps reproduce exactly.
+This page is an experiment in prompt-forward documentation. Every command below was checked against the Neon CLI 4.14.0 command and help semantics on 2026-09-02, and pins that version so the flags stay valid. That check covers the flags and their documented behavior, not an end-to-end live run.
 
 ## Before you start
 
 You'll need:
 
 - [Node.js 20+](https://nodejs.org/). Use Node.js 22.20+ if you install [agent skills](/docs/cli/skills) directly, which run through `npx`.
+- [`jq`](https://jqlang.github.io/jq/), which the setup sequence uses to read IDs out of JSON output.
 - A supported AI coding assistant, such as Cursor or Claude Code (see [supported clients](/docs/ai/connect-mcp-clients-to-neon#supported-agents-add-mcp)).
 - A Neon account. Sign up at [console.neon.tech](https://console.neon.tech/signup).
 
@@ -34,34 +35,41 @@ Your agent needs two things: the [Neon MCP server](/docs/ai/neon-mcp-server) plu
 
 ### The unattended sequence
 
-This is the canonical setup. It runs start to finish with no terminal input, so an agent or a CI job can lift the whole block and run it:
+This is the canonical setup. It runs start to finish with no terminal input, so an agent or a CI job can lift the whole block and run it as is:
 
 ```bash shouldWrap filename="Unattended setup, Neon CLI 4.14.0"
 # Precondition: NEON_API_KEY is the unattended login. There is no non-interactive
-# `neon auth`; without this variable, sign-in opens a browser and the run stalls.
-# Create a key in the Neon Console under API keys.
-export NEON_API_KEY=napi_...
+# `neon auth`, so without this variable sign-in opens a browser and the run stalls.
+# Create a key in the Neon Console, under API keys. The line below asserts the key
+# is already exported and exits with a message if it isn't. It never prints the key.
+: "${NEON_API_KEY:?Set NEON_API_KEY to a Neon API key before running. Create one in the Neon Console, under API keys}"
 
 # Optional safety belt: turns any prompt that does slip through into an immediate
 # error instead of a wait that never ends.
 export CI=true
 
-# 1. List the organizations you can create a project in, and copy the ID you want.
-npx neon@4.14.0 orgs list --output json
+# 1. Pick the organization to create the project in. This takes the first one the
+#    key can see, which is the only one on most accounts. If you belong to several,
+#    run `npx neon@4.14.0 orgs list` and set ORG_ID to the one you want instead.
+ORG_ID=$(npx neon@4.14.0 orgs list --output json | jq -r '.[0].id')
 
-# 2. Create the project. --no-secrets keeps the connection string out of the log.
-#    Read the project ID from .project.id in the JSON output.
-npx neon@4.14.0 projects create --name my-app --region-id aws-us-east-2 --org-id <org-id> --no-secrets --output json
+# 2. Create the project and capture its ID. --no-secrets keeps the connection
+#    string out of the log, which matters when an agent or CI job is capturing it.
+PROJECT_ID=$(npx neon@4.14.0 projects create --name my-app --region-id aws-us-east-2 --org-id "$ORG_ID" --no-secrets --output json | jq -r '.project.id')
 
-# 3. Link this directory to the project. `link` needs --project-id here: with only
-#    --yes it still asks which project to use. Linking also pulls DATABASE_URL and
-#    the other Neon variables into .env, or .env.local if no .env exists.
-npx neon@4.14.0 link --project-id <project-id> --yes
+# 3. Link this directory to the project. `link` needs --project-id here: --yes only
+#    skips the "already linked" confirmation, so on its own it still asks which
+#    project to use. Linking writes the org and project IDs to a .neon file, so
+#    later commands and prompts can read the project ID back from there. It also
+#    pulls DATABASE_URL and the other Neon variables into .env, or into .env.local
+#    if no .env exists.
+npx neon@4.14.0 link --project-id "$PROJECT_ID" --yes
 
 # 4. Install the Neon plugin, which bundles the skills and MCP access, into your
-#    agent. Naming the agent skips the picker. Swap claude-code for your own agent
-#    id: cursor, codex, vscode, and others are supported.
-npx neon@4.14.0 plugins --agent claude-code -y
+#    agent. Naming the agent skips the picker. Set AGENT_ID to the agent you use:
+#    claude-code, cursor, codex, vscode, and others are supported.
+AGENT_ID=claude-code
+npx neon@4.14.0 plugins --agent "$AGENT_ID" -y
 
 # 5. Optional: scaffold a neon.ts config, ready for other Neon services later.
 npx neon@4.14.0 config init --services none
@@ -70,7 +78,7 @@ npx neon@4.14.0 config init --services none
 Two requirements make the difference between a clean run and a hang: `NEON_API_KEY` has to be exported, and `link` has to be given a `--project-id`. There's no separate `neon env pull` step because `link` pulls the env vars itself. Run [`neon env pull --file .env.local`](/docs/cli/env) only if you need the variables in a specific file.
 
 <Admonition type="important" title="neon init -y is not the non-interactive form">
-`neon init` orchestrates these same commands, but it forwards no project identity to `link`, so `link` still asks which project to use unless the directory is already linked. In a pseudo-terminal, which is what most agent harnesses allocate, that question waits forever, and `init` has already written agent config to disk by then. Use the explicit sequence above whenever nobody is there to answer.
+`neon init` orchestrates these same commands, but it forwards no project identity to `link`, so `link` still asks which project to use unless the directory is already linked. In a pseudo-terminal, which is what most agent harnesses allocate, that question waits forever, and `init` has already written agent config to disk by then. Use the explicit sequence above whenever nobody is there to answer. This is drawn from how 4.14.0 orchestrates those commands and from the CLI's own help for `link --yes`, which says it still asks for a project unless one is already linked, rather than from an observed end-to-end run.
 </Admonition>
 
 ### Or one command, if you're at a terminal
@@ -87,25 +95,25 @@ If you only want the MCP server, run [`npx neon@4.14.0 mcp`](/docs/cli/mcp). If 
 
 ## Build the app with one prompt
 
-Paste this into your editor's AI chat. It works in an empty directory and in an existing Next.js app:
+Paste this into your editor's AI chat. It works in a fresh directory and in an existing Next.js app:
 
 ```text shouldWrap filename="AI assistant prompt"
 Build me a working Next.js page backed by Neon Postgres, and use the Neon skills and MCP server you have installed.
 
 Set up:
 
-1. If this directory is empty, scaffold a Next.js app here first (App Router, TypeScript). If it already holds a Next.js app, add to that app instead of replacing it.
-2. Confirm Neon is connected: if there's no `.neon` file, run `npx neon@4.14.0 link --project-id <project-id> --yes`, then check that DATABASE_URL is in my env file. Never print connection strings or other secrets back to me.
-3. Install `drizzle-orm` and `@neondatabase/serverless`, plus `drizzle-kit` as a dev dependency.
+1. Decide whether a Next.js app already exists here. Check for a `package.json` that lists Next.js as a dependency, not whether the directory has files in it: the Neon setup already wrote a `.neon` file and an env file, so even a brand new project looks non-empty. If Next.js isn't installed, scaffold a new Next.js app in this directory (App Router, TypeScript) and leave the existing `.neon` and env files in place. If it is installed, add to that app instead of replacing it.
+2. Confirm Neon is connected. Read `projectId` from the `.neon` file in this directory and use that ID whenever a Neon CLI command needs one. If there's no `.neon` file, the unattended setup sequence from this page hasn't run here, so run that first: it creates a project, captures the ID, and links this directory. Then check that DATABASE_URL is in my env file. Never print connection strings or other secrets back to me.
+3. Install `drizzle-orm`, `@neondatabase/serverless`, and `@next/env`, plus `drizzle-kit` and `tsx` as dev dependencies. Install `@next/env` explicitly rather than relying on it arriving with Next.js, because the Drizzle config and the seed script both import `loadEnvConfig` from it.
 
 Then build:
 
-4. Define a `notes` table with Drizzle: a bigint identity primary key, `title` (text, not null), `body` (text, not null), and `created_at` (timestamptz, not null, defaults to now).
+4. Define a `notes` table with Drizzle: a bigint identity primary key, `title` (text, not null, and unique so the seed can skip rows it already inserted), `body` (text, not null), and `created_at` (timestamptz, not null, defaults to now).
 5. Add a `drizzle.config.ts`. `drizzle-kit` is a standalone CLI and does not read `.env.local` on its own, so load the env first with `loadEnvConfig` from `@next/env`.
 6. Apply the schema with `npx drizzle-kit push`.
-7. Seed 5 sample notes.
+7. Seed 5 sample notes from a script at `lib/db/seed.ts`, and make it idempotent: one insert with `onConflictDoNothing` targeting the unique `title`, so rerunning it leaves the count at 5 instead of inserting duplicates. Call `loadEnvConfig` in the script and build its own Drizzle client there. Don't import the shared client, because that module reads DATABASE_URL when it loads, before the env is in place. Add an `npm run db:seed` script that runs it with `tsx`.
 8. Add a `/notes` page as a Server Component that queries the notes through Drizzle and renders them newest first. Set `export const dynamic = 'force-dynamic'` so Next.js does not statically cache the page.
-9. Prove it works. Run `npm run build`, start the dev server, and fetch http://localhost:3000/notes. Show me the rows you actually got back, not "setup complete". Then give me a command I can rerun myself, such as `npx neon@4.14.0 psql -- -c "select count(*) from notes"`.
+9. Prove it works. Run `npm run db:seed`, then `npm run build`, then start the dev server and fetch http://localhost:3000/notes. Show me the rows you actually got back, not "setup complete". Then give me commands I can rerun myself, such as `npm run db:seed` followed by `npx neon@4.14.0 psql -- -c "select count(*) from notes"`.
 
 If any step fails, show me the error and what you tried. Don't route around it silently.
 ```
@@ -122,17 +130,18 @@ Paths depend on the scaffold, so `src/`-prefixed variants are fine:
 drizzle.config.ts      points drizzle-kit at DATABASE_URL
 lib/db/schema.ts       the notes table
 lib/db/client.ts       Drizzle client over @neondatabase/serverless
+lib/db/seed.ts         idempotent seed for the 5 sample notes
 app/notes/page.tsx     Server Component that renders the rows
 ```
 
-The table definition, the client, and the page:
+The table definition, the client, the seed, and the page:
 
 ```typescript filename="lib/db/schema.ts"
 import { bigint, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 export const notes = pgTable('notes', {
   id: bigint('id', { mode: 'number' }).primaryKey().generatedByDefaultAsIdentity(),
-  title: text('title').notNull(),
+  title: text('title').notNull().unique(),
   body: text('body').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });
@@ -146,6 +155,39 @@ import * as schema from './schema';
 
 const sql = neon(process.env.DATABASE_URL!);
 export const db = drizzle(sql, { schema });
+```
+
+The seed builds its own client instead of importing `lib/db/client.ts`, because that module reads `DATABASE_URL` at import time, before `loadEnvConfig` has run:
+
+```typescript filename="lib/db/seed.ts"
+import { neon } from '@neondatabase/serverless';
+import { loadEnvConfig } from '@next/env';
+import { drizzle } from 'drizzle-orm/neon-http';
+
+import { notes } from './schema';
+
+loadEnvConfig(process.cwd());
+
+const sampleNotes = [
+  { title: 'Welcome to Neon', body: 'This row came from the seed script.' },
+  { title: 'Branching', body: 'Copy the whole database in seconds.' },
+  { title: 'Autoscaling', body: 'Compute follows your traffic.' },
+  { title: 'Scale to zero', body: 'Idle computes suspend, so you stop paying for them.' },
+  { title: 'Serverless driver', body: 'Query Postgres over HTTP from the edge.' },
+];
+
+async function seed() {
+  const db = drizzle(neon(process.env.DATABASE_URL!));
+
+  await db.insert(notes).values(sampleNotes).onConflictDoNothing({ target: notes.title });
+
+  console.log(`Seeded ${sampleNotes.length} notes`);
+}
+
+seed().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 ```
 
 ```tsx filename="app/notes/page.tsx"
@@ -172,10 +214,11 @@ export default async function NotesPage() {
 }
 ```
 
-Then verify it yourself. The schema push, the build, and the row count:
+Then verify it yourself. Push the schema, seed, build, and count the rows:
 
 ```bash filename="Terminal"
 npx drizzle-kit push
+npm run db:seed
 npm run build
 npx neon@4.14.0 psql -- -c "select count(*) from notes"
 ```
@@ -186,6 +229,8 @@ npx neon@4.14.0 psql -- -c "select count(*) from notes"
      5
 (1 row)
 ```
+
+Rerun `npm run db:seed` as often as you like. Because the insert skips conflicts on `title`, the count stays at 5.
 
 With `npm run dev` running, `http://localhost:3000/notes` lists the 5 seeded notes, newest first. You can also open the table in the [Neon Console](https://console.neon.tech).
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -4,13 +4,13 @@ subtitle: Prompt your AI coding agent to build a Next.js app on Neon
 summary: >-
   Connect your AI coding assistant to Neon with one command, then send a single
   prompt that creates a table, seeds sample rows, and adds a page that lists
-  them. Includes the schema and page to expect, and follow-up prompts for
-  sign-in, image uploads, AI summaries, and branching.
+  them. Includes the three files to expect (schema, client, and page), and
+  follow-up prompts for sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-04T18:51:25.816Z'
+updatedOn: '2026-09-04T18:56:19.179Z'
 ---
 
-Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres. Your agent uses the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) to create the project, run the SQL, and seed the data, so you watch it work instead of copy-pasting code.
+Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres. Your agent uses the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) to create the table, run the SQL, and seed the data, so you watch it work instead of copy-pasting code.
 
 <Steps>
 
@@ -22,7 +22,7 @@ Already have a Next.js app? Run this in it. Starting fresh? Create one with `npx
 npx neon@latest init
 ```
 
-`neon init` links a Neon project to your app and installs your AI tooling. It asks you two things: which tooling to set up (a plugin, or agent skills and the Neon MCP server), and which project to link. Linking writes your `DATABASE_URL` to `.env.local` and adds a `neon.ts` config.
+`neon init` links a Neon project to your app and installs your AI tooling. It asks you two things: which tooling to set up (a plugin, or agent skills and the Neon MCP server), and which project to link. Linking writes your `DATABASE_URL` to your env file and adds a `neon.ts` config.
 
 Then pull the connection details into your env file:
 
@@ -40,6 +40,8 @@ npx neon@latest link --project-id <project-id> -y
 npx neon@latest config init --services none
 npx neon@latest env pull
 ```
+
+This connects the database but does not install the agent's Neon tooling, so it assumes [agent skills](/docs/ai/agent-skills) and the [Neon MCP server](/docs/ai/neon-mcp-server) are already set up; if not, install them first.
 
 </Admonition>
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,12 +7,12 @@ summary: >-
   them. Includes the schema and page to expect, and follow-up prompts for
   sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-02T20:37:43.909Z'
+updatedOn: '2026-09-02T20:53:13.819Z'
 ---
 
-Set up Neon and build on it without leaving your editor. Connect your agent once, then send it a single prompt: it creates a table, seeds a few rows, and adds a page that shows them. You end up with a running Next.js app, not just a connection.
+Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres.
 
-Prefer to write every line yourself? [Build a full backend](/docs/get-started/full-backend-quickstart) is the hands-on tutorial that explains each step.
+<Steps>
 
 ## Connect your agent to Neon
 
@@ -92,6 +92,8 @@ npm run dev
 ```
 
 Open [localhost:3000/notes](http://localhost:3000/notes) and you'll see your seeded notes, newest first. You can also open the table in the [Neon Console](https://console.neon.tech).
+
+</Steps>
 
 ## Keep building
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,7 +7,7 @@ summary: >-
   them. Includes the schema and page to expect, and follow-up prompts for
   sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-02T20:30:02.851Z'
+updatedOn: '2026-09-02T20:37:43.909Z'
 ---
 
 Set up Neon and build on it without leaving your editor. Connect your agent once, then send it a single prompt: it creates a table, seeds a few rows, and adds a page that shows them. You end up with a running Next.js app, not just a connection.
@@ -38,7 +38,7 @@ Build me a working notes app backed by Neon Postgres, using the Neon skills and 
 
 ## What you'll get
 
-Your agent writes the schema, a Drizzle client, and the page. The two files that matter:
+Your agent writes the schema, a Drizzle client, and the page:
 
 ```typescript filename="lib/db/schema.ts"
 import { bigint, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
@@ -49,6 +49,16 @@ export const notes = pgTable('notes', {
   body: text('body').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });
+```
+
+```typescript filename="lib/db/client.ts"
+import { neon } from '@neondatabase/serverless';
+import { drizzle } from 'drizzle-orm/neon-http';
+
+import * as schema from './schema';
+
+const sql = neon(process.env.DATABASE_URL!);
+export const db = drizzle(sql, { schema });
 ```
 
 ```tsx filename="app/notes/page.tsx"
@@ -85,7 +95,7 @@ Open [localhost:3000/notes](http://localhost:3000/notes) and you'll see your see
 
 ## Keep building
 
-Each prompt below adds one capability to the app you just built. Send them one at a time.
+Each prompt below adds one capability to the app you just built. Send them one at a time. Object Storage and the AI Gateway are in beta and run in select regions, so if a prompt reports one isn't available, create your project in a supported region such as `aws-us-east-2`.
 
 ```text shouldWrap filename="Prompt: add sign-in"
 Add Managed Better Auth so each note belongs to a signed-in user: add a user_id to notes, scope every query to the current user, and add sign-in and sign-out. Follow https://neon.com/docs/auth/authentication-flow.md, since this API is in beta.
@@ -100,7 +110,7 @@ Add a one-line AI summary to each note using the Neon AI Gateway, stored in a su
 ```
 
 ```text shouldWrap filename="Prompt: work on a branch"
-Create a Neon branch so I can try changes in isolation, then switch to it: npx neon@latest branches create --name my-feature, then neon checkout my-feature.
+Create a Neon branch so I can try changes in isolation, then switch to it: npx neon@latest branches create --name my-feature, then npx neon@latest checkout my-feature.
 ```
 
 <NeedHelp/>

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -7,25 +7,40 @@ summary: >-
   them. Includes the schema and page to expect, and follow-up prompts for
   sign-in, image uploads, AI summaries, and branching.
 enableTableOfContents: true
-updatedOn: '2026-09-02T20:53:13.819Z'
+updatedOn: '2026-09-04T18:51:25.816Z'
 ---
 
-Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres.
+Connect your AI coding agent to Neon once, send it one prompt, and you'll have a running Next.js app backed by Postgres. Your agent uses the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) to create the project, run the SQL, and seed the data, so you watch it work instead of copy-pasting code.
 
 <Steps>
 
 ## Connect your agent to Neon
 
-Run this once. It installs the [Neon MCP server](/docs/ai/neon-mcp-server) and [agent skills](/docs/ai/agent-skills) for your editor, links a Neon project, and writes your `DATABASE_URL` into your env file:
+Already have a Next.js app? Run this in it. Starting fresh? Create one with `npx create-next-app@latest` first.
 
 ```bash
 npx neon@latest init
 ```
 
-Pick how your agent gets Neon (a plugin, or skills and MCP) and which project to use. In an empty folder, `neon init` scaffolds a starter app first. That's it. Your agent now has everything it needs.
+`neon init` links a Neon project to your app and installs your AI tooling. It asks you two things: which tooling to set up (a plugin, or agent skills and the Neon MCP server), and which project to link. Linking writes your `DATABASE_URL` to `.env.local` and adds a `neon.ts` config.
+
+Then pull the connection details into your env file:
+
+```bash
+npx neon@latest env pull
+```
+
+If the directory was already linked, `init` skips the pull, so this step makes sure `DATABASE_URL` is in place before the build. Rerun it any time to refresh the values.
 
 <Admonition type="note">
-Automating this with no one at the keyboard (CI, an autonomous agent)? `neon init` is interactive, so use the [non-interactive setup sequence](/docs/cli/init#run-it-non-interactively) instead.
+`neon init` still prompts for sign-in and which project to link, even with `-y` or `--agent`, so it isn't hands-off. For unattended or CI use, script the explicit commands with a project ID and `NEON_API_KEY` instead:
+
+```bash
+npx neon@latest link --project-id <project-id> -y
+npx neon@latest config init --services none
+npx neon@latest env pull
+```
+
 </Admonition>
 
 ## Build your app with one prompt
@@ -38,7 +53,7 @@ Build me a working notes app backed by Neon Postgres, using the Neon skills and 
 
 ## What you'll get
 
-Your agent writes the schema, a Drizzle client, and the page:
+Your agent writes these three files and uses Neon's MCP tools to create the `notes` table and seed it. You review the result, not every step.
 
 ```typescript filename="lib/db/schema.ts"
 import { bigint, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
@@ -97,7 +112,7 @@ Open [localhost:3000/notes](http://localhost:3000/notes) and you'll see your see
 
 ## Keep building
 
-Each prompt below adds one capability to the app you just built. Send them one at a time. Object Storage and the AI Gateway are in beta and run in select regions, so if a prompt reports one isn't available, create your project in a supported region such as `aws-us-east-2`.
+Each prompt below adds one capability to the app you just built. Send them one at a time. Object Storage and the AI Gateway are in beta and run in select regions, so if a prompt reports one isn't available, create your project in a supported region such as `aws-us-east-2` (Ohio) or `aws-eu-central-1` (Frankfurt).
 
 ```text shouldWrap filename="Prompt: add sign-in"
 Add Managed Better Auth so each note belongs to a signed-in user: add a user_id to notes, scope every query to the current user, and add sign-in and sign-out. Follow https://neon.com/docs/auth/authentication-flow.md, since this API is in beta.

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -105,7 +105,7 @@ Open [localhost:3000/notes](http://localhost:3000/notes) and you'll see your see
 
 ## Keep building
 
-The next three prompts each add a backend service to the app you just built. Your agent manages these services as code in `neon.ts` and applies them with `neon deploy`; add them one at a time.
+The next three prompts each add a backend service to the app you just built. Your agent manages these services as code in `neon.ts` and applies them with `neon deploy`.
 
 AI Gateway requires a paid Neon plan; Object Storage and Functions currently run only in AWS US East (Ohio), so free-plan or non-Ohio projects may not be able to add them yet.
 

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -1,6 +1,6 @@
 ---
-title: Get started with your AI agent
-subtitle: Prompt your AI coding agent to build a Next.js app on Neon
+title: Build a Next.js app with your AI agent
+subtitle: Connect Neon to your agent, then build and grow your app from prompts
 summary: >-
   Connect your AI coding assistant to Neon with one command, then send a single
   prompt that creates a table, seeds sample rows, and adds a page that lists

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -26,6 +26,8 @@ npx neon@latest init
 
 `neon init` links a Neon project to your app and installs your AI tooling. It asks you two things: which tooling to set up (a plugin, or agent skills and the Neon MCP server), and which project to link. Linking writes your `DATABASE_URL` to your env file and adds a `neon.ts` config.
 
+When `neon init` asks "Manage this project's Neon setup as code?", choose **No** — this notes app only needs Postgres, and you can add backend features later with the prompts further down this page.
+
 Then pull the connection details into your env file:
 
 ```bash filename="Terminal"

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -105,7 +105,9 @@ Open [localhost:3000/notes](http://localhost:3000/notes) and you'll see your see
 
 ## Keep building
 
-Each prompt below adds one capability to the app you just built. Send them one at a time. Object Storage and the AI Gateway are in beta and run in select regions, so if a prompt reports one isn't available, create your project in a supported region such as `aws-us-east-2` (Ohio) or `aws-eu-central-1` (Frankfurt).
+The next three prompts each add a backend service to the app you just built. Your agent manages these services as code in `neon.ts` and applies them with `neon deploy`; add them one at a time.
+
+AI Gateway requires a paid Neon plan; Object Storage and Functions currently run only in AWS US East (Ohio), so free-plan or non-Ohio projects may not be able to add them yet.
 
 ```text shouldWrap filename="Prompt: add sign-in"
 Add Managed Better Auth so each note belongs to a signed-in user: add a user_id to notes, scope every query to the current user, and add sign-in and sign-out. Follow https://neon.com/docs/auth/quick-start/nextjs-api-only.md, since this API is in beta.

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-09-04T21:01:38.182Z'
+updatedOn: '2026-09-04T21:20:34.673Z'
 ---
 
 ## Getting started
@@ -25,12 +25,13 @@ Start with a quick setup prompt, or follow a guided tutorial to build the full N
     command="npx neon@latest init"
     description="Run one command to connect Neon to your AI agent, then let it build your backend from a prompt."
     href="/docs/get-started/with-an-agent"
-    linkText="Open guide"
+    linkText="Open quickstart"
   />
   <GuidedPath
     title="Build a full backend yourself"
     description="Write each piece by hand on the full Neon backend: Lakebase Postgres, Auth, Object Storage, and AI Gateway, from create-next-app to deployed."
     href="/docs/get-started/full-backend-quickstart"
+    cta="Open guide"
   />
 </TwinPaths>
 

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-09-04T21:20:34.673Z'
+updatedOn: '2026-09-05T17:09:41.632Z'
 ---
 
 ## Getting started
@@ -23,7 +23,7 @@ Start with a quick setup prompt, or follow a guided tutorial to build the full N
   <QuickPath
     title="Build with an agent"
     command="npx neon@latest init"
-    description="Run one command to connect Neon to your AI agent, then let it build your backend from a prompt."
+    description="Connect Neon to your AI agent, then prompt it to build your backend"
     href="/docs/get-started/with-an-agent"
     linkText="Open quickstart"
   />

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,16 +12,16 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-09-05T17:09:41.632Z'
+updatedOn: '2026-09-05T17:43:23.736Z'
 ---
 
 ## Getting started
 
-Start with a quick setup prompt, or follow a guided tutorial to build the full Neon stack step by step.
+Start fast with an agent, or build the full stack step by step.
 
 <TwinPaths>
   <QuickPath
-    title="Build with an agent"
+    title="Build with your agent"
     command="npx neon@latest init"
     description="Connect Neon to your AI agent, then prompt it to build your backend"
     href="/docs/get-started/with-an-agent"

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-09-04T18:51:25.846Z'
+updatedOn: '2026-09-04T21:01:38.182Z'
 ---
 
 ## Getting started
@@ -25,7 +25,7 @@ Start with a quick setup prompt, or follow a guided tutorial to build the full N
     command="npx neon@latest init"
     description="Run one command to connect Neon to your AI agent, then let it build your backend from a prompt."
     href="/docs/get-started/with-an-agent"
-    linkText="Continue: build an app with your agent"
+    linkText="Open guide"
   />
   <GuidedPath
     title="Build a full backend yourself"

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-09-02T18:49:35.200Z'
+updatedOn: '2026-09-04T18:51:25.846Z'
 ---
 
 ## Getting started
@@ -23,11 +23,13 @@ Start with a quick setup prompt, or follow a guided tutorial to build the full N
   <QuickPath
     title="Build with an agent"
     command="npx neon@latest init"
-    description="AI-guided setup. Creates a project, applies your schema, and writes a .env in one step. Copy the prompt below and get started."
+    description="Run one command to connect Neon to your AI agent, then let it build your backend from a prompt."
+    href="/docs/get-started/with-an-agent"
+    linkText="Continue: build an app with your agent"
   />
   <GuidedPath
-    title="Build a full backend"
-    description="Next.js on the full Neon backend: Lakebase Postgres, Auth, Object Storage, and AI Gateway, from create-next-app to deployed."
+    title="Build a full backend yourself"
+    description="Write each piece by hand on the full Neon backend: Lakebase Postgres, Auth, Object Storage, and AI Gateway, from create-next-app to deployed."
     href="/docs/get-started/full-backend-quickstart"
   />
 </TwinPaths>

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -12,7 +12,7 @@ redirectFrom:
   - /guides/azure-service-connector
   - /guides/azure-todo-static-web-app
   - /guides/azure-functions-referral-system
-updatedOn: '2026-08-18T16:41:42.467Z'
+updatedOn: '2026-09-02T18:49:35.200Z'
 ---
 
 ## Getting started
@@ -21,7 +21,7 @@ Start with a quick setup prompt, or follow a guided tutorial to build the full N
 
 <TwinPaths>
   <QuickPath
-    title="One-command setup"
+    title="Build with an agent"
     command="npx neon@latest init"
     description="AI-guided setup. Creates a project, applies your schema, and writes a .env in one step. Copy the prompt below and get started."
   />

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -15,7 +15,7 @@
     - section: Start with Neon
       icon: start
       items:
-        - title: One-command setup
+        - title: Build with an agent
           slug: get-started/with-an-agent
         - title: Full backend quickstart
           slug: get-started/full-backend-quickstart

--- a/src/components/pages/doc/twin-paths/twin-paths.jsx
+++ b/src/components/pages/doc/twin-paths/twin-paths.jsx
@@ -47,7 +47,7 @@ PathLabel.propTypes = {
   eta: PropTypes.string.isRequired,
 };
 
-const QuickPath = ({ title, command, description, eta = '~5 min' }) => {
+const QuickPath = ({ title, command, description, href, linkText, eta = '~5 min' }) => {
   const [isCopied, setIsCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -101,6 +101,18 @@ const QuickPath = ({ title, command, description, eta = '~5 min' }) => {
             <span className="sr-only">{isCopied ? 'Copied' : 'Copy command'}</span>
           </span>
         </button>
+        {href && linkText && (
+          <Link
+            href={href}
+            className={cn(
+              'mt-3 inline-flex items-center gap-1 text-sm leading-none font-medium text-green-52 transition-colors duration-150',
+              'hover:text-green-52/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00CC88]'
+            )}
+            onClick={() => sendGtagEvent('Card Clicked', { text: `Twin path continue - ${title}` })}
+          >
+            {linkText}
+          </Link>
+        )}
       </div>
     </article>
   );
@@ -110,6 +122,8 @@ QuickPath.propTypes = {
   title: PropTypes.string.isRequired,
   command: PropTypes.string.isRequired,
   description: PropTypes.node.isRequired,
+  href: PropTypes.string,
+  linkText: PropTypes.string,
   eta: PropTypes.string,
 };
 

--- a/src/components/pages/doc/twin-paths/twin-paths.jsx
+++ b/src/components/pages/doc/twin-paths/twin-paths.jsx
@@ -105,8 +105,10 @@ const QuickPath = ({ title, command, description, href, linkText, eta = '~5 min'
           <Link
             href={href}
             className={cn(
-              'mt-3 inline-flex items-center gap-1 text-sm leading-none font-medium text-green-52 transition-colors duration-150',
-              'hover:text-green-52/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00CC88]'
+              'mt-5 inline-flex h-11 w-fit items-center rounded-full border border-gray-new-60 bg-black-pure/2 px-7 text-base leading-none font-medium text-black-pure transition-colors duration-150',
+              'hover:border-black-pure dark:hover:border-gray-new-50',
+              'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FF321F]',
+              'dark:border-gray-new-40 dark:bg-white/2 dark:text-white'
             )}
             onClick={() => sendGtagEvent('Card Clicked', { text: `Twin path continue - ${title}` })}
           >

--- a/tests/critical-flows/docs-onboarding.spec.js
+++ b/tests/critical-flows/docs-onboarding.spec.js
@@ -29,10 +29,10 @@ test.describe('critical documentation onboarding', () => {
     await expectClipboardText(page, INIT_COMMAND);
 
     const quickstartLink = page.getByRole('link', { name: 'Open quickstart' });
-    await expect(quickstartLink).toHaveAttribute(
-      'href',
-      '/docs/get-started/full-backend-quickstart'
-    );
+    await expect(quickstartLink).toHaveAttribute('href', '/docs/get-started/with-an-agent');
+
+    const guideLink = page.getByRole('link', { name: 'Open guide' });
+    await expect(guideLink).toHaveAttribute('href', '/docs/get-started/full-backend-quickstart');
 
     const searchTrigger = page.locator('[data-test="docs-search-trigger"]:visible');
     await expect(searchTrigger).toHaveCount(1);


### PR DESCRIPTION
> **Experiment — do not merge, keep in draft.** Prototype #1 of a "prompt-forward" docs pattern: the steps are prompts an AI agent runs, the samples show what you'll _get back_, and "next steps" are more prompts. The draft status is the experimental signal.

**🔎 Preview**

- Page: https://neon-next-git-polly-prompt-forward-nextjs-q-73395a-neondatabase.vercel.app/docs/get-started/with-an-agent
- What a web-fetching agent sees (`.md`): https://neon-next-git-polly-prompt-forward-nextjs-q-73395a-neondatabase.vercel.app/docs/get-started/with-an-agent.md

**What changed**

Rewrites `content/docs/get-started/with-an-agent.md` (~116 lines) so it ends at a **running app** instead of a proven connection:

1. Connect — `npx neon@latest init`
2. One build prompt gives you a working notes app
3. What you'll get — `schema.ts`, Drizzle client, `/notes` page
4. Run it — `npm run dev`
5. Keep building — four follow-up prompts (sign-in, uploads, AI, branch)

Also renames the nav label `One-command setup` to `Build with an agent` (`navigation.yaml` + the `introduction.md` QuickPath).

**The main thing to test**

Nobody has run the prompt end-to-end against a live agent + Neon project yet. Do that, ideally in both a fresh dir and an existing Next.js app.

**Notes**

- Doc gates pass (build, lint, unit, content-data). CI caveats: repo-wide `check:md` and `check:broken-links` fail for pre-existing / unpublished-page reasons, not this diff.
- `neon init` is the human-first spine; the headless/CI path is a one-line note linking [`/docs/cli/init#run-it-non-interactively`](https://neon.com/docs/cli/init#run-it-non-interactively).
- Prompts are inline fenced blocks (not `<CopyPrompt>`) so an agent fetching the `.md` can still act on them.
- Full reasoning (spine decision, CLI-version analysis, testing method) lives in an external planning wiki.
