### PR TITLE
docs: exclude agent frameworks guide from blog index

### DIFF
--- a/content/guides/best-agent-frameworks-2026.md
+++ b/content/guides/best-agent-frameworks-2026.md
@@ -2,6 +2,7 @@
 title: 'The best AI agent frameworks in 2026, compared'
 subtitle: 'A database-first ranking of the top AI agent frameworks in 2026, covering where Mastra, LangGraph, CrewAI, the OpenAI Agents SDK, and Pydantic AI store agent memory and durable state on Postgres.'
 author: rishi-raj-jain
+excludeFromBlog: true
 enableTableOfContents: true
 createdAt: '2026-09-01T00:00:00.000Z'
 ---


### PR DESCRIPTION
Adds `excludeFromBlog: true` to `content/guides/best-agent-frameworks-2026.md` so it no longer appears on the blog index.

This pull request and its description were written by Isaac.