### PR TITLE
Add token economics projection figure

### DIFF
--- a/content/blog/posts/comparing-token-economics-across-42-ai-models.md
+++ b/content/blog/posts/comparing-token-economics-across-42-ai-models.md
@@ -251,7 +251,7 @@ So to amuse us,
 
 At published AI gateway rates, this would come up to:
 
-**[ADD FIGURE 9]**
+![Estimated model cost differences for 100-person and 1,000-person software companies](https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/figure-9.jpg)
 
 Under these assumptions, model selection would change inference spend by roughly 86×. Of course, this would not mean that Llama is the right coding model for either company - all kinds of metrics have to be evaluated and tested, including the other parameters we mentioned in this experiment (time to completion, pass rate) plus overall output quality. But this is a good sample to indicate the huge impact optimization in token cost can have in companies today.
 


### PR DESCRIPTION
## Summary
- Replaces the remaining \`**[ADD FIGURE 9]**\` placeholder with the CDN projection figure from @americano98's work in #5752.
- Opens against current \`main\`, so it keeps \`draft: true\` / \`noindex: true\` and the cover + smaller figure-2 layout from #5750.

#5752 targeted the older \`blog/comparing-token-economics-across-42-ai-models\` branch and would have missed those updates.

## Preview
https://neon.com/blog-preview/comparing-token-economics-across-42-ai-models?branch=blog/token-economics-figure-9

## Test plan
- [ ] Figure 9 renders in the projections section
- [ ] Post stays unpublished (\`draft: true\`)
- [ ] Cover image and smaller figure 2 are unchanged