### PR TITLE
fix: redirect common 404 paths to their real pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -206,6 +206,37 @@ const defaultConfig = {
     }, []);
 
     return [
+      // Common paths from the logs with no page of their own; send them to the closest real page.
+      {
+        source: '/about',
+        destination: '/about-us',
+        permanent: true,
+      },
+      {
+        source: '/contact',
+        destination: '/contact-sales',
+        permanent: true,
+      },
+      {
+        source: '/contact-us',
+        destination: '/contact-sales',
+        permanent: true,
+      },
+      {
+        source: '/leadership',
+        destination: '/about-us',
+        permanent: true,
+      },
+      {
+        source: '/people',
+        destination: '/about-us',
+        permanent: true,
+      },
+      {
+        source: '/our-team',
+        destination: '/about-us',
+        permanent: true,
+      },
       {
         // Legacy favicon path removed in #4345; redirect stale references to the current icon.
         source: '/favicon/favicon.png',


### PR DESCRIPTION
Six paths show up as common 404s in the Vercel logs: /about, /contact, /contact-us, /leadership, /people, and /our-team. None have a page of their own.

Redirect them permanently to the closest pages that exist, /about-us and /contact-sales, following the existing /team to /about-us convention.

This pull request and its description were written by Isaac.
