### PR TITLE
Publish token economics blog post

### DIFF
--- a/content/blog/posts/comparing-token-economics-across-42-ai-models.md
+++ b/content/blog/posts/comparing-token-economics-across-42-ai-models.md
@@ -20,14 +20,14 @@ cover:
     https://cdn.neonapi.io/public/images/pages/blog/comparing-token-economics-across-42-ai-models/cover.jpg
   alt: null
 isFeatured: false
-draft: true
+draft: false
 seo:
   title: Comparing token economics across 42 AI models - Neon
   description: >-
     We ran the same workload through all models listed in Neon AI Gateway and
     compared total costs, accuracy, and time to completion
   keywords: []
-  noindex: true
+  noindex: false
   ogTitle: Comparing token economics across 42 AI models - Neon
   ogDescription: >-
     We ran the same workload through all models listed in Neon AI Gateway and


### PR DESCRIPTION
## Summary
- Sets \`draft: false\` and \`seo.noindex: false\` so the post is public on neon.com/blog.

## Test plan
- [ ] https://neon.com/blog/comparing-token-economics-across-42-ai-models loads after deploy
- [ ] Post appears on https://neon.com/blog