### PR TITLE
docs: scope Free plan egress per project across docs and FAQs

### DIFF
--- a/content/docs/guides/ai-agent-integration.md
+++ b/content/docs/guides/ai-agent-integration.md
@@ -11,7 +11,7 @@ summary: >-
   Project transfers require a personal API key.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-09-02T18:59:27.831Z'
 ---
 
 This guide covers the technical implementation of the Neon agent plan for your platform. You'll learn how to provision databases, implement versioning, manage user upgrades, and monitor usage at scale.
@@ -100,12 +100,12 @@ For detailed quota examples and consumption limits, see [Configure consumption l
 
 For free-tier users, create projects in your Free organization (sponsored by Neon) with resource quotas matching (or within) Neon's Free plan limits using the [Create project](/docs/reference/api/projects/create-project) API:
 
-| Resource          | Free Tier Quota    | Description                             |
-| ----------------- | ------------------ | --------------------------------------- |
-| **Compute**       | 0.25 / 2 CU        | Autoscales from 0.25 to 2 compute units |
-| **Active time**   | `360000` seconds   | 100 hours of compute activity per month |
-| **Storage**       | `536870912` bytes  | 512 MB total storage limit              |
-| **Data transfer** | `5368709120` bytes | 5 GB data transfer per month            |
+| Resource          | Free Tier Quota    | Description                              |
+| ----------------- | ------------------ | ---------------------------------------- |
+| **Compute**       | 0.25 / 2 CU        | Autoscales from 0.25 to 2 compute units  |
+| **Active time**   | `360000` seconds   | 100 hours of compute activity per month  |
+| **Storage**       | `536870912` bytes  | 512 MB total storage limit               |
+| **Data transfer** | `5368709120` bytes | 5 GB data transfer per project per month |
 
 Example API request:
 

--- a/content/docs/introduction/cost-optimization.md
+++ b/content/docs/introduction/cost-optimization.md
@@ -14,7 +14,7 @@ summary: >-
   $1.50/branch-month over the plan allowance. Paid plans include 500 GB of
   public data transfer per project per month, then $0.10/GB.
 enableTableOfContents: true
-updatedOn: '2026-06-05T17:20:32.620Z'
+updatedOn: '2026-09-02T18:59:27.831Z'
 ---
 
 Managing your Neon costs effectively requires understanding how each billing factor works and implementing strategies to control usage. This guide provides actionable recommendations for optimizing costs across all billing metrics.
@@ -173,7 +173,7 @@ Extra branches beyond your plan's allowance are billed at $1.50/branch-month, pr
 
 ## Public data transfer
 
-Public network transfer (egress) is the data sent from your databases over the public internet. Free plans include 5 GB/month. On paid plans, the first 500 GB per project per month is included, then $0.10/GB. You see no data transfer cost until a project exceeds that allowance, so the charge might show up unexpectedly if you're not monitoring data transfer. For a deeper look at what causes high network transfer and how to monitor it, see [Network transfer](/docs/introduction/network-transfer).
+Public network transfer (egress) is the data sent from your databases over the public internet. Free plans include 5 GB per project per month. On paid plans, the first 500 GB per project per month is included, then $0.10/GB. You see no data transfer cost until a project exceeds that allowance, so the charge might show up unexpectedly if you're not monitoring data transfer. For a deeper look at what causes high network transfer and how to monitor it, see [Network transfer](/docs/introduction/network-transfer).
 
 **Optimization strategies:**
 

--- a/content/docs/introduction/network-transfer.md
+++ b/content/docs/introduction/network-transfer.md
@@ -9,7 +9,7 @@ summary: >-
   replication syncs, and to monitor usage via the Console or Consumption API.
   Reduction strategies include scoping SELECT columns, using Neon snapshots,
   adding replication filters, and routing traffic over Private Link.
-updatedOn: '2026-08-25T15:36:44.109Z'
+updatedOn: '2026-09-02T18:59:27.831Z'
 ---
 
 Network transfer is one of the usage metrics that affects your Neon bill. This guide explains what network transfer is, what causes it to increase, how to monitor it, and how to reduce it. For broader cost guidance, see [Cost optimization](/docs/introduction/cost-optimization). For plan allowances and pricing, see [Plans](/docs/introduction/plans).
@@ -21,7 +21,7 @@ Neon measures data sent from your databases through the [Neon proxy](/docs/intro
 There are two types of network transfer:
 
 - **Public network transfer**: Data sent over the public internet. [Logical replication](/docs/guides/logical-replication-neon) to any destination counts as public network transfer.
-  - **Free plan**: 5 GB/month included. Exceeding this suspends your compute until the next billing cycle or you upgrade.
+  - **Free plan**: 5 GB per project per month included. Exceeding this suspends your compute until the next billing cycle or you upgrade.
   - **Launch / Scale plans**: 500 GB per project per month included, then $0.10/GB.
 - **Private network transfer**: Traffic routed over AWS PrivateLink. Available on the Scale plan only. Billed at $0.01/GB, bi-directional. Unlike public network transfer, which only counts outbound data, private network transfer counts traffic in both directions: data sent from your database to clients and data sent from clients to your database.
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/conceptual-guides/glossary
   - /docs/cloud/concepts/
-updatedOn: '2026-08-18T10:29:02.410Z'
+updatedOn: '2026-09-02T18:59:27.831Z'
 ---
 
 ## access token
@@ -217,7 +217,7 @@ A method of storing inactive data that converts plaintext data into a coded form
 
 ## Data transfer
 
-A usage metric that measures the total volume of data transferred out of Neon (egress) during a billing period. Egress also includes data transferred from Neon via Postgres logical replication to any destination, including Neon itself. Free plan projects are limited to 5 GB per month.
+A usage metric that measures the total volume of data transferred out of Neon (egress) during a billing period. Egress also includes data transferred from Neon via Postgres logical replication to any destination, including Neon itself. Each Free plan project is limited to 5 GB per month.
 
 ## Database
 

--- a/content/faqs/affordable-managed-postgres-options-startups.md
+++ b/content/faqs/affordable-managed-postgres-options-startups.md
@@ -28,7 +28,7 @@ The [Free plan](/docs/introduction/plans) covers most prototypes:
 - 100 projects, 10 branches/project
 - 100 CU-hours/project/month (enough to run a 0.25 CU compute for 400 hours)
 - 0.5 GB storage/project
-- 5 GB of public network transfer per month
+- 5 GB of public network transfer per project per month
 
 When you outgrow Free, the [Launch plan](/docs/introduction/plans) is pay-as-you-go with no minimum:
 
@@ -50,7 +50,7 @@ If you eventually need SOC 2, HIPAA, private networking, or an uptime SLA, those
 | -------------------- | -------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Neon (Launch)        | Compute drops to $0 while suspended; storage continues to bill | 0.25 CU (≈1 GB RAM)      | Auto-suspend after 5 minutes; resumes in a few hundred ms                                                                                                                                                                                                                                        |
 | Aurora Serverless v2 | Compute pauses at 0 ACUs                                       | 0 ACUs (with auto-pause) | Auto-pause requires setting min capacity to 0 ACUs ([docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2-auto-pause.html)); each ACU is ≈2 GiB ([docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.how-it-works.html)) |
-| RDS for Postgres   | Billed 24/7                                                    | Smallest instance class  | Instance-hour pricing; reserved instances available for committed workloads ([docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithReservedDBInstances.WorkingWith.html))                                                                                                |
+| RDS for Postgres     | Billed 24/7                                                    | Smallest instance class  | Instance-hour pricing; reserved instances available for committed workloads ([docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithReservedDBInstances.WorkingWith.html))                                                                                                |
 | Supabase             | Project compute billed hourly even when idle (paid plans)      | Micro: ~$10/month        | Free Plan pauses inactive projects; paid plans run a dedicated VM per project around the clock ([docs](https://supabase.com/docs/guides/platform/manage-your-usage/compute))                                                                                                                     |
 
 Aurora Serverless v2 is the closest match for variable workloads. The main differences for a startup: Neon's 0.25 CU minimum (when active) bills at $0.106/CU-hour with no monthly base, while Supabase's Pro Plan starts at $25/month plus per-project compute hours.

--- a/content/faqs/best-backend-solo-developer-indie-hacker-multiple-apps.md
+++ b/content/faqs/best-backend-solo-developer-indie-hacker-multiple-apps.md
@@ -19,7 +19,7 @@ Neon. An indie developer's portfolio is a few apps that make money, a few that m
 
 Say eight apps are quiet and two are busy. On Launch, the quiet ones cost storage only: 0.5 GB × $0.35 = $0.18/month each, with compute at $0 while suspended. The two busy ones run a 0.25 CU compute (≈1 GB RAM) for, say, 200 hours a month each: 50 CU-hours × $0.106 = $5.30 each. Ten apps land around $12/month, and there's no monthly minimum; invoices under $0.50 aren't collected.
 
-On the Free plan, all ten fit within 100 projects, each with its own 100 CU-hours of compute, 0.5 GB of storage, and 5 GB of public network transfer per month. Upgrade when one of them takes off, without migrating anything ([free to production](/faqs/postgres-services-free-to-production)).
+On the Free plan, all ten fit within 100 projects, each with its own 100 CU-hours of compute, 0.5 GB of storage, and 5 GB of public network transfer per project per month. Upgrade when one of them takes off, without migrating anything ([free to production](/faqs/postgres-services-free-to-production)).
 
 ## One account, every backend piece
 

--- a/content/faqs/best-free-low-cost-managed-postgres-services.md
+++ b/content/faqs/best-free-low-cost-managed-postgres-services.md
@@ -26,7 +26,7 @@ The Neon [Free plan](/docs/introduction/plans) is designed for prototypes and sm
 - Autoscaling up to 2 CU (≈8 GB RAM)
 - Scale-to-zero after 5 minutes of inactivity
 - 6-hour instant restore window, up to 1 GB of change history
-- 5 GB of public network transfer per month
+- 5 GB of public network transfer per project per month
 
 100 CU-hours is enough to run a 0.25 CU compute for about 400 hours a month, or a 0.5 CU compute for 200 hours. Combined with scale-to-zero, that covers most side projects.
 

--- a/content/faqs/change-region-existing-neon-project.md
+++ b/content/faqs/change-region-existing-neon-project.md
@@ -3,7 +3,7 @@ title: 'How do I migrate an existing Neon project to a different AWS region?'
 subtitle: 'Create a new project in the target region, copy data over with pg_dump and pg_restore, then cut over.'
 enableTableOfContents: true
 createdAt: '2026-05-18T00:00:00.000Z'
-updatedOn: '2026-08-14T02:59:16.781Z'
+updatedOn: '2026-09-02T18:59:27.831Z'
 isDraft: false
 redirectFrom: []
 previousLink:
@@ -64,6 +64,6 @@ Writes to the source database during the dump and restore won't appear in the ne
 
 ## Data transfer costs
 
-Egress between Neon regions counts as public network transfer. Check the [Pricing page](/pricing) for the current per-GB rate. The Free plan includes 5 GB/month of public network transfer, which is usually enough for a one-off migration.
+Egress between Neon regions counts as public network transfer. Check the [Pricing page](/pricing) for the current per-GB rate. The Free plan includes 5 GB per project per month of public network transfer, which is usually enough for a one-off migration.
 
 <CTA title="Compare migration paths" description="The region migration guide compares the Import Data Assistant, dump and restore, and logical replication." buttonText="Region migration guide" buttonUrl="https://neon.com/docs/import/migrate-neon-to-another-region" />

--- a/content/faqs/databases-instantly-spin-up-postgres-instance.md
+++ b/content/faqs/databases-instantly-spin-up-postgres-instance.md
@@ -40,7 +40,7 @@ If you don't want to sign up at all, [Claimable Neon](https://neon.com/claimable
 - Autoscaling up to 2 CU (≈8 GB RAM)
 - Scale-to-zero after 5 minutes of inactivity
 - 100 CU-hours/project/month and 0.5 GB of storage/project
-- 5 GB of public network transfer per month
+- 5 GB of public network transfer per project per month
 - Up to 10 branches per project, 100 projects
 
 See [Plans](/docs/introduction/plans) for the full breakdown.

--- a/content/faqs/free-plan-limits-and-quotas.md
+++ b/content/faqs/free-plan-limits-and-quotas.md
@@ -3,7 +3,7 @@ title: "What are the limits and quotas for Neon's Free plan?"
 subtitle: '100 projects, 10 branches each, 100 CU-hours per project, and 0.5 GB storage per project.'
 enableTableOfContents: true
 createdAt: '2026-05-18T00:00:00.000Z'
-updatedOn: '2026-08-14T03:15:28.979Z'
+updatedOn: '2026-09-02T18:59:27.831Z'
 isDraft: false
 redirectFrom: []
 previousLink:
@@ -14,7 +14,7 @@ nextLink:
   slug: import-csv-into-database
 ---
 
-The Neon Free plan costs $0/month and includes 100 projects, 10 branches per project, 100 CU-hours of compute per project per month, 0.5 GB of storage per project, and 5 GB of public network transfer per month. Computes scale to zero after 5 minutes of inactivity and can scale up to 2 CU (≈8 GB RAM) when active. See the [Plans page](/docs/introduction/plans) for the full table.
+The Neon Free plan costs $0/month and includes 100 projects, 10 branches per project, 100 CU-hours of compute per project per month, 0.5 GB of storage per project, and 5 GB of public network transfer per project per month. Computes scale to zero after 5 minutes of inactivity and can scale up to 2 CU (≈8 GB RAM) when active. See the [Plans page](/docs/introduction/plans) for the full table.
 
 ## What's included
 
@@ -26,7 +26,7 @@ The Neon Free plan costs $0/month and includes 100 projects, 10 branches per pro
 | Autoscaling                | Up to 2 CU (≈8 GB RAM)                     |
 | Scale to zero              | After 5 min inactivity, cannot be disabled |
 | Storage                    | 0.5 GB per project                         |
-| Public network transfer    | 5 GB/month                                 |
+| Public network transfer    | 5 GB per project per month                 |
 | Instant restore history    | 6 hours, capped at 1 GB of change history  |
 | Manual snapshots           | 1                                          |
 | Managed Better Auth (Beta) | Up to 60,000 MAU                           |

--- a/content/faqs/managed-postgres-databases-free-tier.md
+++ b/content/faqs/managed-postgres-databases-free-tier.md
@@ -23,7 +23,7 @@ Each project on the Free plan includes:
 - **Compute:** 100 CU-hours/month, with autoscaling up to 2 CU (≈8 GB RAM)
 - **Branches:** up to 10 per project, useful for previews and migrations
 - **Instant restore:** 6-hour history window (capped at 1 GB of change history)
-- **Egress:** 5 GB/month of public network transfer
+- **Egress:** 5 GB per project per month of public network transfer
 
 Hitting the monthly CU-hour or network transfer limit suspends compute until the next billing cycle. Exceeding 0.5 GB storage causes writes that increase storage to fail until you free space or upgrade. If you need spend alerts on a paid plan, set up [spending notifications](/docs/introduction/spending-notifications).
 

--- a/content/faqs/postgres-providers-multiple-apps-separate-databases-under-10.md
+++ b/content/faqs/postgres-providers-multiple-apps-separate-databases-under-10.md
@@ -23,7 +23,7 @@ Each Neon project is an isolated Postgres instance with its own connection strin
 - 100 CU-hours per project per month
 - 0.5 GB storage per project
 - 10 branches per project
-- 5 GB public network transfer per month
+- 5 GB public network transfer per project per month
 
 100 CU-hours is enough to run a 0.25 CU compute (≈1 GB RAM) for roughly 400 hours per month. For low-traffic apps that scale to zero between requests, that covers most or all of your active time. Compute suspends after 5 minutes idle and resumes in a few hundred milliseconds when a query arrives. See the [Free plan details](/docs/introduction/plans) for the full breakdown.
 

--- a/content/faqs/simplest-postgres-setup-for-startups.md
+++ b/content/faqs/simplest-postgres-setup-for-startups.md
@@ -22,7 +22,7 @@ Sign up at [console.neon.tech](https://console.neon.tech/signup), create a proje
 - 100 projects (one project per app or customer is the recommended pattern)
 - 0.5 GB of storage per project
 - 100 CU-hours/month of compute per project, autoscaling up to 2 CU (≈8 GB RAM)
-- 5 GB of public network transfer per month
+- 5 GB of public network transfer per project per month
 - 10 branches per project for development and previews
 - Scale to zero after 5 minutes of inactivity, so idle prototypes don't burn through the CU-hour allowance
 


### PR DESCRIPTION
## Overview

A follow-up to #5713, which scoped the Free plan egress allowance per project on the plans page. This applies the same "per project per month" wording everywhere else the Free plan's 5 GB public network transfer allowance appears: network-transfer.md, cost-optimization.md, the glossary, the AI agent integration reference, and nine Free plan FAQs.

This pull request and its description were written by Isaac.
