### PR TITLE
Add cover image to scale to zero blog post

### DIFF
--- a/content/blog/posts/building-patterns-unlocked-by-scale-to-zero.md
+++ b/content/blog/posts/building-patterns-unlocked-by-scale-to-zero.md
@@ -14,8 +14,11 @@ categories:
 authors:
   - carlota-soto
 cover:
-  image: null
-  alt: null
+  image: >-
+    https://cdn.neonapi.io/public/images/pages/blog/building-patterns-unlocked-by-scale-to-zero/cover.jpg
+  alt: >-
+    A wireframe cube labeled "wake on request" beside a stack of metallic cubes,
+    illustrating compute suspending and restarting on demand
 isFeatured: false
 seo:
   title: Building patterns unlocked by scale to zero - Neon
@@ -24,7 +27,8 @@ seo:
   noindex: false
   ogTitle: Building patterns unlocked by scale to zero - Neon
   ogDescription: When idle databases stop wasting compute
-  image: null
+  image: >-
+    https://cdn.neonapi.io/public/images/pages/blog/building-patterns-unlocked-by-scale-to-zero/cover.jpg
 ---
 
 Most hosted Postgres pricing works like this:


### PR DESCRIPTION
Targets the #5673 branch, so the only change under review is the cover image.

- Uploaded `cover.jpg` to the blog CDN: `https://cdn.neonapi.io/public/images/pages/blog/building-patterns-unlocked-by-scale-to-zero/cover.jpg`
- Set `cover.image` and `cover.alt`
- Set `seo.image` so the Open Graph share image is no longer `null`

Merging this into `blog/building-patterns-unlocked-by-scale-to-zero` makes the cover image part of #5673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)