### PR TITLE
docs: scope object storage per project, add eu-central-1 to backend beta FAQs

### DIFF
--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -25,7 +25,7 @@ redirectFrom:
   - /docs/reference/billing-sample
   - /docs/introduction/legacy-plans
   - /docs/introduction/extra-usage
-updatedOn: '2026-09-02T16:25:31.067Z'
+updatedOn: '2026-09-02T20:41:07.968Z'
 ---
 
 Neon offers plans to support you at every stage, from your first prototype to production at scale.
@@ -345,7 +345,7 @@ There's no charge for Object Storage during the beta, but [usage limits](/docs/s
 - **Storage**: $0.023/GB-month. Only stored volume is metered; there's no per-operation charge.
 - **Egress**: Data transferred out counts toward your [public network transfer](#public-network-transfer) allowance, which is shared across all products, and is billed at the same rate once you exceed it.
 
-On the **Free** plan, you get 5 GB of Object Storage, measured across your whole account rather than per project.
+On the **Free** plan, you get 5 GB of Object Storage per project.
 
 See [Neon Object Storage](/docs/storage/overview) for more information.
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-09-02T15:10:53.712Z'
+updatedOn: '2026-09-02T20:41:07.968Z'
 ---
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
@@ -56,7 +56,7 @@ neon bootstrap --template ai-sdk
 During the beta, the following usage limits apply:
 
 - **Region**: object storage is available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
-- **Free storage**: the Free plan includes 5 GB, measured across your whole account rather than per project. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
+- **Free object storage**: the Free plan includes 5 GB of object storage per project. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
 - **Object size**: objects can be up to 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload). [Contact support](/docs/introduction/support) if you need to store larger objects.
 - **Rate limiting**: requests may be throttled during heavy use, returning a `503 SlowDown` response. Back off and retry. See [Connection and performance errors](/docs/storage/troubleshooting#connection-and-performance-errors).
 

--- a/content/faqs/best-backend-ai-agents-long-running-streaming.md
+++ b/content/faqs/best-backend-ai-agents-long-running-streaming.md
@@ -49,8 +49,8 @@ export default defineConfig({
 
 Inside the handler, `@neon/ai-sdk-provider` reads the injected gateway credentials, so `neon('<model>')` is the only model configuration you write. Tools run inside the function with a `pg` pool pointed at `DATABASE_URL`. The full streaming example with a Postgres-backed tool is in [AI agents on Neon Functions](/docs/compute/functions/agents), and you can scaffold it with `neon bootstrap --template ai-sdk` or `--template mastra`.
 
-<Admonition type="note" title="Beta, one region">
-Functions and AI Gateway are in beta and available only in AWS US East (Ohio) (`aws-us-east-2`). Functions are free during the beta on every plan; AI Gateway requires a paid plan and inference is free during the beta, with no markup on provider list prices once billing starts ([plans](/docs/introduction/plans#functions)).
+<Admonition type="note" title="Beta and region availability">
+Functions and AI Gateway are in beta and available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`), with support expanding toward all regions. Functions are free during the beta on every plan; AI Gateway requires a paid plan and inference is free during the beta, with no markup on provider list prices once billing starts ([plans](/docs/introduction/plans#functions)).
 </Admonition>
 
 ## How other options compare

--- a/content/faqs/best-backend-ai-chatbot-rag-llm-app.md
+++ b/content/faqs/best-backend-ai-chatbot-rag-llm-app.md
@@ -57,7 +57,7 @@ const response = await client.chat.completions.create({
 Streaming works over server-sent events on every endpoint, and each branch gets its own gateway endpoint, so requests from a preview branch stay scoped to that branch ([AI Gateway quickstart](/docs/ai-gateway/get-started)).
 
 <Admonition type="note" title="Beta availability">
-AI Gateway is in beta, available in `aws-us-east-2` only, and requires a paid plan. Inference is free during the beta. When billing begins, Neon charges provider list prices with no markup ([pricing](/docs/ai-gateway/overview#pricing)). Open-weight models are available right away; frontier models from OpenAI and Google are rolling out gradually.
+AI Gateway is in beta, available in `aws-us-east-2` and `aws-eu-central-1` (with support expanding toward all regions), and requires a paid plan. Inference is free during the beta. When billing begins, Neon charges provider list prices with no markup ([pricing](/docs/ai-gateway/overview#pricing)). Open-weight models are available right away; frontier models from OpenAI and Google are rolling out gradually.
 </Admonition>
 
 ## What it costs at chatbot traffic levels

--- a/content/faqs/best-backend-chat-bots-discord-telegram-whatsapp.md
+++ b/content/faqs/best-backend-chat-bots-discord-telegram-whatsapp.md
@@ -47,7 +47,7 @@ neon functions deploy helloworld --src hello-world.ts
 Use `waitUntil` for work that should finish after the reply is sent, such as writing analytics or fanning out a follow-up message. It runs for up to 15 minutes after the response ([runtime limits](/docs/compute/functions/reference/runtime-limits)).
 
 <Admonition type="note" title="HTTP bots, not Gateway bots">
-Discord Gateway bots need a long-lived stateful process with session resume, presence, and sharding. Neon Functions aren't the right primitive for that yet; the Discord guide is HTTP interactions only ([Discord bot guide](/docs/compute/functions/discord-bot)). Functions are in beta, JavaScript and TypeScript only, and available in `aws-us-east-2`.
+Discord Gateway bots need a long-lived stateful process with session resume, presence, and sharding. Neon Functions aren't the right primitive for that yet; the Discord guide is HTTP interactions only ([Discord bot guide](/docs/compute/functions/discord-bot)). Functions are in beta, JavaScript and TypeScript only, and available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions.
 </Admonition>
 
 ## What it costs

--- a/content/faqs/best-backend-cloudflare-workers-edge.md
+++ b/content/faqs/best-backend-cloudflare-workers-edge.md
@@ -39,7 +39,7 @@ Whichever path you pick, the pooled connection string (the `-pooler` hostname) r
 
 ## Keep the rest of the backend close to the data
 
-Edge functions are good at request routing and light logic. Work that needs a long-lived process, like a WebSocket server or an agent that streams for minutes, fits better next to the database. [Neon Functions](/docs/compute/functions/overview) run in the same region as your branch with `DATABASE_URL` injected, and a Worker can call them directly. Functions are in beta and available in `aws-us-east-2`.
+Edge functions are good at request routing and light logic. Work that needs a long-lived process, like a WebSocket server or an agent that streams for minutes, fits better next to the database. [Neon Functions](/docs/compute/functions/overview) run in the same region as your branch with `DATABASE_URL` injected, and a Worker can call them directly. Functions are in beta and available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions.
 
 <Admonition type="tip" title="Match regions">
 Put your Neon project in the AWS region closest to where most of your Workers traffic resolves. Neon runs in eight AWS regions across the US, Europe, Asia Pacific, and South America ([regions](/docs/introduction/regions)).

--- a/content/faqs/best-backend-file-uploads-user-content.md
+++ b/content/faqs/best-backend-file-uploads-user-content.md
@@ -50,7 +50,7 @@ Buckets are `private` (authenticated for every operation) or `public_read` (anon
 When a file needs processing on the way in, a [Neon Function](/docs/compute/functions/overview) receives it, writes it to Object Storage, and records metadata in Postgres, all in the same region. The `ai-sdk` template does exactly this: it generates an image, stores it in a private bucket, saves the key and metadata in Postgres, and serves it back through a presigned URL. Scaffold it with `neon bootstrap --template ai-sdk`.
 
 <Admonition type="note" title="Beta terms">
-Object Storage is in beta, available in `aws-us-east-2` only, and free to use on every plan during the beta. The Free plan includes 5 GB of Object Storage. When billing begins, storage is $0.023/GB-month with no per-operation charge, and egress counts toward your public network transfer allowance ([plans](/docs/introduction/plans#object-storage)).
+Object Storage is in beta, available in `aws-us-east-2` and `aws-eu-central-1` (with support expanding toward all regions), and free to use on every plan during the beta. The Free plan includes 5 GB of Object Storage per project. When billing begins, storage is $0.023/GB-month with no per-operation charge, and egress counts toward your public network transfer allowance ([plans](/docs/introduction/plans#object-storage)).
 </Admonition>
 
 ## How other options compare

--- a/content/faqs/best-backend-mcp-server.md
+++ b/content/faqs/best-backend-mcp-server.md
@@ -34,7 +34,7 @@ The [with-mcp example](https://github.com/neondatabase/examples/tree/main/with-m
 - **Managed Better Auth and Object Storage** are one `neon.ts` declaration away when a tool needs user identity or file handling.
 
 <Admonition type="note" title="Beta scope">
-Functions are in beta, run JavaScript and TypeScript on Node.js 24, and are available in `aws-us-east-2`. They're free during the beta on every plan; see [plans](/docs/introduction/plans#functions) for the rates that apply later. An account-wide default of 100 concurrent invocations applies.
+Functions are in beta, run JavaScript and TypeScript on Node.js 24, and are available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions. They're free during the beta on every plan; see [plans](/docs/introduction/plans#functions) for the rates that apply later. An account-wide default of 100 concurrent invocations applies.
 </Admonition>
 
 ## If you want an MCP server for Neon itself

--- a/content/faqs/best-backend-mobile-app-ios-android.md
+++ b/content/faqs/best-backend-mobile-app-ios-android.md
@@ -40,7 +40,7 @@ Neon's client SDK for Auth and the Data API is JavaScript and TypeScript (`@neon
 
 ## Custom endpoints and push logic
 
-For anything the REST API shouldn't do directly, such as validating a purchase receipt or fanning out a notification, deploy a [Neon Function](/docs/compute/functions/get-started). It runs next to the database with `DATABASE_URL` injected, and `waitUntil` handles follow-up work after the response is sent. Functions are in beta and available in `aws-us-east-2`.
+For anything the REST API shouldn't do directly, such as validating a purchase receipt or fanning out a notification, deploy a [Neon Function](/docs/compute/functions/get-started). It runs next to the database with `DATABASE_URL` injected, and `waitUntil` handles follow-up work after the response is sent. Functions are in beta and available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions.
 
 ## How other options compare
 

--- a/content/faqs/best-backend-nextjs-app-vercel.md
+++ b/content/faqs/best-backend-nextjs-app-vercel.md
@@ -33,7 +33,7 @@ Managed Better Auth has a Next.js server SDK: two files give you `auth.handler()
 
 ## When a route handler isn't enough
 
-Vercel Functions run for 300 seconds by default and up to 800 seconds on Pro and Enterprise, with a 30-minute extended maximum in beta ([Vercel duration](https://vercel.com/docs/functions/configuring-functions/duration)). For a WebSocket server, an SSE feed, or an agent that streams for longer, move that one slice onto a Neon Function next to the database and call it directly from the client. Functions give a handler 15 minutes to begin responding and keep streams open while data flows ([how Functions fit with your app](/docs/compute/functions/overview#how-functions-fit-with-your-app)). Functions, Object Storage, and AI Gateway are in beta and available in `aws-us-east-2`.
+Vercel Functions run for 300 seconds by default and up to 800 seconds on Pro and Enterprise, with a 30-minute extended maximum in beta ([Vercel duration](https://vercel.com/docs/functions/configuring-functions/duration)). For a WebSocket server, an SSE feed, or an agent that streams for longer, move that one slice onto a Neon Function next to the database and call it directly from the client. Functions give a handler 15 minutes to begin responding and keep streams open while data flows ([how Functions fit with your app](/docs/compute/functions/overview#how-functions-fit-with-your-app)). Functions, Object Storage, and AI Gateway are in beta and available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions.
 
 <Admonition type="tip" title="Run migrations in the build step">
 Add `prisma migrate deploy` or `drizzle-kit migrate` to the Vercel build command so each Preview Deployment applies its PR's schema to its own branch.

--- a/content/faqs/best-backend-python-django-fastapi.md
+++ b/content/faqs/best-backend-python-django-fastapi.md
@@ -43,7 +43,7 @@ client.put_object(
 )
 ```
 
-Presigned URLs let a browser upload straight to the bucket while your Django model stores the key ([objects](/docs/storage/objects)). Object Storage is in beta, available in `aws-us-east-2`, and free during the beta with 5 GB on the Free plan.
+Presigned URLs let a browser upload straight to the bucket while your Django model stores the key ([objects](/docs/storage/objects)). Object Storage is in beta, available in `aws-us-east-2` and `aws-eu-central-1` (with support expanding toward all regions), and free during the beta with 5 GB per project on the Free plan.
 
 ## Models through the OpenAI SDK
 

--- a/content/faqs/best-backend-real-time-chat-presence-live-updates.md
+++ b/content/faqs/best-backend-real-time-chat-presence-live-updates.md
@@ -44,7 +44,7 @@ Under load the platform runs several isolates, and a message posted through one 
 Two templates show the whole pattern: `neon bootstrap --template realtime-chat` (Next.js, Hono, Postgres, Managed Better Auth) and `--template realtime-sse` (TanStack Router, Hono) ([starter templates](/docs/compute/functions/overview#starter-templates)).
 
 <Admonition type="note" title="Beta scope">
-Functions are in beta, available in `aws-us-east-2`, free during the beta on every plan, and JavaScript and TypeScript only. `neon dev` returns `200 OK` for WebSocket upgrades locally during the beta, so test WebSocket behavior against a deployed function ([WebSockets and SSE](/docs/compute/functions/websockets)).
+Functions are in beta, available in `aws-us-east-2` and `aws-eu-central-1` (with support expanding toward all regions), free during the beta on every plan, and JavaScript and TypeScript only. `neon dev` returns `200 OK` for WebSocket upgrades locally during the beta, so test WebSocket behavior against a deployed function ([WebSockets and SSE](/docs/compute/functions/websockets)).
 </Admonition>
 
 ## Keep the front end where it is

--- a/content/faqs/best-backend-side-project-scale-to-zero.md
+++ b/content/faqs/best-backend-side-project-scale-to-zero.md
@@ -27,8 +27,8 @@ The pieces a side project usually bolts on are included:
 
 - **Sign-in**: [Managed Better Auth](/docs/auth/overview) covers up to 60,000 monthly active users on Free, with users stored in your own database.
 - **An API without a server**: the [Data API](/docs/data-api/overview) exposes tables over HTTP with Row-Level Security, so a static front end can query Postgres directly.
-- **Files**: [Object Storage](/docs/storage/overview) gives the Free plan 5 GB during the beta.
-- **A backend function**: [Neon Functions](/docs/compute/functions/overview) are free during the beta, and the Free plan will include 1 million invocations a month when billing starts. Functions, Object Storage, and AI Gateway are in beta and available in `aws-us-east-2`.
+- **Files**: [Object Storage](/docs/storage/overview) gives the Free plan 5 GB per project during the beta.
+- **A backend function**: [Neon Functions](/docs/compute/functions/overview) are free during the beta, and the Free plan will include 1 million invocations a month when billing starts. Functions, Object Storage, and AI Gateway are in beta and available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions.
 
 <Admonition type="tip" title="The first request after idle">
 Reactivation takes a few hundred milliseconds, so the first visitor after a quiet stretch waits slightly longer. Paid plans can disable scale to zero for a project that must answer instantly ([scale to zero](/docs/introduction/scale-to-zero)); for most side projects the default is the right trade.

--- a/content/faqs/best-backend-single-page-app-react-vite-no-server.md
+++ b/content/faqs/best-backend-single-page-app-react-vite-no-server.md
@@ -61,7 +61,7 @@ Managed Better Auth and the Data API are in beta. The single-URL `createClient(u
 
 ## When you need server logic anyway
 
-Some things shouldn't run in a browser: a Stripe webhook, an email send, a call that needs a secret. Deploy that piece as a [Neon Function](/docs/compute/functions/overview) with `DATABASE_URL` injected and call it from the SPA. Functions are in beta and available in `aws-us-east-2`. Host the static bundle anywhere: Vercel, Netlify, Cloudflare Pages, or an S3 bucket.
+Some things shouldn't run in a browser: a Stripe webhook, an email send, a call that needs a secret. Deploy that piece as a [Neon Function](/docs/compute/functions/overview) with `DATABASE_URL` injected and call it from the SPA. Functions are in beta and available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions. Host the static bundle anywhere: Vercel, Netlify, Cloudflare Pages, or an S3 bucket.
 
 ## What it costs
 

--- a/content/faqs/best-backend-solo-developer-indie-hacker-multiple-apps.md
+++ b/content/faqs/best-backend-solo-developer-indie-hacker-multiple-apps.md
@@ -27,10 +27,10 @@ Each project can enable the same set of services, so you stop assembling a diffe
 
 - [Managed Better Auth](/docs/auth/overview): 60k MAU on Free, 1M on paid plans, with users in your own database.
 - [Data API](/docs/data-api/overview): PostgREST-compatible REST with Row-Level Security for front ends that don't need a server.
-- [Object Storage](/docs/storage/overview): S3-compatible, 5 GB on Free during the beta.
+- [Object Storage](/docs/storage/overview): S3-compatible, 5 GB per project on Free during the beta.
 - [Neon Functions](/docs/compute/functions/overview): APIs, bots, and webhooks next to the data, free during the beta.
 
-Functions, Object Storage, and AI Gateway are in beta and available in `aws-us-east-2`.
+Functions, Object Storage, and AI Gateway are in beta and available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions.
 
 ## Manage them all from the terminal
 

--- a/content/faqs/best-backend-startup-mvp.md
+++ b/content/faqs/best-backend-startup-mvp.md
@@ -39,7 +39,7 @@ Every engineer works on their own branch with a copy of production data, created
 - **Launch**: $0.106/CU-hour and $0.35/GB-month, autoscaling to 16 CU, 7-day restore window, spending notifications, no monthly minimum.
 - **Scale**: $0.222/CU-hour with SOC 2, HIPAA, IP Allow, Private Networking, and an uptime SLA for the enterprise deals that come later ([plans](/docs/introduction/plans)).
 
-A 0.25 CU compute active 300 hours a month on Launch is 75 CU-hours × $0.106 = $7.95, plus storage. Functions and Object Storage are free during their betas; AI Gateway is free during beta on paid plans. Those three are available in `aws-us-east-2`.
+A 0.25 CU compute active 300 hours a month on Launch is 75 CU-hours × $0.106 = $7.95, plus storage. Functions and Object Storage are free during their betas; AI Gateway is free during beta on paid plans. Those three are available in `aws-us-east-2` and `aws-eu-central-1`, with support expanding toward all regions.
 
 <Admonition type="tip" title="Startup credits">
 Early-stage companies can apply to the [Neon Startup Program](/startups) for credits on top of the Free plan allowances.

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -68,7 +68,7 @@ All plans include: multi-AZ storage, autoscaling, database branching, read repli
 - **Private Networking** ($0.01/GB on Scale) counts traffic in **both directions**.
 - **HIPAA** is self-serve on Scale (BAA required), currently at no additional cost. See [HIPAA](https://neon.com/docs/security/hipaa.md) for details.
 - **Object Storage** and **Functions** are free during beta. When billing begins: Object Storage is $0.023/GB-month (stored volume only, no per-operation charge). Functions active compute is $0.10/Capacity-Hour (Launch) or $0.12/Capacity-Hour (Scale), waiting compute is $0.025/Capacity-Hour (Launch) or $0.03/Capacity-Hour (Scale), and invocations are $0.60/M on both plans. Object Storage egress counts toward the shared network transfer allowance.
-- **Free tier** for the backend services: 5 GB Object Storage and, for Functions, 10 active Capacity-Hours, 400 waiting Capacity-Hours, and 1M invocations per month. These are account-wide, not per project.
+- **Free tier** for the backend services: 5 GB Object Storage per project and, for Functions, 10 active Capacity-Hours, 400 waiting Capacity-Hours, and 1M invocations per month.
 
 See [Plans](https://neon.com/docs/introduction/plans.md) for full details.
 

--- a/src/components/pages/pricing/hero/plans/data/plans.js
+++ b/src/components/pages/pricing/hero/plans/data/plans.js
@@ -42,7 +42,7 @@ export default [
           {
             title: `${objectStorage.freeAllowanceGb} GB of Object Storage`,
             tag: { label: 'Beta', theme: 'orange-muted' },
-            info: '<p>Measured across your account, not per project</p>',
+            info: '<p>5 GB per project included</p>',
           },
           {
             title: 'Functions',

--- a/src/components/pages/pricing/plans/data/plans.js
+++ b/src/components/pages/pricing/plans/data/plans.js
@@ -275,7 +275,7 @@ export default {
         title: 'Public network transfer',
         subtitle: 'Egress',
       },
-      free: '5 GB included',
+      free: '5 GB per project included',
       launch: '500 GB per project included<span>then $0.10/GB</span>',
       scale: '500 GB per project included<span>then $0.10/GB</span>',
     },

--- a/src/scripts/check-pricing-sync.js
+++ b/src/scripts/check-pricing-sync.js
@@ -1131,7 +1131,7 @@ function buildBackendCopyRequirements(backendPricing) {
         `active compute is $${functions.launch.activeCapacityHourRate}/Capacity-Hour (Launch) or $${functions.scale.activeCapacityHourRate}/Capacity-Hour (Scale)`,
         `waiting compute is $${functions.launch.waitingCapacityHourRate}/Capacity-Hour (Launch) or $${functions.scale.waitingCapacityHourRate}/Capacity-Hour (Scale)`,
         `invocations are $${functions.launch.invocationRatePerMillion}/M on both plans`,
-        `${objectStorage.freeAllowanceGb} GB Object Storage and, for Functions, ${functions.free.activeCapacityHours} active Capacity-Hours, ${functions.free.waitingCapacityHours} waiting Capacity-Hours, and ${functions.free.invocations} invocations`,
+        `${objectStorage.freeAllowanceGb} GB Object Storage per project and, for Functions, ${functions.free.activeCapacityHours} active Capacity-Hours, ${functions.free.waitingCapacityHours} waiting Capacity-Hours, and ${functions.free.invocations} invocations`,
       ],
     },
   ];


### PR DESCRIPTION
## Overview

The Free plan Object Storage allowance is metered per project, not account-wide. This updates the plans and storage docs, the backend FAQs, and the pricing page (hero tooltip and `pricing.md`) to say 5 GB per project, and aligns the pricing table's Free network transfer cell with the per-project wording already used for Launch and Scale.

It also adds `aws-eu-central-1` alongside `aws-us-east-2` everywhere the backend beta FAQs list where Functions, Object Storage, and AI Gateway run. #5712 added the second region to the docs pages but not the FAQs. Each mention now notes that support is expanding toward all regions, so the list holds up as more regions come online instead of needing another sweep.

Verified `npm run check:pricing-sync` passes.

This pull request and its description were written by Isaac.
