### PR TITLE
fix: restore topbar

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'The average Neon production DB resizes every 81 seconds. Here's a deep dive on how our autoscaling is built'
+text: "The average Neon production DB resizes every 81 seconds. Here's a deep dive on how our autoscaling is built"
 link:
   url: 'https://neon.com/blog/autoscaling-lakebase-postgres'
   target: '_blank'


### PR DESCRIPTION
Fix the YAML quoting in the topbar announcement. This restores the banner while preserving its latest text and link.

[Preview](https://neon-next-git-fix-restore-topbar-pixelpoint.vercel.app/)