### PR TITLE
docs: add context windows and Fable 5.1 pdf input for the new models

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -85,13 +85,15 @@
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
         "limit": {
+          "context": 1000000,
           "output": 128000
         },
         "cost": {
@@ -1997,6 +1999,7 @@
           ]
         },
         "limit": {
+          "context": 1048576,
           "output": 131072
         },
         "cost": {
@@ -2141,6 +2144,7 @@
           ]
         },
         "limit": {
+          "context": 500000,
           "output": 524288
         }
       }


### PR DESCRIPTION
## Overview

Adds the context window for claude-fable-5-1 (1M), glm-5-3-flash (1,048,576), and
grok-4-6 (500K), and pdf input support for claude-fable-5-1. Values verified against
the gateway and the Databricks supported-models documentation.

As a followup to https://github.com/neondatabase/website/pull/5749

This pull request and its description were written by Isaac.
