### PR TITLE
Drop false reasoning toggles on GLM-5.3 Flash and Grok 4.6

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -1970,9 +1970,6 @@
         "reasoning": true,
         "reasoning_options": [
           {
-            "type": "toggle"
-          },
-          {
             "type": "effort",
             "values": [
               "minimal",
@@ -2115,9 +2112,6 @@
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [
-          {
-            "type": "toggle"
-          },
           {
             "type": "effort",
             "values": [


### PR DESCRIPTION
## Problem

`neon.com/models.json` lists a `{ "type": "toggle" }` reasoning option on `glm-5-3-flash` and `grok-4-6`. A toggle in `reasoning_options` tells callers the model's thinking can be switched off. On these two models it can't, or not that way:

- `glm-5-3-flash` has no off switch. `POST /v1/chat/completions` with `thinking: { "type": "disabled" }` returns 200 and the response still carries `message.reasoning_content`. `reasoning_effort: "none"` is rejected because the model is thinking-only.
- `grok-4-6` turns thinking off with `reasoning_effort: "none"`, and `none` is already in its published effort list. The toggle advertises a second off switch that doesn't exist.

`/models` spreads catalog entries verbatim (`src/app/models/resolve.js`), so the false toggle reaches every consumer of either endpoint.

## Change

The two toggle objects are removed from `src/app/models.json/data.json`. The measured effort lists stay as they were:

```json
"glm-5-3-flash": {
  "reasoning_options": [
    { "type": "effort", "values": ["minimal", "low", "medium", "high", "xhigh", "max"] }
  ]
}
```

```json
"grok-4-6": {
  "reasoning_options": [
    { "type": "effort", "values": ["none", "minimal", "low", "medium", "high", "xhigh"] }
  ]
}
```

Nothing else in the catalog changes. Toggle entries on other models are untouched.

## Verification

- `POST /v1/chat/completions` against both live models, as described above: the GLM disable attempt still returned `reasoning_content`, and its `reasoning_effort: "none"` attempt was rejected.
- `npx vitest run` on `src/components/pages/doc/ai-gateway-model-index/model-rows.test.js` and `src/scripts/import-models-from-models-dev.test.js`: 5 tests, all passing.

## For your attention

- `import-models-from-models-dev.mjs` replaces the whole entry. A re-import from models.dev would overwrite the measured effort lists (dropping `none` from `grok-4-6`, which is its only off switch). This PR only corrects `data.json`.
