### PR TITLE
Adjust token economics blog images

### DIFF
--- a/content/blog/posts/comparing-token-economics-across-42-ai-models.md
+++ b/content/blog/posts/comparing-token-economics-across-42-ai-models.md
@@ -65,7 +65,7 @@ At the end of the test, to get back to our tokenomics question, we estimated how
 
 **For 50 engineers, there'd be a $18k/month difference** between the cheap model and the expensive one. That's $188k per month if there were 500 engineers, or a **86× price gap** from model choice alone (and we're not even picking the extremes).
 
-<img src="https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/figure-2.jpg" alt="Monthly cost comparison between Llama 3.1 8B Instruct and Claude Fable 5" width="640" className="mx-auto" />
+<img src="https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/figure-2.jpg" alt="Monthly cost comparison between Llama 3.1 8B Instruct and Claude Fable 5" width="420" className="mx-auto" />
 
 Of course, these are results for one workload, not general model rankings, and this was a small experiment run in messy real-world conditions, not a lab. Still, it shows why tokenomics will matter a lot as agents become part of how companies get work done.
 

--- a/content/blog/posts/comparing-token-economics-across-42-ai-models.md
+++ b/content/blog/posts/comparing-token-economics-across-42-ai-models.md
@@ -36,6 +36,8 @@ seo:
     https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/social.jpg
 ---
 
+![Comparing token economics across 42 AI models](https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/cover.jpg)
+
 If headcount is a company's largest cost, tokens will soon be a close second as agents take on more work. Token economics (tokenomics?) will be a very important thing - imagine how much $$ a software company will be able to save just by pre-selecting models that are efficient to run, especially in large companies with many engineers using coding agents.
 
 To beyond just imagination, we actually ran a small experiment: we wrote a synthetic workload (responding to 100 support tickets) and asked the LLMs to execute it, all through 42 models listed in [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview). We then took a look at the final costs, how usable was the output in each model, and how much time it required each LLM to finish.
@@ -63,7 +65,7 @@ At the end of the test, to get back to our tokenomics question, we estimated how
 
 **For 50 engineers, there'd be a $18k/month difference** between the cheap model and the expensive one. That's $188k per month if there were 500 engineers, or a **86× price gap** from model choice alone (and we're not even picking the extremes).
 
-![Monthly cost comparison between Llama 3.1 8B Instruct and Claude Fable 5](https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/figure-2.jpg)
+<img src="https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/figure-2.jpg" alt="Monthly cost comparison between Llama 3.1 8B Instruct and Claude Fable 5" width="640" className="mx-auto" />
 
 Of course, these are results for one workload, not general model rankings, and this was a small experiment run in messy real-world conditions, not a lab. Still, it shows why tokenomics will matter a lot as agents become part of how companies get work done.
 


### PR DESCRIPTION
## Summary
- Add the cover image at the top of the blog post body
- Reduce the monthly cost comparison image to a centered 640 px width

## Preview
https://neon.com/blog-preview/comparing-token-economics-across-42-ai-models?branch=blog/token-economics-image-layout

## Test plan
- [ ] Confirm the cover image appears before the opening paragraph
- [ ] Confirm the monthly cost comparison image is smaller and centered
- [ ] Confirm both images remain responsive on mobile