### PR TITLE
feat: reindex guides and changelog separately from official docs

### DIFF
--- a/.github/workflows/docs-reindex.yml
+++ b/.github/workflows/docs-reindex.yml
@@ -104,6 +104,14 @@ jobs:
                   `Not a neon.com markdown url: ${url} (expected https://neon.com/**.md with no port, userinfo, query, or hash)`,
                 );
               }
+              if (
+                parsed.pathname.startsWith('/guides/') ||
+                parsed.pathname.startsWith('/docs/changelog/')
+              ) {
+                throw new Error(
+                  `Guide and changelog URLs go to the Site reindex workflow: ${url}`,
+                );
+              }
             }
             const payload = JSON.stringify({
               pages: urls.map((url) => ({ url, deleted: false })),

--- a/.github/workflows/site-reindex.yml
+++ b/.github/workflows/site-reindex.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       urls:
-        description: Space-separated https://neon.com/guides/**.md or /docs/changelog/**.md URLs to reindex (upsert)
+        description: Space-separated https://neon.com/guides/**.md or https://neon.com/docs/changelog/**.md URLs to reindex (upsert)
         required: true
         type: string
 
@@ -49,7 +49,7 @@ jobs:
           sha="${{ github.sha }}"
           zeros='0000000000000000000000000000000000000000'
           if [ "${before}" = "${zeros}" ]; then
-            echo "github.event.before is the all-zeros SHA; refusing to guess the compare range. Use workflow_dispatch with the https://neon.com/**.md URLs instead."
+            echo "github.event.before is the all-zeros SHA; refusing to guess the compare range. Use workflow_dispatch with the https://neon.com/guides/**.md or https://neon.com/docs/changelog/**.md URLs to upsert. Dispatch cannot delete pages."
             exit 1
           fi
           gh api "repos/${GITHUB_REPOSITORY}/compare/${before}...${sha}" --jq '.files' \
@@ -85,7 +85,9 @@ jobs:
               try {
                 parsed = new URL(url);
               } catch {
-                throw new Error(`Not a neon.com markdown url: ${url}`);
+                throw new Error(
+                  `Not a guides or changelog markdown url: ${url} (expected https://neon.com/guides/**.md or https://neon.com/docs/changelog/**.md with no port, userinfo, query, or hash)`,
+                );
               }
               if (
                 parsed.protocol !== 'https:' ||
@@ -101,7 +103,9 @@ jobs:
                   parsed.pathname.startsWith('/docs/changelog/')
                 )
               ) {
-                throw new Error(`Not a guides or changelog markdown url: ${url}`);
+                throw new Error(
+                  `Not a guides or changelog markdown url: ${url} (expected https://neon.com/guides/**.md or https://neon.com/docs/changelog/**.md with no port, userinfo, query, or hash)`,
+                );
               }
             }
             const payload = JSON.stringify({

--- a/.github/workflows/site-reindex.yml
+++ b/.github/workflows/site-reindex.yml
@@ -140,24 +140,36 @@ jobs:
           fi
           node <<'NODE'
           const { createHmac } = require('node:crypto');
-          const body = process.env.PAYLOAD;
-          const signature = `sha256=${createHmac('sha256', process.env.NEON_AGENT_DOCS_REINDEX_SECRET)
-            .update(body)
-            .digest('hex')}`;
+          const { chunkReindexPages } = require('./src/scripts/site-reindex-map.js');
+          const parsed = JSON.parse(process.env.PAYLOAD);
+          if (!parsed || !Array.isArray(parsed.pages)) {
+            throw new Error('payload must be {"pages":[...]}');
+          }
           (async () => {
-            const response = await fetch(process.env.NEON_AGENT_SITE_REINDEX_URL, {
-              method: 'POST',
-              headers: {
-                'content-type': 'application/json',
-                'x-site-reindex-signature': signature,
-              },
-              body,
-            });
-            await response.arrayBuffer();
-            if (response.status !== 202) {
-              throw new Error(`site reindex returned ${response.status}`);
+            const chunks = chunkReindexPages(parsed.pages);
+            for (const [index, pages] of chunks.entries()) {
+              const body = JSON.stringify({ pages });
+              const signature = `sha256=${createHmac('sha256', process.env.NEON_AGENT_DOCS_REINDEX_SECRET)
+                .update(body)
+                .digest('hex')}`;
+              const response = await fetch(process.env.NEON_AGENT_SITE_REINDEX_URL, {
+                method: 'POST',
+                headers: {
+                  'content-type': 'application/json',
+                  'x-site-reindex-signature': signature,
+                },
+                body,
+              });
+              await response.arrayBuffer();
+              if (response.status !== 202) {
+                throw new Error(
+                  `site reindex chunk ${index + 1}/${chunks.length} returned ${response.status}`,
+                );
+              }
+              console.log(
+                `site reindex chunk ${index + 1}/${chunks.length} returned ${response.status}`,
+              );
             }
-            console.log(`site reindex returned ${response.status}`);
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);
             process.exit(1);

--- a/.github/workflows/site-reindex.yml
+++ b/.github/workflows/site-reindex.yml
@@ -1,17 +1,16 @@
-name: Docs reindex
+name: Site reindex
 
 on:
   push:
     branches:
       - main
     paths:
-      # Official docs catalog. Guides and changelog are site-reindex.yml.
-      - 'content/docs/**'
-      - 'content/branching/**'
+      - 'content/guides/**'
+      - 'content/changelog/**'
   workflow_dispatch:
     inputs:
       urls:
-        description: Space-separated https://neon.com/**.md URLs to reindex (upsert)
+        description: Space-separated https://neon.com/guides/**.md or /docs/changelog/**.md URLs to reindex (upsert)
         required: true
         type: string
 
@@ -20,7 +19,7 @@ permissions:
 
 jobs:
   reindex:
-    name: 'Reindex changed docs pages'
+    name: 'Reindex changed guides and changelog pages'
     runs-on:
       group: neondatabase-protected-runner-group
       labels: linux-ubuntu-latest
@@ -54,8 +53,8 @@ jobs:
             exit 1
           fi
           gh api "repos/${GITHUB_REPOSITORY}/compare/${before}...${sha}" --jq '.files' \
-            > /tmp/docs-reindex-files.json
-          payload="$(node src/scripts/docs-reindex-map.js < /tmp/docs-reindex-files.json)"
+            > /tmp/site-reindex-files.json
+          payload="$(node src/scripts/site-reindex-map.js < /tmp/site-reindex-files.json)"
           if [ -z "${payload}" ]; then
             echo "payload=" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -78,7 +77,7 @@ jobs:
             const urls = process.env.URLS.trim().split(/\s+/).filter(Boolean);
             if (urls.length === 0) {
               throw new Error(
-                'workflow_dispatch requires at least one https://neon.com/**.md URL with no port, userinfo, query, or hash',
+                'workflow_dispatch requires at least one https://neon.com/guides/**.md or https://neon.com/docs/changelog/**.md URL',
               );
             }
             for (const url of urls) {
@@ -86,9 +85,7 @@ jobs:
               try {
                 parsed = new URL(url);
               } catch {
-                throw new Error(
-                  `Not a neon.com markdown url: ${url} (expected https://neon.com/**.md with no port, userinfo, query, or hash)`,
-                );
+                throw new Error(`Not a neon.com markdown url: ${url}`);
               }
               if (
                 parsed.protocol !== 'https:' ||
@@ -98,11 +95,13 @@ jobs:
                 parsed.password !== '' ||
                 parsed.search !== '' ||
                 parsed.hash !== '' ||
-                !parsed.pathname.endsWith('.md')
+                !parsed.pathname.endsWith('.md') ||
+                !(
+                  parsed.pathname.startsWith('/guides/') ||
+                  parsed.pathname.startsWith('/docs/changelog/')
+                )
               ) {
-                throw new Error(
-                  `Not a neon.com markdown url: ${url} (expected https://neon.com/**.md with no port, userinfo, query, or hash)`,
-                );
+                throw new Error(`Not a guides or changelog markdown url: ${url}`);
               }
             }
             const payload = JSON.stringify({
@@ -111,7 +110,7 @@ jobs:
             if (process.env.GITHUB_STEP_SUMMARY) {
               await fs.promises.appendFile(
                 process.env.GITHUB_STEP_SUMMARY,
-                `## Docs reindex map\n\nQueued **${urls.length}** page(s) for reindex.\n`,
+                `## Site reindex map\n\nQueued **${urls.length}** page(s) for reindex.\n`,
               );
             }
             await fs.promises.appendFile(
@@ -129,14 +128,14 @@ jobs:
       - name: POST reindex
         if: steps.map.outputs.payload != '' || steps.dispatch.outputs.payload != ''
         env:
-          NEON_AGENT_DOCS_REINDEX_URL: ${{ secrets.NEON_AGENT_DOCS_REINDEX_URL }}
+          NEON_AGENT_SITE_REINDEX_URL: ${{ secrets.NEON_AGENT_SITE_REINDEX_URL }}
           NEON_AGENT_DOCS_REINDEX_SECRET: ${{ secrets.NEON_AGENT_DOCS_REINDEX_SECRET }}
           PAYLOAD: ${{ steps.map.outputs.payload || steps.dispatch.outputs.payload }}
         shell: bash
         run: |
           set -o pipefail
-          if [ -z "${NEON_AGENT_DOCS_REINDEX_URL}" ] || [ -z "${NEON_AGENT_DOCS_REINDEX_SECRET}" ]; then
-            echo "NEON_AGENT_DOCS_REINDEX_URL and NEON_AGENT_DOCS_REINDEX_SECRET must be set"
+          if [ -z "${NEON_AGENT_SITE_REINDEX_URL}" ] || [ -z "${NEON_AGENT_DOCS_REINDEX_SECRET}" ]; then
+            echo "NEON_AGENT_SITE_REINDEX_URL and NEON_AGENT_DOCS_REINDEX_SECRET must be set"
             exit 1
           fi
           node <<'NODE'
@@ -146,19 +145,19 @@ jobs:
             .update(body)
             .digest('hex')}`;
           (async () => {
-            const response = await fetch(process.env.NEON_AGENT_DOCS_REINDEX_URL, {
+            const response = await fetch(process.env.NEON_AGENT_SITE_REINDEX_URL, {
               method: 'POST',
               headers: {
                 'content-type': 'application/json',
-                'x-docs-reindex-signature': signature,
+                'x-site-reindex-signature': signature,
               },
               body,
             });
             await response.arrayBuffer();
             if (response.status !== 202) {
-              throw new Error(`docs reindex returned ${response.status}`);
+              throw new Error(`site reindex returned ${response.status}`);
             }
-            console.log(`docs reindex returned ${response.status}`);
+            console.log(`site reindex returned ${response.status}`);
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);
             process.exit(1);

--- a/src/scripts/site-reindex-map.js
+++ b/src/scripts/site-reindex-map.js
@@ -1,0 +1,183 @@
+const path = require('path');
+
+const { EXCLUDED_DIRS } = require('../constants/content');
+
+const BASE_URL = 'https://neon.com';
+const EXCLUDED_FILES = ['README.md', 'index.md', '_index.md', 'GUIDE_TEMPLATE.md'];
+
+const SITE_ROUTES = [
+  { srcPath: 'content/guides', urlPrefix: 'guides' },
+  { srcPath: 'content/changelog', urlPrefix: 'docs/changelog' },
+].sort((a, b) => b.srcPath.length - a.srcPath.length);
+
+function posix(file) {
+  return file.split(path.sep).join('/');
+}
+
+function isMarkdown(file) {
+  return file.endsWith('.md');
+}
+
+function hasExcludedDir(file) {
+  return posix(file)
+    .split('/')
+    .some((segment) => EXCLUDED_DIRS.includes(segment));
+}
+
+function matchSiteRoute(file) {
+  const normalized = posix(file);
+  for (const route of SITE_ROUTES) {
+    const prefix = `${route.srcPath}/`;
+    if (normalized === route.srcPath || normalized.startsWith(prefix)) {
+      return {
+        ...route,
+        relPath: path.posix.relative(route.srcPath, normalized),
+      };
+    }
+  }
+  return undefined;
+}
+
+function catalogUrl(file) {
+  const matched = matchSiteRoute(file);
+  if (!matched) {
+    return undefined;
+  }
+  return `${BASE_URL}/${matched.urlPrefix}/${matched.relPath}`;
+}
+
+function classify(file) {
+  const normalized = posix(file);
+  if (!isMarkdown(normalized)) {
+    return { kind: 'notMarkdown' };
+  }
+  if (hasExcludedDir(normalized)) {
+    return { kind: 'sharedContent' };
+  }
+  const basename = path.posix.basename(normalized);
+  if (EXCLUDED_FILES.includes(basename)) {
+    return { kind: 'excluded' };
+  }
+  const url = catalogUrl(normalized);
+  if (!url) {
+    return { kind: 'notSite' };
+  }
+  return { kind: 'catalog', url };
+}
+
+function addPage(pages, url, deleted) {
+  pages.set(url, { url, deleted });
+}
+
+function bump(skipped, kind) {
+  skipped[kind] += 1;
+}
+
+/**
+ * @param {Array<{ filename: string, status: string, previous_filename?: string }>} files
+ */
+function mapCompareFiles(files) {
+  const pages = new Map();
+  const skipped = {
+    sharedContent: 0,
+    excluded: 0,
+    notSite: 0,
+    notMarkdown: 0,
+  };
+
+  for (const file of files) {
+    const status = file.status;
+    if (status === 'renamed' && file.previous_filename) {
+      const previous = classify(file.previous_filename);
+      if (previous.kind === 'catalog') {
+        addPage(pages, previous.url, true);
+      } else {
+        bump(skipped, previous.kind);
+      }
+    }
+
+    const current = classify(file.filename);
+    if (current.kind !== 'catalog') {
+      bump(skipped, current.kind);
+      continue;
+    }
+    if (status === 'removed') {
+      addPage(pages, current.url, true);
+      continue;
+    }
+    if (
+      status === 'added' ||
+      status === 'modified' ||
+      status === 'changed' ||
+      status === 'copied' ||
+      status === 'renamed'
+    ) {
+      addPage(pages, current.url, false);
+    }
+  }
+
+  return {
+    pages: [...pages.values()],
+    skipped,
+  };
+}
+
+function skippedSummary(skipped) {
+  const parts = [];
+  if (skipped.sharedContent) {
+    parts.push(`${skipped.sharedContent} shared-content`);
+  }
+  if (skipped.excluded) {
+    parts.push(`${skipped.excluded} excluded`);
+  }
+  if (skipped.notSite) {
+    parts.push(`${skipped.notSite} not site`);
+  }
+  if (skipped.notMarkdown) {
+    parts.push(`${skipped.notMarkdown} not markdown`);
+  }
+  return parts.join(', ');
+}
+
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  const files = raw === '' ? [] : JSON.parse(raw);
+  if (!Array.isArray(files)) {
+    throw new Error('site-reindex-map expected a JSON array of GitHub compare files');
+  }
+  const result = mapCompareFiles(files);
+  const summary = skippedSummary(result.skipped);
+  if (summary) {
+    process.stderr.write(`skipped: ${summary}\n`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFile } = require('fs').promises;
+    const lines = ['## Site reindex map', '', `Mapped **${result.pages.length}** site page(s).`];
+    if (summary) {
+      lines.push(`Skipped: ${summary}.`);
+    }
+    lines.push('');
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+  }
+  if (result.pages.length === 0) {
+    process.exit(0);
+  }
+  process.stdout.write(`${JSON.stringify({ pages: result.pages })}\n`);
+}
+
+module.exports = {
+  mapCompareFiles,
+  classify,
+  skippedSummary,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/src/scripts/site-reindex-map.js
+++ b/src/scripts/site-reindex-map.js
@@ -4,6 +4,7 @@ const { EXCLUDED_DIRS } = require('../constants/content');
 
 const BASE_URL = 'https://neon.com';
 const EXCLUDED_FILES = ['README.md', 'index.md', '_index.md', 'GUIDE_TEMPLATE.md'];
+const SITE_REINDEX_MAX_PAGES = 200;
 
 const SITE_ROUTES = [
   { srcPath: 'content/guides', urlPrefix: 'guides' },
@@ -122,6 +123,17 @@ function mapCompareFiles(files) {
   };
 }
 
+function chunkReindexPages(pages, size = SITE_REINDEX_MAX_PAGES) {
+  if (!Number.isInteger(size) || size < 1) {
+    throw new Error('chunk size must be a positive integer');
+  }
+  const chunks = [];
+  for (let i = 0; i < pages.length; i += size) {
+    chunks.push(pages.slice(i, i + size));
+  }
+  return chunks;
+}
+
 function skippedSummary(skipped) {
   const parts = [];
   if (skipped.sharedContent) {
@@ -173,6 +185,8 @@ module.exports = {
   mapCompareFiles,
   classify,
   skippedSummary,
+  chunkReindexPages,
+  SITE_REINDEX_MAX_PAGES,
 };
 
 if (require.main === module) {

--- a/src/scripts/site-reindex-map.test.js
+++ b/src/scripts/site-reindex-map.test.js
@@ -3,7 +3,11 @@ import { createRequire } from 'module';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { mapCompareFiles } = require('./site-reindex-map.js');
+const {
+  chunkReindexPages,
+  mapCompareFiles,
+  SITE_REINDEX_MAX_PAGES,
+} = require('./site-reindex-map.js');
 
 describe('mapCompareFiles', () => {
   it('maps a community guide and a changelog entry', () => {
@@ -61,6 +65,27 @@ describe('mapCompareFiles', () => {
     expect(result.pages).toEqual([
       { url: 'https://neon.com/guides/old-name.md', deleted: true },
       { url: 'https://neon.com/guides/new-name.md', deleted: false },
+    ]);
+  });
+});
+
+describe('chunkReindexPages', () => {
+  it('keeps a full 200-page payload as one chunk', () => {
+    const pages = Array.from({ length: SITE_REINDEX_MAX_PAGES }, (_, i) => ({
+      url: `https://neon.com/guides/${i}.md`,
+      deleted: false,
+    }));
+    expect(chunkReindexPages(pages).map((chunk) => chunk.length)).toEqual([SITE_REINDEX_MAX_PAGES]);
+  });
+
+  it('splits 201 pages into 200 and 1', () => {
+    const pages = Array.from({ length: SITE_REINDEX_MAX_PAGES + 1 }, (_, i) => ({
+      url: `https://neon.com/guides/${i}.md`,
+      deleted: false,
+    }));
+    expect(chunkReindexPages(pages).map((chunk) => chunk.length)).toEqual([
+      SITE_REINDEX_MAX_PAGES,
+      1,
     ]);
   });
 });

--- a/src/scripts/site-reindex-map.test.js
+++ b/src/scripts/site-reindex-map.test.js
@@ -1,0 +1,66 @@
+import { createRequire } from 'module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { mapCompareFiles } = require('./site-reindex-map.js');
+
+describe('mapCompareFiles', () => {
+  it('maps a community guide and a changelog entry', () => {
+    expect(
+      mapCompareFiles([
+        { filename: 'content/guides/drizzle.md', status: 'added' },
+        { filename: 'content/changelog/2026-08-28.md', status: 'modified' },
+      ])
+    ).toEqual({
+      pages: [
+        { url: 'https://neon.com/guides/drizzle.md', deleted: false },
+        { url: 'https://neon.com/docs/changelog/2026-08-28.md', deleted: false },
+      ],
+      skipped: {
+        sharedContent: 0,
+        excluded: 0,
+        notSite: 0,
+        notMarkdown: 0,
+      },
+    });
+  });
+
+  it('skips official docs pages', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/docs/introduction/branching.md', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.skipped.notSite).toBe(1);
+  });
+
+  it('skips GUIDE_TEMPLATE and README', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/guides/GUIDE_TEMPLATE.md', status: 'modified' },
+      { filename: 'content/guides/README.md', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.skipped.excluded).toBe(2);
+  });
+
+  it('maps a delete', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/guides/old-guide.md', status: 'removed' },
+    ]);
+    expect(result.pages).toEqual([{ url: 'https://neon.com/guides/old-guide.md', deleted: true }]);
+  });
+
+  it('maps a rename as delete old plus upsert new', () => {
+    const result = mapCompareFiles([
+      {
+        filename: 'content/guides/new-name.md',
+        status: 'renamed',
+        previous_filename: 'content/guides/old-name.md',
+      },
+    ]);
+    expect(result.pages).toEqual([
+      { url: 'https://neon.com/guides/old-name.md', deleted: true },
+      { url: 'https://neon.com/guides/new-name.md', deleted: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

When a guide or changelog page lands on `main`, nothing reindexes it in the Neon assistant search index. Official docs already have this: `docs-reindex.yml` maps changed files to `https://neon.com/**.md` URLs and POSTs them to the reindex endpoint. Guides (`content/guides/**`) and changelog entries (`content/changelog/**`) fall outside the routes that workflow's mapper knows about, so an edited guide either goes stale in the index or has to be reindexed by hand.

The two catalogs also can't share one workflow. Guides and changelog pages index against a different endpoint than official docs, and `docs-reindex.yml` triggered on `content/**`, so every guide edit fired a docs run that had nothing to do.

## Solution

A new `site-reindex.yml` workflow, shaped like `docs-reindex.yml`, owns guides and changelog. `docs-reindex.yml` keeps owning official docs and its path glob narrows from `content/**` to `content/docs/**` and `content/branching/**`, so a guide edit no longer fires the docs job.

On push to `main` touching `content/guides/**` or `content/changelog/**`, the workflow fetches the GitHub compare between `github.event.before` and `github.sha`, maps each changed file to its public URL and POSTs an HMAC-signed `{ pages: [{ url, deleted }] }` payload to the endpoint in the `NEON_AGENT_SITE_REINDEX_URL` repo secret, signed with `NEON_AGENT_DOCS_REINDEX_SECRET` in an `x-site-reindex-signature` header. Anything other than a 202 fails the job.

The mapping lives in `src/scripts/site-reindex-map.js` (stdin: the compare's `files` array, stdout: the payload) so it's unit-testable outside the workflow:

- `content/guides/drizzle.md` becomes `https://neon.com/guides/drizzle.md`
- `content/changelog/2026-08-28.md` becomes `https://neon.com/docs/changelog/2026-08-28.md` (the changelog source folder and its public path differ)
- `removed` maps to `deleted: true`; `renamed` maps to a delete of the old URL plus an upsert of the new one
- `README.md`, `index.md`, `_index.md`, `GUIDE_TEMPLATE.md` and anything under `shared-content/` or `unused/` are skipped, with skip counts on stderr and in the step summary

Payloads over 200 pages go out as successive 200-page chunks, each signed and POSTed separately, so a bulk content move can't produce an oversized request.

## workflow_dispatch

Manual reindex takes full URLs, space-separated:

```
https://neon.com/guides/drizzle.md https://neon.com/docs/changelog/2026-08-28.md
```

Each URL must be `https://neon.com/guides/**.md` or `https://neon.com/docs/changelog/**.md` with no port, userinfo, query or hash; anything else fails with the expected shape in the error. Dispatch is upsert-only: every page goes out as `deleted: false`.

The two dispatch paths reject each other's URLs. `docs-reindex.yml` now throws on `/guides/` and `/docs/changelog/` paths (`Guide and changelog URLs go to the Site reindex workflow`), so a guide URL can't be posted to the docs endpoint by hand.

## All-zeros before SHA

When `github.event.before` is the all-zeros SHA there is no compare range, so the push job fails with instructions instead of guessing. Recovery is a dispatch with the affected URLs. Since dispatch only upserts, a deletion inside that unresolvable range stays in the index; see below.

## Also in here

- A comment in `docs-reindex.yml`'s path filter naming the split, so the narrowed glob reads as intent rather than an accident.

## Verification

`npx vitest run src/scripts/site-reindex-map.test.js`: 7 tests pass.

- a guide and a changelog file map to their public URLs, changelog under `/docs/changelog/`
- an official docs file is skipped as not-site
- `GUIDE_TEMPLATE.md` and `README.md` are skipped as excluded
- a removed file maps to `deleted: true`
- a rename maps to delete-old plus upsert-new
- 200 pages stay one chunk, 201 pages split into 200 and 1

Not verified end to end: no push to `main` or dispatch has run this workflow against the live endpoint. The POST step fails loudly when either the URL or the secret env is empty, so a misconfigured repo shows up as a red run rather than a silent skip.

## For your attention

- **Deletions are lost when `before` is all zeros.** The push job refuses to guess the range and the dispatch fallback can't send `deleted: true`, so a page removed in that push lingers in the index until something else removes it. Adding delete support to dispatch would also make it a hand-typed deletion tool, which is the riskier trade.
- **Both workflows sign with the same secret**, `NEON_AGENT_DOCS_REINDEX_SECRET`. Separate secrets per endpoint would let them rotate independently.
- **The site mapper is a sibling of `docs-reindex-map.js`, not a refactor of it.** The docs mapper carries route collapsing and llms-index config the site catalog doesn't need; the shared shape is small enough that duplicating it beat threading a config through both.
