### PR TITLE
Fix models.json metadata for Claude Fable 5.1, GLM-5.3 Flash, and Grok 4.6

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -78,7 +78,7 @@
         ],
         "tool_call": true,
         "temperature": false,
-        "structured_output": true,
+        "structured_output": false,
         "open_weights": false,
         "release_date": "2026-09-01",
         "last_updated": "2026-09-01",
@@ -1975,6 +1975,7 @@
           {
             "type": "effort",
             "values": [
+              "minimal",
               "low",
               "medium",
               "high",
@@ -2121,6 +2122,7 @@
             "type": "effort",
             "values": [
               "none",
+              "minimal",
               "low",
               "medium",
               "high",

--- a/src/components/pages/doc/ai-gateway-model-index/model-rows.js
+++ b/src/components/pages/doc/ai-gateway-model-index/model-rows.js
@@ -18,6 +18,7 @@ const PROVIDER_ORDER = [
   'zhipuai',
   'thinkingmachines',
   'moonshotai',
+  'xai',
 ];
 
 const PROVIDER_LABELS = {
@@ -29,6 +30,7 @@ const PROVIDER_LABELS = {
   zhipuai: 'Zhipu AI',
   thinkingmachines: 'Thinking Machines',
   moonshotai: 'Moonshot AI',
+  xai: 'xAI',
 };
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];

--- a/src/components/pages/doc/ai-gateway-model-index/model-rows.test.js
+++ b/src/components/pages/doc/ai-gateway-model-index/model-rows.test.js
@@ -34,4 +34,12 @@ describe('AI Gateway model rows', () => {
     expect(row.isImageCapable).toBe(false);
     expect(row.endpoints).toEqual([]);
   });
+
+  it('labels Grok as xAI and includes the Responses endpoint', () => {
+    const row = rows.find(({ id }) => id === 'grok-4-6');
+
+    expect(row.provider).toBe('xai');
+    expect(row.providerName).toBe('xAI');
+    expect(row.endpoints).toEqual(['chat/completions', 'openai/responses']);
+  });
 });

--- a/src/scripts/check-models-sync.mjs
+++ b/src/scripts/check-models-sync.mjs
@@ -36,7 +36,7 @@ const LOCAL_DATA_PATH = path.resolve(DIRNAME, '../app/models.json/data.json');
 
 const UPSTREAM_PR_HINT =
   'Open a PR on anomalyco/models.dev updating providers/neon/ to match. See the ' +
-  '`neon-ai-gateway-model-changes` skill for the entry format.';
+  '`add-model-to-ai-gateway` skill for the entry format.';
 
 async function fetchJson(url) {
   const res = await fetch(url, { headers: { accept: 'application/json' } });

--- a/src/scripts/import-models-from-models-dev.mjs
+++ b/src/scripts/import-models-from-models-dev.mjs
@@ -83,6 +83,7 @@ const PROVIDER_ORDER = [
   'zhipuai',
   'thinkingmachines',
   'moonshotai',
+  'xai',
 ];
 
 // The organisation that made the model, matching models.dev provider ids — not
@@ -105,9 +106,11 @@ function providerFor(model) {
                 ? 'zhipuai'
                 : s.startsWith('kimi')
                   ? 'moonshotai'
-                  : s === 'ling' || s.startsWith('inkling')
-                    ? 'thinkingmachines'
-                    : undefined;
+                  : s.startsWith('grok')
+                    ? 'xai'
+                    : s === 'ling' || s.startsWith('inkling')
+                      ? 'thinkingmachines'
+                      : undefined;
   const family = typeof model.family === 'string' ? model.family : '';
   const id = typeof model.id === 'string' ? model.id : '';
   return match(family) || match(id) || (id.includes('llama') ? 'meta' : undefined);

--- a/src/scripts/import-models-from-models-dev.test.js
+++ b/src/scripts/import-models-from-models-dev.test.js
@@ -1,0 +1,41 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import catalog from '../app/models.json/data.json';
+
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(DIRNAME, 'import-models-from-models-dev.mjs');
+const temps = [];
+
+afterEach(() => {
+  for (const file of temps.splice(0)) fs.rmSync(file, { force: true });
+});
+
+describe('import-models-from-models-dev', () => {
+  // The committed catalog already has provider: xai. That does not prove
+  // providerFor() maps grok; deleting the prefix rule still leaves data.json
+  // and model-rows.test.js green.
+  it('assigns grok ids to xai even when the upstream entry names another maker', () => {
+    const from = path.join(os.tmpdir(), `import-grok-${process.pid}.json`);
+    temps.push(from);
+    const grok = catalog.neon.models['grok-4-6'];
+    fs.writeFileSync(
+      from,
+      JSON.stringify({
+        neon: { models: { 'grok-4-6': { ...grok, provider: 'wrong-upstream-host' } } },
+      })
+    );
+
+    const stdout = execFileSync(process.execPath, [SCRIPT, '--from', from, '--models', 'grok-4-6', '--stdout'], {
+      encoding: 'utf8',
+    });
+    const merged = JSON.parse(stdout);
+
+    expect(merged.neon.models['grok-4-6'].provider).toBe('xai');
+  });
+});


### PR DESCRIPTION
## Problem

`neon.com/models.json` is the source of truth for the AI Gateway catalog, and three entries disagreed with what the gateway actually does:

- **Claude Fable 5.1** claimed `structured_output: true`. The gateway rejects structured output requests for this model, so a client that trusts the catalog and sends `response_format` gets an error.
- **GLM-5.3 Flash** and **Grok 4.6** omitted `minimal` from their `reasoning_options` effort values. The gateway accepts `reasoning_effort: "minimal"` on both, so the catalog understated what callers can send.

Separately, nothing in the repo knew that `grok` models are made by xAI. The import script (`import-models-from-models-dev.mjs`) could not assign a maker to a grok id, and the docs model index rendered the maker from its capitalize-the-id fallback ("Xai") and sorted xAI rows after every known provider instead of in a deliberate position.

## The corrected catalog fields

`claude-fable-5-1`:

```json
"tool_call": true,
"temperature": false,
"structured_output": false
```

`glm-5-3-flash` (`minimal` added):

```json
"reasoning_options": [
  { "type": "toggle" },
  { "type": "effort", "values": ["minimal", "low", "medium", "high", "xhigh", "max"] }
]
```

`grok-4-6` (`minimal` added):

```json
"reasoning_options": [
  { "type": "toggle" },
  { "type": "effort", "values": ["none", "minimal", "low", "medium", "high", "xhigh"] }
]
```

These fields ship verbatim on `neon.com/models.json`; the docs model index and its llms markdown mirror derive from the same data.

## xAI as a known maker

- `providerFor` in `import-models-from-models-dev.mjs` now maps ids and families starting with `grok` to `xai`, so future grok imports resolve their maker.
- `PROVIDER_ORDER` and `PROVIDER_LABELS` in `model-rows.js` (and the importer's order list) gain `xai` / `xAI`, so the model index labels Grok rows "xAI" and places them after Moonshot AI rather than in the unknown-provider tail.

Nothing changes for models the catalog already listed under other makers; the three models themselves are already published — this corrects their metadata only.

## Also in here

- The sync-debt hint in `check-models-sync.mjs` now names the `add-model-to-ai-gateway` skill; the skill name it referenced is retired.

## Verification

- `validateCatalog` passes on the edited `data.json`.
- `check-models-endpoint-sync`: 45 models in sync.
- Vitest: `models-catalog.test.js` 38 passed, `model-rows.test.js` 4 passed, `route.test.js` passed.
- New test in `model-rows.test.js`: `grok-4-6` resolves `provider: "xai"`, `providerName: "xAI"`, and endpoints `["chat/completions", "openai/responses"]`.
- `check:models-sync` reports sync debt on these three ids. That is the expected state: the models.dev `neon` provider is a mirror of this file and lags until an upstream PR merges; the check only fails on real faults.

## For your attention

- The models.dev mirror is now behind on these three entries. It needs a follow-up PR on `anomalyco/models.dev` updating `providers/neon/`; the sync check will report the debt until that merges.
