### PR TITLE
docs: update object storage limits

### DIFF
--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,12 +6,14 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-08-17T23:18:55.558Z'
+updatedOn: '2026-09-03T13:04:38.014Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
 
 A bucket is a named container for objects in Neon Object Storage. Buckets are scoped to a branch and inherit from parent branches when a new branch is created. No data is copied on fork.
+
+A single bucket can hold an unlimited number of objects with no maximum bucket size. For object size limits and other constraints, see [Limits](/docs/storage/overview#limits).
 
 ## Create a bucket
 
@@ -174,5 +176,6 @@ This makes it safe to test bucket changes in a preview branch without affecting 
 
 - [Objects](/docs/storage/objects): upload, download, list, and delete objects
 - [Authentication](/docs/storage/authentication): credential scopes and branch binding
+- [Limits](/docs/storage/overview#limits): object size, bucket capacity, and usage limits
 
 <NeedHelp/>

--- a/content/docs/storage/buckets.md
+++ b/content/docs/storage/buckets.md
@@ -6,14 +6,14 @@ summary: >-
   buckets via the Neon Console, the Neon API, or the S3 API. Set the access
   level to private or public_read to control who can read objects.
 enableTableOfContents: true
-updatedOn: '2026-09-03T13:04:38.014Z'
+updatedOn: '2026-09-10T09:10:58.044Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
 
 A bucket is a named container for objects in Neon Object Storage. Buckets are scoped to a branch and inherit from parent branches when a new branch is created. No data is copied on fork.
 
-A single bucket can hold an unlimited number of objects with no maximum bucket size. For object size limits and other constraints, see [Limits](/docs/storage/overview#limits).
+For object size and storage limits, see [Limits](/docs/storage/overview#limits).
 
 ## Create a bucket
 
@@ -176,6 +176,6 @@ This makes it safe to test bucket changes in a preview branch without affecting 
 
 - [Objects](/docs/storage/objects): upload, download, list, and delete objects
 - [Authentication](/docs/storage/authentication): credential scopes and branch binding
-- [Limits](/docs/storage/overview#limits): object size, bucket capacity, and usage limits
+- [Limits](/docs/storage/overview#limits): object size and usage limits
 
 <NeedHelp/>

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   or the AWS CLI. Supports single-part and multipart uploads, range requests,
   batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-08-21T15:53:18.662Z'
+updatedOn: '2026-09-03T13:01:17.594Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -72,7 +72,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 
 ## Multipart upload
 
-During beta, the maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. This is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects. For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload makes large uploads more reliable because each part is retried independently, though it doesn't raise the per-object limit during beta.
+A single `PutObject` request can upload up to 5 GiB. To store a larger object, up to the 5 TiB per-object maximum, use multipart upload. For large files, the AWS SDK automatically switches to multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload also makes large uploads more reliable because each part is retried independently.
 
 <CodeTabs labels={["TypeScript", "Python"]}>
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   or the AWS CLI. Supports single-part and multipart uploads, range requests,
   batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-09-03T13:01:17.594Z'
+updatedOn: '2026-09-03T13:04:38.014Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -72,7 +72,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 
 ## Multipart upload
 
-A single `PutObject` request can upload up to 5 GiB. To store a larger object, up to the 5 TiB per-object maximum, use multipart upload. For large files, the AWS SDK automatically switches to multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload also makes large uploads more reliable because each part is retried independently.
+A single `PutObject` request can upload up to 5 GiB. To store a larger object, up to the 5 TiB per-object maximum, use multipart upload. For large files, the AWS SDK automatically switches to multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload also makes large uploads more reliable because each part is retried independently. For all size and capacity limits, see [Limits](/docs/storage/overview#limits).
 
 <CodeTabs labels={["TypeScript", "Python"]}>
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   or the AWS CLI. Supports single-part and multipart uploads, range requests,
   batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-09-03T13:04:38.014Z'
+updatedOn: '2026-09-10T09:10:58.044Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -72,7 +72,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 
 ## Multipart upload
 
-A single `PutObject` request can upload up to 5 GiB. To store a larger object, up to the 5 TiB per-object maximum, use multipart upload. For large files, the AWS SDK automatically switches to multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload also makes large uploads more reliable because each part is retried independently. For all size and capacity limits, see [Limits](/docs/storage/overview#limits).
+During beta, the maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload makes large uploads more reliable because each part is retried independently. For all size and capacity limits, see [Limits](/docs/storage/overview#limits).
 
 <CodeTabs labels={["TypeScript", "Python"]}>
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-09-02T20:41:07.968Z'
+updatedOn: '2026-09-03T13:01:17.594Z'
 ---
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
@@ -57,7 +57,8 @@ During the beta, the following usage limits apply:
 
 - **Region**: object storage is available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
 - **Free object storage**: the Free plan includes 5 GB of object storage per project. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
-- **Object size**: objects can be up to 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload). [Contact support](/docs/introduction/support) if you need to store larger objects.
+- **Bucket capacity**: a single bucket can hold an unlimited number of objects, and there's no maximum limit on overall bucket size.
+- **Object size**: a single object can be up to 5 TiB. A single `PutObject` request can upload up to 5 GiB; larger objects require [multipart upload](/docs/storage/objects#multipart-upload).
 - **Rate limiting**: requests may be throttled during heavy use, returning a `503 SlowDown` response. Back off and retry. See [Connection and performance errors](/docs/storage/troubleshooting#connection-and-performance-errors).
 
 For S3 API and feature limitations (as opposed to usage limits), see [Known limitations](/docs/storage/s3-compatibility#known-limitations).

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-09-03T13:01:17.594Z'
+updatedOn: '2026-09-03T13:03:04.907Z'
 ---
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
@@ -53,12 +53,19 @@ neon bootstrap --template ai-sdk
 
 ## Limits
 
-During the beta, the following usage limits apply:
+During the beta, the following limits apply:
+
+| Limit                      | Value                                                                                     |
+| -------------------------- | ----------------------------------------------------------------------------------------- |
+| Objects per bucket         | Unlimited                                                                                 |
+| Bucket size                | No maximum                                                                                |
+| Object size (maximum)      | 5 TiB                                                                                     |
+| Single `PutObject` request | 5 GiB (larger objects require [multipart upload](/docs/storage/objects#multipart-upload)) |
+| Free plan object storage   | 5 GB per project ([rates](/docs/introduction/plans#object-storage))                       |
+
+Two limits are behavioral rather than fixed numbers:
 
 - **Region**: object storage is available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
-- **Free object storage**: the Free plan includes 5 GB of object storage per project. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
-- **Bucket capacity**: a single bucket can hold an unlimited number of objects, and there's no maximum limit on overall bucket size.
-- **Object size**: a single object can be up to 5 TiB. A single `PutObject` request can upload up to 5 GiB; larger objects require [multipart upload](/docs/storage/objects#multipart-upload).
 - **Rate limiting**: requests may be throttled during heavy use, returning a `503 SlowDown` response. Back off and retry. See [Connection and performance errors](/docs/storage/troubleshooting#connection-and-performance-errors).
 
 For S3 API and feature limitations (as opposed to usage limits), see [Known limitations](/docs/storage/s3-compatibility#known-limitations).

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-09-03T13:03:04.907Z'
+updatedOn: '2026-09-10T09:10:58.044Z'
 ---
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
@@ -55,13 +55,10 @@ neon bootstrap --template ai-sdk
 
 During the beta, the following limits apply:
 
-| Limit                      | Value                                                                                     |
-| -------------------------- | ----------------------------------------------------------------------------------------- |
-| Objects per bucket         | Unlimited                                                                                 |
-| Bucket size                | No maximum                                                                                |
-| Object size (maximum)      | 5 TiB                                                                                     |
-| Single `PutObject` request | 5 GiB (larger objects require [multipart upload](/docs/storage/objects#multipart-upload)) |
-| Free plan object storage   | 5 GB per project ([rates](/docs/introduction/plans#object-storage))                       |
+| Limit                    | Value                                                                                                          |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Object size (maximum)    | 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload) |
+| Free plan object storage | 5 GB per project ([rates](/docs/introduction/plans#object-storage))                                            |
 
 Two limits are behavioral rather than fixed numbers:
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-08-21T15:53:18.662Z'
+updatedOn: '2026-09-03T13:01:17.594Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -114,9 +114,9 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 
 ### `EntityTooLarge`
 
-The object exceeds the maximum size. During beta, Neon Object Storage allows objects up to 5 GiB. A single-request `PutObject` fails immediately; a multipart upload fails at `CompleteMultipartUpload` once the assembled object would exceed the limit.
+The upload exceeds a size limit. A single `PutObject` request can upload up to 5 GiB, and a single object can be up to 5 TiB. A single-request `PutObject` above 5 GiB fails immediately; a multipart upload fails at `CompleteMultipartUpload` once the assembled object would exceed 5 TiB.
 
-**Fix:** Split the data across multiple objects, or confirm the upload isn't unexpectedly large. Multipart upload makes large uploads more reliable but doesn't raise the per-object limit. The 5 GiB limit is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects.
+**Fix:** For objects larger than 5 GiB, use [multipart upload](/docs/storage/objects#multipart-upload) instead of a single `PutObject` request. For objects that would exceed 5 TiB, split the data across multiple objects.
 
 ## Connection and performance errors
 

--- a/content/docs/storage/troubleshooting.md
+++ b/content/docs/storage/troubleshooting.md
@@ -6,7 +6,7 @@ summary: >-
   failures, access denied errors, SDK configuration issues, and S3
   compatibility limitations.
 enableTableOfContents: true
-updatedOn: '2026-09-03T13:01:17.594Z'
+updatedOn: '2026-09-10T09:10:58.044Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -114,9 +114,9 @@ See [S3 compatibility](/docs/storage/s3-compatibility#not-supported) for the ful
 
 ### `EntityTooLarge`
 
-The upload exceeds a size limit. A single `PutObject` request can upload up to 5 GiB, and a single object can be up to 5 TiB. A single-request `PutObject` above 5 GiB fails immediately; a multipart upload fails at `CompleteMultipartUpload` once the assembled object would exceed 5 TiB.
+The object exceeds the maximum size. During beta, Neon Object Storage allows objects up to 5 GiB, whether uploaded in a single request or via [multipart upload](/docs/storage/objects#multipart-upload). A single-request `PutObject` fails immediately; a multipart upload fails at `CompleteMultipartUpload` once the assembled object would exceed the limit.
 
-**Fix:** For objects larger than 5 GiB, use [multipart upload](/docs/storage/objects#multipart-upload) instead of a single `PutObject` request. For objects that would exceed 5 TiB, split the data across multiple objects.
+**Fix:** Split the data across multiple objects, or confirm the upload isn't unexpectedly large. Multipart upload makes large uploads more reliable but doesn't raise the per-object limit during beta. [Contact support](/docs/introduction/support) if you need to store larger objects.
 
 ## Connection and performance errors
 


### PR DESCRIPTION
Improves how the current (beta) Neon Object Storage limits are presented, and adds cross-references so readers can find them. No change to the actual limits: the object-size cap stays 5 GiB during beta (single request or multipart), which matches what the storage backend enforces today (`max_object_bytes = 5 GiB` in prod).

GA / "when billing begins" limits (larger objects, no fixed storage or object-count cap) are handled separately in #5798.

## Changed files

| Page | Preview | Change |
| --- | --- | --- |
| overview | https://neon-next-git-docs-object-storage-limits-update-neondatabase.vercel.app/docs/storage/overview | Limits section now a table |
| objects | https://neon-next-git-docs-object-storage-limits-update-neondatabase.vercel.app/docs/storage/objects | Multipart intro tidied + link to Limits |
| troubleshooting | https://neon-next-git-docs-object-storage-limits-update-neondatabase.vercel.app/docs/storage/troubleshooting | `EntityTooLarge` tidied + link to multipart |
| buckets | https://neon-next-git-docs-object-storage-limits-update-neondatabase.vercel.app/docs/storage/buckets | Cross-references to Limits |

This pull request and its description were written by Isaac.