### PR TITLE
feat: publish unlinked guides and changelog llms.txt indexes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2704,6 +2704,10 @@ const defaultConfig = {
         { source: '/docs/:path*/llms.txt', destination: '/docs/:path*/llms.txt' },
         { source: '/docs/:path*/llms-full.txt', destination: '/docs/:path*/llms-full.txt' },
         { source: '/docs/llms-full.txt', destination: '/docs/llms-full.txt' },
+        // Unlinked community-guides index. The /guides catch-all would eat this
+        // without a beforeFiles identity rewrite; /docs/changelog/llms.txt is
+        // already covered by /docs/:path*/llms.txt above.
+        { source: '/guides/llms.txt', destination: '/guides/llms.txt' },
         // Skill discovery under /docs/ — wildcard :name handles all skills without per-skill edits.
         // Must be beforeFiles to avoid the docs/[...slug] catch-all intercepting them.
         // /docs/skill.md is a single-entrypoint alias for the primary skill (see config/skills.json).

--- a/src/scripts/generate-llms-index.js
+++ b/src/scripts/generate-llms-index.js
@@ -22,7 +22,7 @@ const config = require('./llms-index-config');
 
 const BASE_URL = 'https://neon.com';
 const OUTPUT_PATH = 'public/docs/llms.txt';
-const EXCLUDED_FILES = ['README.md', 'index.md', '_index.md'];
+const EXCLUDED_FILES = ['README.md', 'index.md', '_index.md', 'GUIDE_TEMPLATE.md'];
 
 const COLLAPSED_ROUTES = config.collapsedRoutes || {};
 
@@ -62,8 +62,9 @@ function toTitleCase(str) {
  * @param {string} dirPath - absolute path to content directory
  * @param {string} baseContentPath - absolute path to content/ root (for URL generation)
  * @param {string} routeKey - the route key from CONTENT_ROUTES (used as fallback section name)
+ * @param {string} [urlPrefix] - public URL prefix after neon.com, e.g. "docs/changelog"
  */
-async function scanDirectory(dirPath, baseContentPath, routeKey) {
+async function scanDirectory(dirPath, baseContentPath, routeKey, urlPrefix) {
   const docs = [];
   const excludeMatchCounts = new Map();
   for (const prefix of ALL_EXCLUDE_PATHS) {
@@ -108,7 +109,7 @@ async function scanDirectory(dirPath, baseContentPath, routeKey) {
           const subtitle = frontmatter.subtitle || '';
 
           const mdPath = path.relative(baseContentPath, fullPath);
-          const url = `${BASE_URL}/${mdPath}`;
+          const url = urlPrefix ? `${BASE_URL}/${urlPrefix}/${relPath}` : `${BASE_URL}/${mdPath}`;
 
           docs.push({
             section,
@@ -426,6 +427,23 @@ function generateSubIndexText(sectionName, sectionConf, sectionData) {
   return `${lines.join('\n').trim()}\n`;
 }
 
+function generateUnlinkedIndexText(indexConf, docs) {
+  const lines = [];
+  lines.push(`# ${indexConf.title}`);
+  lines.push('');
+  if (indexConf.intro) {
+    lines.push(indexConf.intro);
+    lines.push('');
+  }
+  const sorted = [...docs].sort((a, b) => a.title.localeCompare(b.title));
+  for (const doc of sorted) {
+    const description = doc.subtitle ? `: ${doc.subtitle}` : '';
+    lines.push(`- [${doc.title}](${doc.url})${description}`);
+  }
+  lines.push('');
+  return `${lines.join('\n').trim()}\n`;
+}
+
 /**
  * Validate config against scanned results and emit warnings
  */
@@ -531,10 +549,38 @@ async function main() {
     });
   }
 
+  const unlinkedIndexFiles = [];
+  for (const indexConf of config.unlinkedIndexes || []) {
+    const srcPath = CONTENT_ROUTES[indexConf.route];
+    if (!srcPath) {
+      throw new Error(`unlinkedIndex route is not a content route: ${indexConf.route}`);
+    }
+    const fullPath = path.join(projectRoot, srcPath);
+    const { docs } = await scanDirectory(
+      fullPath,
+      contentPath,
+      indexConf.route,
+      indexConf.publicPath
+    );
+    if (docs.length === 0) {
+      throw new Error(`Unlinked index ${indexConf.route} scanned zero pages`);
+    }
+    unlinkedIndexFiles.push({
+      name: indexConf.route,
+      outputPath: indexConf.outputPath,
+      content: generateUnlinkedIndexText(indexConf, docs),
+    });
+    console.log(`  ${indexConf.route} (unlinked): ${docs.length} files`);
+  }
+
   if (dryRun) {
     console.log('--- Generated llms.txt ---\n');
     console.log(indexContent);
     for (const sub of subIndexFiles) {
+      console.log(`--- Generated ${sub.outputPath} ---\n`);
+      console.log(sub.content);
+    }
+    for (const sub of unlinkedIndexFiles) {
       console.log(`--- Generated ${sub.outputPath} ---\n`);
       console.log(sub.content);
     }
@@ -544,6 +590,12 @@ async function main() {
     console.log(`Written to ${outputPath}`);
 
     for (const sub of subIndexFiles) {
+      const subPath = path.join(projectRoot, sub.outputPath);
+      await fs.mkdir(path.dirname(subPath), { recursive: true });
+      await fs.writeFile(subPath, sub.content);
+      console.log(`Written to ${subPath}`);
+    }
+    for (const sub of unlinkedIndexFiles) {
       const subPath = path.join(projectRoot, sub.outputPath);
       await fs.mkdir(path.dirname(subPath), { recursive: true });
       await fs.writeFile(subPath, sub.content);
@@ -563,4 +615,4 @@ if (require.main === module) {
 }
 
 // Export for testing
-module.exports = { generateIndexText };
+module.exports = { generateIndexText, generateUnlinkedIndexText };

--- a/src/scripts/generate-llms-index.test.js
+++ b/src/scripts/generate-llms-index.test.js
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 import { describe, it, expect } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { generateIndexText } = require('./generate-llms-index');
+const { generateIndexText, generateUnlinkedIndexText } = require('./generate-llms-index');
 const config = require('./llms-index-config');
 
 // getSectionOrder (in the generator) includes any configured section that has a
@@ -29,5 +29,36 @@ describe('generateIndexText — Common tasks', () => {
     const text = generateIndexText(buildMinimalOrganized(), []);
     expect(text).not.toContain('## When to use Neon');
     expect(text).not.toContain('## Common Queries');
+  });
+
+  it('does not link unlinked site-search indexes from the parent docs index', () => {
+    const text = generateIndexText(buildMinimalOrganized(), [
+      { title: 'Community Guides', url: 'https://neon.com/guides', description: 'tutorials' },
+      { title: 'Changelog', url: 'https://neon.com/docs/changelog', description: 'releases' },
+    ]);
+    expect(text).not.toContain('https://neon.com/guides/llms.txt');
+    expect(text).not.toContain('https://neon.com/docs/changelog/llms.txt');
+    expect(config.unlinkedIndexes.map((index) => index.outputPath)).toEqual([
+      'public/guides/llms.txt',
+      'public/docs/changelog/llms.txt',
+    ]);
+  });
+});
+
+describe('generateUnlinkedIndexText', () => {
+  it('lists markdown urls without linking the parent docs index', () => {
+    const text = generateUnlinkedIndexText(
+      { title: 'Neon Changelog', intro: 'Latest updates and releases.' },
+      [
+        {
+          title: 'August 28',
+          url: 'https://neon.com/docs/changelog/2026-08-28.md',
+          subtitle: '',
+        },
+      ]
+    );
+    expect(text).toContain('# Neon Changelog');
+    expect(text).toContain('[August 28](https://neon.com/docs/changelog/2026-08-28.md)');
+    expect(text).not.toContain('https://neon.com/docs/llms.txt');
   });
 });

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -324,6 +324,26 @@ module.exports = {
     },
   ],
 
+  // Indexes written at build time that are not linked from public/docs/llms.txt.
+  // Site search ingest walks these URLs; the official docs catalog walk stays on the parent index.
+  unlinkedIndexes: [
+    {
+      route: 'guides',
+      publicPath: 'guides',
+      outputPath: 'public/guides/llms.txt',
+      title: 'Neon Community Guides',
+      intro:
+        'Step-by-step tutorials for frameworks, ORMs, auth providers, and deployment platforms.',
+    },
+    {
+      route: 'docs/changelog',
+      publicPath: 'docs/changelog',
+      outputPath: 'public/docs/changelog/llms.txt',
+      title: 'Neon Changelog',
+      intro: 'Latest updates and releases.',
+    },
+  ],
+
   // Configuration for llms-full.txt (single file with all doc content).
   // Uses shared excludePaths, EXCLUDED_DIRS, EXCLUDED_FILES from this config.
   // Section `collapse` settings are index-only and do not apply here.


### PR DESCRIPTION
## Problem

A site-search indexer needs a machine-readable catalog of every community guide and changelog page in `.md` form. The build already emits `public/docs/llms.txt` plus per-section sub-indexes, but two content sets never appear in anything it can walk: community guides live under `/guides`, outside the docs tree entirely, and the changelog is deliberately collapsed out of the docs index. An indexer starting at `https://neon.com/docs/llms.txt` cannot reach either.

Adding them to `public/docs/llms.txt` is the wrong fix. That file is the official docs catalog that agents and LLMs consume, and it excludes the changelog and guides on purpose. The new catalogs have to exist as standalone files that the parent index does not link.

## What the build emits now

`generate-llms-index.js` reads a new `unlinkedIndexes` list in `llms-index-config.js` and writes two extra files:

| File | Pages | URL prefix |
| --- | --- | --- |
| `public/guides/llms.txt` | 175 | `https://neon.com/guides/*.md` |
| `public/docs/changelog/llms.txt` | 263 | `https://neon.com/docs/changelog/*.md` |

Each is a flat list sorted by title, linking the `.md` version of every page, with the frontmatter subtitle as the description when one exists:

```
# Neon Community Guides

Step-by-step tutorials for frameworks, ORMs, auth providers, and deployment platforms.

- [Add feature flags in SvelteKit apps with Lakebase Postgres](https://neon.com/guides/feature-flags-sveltekit.md): A step-by-step guide to integrating feature flags in SvelteKit apps with Postgres
```

```
# Neon Changelog

Latest updates and releases.

- [10x-ing Projects on the Free Plan, drag-to-zoom monitoring graphs, and more](https://neon.com/docs/changelog/2024-10-11.md)
```

A catalog entry is declared in config; the generator resolves the route against `CONTENT_ROUTES` and fails the build if the route is unknown or scans zero pages:

```js
unlinkedIndexes: [
  {
    route: 'guides',
    publicPath: 'guides',
    outputPath: 'public/guides/llms.txt',
    title: 'Neon Community Guides',
    intro: 'Step-by-step tutorials for frameworks, ORMs, auth providers, and deployment platforms.',
  },
  // ...
],
```

`scanDirectory` gained an optional `urlPrefix` parameter so guide URLs come out as `https://neon.com/guides/<slug>.md` instead of the raw content path. Callers that omit it behave exactly as before, so the docs index and sub-indexes are unchanged.

`next.config.js` gets one `beforeFiles` rewrite for `/guides/llms.txt`. The `/guides` catch-all would otherwise intercept the static file. `/docs/changelog/llms.txt` is already covered by the existing `/docs/:path*/llms.txt` rewrite.

## Verification

- `npx vitest run src/scripts/generate-llms-index.test.js` passes (4 tests). New behaviours covered: an unlinked catalog renders title, intro and `.md` links without referencing the parent index; the parent index output contains neither `https://neon.com/guides/llms.txt` nor `https://neon.com/docs/changelog/llms.txt`; the configured output paths are pinned so a config edit that moves them fails the test.
- `node src/scripts/generate-llms-index.js --dry-run` on this branch reports `guides (unlinked): 175 files` and `docs/changelog (unlinked): 263 files`, every URL under the two prefixes above.
- The parent `llms.txt` in the same dry run links only `/docs/*` sub-indexes, unchanged from `main`.

Not verified: the `/guides/llms.txt` rewrite against a running production build. The pattern is an identity rewrite matching the existing `/docs/:path*/llms.txt` entries a few lines above it.

## For your attention

- The changelog stays collapsed in the official docs index; its catalog exists only at `/docs/changelog/llms.txt` for indexers that are given the URL directly. Anything that should discover these files needs the URLs handed to it.
- Docs-relative `excludePaths` do not apply to the guides scan. Filename exclusions (`README.md`, `GUIDE_TEMPLATE.md`) still do.