### PR TITLE
docs: point the Manage LLM index at databases and skip AutoscalingViz

### DIFF
--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -147,7 +147,7 @@ module.exports = {
           'manage/branches.md',
           'manage/computes.md',
           'manage/organizations.md',
-          'manage/backups.md',
+          'manage/databases.md',
         ],
       },
     },

--- a/src/scripts/process-md-for-llms.js
+++ b/src/scripts/process-md-for-llms.js
@@ -216,6 +216,7 @@ const IGNORED_COMPONENTS = [
   'ComputeCalculator', // Interactive widget
   'UseCaseContext', // Repetitive boilerplate
   'McpSetupConfigurator', // Interactive MCP setup widget
+  'AutoscalingViz', // Animated autoscaling visualization (figures are in the surrounding prose)
 ];
 
 // ESM modules loaded dynamically


### PR DESCRIPTION
## Overview

Two small fixes to the LLM content pipeline.

The Manage sub-index (`public/docs/manage/llms.txt`) highlighted `manage/backups.md`, which was removed when backup/restore content moved under Postgres in the nav (#5621). It now highlights `manage/databases.md`.

`AutoscalingViz` is now skipped when generating the markdown mirror, since it is an animated visualization with no text content and its figures already appear in the surrounding prose.

This pull request and its description were written by Isaac.
