### PR TITLE
Reindex neon.com docs pages when content lands on main

### DIFF
--- a/.github/workflows/docs-reindex.yml
+++ b/.github/workflows/docs-reindex.yml
@@ -1,0 +1,164 @@
+name: Docs reindex
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'content/**'
+  workflow_dispatch:
+    inputs:
+      urls:
+        description: Space-separated https://neon.com/**.md URLs to reindex (upsert)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  reindex:
+    name: 'Reindex changed docs pages'
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '22'
+
+      - name: Map changed files
+        id: map
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -o pipefail
+          before="${{ github.event.before }}"
+          sha="${{ github.sha }}"
+          zeros='0000000000000000000000000000000000000000'
+          if [ "${before}" = "${zeros}" ]; then
+            echo "github.event.before is the all-zeros SHA; refusing to guess the compare range. Use workflow_dispatch with the https://neon.com/**.md URLs instead."
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/compare/${before}...${sha}" --jq '.files' \
+            > /tmp/docs-reindex-files.json
+          payload="$(node src/scripts/docs-reindex-map.js < /tmp/docs-reindex-files.json)"
+          if [ -z "${payload}" ]; then
+            echo "payload=" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          {
+            echo 'payload<<EOF'
+            printf '%s\n' "${payload}"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Map dispatch URLs
+        id: dispatch
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -o pipefail
+          node <<'NODE'
+          const fs = require('fs');
+          (async () => {
+            const urls = process.env.URLS.trim().split(/\s+/).filter(Boolean);
+            if (urls.length === 0) {
+              throw new Error(
+                'workflow_dispatch requires at least one https://neon.com/**.md URL with no port, userinfo, query, or hash',
+              );
+            }
+            for (const url of urls) {
+              let parsed;
+              try {
+                parsed = new URL(url);
+              } catch {
+                throw new Error(
+                  `Not a neon.com markdown url: ${url} (expected https://neon.com/**.md with no port, userinfo, query, or hash)`,
+                );
+              }
+              if (
+                parsed.protocol !== 'https:' ||
+                parsed.hostname !== 'neon.com' ||
+                parsed.port !== '' ||
+                parsed.username !== '' ||
+                parsed.password !== '' ||
+                parsed.search !== '' ||
+                parsed.hash !== '' ||
+                !parsed.pathname.endsWith('.md')
+              ) {
+                throw new Error(
+                  `Not a neon.com markdown url: ${url} (expected https://neon.com/**.md with no port, userinfo, query, or hash)`,
+                );
+              }
+            }
+            const payload = JSON.stringify({
+              pages: urls.map((url) => ({ url, deleted: false })),
+            });
+            if (process.env.GITHUB_STEP_SUMMARY) {
+              await fs.promises.appendFile(
+                process.env.GITHUB_STEP_SUMMARY,
+                `## Docs reindex map\n\nQueued **${urls.length}** page(s) for reindex.\n`,
+              );
+            }
+            await fs.promises.appendFile(
+              process.env.GITHUB_OUTPUT,
+              `payload<<EOF\n${payload}\nEOF\n`,
+            );
+          })().catch((error) => {
+            console.error(error instanceof Error ? error.message : error);
+            process.exit(1);
+          });
+          NODE
+        env:
+          URLS: ${{ inputs.urls }}
+
+      - name: POST reindex
+        if: steps.map.outputs.payload != '' || steps.dispatch.outputs.payload != ''
+        env:
+          NEON_AGENT_DOCS_REINDEX_URL: ${{ secrets.NEON_AGENT_DOCS_REINDEX_URL }}
+          NEON_AGENT_DOCS_REINDEX_SECRET: ${{ secrets.NEON_AGENT_DOCS_REINDEX_SECRET }}
+          PAYLOAD: ${{ steps.map.outputs.payload || steps.dispatch.outputs.payload }}
+        shell: bash
+        run: |
+          set -o pipefail
+          if [ -z "${NEON_AGENT_DOCS_REINDEX_URL}" ] || [ -z "${NEON_AGENT_DOCS_REINDEX_SECRET}" ]; then
+            echo "NEON_AGENT_DOCS_REINDEX_URL and NEON_AGENT_DOCS_REINDEX_SECRET must be set"
+            exit 1
+          fi
+          node <<'NODE'
+          const { createHmac } = require('node:crypto');
+          const body = process.env.PAYLOAD;
+          const signature = `sha256=${createHmac('sha256', process.env.NEON_AGENT_DOCS_REINDEX_SECRET)
+            .update(body)
+            .digest('hex')}`;
+          (async () => {
+            const response = await fetch(process.env.NEON_AGENT_DOCS_REINDEX_URL, {
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+                'x-docs-reindex-signature': signature,
+              },
+              body,
+            });
+            await response.arrayBuffer();
+            if (response.status !== 202) {
+              throw new Error(`docs reindex returned ${response.status}`);
+            }
+            console.log(`docs reindex returned ${response.status}`);
+          })().catch((error) => {
+            console.error(error instanceof Error ? error.message : error);
+            process.exit(1);
+          });
+          NODE

--- a/src/scripts/docs-reindex-map.js
+++ b/src/scripts/docs-reindex-map.js
@@ -1,0 +1,215 @@
+const path = require('path');
+
+const { CONTENT_ROUTES, EXCLUDED_DIRS } = require('../constants/content');
+const config = require('./llms-index-config');
+
+const BASE_URL = 'https://neon.com';
+const EXCLUDED_FILES = ['README.md', 'index.md', '_index.md'];
+const COLLAPSED_ROUTES = config.collapsedRoutes || {};
+const EXCLUDE_PATHS = config.excludePaths || [];
+const ADDITIONAL_RESOURCE_PATHS = new Set(
+  (config.additionalResources || []).filter((r) => r.sourcePath).map((r) => r.sourcePath)
+);
+
+const INDEXED_ROUTES = Object.entries(CONTENT_ROUTES)
+  .filter(([route]) => !(route in COLLAPSED_ROUTES))
+  .sort((a, b) => b[1].length - a[1].length);
+
+function posix(file) {
+  return file.split(path.sep).join('/');
+}
+
+function isMarkdown(file) {
+  return file.endsWith('.md');
+}
+
+function hasExcludedDir(file) {
+  return posix(file)
+    .split('/')
+    .some((segment) => EXCLUDED_DIRS.includes(segment));
+}
+
+function matchIndexedRoute(file) {
+  const normalized = posix(file);
+  for (const [route, srcPath] of INDEXED_ROUTES) {
+    const prefix = `${srcPath}/`;
+    if (normalized === srcPath || normalized.startsWith(prefix)) {
+      return { route, srcPath, relPath: path.posix.relative(srcPath, normalized) };
+    }
+  }
+  return undefined;
+}
+
+function isExcludedRelPath(relPath) {
+  if (ADDITIONAL_RESOURCE_PATHS.has(relPath)) {
+    return false;
+  }
+  return EXCLUDE_PATHS.some((prefix) => relPath === prefix || relPath.startsWith(prefix));
+}
+
+function catalogUrl(file) {
+  const normalized = posix(file);
+  if (!normalized.startsWith('content/')) {
+    return undefined;
+  }
+  return `${BASE_URL}/${normalized.slice('content/'.length)}`;
+}
+
+function classify(file) {
+  const normalized = posix(file);
+  if (!isMarkdown(normalized)) {
+    return { kind: 'notMarkdown' };
+  }
+  if (hasExcludedDir(normalized)) {
+    return { kind: 'sharedContent' };
+  }
+  const basename = path.posix.basename(normalized);
+  if (EXCLUDED_FILES.includes(basename)) {
+    return { kind: 'excluded' };
+  }
+  const matched = matchIndexedRoute(normalized);
+  if (!matched) {
+    const underContent = Object.values(CONTENT_ROUTES).some(
+      (srcPath) => normalized === srcPath || normalized.startsWith(`${srcPath}/`)
+    );
+    return { kind: underContent ? 'collapsed' : 'notContent' };
+  }
+  if (isExcludedRelPath(matched.relPath)) {
+    return { kind: 'excluded' };
+  }
+  const url = catalogUrl(normalized);
+  if (!url) {
+    return { kind: 'notContent' };
+  }
+  return { kind: 'catalog', url };
+}
+
+function addPage(pages, url, deleted) {
+  pages.set(url, { url, deleted });
+}
+
+function bump(skipped, kind) {
+  skipped[kind] += 1;
+}
+
+/**
+ * @param {Array<{ filename: string, status: string, previous_filename?: string }>} files
+ */
+function mapCompareFiles(files) {
+  const pages = new Map();
+  const skipped = {
+    sharedContent: 0,
+    collapsed: 0,
+    excluded: 0,
+    notContent: 0,
+    notMarkdown: 0,
+  };
+
+  for (const file of files) {
+    const status = file.status;
+    if (status === 'renamed' && file.previous_filename) {
+      const previous = classify(file.previous_filename);
+      if (previous.kind === 'catalog') {
+        addPage(pages, previous.url, true);
+      } else {
+        bump(skipped, previous.kind);
+      }
+    }
+
+    const current = classify(file.filename);
+    if (current.kind !== 'catalog') {
+      bump(skipped, current.kind);
+      continue;
+    }
+    if (status === 'removed') {
+      addPage(pages, current.url, true);
+      continue;
+    }
+    if (
+      status === 'added' ||
+      status === 'modified' ||
+      status === 'changed' ||
+      status === 'copied' ||
+      status === 'renamed'
+    ) {
+      addPage(pages, current.url, false);
+    }
+  }
+
+  return {
+    pages: [...pages.values()],
+    skipped,
+  };
+}
+
+function skippedSummary(skipped) {
+  const parts = [];
+  if (skipped.sharedContent) {
+    parts.push(`${skipped.sharedContent} shared-content`);
+  }
+  if (skipped.collapsed) {
+    parts.push(`${skipped.collapsed} collapsed`);
+  }
+  if (skipped.excluded) {
+    parts.push(`${skipped.excluded} excluded`);
+  }
+  if (skipped.notContent) {
+    parts.push(`${skipped.notContent} not content`);
+  }
+  if (skipped.notMarkdown) {
+    parts.push(`${skipped.notMarkdown} not markdown`);
+  }
+  return parts.join(', ');
+}
+
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  const files = raw === '' ? [] : JSON.parse(raw);
+  if (!Array.isArray(files)) {
+    throw new Error('docs-reindex-map expected a JSON array of GitHub compare files');
+  }
+  const result = mapCompareFiles(files);
+  const summary = skippedSummary(result.skipped);
+  if (summary) {
+    process.stderr.write(`skipped: ${summary}\n`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFile } = require('fs').promises;
+    const lines = [
+      '## Docs reindex map',
+      '',
+      `Mapped **${result.pages.length}** catalog page(s).`,
+    ];
+    if (summary) {
+      lines.push(`Skipped: ${summary}.`);
+    }
+    if (result.skipped.sharedContent) {
+      lines.push(
+        'shared-content changes do not reindex includer pages; full ingest is the backstop.'
+      );
+    }
+    lines.push('');
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+  }
+  if (result.pages.length === 0) {
+    process.exit(0);
+  }
+  process.stdout.write(`${JSON.stringify({ pages: result.pages })}\n`);
+}
+
+module.exports = {
+  mapCompareFiles,
+  classify,
+  skippedSummary,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/src/scripts/docs-reindex-map.test.js
+++ b/src/scripts/docs-reindex-map.test.js
@@ -1,0 +1,125 @@
+import { createRequire } from 'module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { mapCompareFiles } = require('./docs-reindex-map.js');
+
+describe('mapCompareFiles', () => {
+  it('maps a docs page add and modify', () => {
+    expect(
+      mapCompareFiles([
+        { filename: 'content/docs/introduction/branching.md', status: 'added' },
+        { filename: 'content/docs/connect/choose-connection.md', status: 'modified' },
+      ])
+    ).toEqual({
+      pages: [
+        { url: 'https://neon.com/docs/introduction/branching.md', deleted: false },
+        { url: 'https://neon.com/docs/connect/choose-connection.md', deleted: false },
+      ],
+      skipped: {
+        sharedContent: 0,
+        collapsed: 0,
+        excluded: 0,
+        notContent: 0,
+        notMarkdown: 0,
+      },
+    });
+  });
+
+  it('includes branching pages and glossary', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/branching/reset-from-parent.md', status: 'modified' },
+      { filename: 'content/docs/reference/glossary.md', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([
+      { url: 'https://neon.com/branching/reset-from-parent.md', deleted: false },
+      { url: 'https://neon.com/docs/reference/glossary.md', deleted: false },
+    ]);
+  });
+
+  it('skips shared-content', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/docs/shared-content/mcp-tools.md', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.skipped.sharedContent).toBe(1);
+  });
+
+  it('skips collapsed changelog files', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/changelog/2026-09-01.md', status: 'added' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.skipped.collapsed).toBe(1);
+  });
+
+  it('skips excludePaths such as introduction.md', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/docs/introduction.md', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.skipped.excluded).toBe(1);
+  });
+
+  it('maps a delete', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/docs/connect/old-driver.md', status: 'removed' },
+    ]);
+    expect(result.pages).toEqual([
+      { url: 'https://neon.com/docs/connect/old-driver.md', deleted: true },
+    ]);
+  });
+
+  it('maps a rename as delete old plus upsert new', () => {
+    const result = mapCompareFiles([
+      {
+        filename: 'content/docs/connect/new-name.md',
+        status: 'renamed',
+        previous_filename: 'content/docs/connect/old-name.md',
+      },
+    ]);
+    expect(result.pages).toEqual([
+      { url: 'https://neon.com/docs/connect/old-name.md', deleted: true },
+      { url: 'https://neon.com/docs/connect/new-name.md', deleted: false },
+    ]);
+  });
+
+  it('deletes the old url when a catalog page is renamed into shared-content', () => {
+    const result = mapCompareFiles([
+      {
+        filename: 'content/docs/shared-content/moved.md',
+        status: 'renamed',
+        previous_filename: 'content/docs/connect/moved.md',
+      },
+    ]);
+    expect(result.pages).toEqual([
+      { url: 'https://neon.com/docs/connect/moved.md', deleted: true },
+    ]);
+    expect(result.skipped.sharedContent).toBe(1);
+  });
+
+  it('upserts the new url when a collapsed file is renamed into docs', () => {
+    const result = mapCompareFiles([
+      {
+        filename: 'content/docs/guides/from-changelog.md',
+        status: 'renamed',
+        previous_filename: 'content/changelog/from-changelog.md',
+      },
+    ]);
+    expect(result.pages).toEqual([
+      { url: 'https://neon.com/docs/guides/from-changelog.md', deleted: false },
+    ]);
+    expect(result.skipped.collapsed).toBe(1);
+  });
+
+  it('skips non-content files', () => {
+    const result = mapCompareFiles([
+      { filename: 'src/app/page.md', status: 'modified' },
+      { filename: 'package.json', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.skipped.notContent).toBe(1);
+    expect(result.skipped.notMarkdown).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

The Neon assistant answers from an index of `https://neon.com/**.md` pages. Nothing tells it when a docs page changes: an edit, rename or delete under `content/` reaches the index only when the next full ingest runs, and until then the assistant serves the old version of the page.

## What this adds

A `docs-reindex` GitHub Action that runs on every push to `main` touching `content/**`. It reads the changed files from the GitHub compare API, maps them to catalog URLs and POSTs the result to the assistant's docs-reindex webhook, signed with HMAC SHA-256.

The mapping reuses the site's existing index rules. `src/scripts/docs-reindex-map.js` reads `CONTENT_ROUTES` and `EXCLUDED_DIRS` from `src/constants/content.js`, and `collapsedRoutes`, `excludePaths` and `additionalResources` from `src/scripts/llms-index-config.js`. The set of pages this reindexes is the set llms.txt indexes.

Per changed file:

| Change | Payload |
| --- | --- |
| added, modified, changed, copied | `{ url, deleted: false }` |
| removed | `{ url, deleted: true }` |
| renamed | delete for the old URL plus upsert for the new one |
| shared-content, collapsed routes (changelog), `excludePaths`, `README.md` / `index.md`, non-content, non-markdown | skipped and counted in the step summary |

Duplicate URLs collapse to one entry, last status wins.

## Interface

Workflow triggers:

```yaml
on:
  push:
    branches: [main]
    paths: ['content/**']
  workflow_dispatch:
    inputs:
      urls: # space-separated https://neon.com/**.md URLs to reindex (upsert)
```

The mapper is a plain Node script, JSON array of compare files on stdin:

```bash
gh api "repos/neondatabase/website/compare/<before>...<sha>" --jq '.files' \
  | node src/scripts/docs-reindex-map.js
```

Its stdout is the webhook request body:

```json
{ "pages": [{ "url": "https://neon.com/docs/introduction/branching.md", "deleted": false }] }
```

The POST carries `x-docs-reindex-signature: sha256=<hex>`, an HMAC SHA-256 of the raw body keyed with `NEON_AGENT_DOCS_REINDEX_SECRET`. Any response other than 202 fails the job. The webhook URL and secret come from the repository secrets `NEON_AGENT_DOCS_REINDEX_URL` and `NEON_AGENT_DOCS_REINDEX_SECRET`, both already set.

`workflow_dispatch` is the manual path. It rejects any URL that isn't exactly `https://neon.com/**.md` with no port, userinfo, query or hash, and it always sends `deleted: false`.

Two cases fail loudly instead of guessing:

- A push whose `before` SHA is all zeros has no compare range. The job fails and points to `workflow_dispatch`.
- Missing secrets fail the POST step before any request is made.

An empty mapping (a push that only touched skipped files) skips the POST step entirely.

## Verification

Unit tests on the mapper:

```bash
npx vitest run src/scripts/docs-reindex-map.test.js  # 10 pass
```

Behaviors covered:

- adds and modifies map to catalog URLs with `deleted: false`, including routes beyond `docs/` (branching pages, the glossary)
- a delete maps to `deleted: true`
- a rename produces a delete for the old URL and an upsert for the new one
- a rename into shared-content deletes the old URL only; a rename out of a collapsed route upserts the new URL only
- shared-content, collapsed changelog files, `excludePaths` entries (`docs/introduction.md`), non-content and non-markdown files are skipped and counted

Against the live webhook: a signed POST of the payload shown above returned `202 {"accepted":1,"jobs":1}`, and the assistant's `GET /health` and `POST /ask` returned 200 afterwards.

Not verified: the workflow run itself. `gh workflow run docs-reindex.yml` returns 404 until the workflow file exists on the default branch (GitHub limitation). After merge, `workflow_dispatch` with one neon.com markdown URL is the end-to-end check.

## For your attention

- **Shared-content edits don't fan out.** A change to `content/docs/shared-content/*.md` is skipped, so pages that include it stay stale until the next full ingest. Fanning out needs an include graph this workflow doesn't have; the step summary notes the backstop whenever it skips one.
- **A force push to `main` skips reindexing.** The job fails rather than guessing a compare range. Recovery is `workflow_dispatch` with the affected URLs.
- **Deletes have no manual path.** `workflow_dispatch` is upsert-only; only the push path emits `deleted: true`.
