### PR TITLE
Remove the "Watch: Git for databases" docs modal

### DIFF
--- a/src/components/pages/doc/modal/data.js
+++ b/src/components/pages/doc/modal/data.js
@@ -41,19 +41,6 @@
 /** @type {VideoModalConfig[]} */
 const MODALS = [
   {
-    id: 'branching-video',
-    embedId: 'UuHnFlg66Io',
-    title: 'Watch: Git for databases',
-    description: 'See how Neon branching works in practice.',
-    targeting: {
-      all: true,
-    },
-    destination: {
-      label: 'Watch the video',
-      url: '/docs/introduction/branching',
-    },
-  },
-  {
     id: 'serverless-video',
     embedId: 'llSTZMVrbx8',
     title: 'Watch: Neon Database',


### PR DESCRIPTION
Removes the `branching-video` entry from the docs modal config in `src/components/pages/doc/modal/data.js`.

It was the only modal configured with `targeting: { all: true }`, so it rendered as a fallback popup on every docs page (except `/docs/introduction/branching`, its own destination).

The two remaining modals are page-targeted and unchanged:

- `serverless-video` on `/docs/introduction/serverless`
- `autoscaling-video` on `/docs/introduction/autoscaling`

No component changes needed: `selectModal` returns `null` when nothing matches, and `post.jsx` already guards with `{modal && <Modal ... />}`.

This pull request and its description were written by Isaac.