### PR TITLE
Unpublish token economics blog post

### DIFF
--- a/content/blog/posts/comparing-token-economics-across-42-ai-models.md
+++ b/content/blog/posts/comparing-token-economics-across-42-ai-models.md
@@ -20,13 +20,14 @@ cover:
     https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/cover.jpg
   alt: null
 isFeatured: false
+draft: true
 seo:
   title: Comparing token economics across 42 AI models - Neon
   description: >-
     We ran the same workload through all models listed in Neon AI Gateway and
     compared total costs, accuracy, and time to completion
   keywords: []
-  noindex: false
+  noindex: true
   ogTitle: Comparing token economics across 42 AI models - Neon
   ogDescription: >-
     We ran the same workload through all models listed in Neon AI Gateway and


### PR DESCRIPTION

- Marks [Comparing token economics across 42 AI models](https://neon.com/blog/comparing-token-economics-across-42-ai-models) as `draft: true` so production hides the post (index, sitemap, and permalink).
