### PR TITLE
docs: link the API endpoint index and refine Reference entries in llms.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ public/robots.txt
 public/md
 public/docs/**/llms.txt
 public/docs/llms-full.txt
+public/guides/**/llms.txt
 src/utils/data/github-stars.generated.json
 
 # API ref generator output (never commit — CI regenerates on every deploy)

--- a/content/docs/reference/api.md
+++ b/content/docs/reference/api.md
@@ -1,5 +1,6 @@
 ---
 title: Neon API
+subtitle: Manage Neon projects, branches, and backend services over HTTP.
 summary: >-
   Browse all Neon API endpoints by resource, or get started with authentication
   and your first request.

--- a/content/docs/reference/api/get-started.md
+++ b/content/docs/reference/api/get-started.md
@@ -1,5 +1,6 @@
 ---
 title: Get started with the Neon API
+subtitle: Create an API key and make your first authenticated request.
 summary: >-
   Create a Neon API key, authenticate with the REST API, and make your first
   request to list projects using curl.

--- a/content/docs/reference/api/key-concepts.md
+++ b/content/docs/reference/api/key-concepts.md
@@ -1,5 +1,6 @@
 ---
 title: Neon API key concepts
+subtitle: Asynchronous operations, rate limits, and pagination.
 summary: >-
   Understand asynchronous operations, rate limits, pagination, and important
   constraints before building automation with the Neon API.

--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -197,6 +197,11 @@ module.exports = {
         'API reference, SDKs, Terraform provider, Postgres compatibility, and platform-level tooling.',
       extraEntries: [
         {
+          title: 'Neon API endpoint index',
+          url: 'https://neon.com/docs/reference/api/llms.txt',
+          description: 'Index of every Neon API endpoint, grouped by resource',
+        },
+        {
           title: 'Neon API OpenAPI Spec',
           url: 'https://neon.com/api_spec/release/v2.json',
           description: 'Machine-readable OpenAPI 3.0 specification for the Neon API',
@@ -276,6 +281,9 @@ module.exports = {
   // listing individual files when an entire path subtree should move together.
   reclassifyPrefixes: [
     { pathPrefix: 'cli/', section: 'Neon CLI' },
+    // Fold the hand-written API intro pages (reference/api/*.md) into the main
+    // Reference list instead of a two-item "API" subsection.
+    { pathPrefix: 'reference/api/', section: 'Reference', subsection: null },
     { pathPrefix: 'compute/', section: 'Neon Functions', subsection: null },
     { pathPrefix: 'postgresql/', section: 'PostgreSQL', subsection: 'General' },
     { pathPrefix: 'data-types/', section: 'PostgreSQL', subsection: 'Data Types' },


### PR DESCRIPTION
## Overview

Tidies how the Neon API is represented in the docs index (llms.txt). Adds a link to the API endpoint index, folds the hand-written API intro pages (get-started, key-concepts) into the main Reference list rather than a two-item subsection, and gives the three API reference pages subtitles so they read as distinct entries instead of bare or near-duplicate links.

Also ignores the generated public/guides/llms.txt, which had no matching ignore rule.

This pull request and its description were written by Isaac.
