### PR TITLE
chore: regenerate the API reference from the OpenAPI spec

### DIFF
--- a/content/docs/api-navigation.yaml
+++ b/content/docs/api-navigation.yaml
@@ -486,6 +486,12 @@
     - title: "Revoke a credential"
       slug: reference/api/credentials/revoke-credential
       method: DELETE
+    - title: "Reveal a credential's secrets"
+      slug: reference/api/credentials/reveal-credential
+      method: POST
+    - title: "Rotate a credential's secrets"
+      slug: reference/api/credentials/rotate-credential
+      method: POST
 - title: "Functions"
   slug: reference/api/functions
   items:

--- a/content/docs/api-operation-ids.json
+++ b/content/docs/api-operation-ids.json
@@ -1,6 +1,6 @@
 {
   "_generatedBy": "scripts/generate-api-ref.mjs — do not edit by hand",
-  "count": 172,
+  "count": 174,
   "operationIds": [
     "acceptProjectTransferRequest",
     "addBranchNeonAuthOauthProvider",
@@ -137,10 +137,12 @@
     "restartProjectEndpoint",
     "restoreProjectBranch",
     "restoreSnapshot",
+    "revealCredential",
     "revokeApiKey",
     "revokeCredential",
     "revokeOrgApiKey",
     "revokePermissionFromProject",
+    "rotateCredential",
     "sendNeonAuthEmailProviderTest",
     "sendNeonAuthTestEmail",
     "setDefaultProjectBranch",


### PR DESCRIPTION
## Overview

Regenerate the API reference from the release OpenAPI spec. The spec added two operations under the Credentials tag:

- `revealCredential` (POST) — "Reveal a credential's secrets"
- `rotateCredential` (POST) — "Rotate a credential's secrets"

Operation count goes 172 to 174, with no operations removed and no tags changed. Only the committed artifacts (`api-navigation.yaml`, `api-operation-ids.json`) change; the rest of the generated reference is gitignored build output.

`npm run check:api-ref-generated` passes.

This pull request and its description were written by Isaac.
