### PR TITLE
Trigger a docs catalog sync when catalog-shaping files change

### DIFF
--- a/.github/workflows/docs-reindex.yml
+++ b/.github/workflows/docs-reindex.yml
@@ -8,12 +8,24 @@ on:
       # Official docs catalog. Guides and changelog are site-reindex.yml.
       - 'content/docs/**'
       - 'content/branching/**'
+      # Membership of generated pages (API endpoints) lives here, not in git.
+      - 'src/scripts/llms-index-config.js'
+      - 'src/scripts/generate-llms-index.js'
+      - 'scripts/generate-api-ref.mjs'
+      - 'scripts/lib/api-ref-output.mjs'
+      - 'scripts/lib/openapi-spec-source.mjs'
   workflow_dispatch:
     inputs:
       urls:
         description: Space-separated https://neon.com/**.md URLs to reindex (upsert)
-        required: true
+        required: false
         type: string
+        default: ''
+      sync:
+        description: Diff the live docs catalog against indexed pages (add missing, drop extras)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -75,10 +87,11 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
           (async () => {
-            const urls = process.env.URLS.trim().split(/\s+/).filter(Boolean);
-            if (urls.length === 0) {
+            const urls = (process.env.URLS ?? '').trim().split(/\s+/).filter(Boolean);
+            const sync = process.env.SYNC === 'true';
+            if (urls.length === 0 && !sync) {
               throw new Error(
-                'workflow_dispatch requires at least one https://neon.com/**.md URL with no port, userinfo, query, or hash',
+                'workflow_dispatch requires https://neon.com/**.md URLs and/or sync',
               );
             }
             for (const url of urls) {
@@ -113,13 +126,19 @@ jobs:
                 );
               }
             }
-            const payload = JSON.stringify({
-              pages: urls.map((url) => ({ url, deleted: false })),
-            });
+            const payload = JSON.stringify(
+              sync
+                ? urls.length > 0
+                  ? { pages: urls.map((url) => ({ url, deleted: false })), sync: 'docs' }
+                  : { sync: 'docs' }
+                : { pages: urls.map((url) => ({ url, deleted: false })) },
+            );
             if (process.env.GITHUB_STEP_SUMMARY) {
               await fs.promises.appendFile(
                 process.env.GITHUB_STEP_SUMMARY,
-                `## Docs reindex map\n\nQueued **${urls.length}** page(s) for reindex.\n`,
+                `## Docs reindex map\n\nQueued **${urls.length}** page(s) for reindex${
+                  sync ? ' plus catalog sync' : ''
+                }.\n`,
               );
             }
             await fs.promises.appendFile(
@@ -133,6 +152,7 @@ jobs:
           NODE
         env:
           URLS: ${{ inputs.urls }}
+          SYNC: ${{ inputs.sync }}
 
       - name: POST reindex
         if: steps.map.outputs.payload != '' || steps.dispatch.outputs.payload != ''

--- a/.github/workflows/docs-reindex.yml
+++ b/.github/workflows/docs-reindex.yml
@@ -8,7 +8,7 @@ on:
       # Official docs catalog. Guides and changelog are site-reindex.yml.
       - 'content/docs/**'
       - 'content/branching/**'
-      # Membership of generated pages (API endpoints) lives here, not in git.
+      # Catalog membership can change without a markdown edit.
       - 'src/constants/content.js'
       - 'src/scripts/llms-index-config.js'
       - 'src/scripts/generate-llms-index.js'

--- a/.github/workflows/docs-reindex.yml
+++ b/.github/workflows/docs-reindex.yml
@@ -127,19 +127,28 @@ jobs:
                 );
               }
             }
-            const payload = JSON.stringify(
-              sync
-                ? urls.length > 0
-                  ? { pages: urls.map((url) => ({ url, deleted: false })), sync: 'docs' }
-                  : { sync: 'docs' }
-                : { pages: urls.map((url) => ({ url, deleted: false })) },
-            );
+            const { toWebhookPayload } = require('./src/scripts/docs-reindex-map.js');
+            const payloadObj = toWebhookPayload({
+              pages: urls.map((url) => ({ url, deleted: false })),
+              sync,
+            });
+            if (!payloadObj) {
+              throw new Error(
+                'workflow_dispatch requires https://neon.com/**.md URLs and/or sync',
+              );
+            }
+            const payload = JSON.stringify(payloadObj);
             if (process.env.GITHUB_STEP_SUMMARY) {
+              const parts = [];
+              if (urls.length > 0) {
+                parts.push(`Queued **${urls.length}** page(s) for reindex`);
+              }
+              if (sync) {
+                parts.push(urls.length > 0 ? 'plus catalog sync' : 'Catalog sync queued');
+              }
               await fs.promises.appendFile(
                 process.env.GITHUB_STEP_SUMMARY,
-                `## Docs reindex map\n\nQueued **${urls.length}** page(s) for reindex${
-                  sync ? ' plus catalog sync' : ''
-                }.\n`,
+                `## Docs reindex map\n\n${parts.join(' ')}.\n`,
               );
             }
             await fs.promises.appendFile(

--- a/.github/workflows/docs-reindex.yml
+++ b/.github/workflows/docs-reindex.yml
@@ -9,6 +9,7 @@ on:
       - 'content/docs/**'
       - 'content/branching/**'
       # Membership of generated pages (API endpoints) lives here, not in git.
+      - 'src/constants/content.js'
       - 'src/scripts/llms-index-config.js'
       - 'src/scripts/generate-llms-index.js'
       - 'scripts/generate-api-ref.mjs'

--- a/src/scripts/docs-reindex-map.js
+++ b/src/scripts/docs-reindex-map.js
@@ -94,14 +94,16 @@ function classify(file) {
   return { kind: 'catalog', url };
 }
 
+function isCatalogSyncPath(file) {
+  return CATALOG_SYNC_PATHS.has(posix(file));
+}
+
 function catalogShapingChanged(files) {
   return files.some((file) => {
-    if (CATALOG_SYNC_PATHS.has(posix(file.filename))) {
+    if (isCatalogSyncPath(file.filename)) {
       return true;
     }
-    return Boolean(
-      file.previous_filename && CATALOG_SYNC_PATHS.has(posix(file.previous_filename))
-    );
+    return Boolean(file.previous_filename && isCatalogSyncPath(file.previous_filename));
   });
 }
 
@@ -132,14 +134,16 @@ function mapCompareFiles(files) {
       const previous = classify(file.previous_filename);
       if (previous.kind === 'catalog') {
         addPage(pages, previous.url, true);
-      } else {
+      } else if (!isCatalogSyncPath(file.previous_filename)) {
         bump(skipped, previous.kind);
       }
     }
 
     const current = classify(file.filename);
     if (current.kind !== 'catalog') {
-      bump(skipped, current.kind);
+      if (!isCatalogSyncPath(file.filename)) {
+        bump(skipped, current.kind);
+      }
       continue;
     }
     if (status === 'removed') {

--- a/src/scripts/docs-reindex-map.js
+++ b/src/scripts/docs-reindex-map.js
@@ -217,7 +217,7 @@ async function main() {
     const { appendFile } = require('fs').promises;
     const lines = ['## Docs reindex map', '', `Mapped **${result.pages.length}** catalog page(s).`];
     if (result.sync) {
-      lines.push('Catalog sync: index pages added or removed from llms.txt.');
+      lines.push('Catalog sync queued.');
     }
     if (summary) {
       lines.push(`Skipped: ${summary}.`);

--- a/src/scripts/docs-reindex-map.js
+++ b/src/scripts/docs-reindex-map.js
@@ -13,6 +13,7 @@ const ADDITIONAL_RESOURCE_PATHS = new Set(
 );
 
 const CATALOG_SYNC_PATHS = new Set([
+  'src/constants/content.js',
   'src/scripts/llms-index-config.js',
   'src/scripts/generate-llms-index.js',
   'scripts/generate-api-ref.mjs',

--- a/src/scripts/docs-reindex-map.js
+++ b/src/scripts/docs-reindex-map.js
@@ -12,6 +12,14 @@ const ADDITIONAL_RESOURCE_PATHS = new Set(
   (config.additionalResources || []).filter((r) => r.sourcePath).map((r) => r.sourcePath)
 );
 
+const CATALOG_SYNC_PATHS = new Set([
+  'src/scripts/llms-index-config.js',
+  'src/scripts/generate-llms-index.js',
+  'scripts/generate-api-ref.mjs',
+  'scripts/lib/api-ref-output.mjs',
+  'scripts/lib/openapi-spec-source.mjs',
+]);
+
 const INDEXED_ROUTES = Object.entries(CONTENT_ROUTES)
   .filter(([route]) => !(route in COLLAPSED_ROUTES))
   .sort((a, b) => b[1].length - a[1].length);
@@ -85,6 +93,17 @@ function classify(file) {
   return { kind: 'catalog', url };
 }
 
+function catalogShapingChanged(files) {
+  return files.some((file) => {
+    if (CATALOG_SYNC_PATHS.has(posix(file.filename))) {
+      return true;
+    }
+    return Boolean(
+      file.previous_filename && CATALOG_SYNC_PATHS.has(posix(file.previous_filename))
+    );
+  });
+}
+
 function addPage(pages, url, deleted) {
   pages.set(url, { url, deleted });
 }
@@ -140,6 +159,7 @@ function mapCompareFiles(files) {
   return {
     pages: [...pages.values()],
     skipped,
+    sync: catalogShapingChanged(files),
   };
 }
 
@@ -163,6 +183,19 @@ function skippedSummary(skipped) {
   return parts.join(', ');
 }
 
+function toWebhookPayload(result) {
+  if (result.sync) {
+    if (result.pages.length === 0) {
+      return { sync: 'docs' };
+    }
+    return { pages: result.pages, sync: 'docs' };
+  }
+  if (result.pages.length === 0) {
+    return undefined;
+  }
+  return { pages: result.pages };
+}
+
 async function main() {
   const chunks = [];
   for await (const chunk of process.stdin) {
@@ -178,9 +211,13 @@ async function main() {
   if (summary) {
     process.stderr.write(`skipped: ${summary}\n`);
   }
+  const payload = toWebhookPayload(result);
   if (process.env.GITHUB_STEP_SUMMARY) {
     const { appendFile } = require('fs').promises;
     const lines = ['## Docs reindex map', '', `Mapped **${result.pages.length}** catalog page(s).`];
+    if (result.sync) {
+      lines.push('Catalog sync: index pages added or removed from llms.txt.');
+    }
     if (summary) {
       lines.push(`Skipped: ${summary}.`);
     }
@@ -192,16 +229,18 @@ async function main() {
     lines.push('');
     await appendFile(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
   }
-  if (result.pages.length === 0) {
+  if (!payload) {
     process.exit(0);
   }
-  process.stdout.write(`${JSON.stringify({ pages: result.pages })}\n`);
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
 }
 
 module.exports = {
   mapCompareFiles,
   classify,
   skippedSummary,
+  toWebhookPayload,
+  CATALOG_SYNC_PATHS,
 };
 
 if (require.main === module) {

--- a/src/scripts/docs-reindex-map.test.js
+++ b/src/scripts/docs-reindex-map.test.js
@@ -131,6 +131,7 @@ describe('mapCompareFiles', () => {
     ]);
     expect(result.pages).toEqual([]);
     expect(result.sync).toBe(true);
+    expect(result.skipped.notMarkdown).toBe(0);
     expect(toWebhookPayload(result)).toEqual({ sync: 'docs' });
   });
 
@@ -140,7 +141,7 @@ describe('mapCompareFiles', () => {
     ]);
     expect(result.pages).toEqual([]);
     expect(result.sync).toBe(true);
-    expect(result.skipped.notMarkdown).toBe(1);
+    expect(result.skipped.notMarkdown).toBe(0);
     expect(toWebhookPayload(result)).toEqual({ sync: 'docs' });
   });
 

--- a/src/scripts/docs-reindex-map.test.js
+++ b/src/scripts/docs-reindex-map.test.js
@@ -125,7 +125,14 @@ describe('mapCompareFiles', () => {
     expect(result.sync).toBe(false);
   });
 
-  it('sets catalog sync when llms-index-config.js changes', () => {
+  it('sets catalog sync when content.js routes change', () => {
+    const result = mapCompareFiles([
+      { filename: 'src/constants/content.js', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.sync).toBe(true);
+    expect(toWebhookPayload(result)).toEqual({ sync: 'docs' });
+  });
     const result = mapCompareFiles([
       { filename: 'src/scripts/llms-index-config.js', status: 'modified' },
     ]);

--- a/src/scripts/docs-reindex-map.test.js
+++ b/src/scripts/docs-reindex-map.test.js
@@ -167,14 +167,15 @@ describe('mapCompareFiles', () => {
     });
   });
 
-  it('sets catalog sync when a catalog-shaping file is renamed', () => {
+  it('sets catalog sync when a catalog-shaping file is renamed away', () => {
     const result = mapCompareFiles([
       {
-        filename: 'src/scripts/llms-index-config.js',
+        filename: 'src/scripts/renamed-llms-index-config.js',
         status: 'renamed',
-        previous_filename: 'src/scripts/old-llms-index-config.js',
+        previous_filename: 'src/scripts/llms-index-config.js',
       },
     ]);
     expect(result.sync).toBe(true);
+    expect(toWebhookPayload(result)).toEqual({ sync: 'docs' });
   });
 });

--- a/src/scripts/docs-reindex-map.test.js
+++ b/src/scripts/docs-reindex-map.test.js
@@ -133,6 +133,8 @@ describe('mapCompareFiles', () => {
     expect(result.sync).toBe(true);
     expect(toWebhookPayload(result)).toEqual({ sync: 'docs' });
   });
+
+  it('sets catalog sync when llms-index-config.js changes', () => {
     const result = mapCompareFiles([
       { filename: 'src/scripts/llms-index-config.js', status: 'modified' },
     ]);

--- a/src/scripts/docs-reindex-map.test.js
+++ b/src/scripts/docs-reindex-map.test.js
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { mapCompareFiles } = require('./docs-reindex-map.js');
+const { mapCompareFiles, toWebhookPayload } = require('./docs-reindex-map.js');
 
 describe('mapCompareFiles', () => {
   it('maps a docs page add and modify', () => {
@@ -24,6 +24,7 @@ describe('mapCompareFiles', () => {
         notContent: 0,
         notMarkdown: 0,
       },
+      sync: false,
     });
   });
 
@@ -121,5 +122,50 @@ describe('mapCompareFiles', () => {
     expect(result.pages).toEqual([]);
     expect(result.skipped.notContent).toBe(1);
     expect(result.skipped.notMarkdown).toBe(1);
+    expect(result.sync).toBe(false);
+  });
+
+  it('sets catalog sync when llms-index-config.js changes', () => {
+    const result = mapCompareFiles([
+      { filename: 'src/scripts/llms-index-config.js', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([]);
+    expect(result.sync).toBe(true);
+    expect(result.skipped.notMarkdown).toBe(1);
+    expect(toWebhookPayload(result)).toEqual({ sync: 'docs' });
+  });
+
+  it('sets catalog sync when the API-ref generator changes', () => {
+    const result = mapCompareFiles([
+      { filename: 'scripts/generate-api-ref.mjs', status: 'modified' },
+    ]);
+    expect(result.sync).toBe(true);
+    expect(toWebhookPayload(result)).toEqual({ sync: 'docs' });
+  });
+
+  it('combines mapped pages with catalog sync', () => {
+    const result = mapCompareFiles([
+      { filename: 'content/docs/reference/api.md', status: 'modified' },
+      { filename: 'src/scripts/llms-index-config.js', status: 'modified' },
+    ]);
+    expect(result.pages).toEqual([
+      { url: 'https://neon.com/docs/reference/api.md', deleted: false },
+    ]);
+    expect(result.sync).toBe(true);
+    expect(toWebhookPayload(result)).toEqual({
+      pages: [{ url: 'https://neon.com/docs/reference/api.md', deleted: false }],
+      sync: 'docs',
+    });
+  });
+
+  it('sets catalog sync when a catalog-shaping file is renamed', () => {
+    const result = mapCompareFiles([
+      {
+        filename: 'src/scripts/llms-index-config.js',
+        status: 'renamed',
+        previous_filename: 'src/scripts/old-llms-index-config.js',
+      },
+    ]);
+    expect(result.sync).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

The docs reindex workflow maps changed markdown files under `content/docs/**` and `content/branching/**` to `https://neon.com/**.md` URLs and POSTs them to the reindex webhook. That mapping only sees markdown.

Catalog membership can change without a markdown edit. Adding a route in `src/constants/content.js`, excluding or collapsing a path in `src/scripts/llms-index-config.js` or changing the API reference generators all add or remove live pages while touching zero files the workflow watched. There is no file-to-URL mapping for those changes, so nothing told the indexer which pages appeared or disappeared. The index drifted until the next manual dispatch.

## Solution

The webhook payload gains a `sync` field. When a push to `main` touches one of six catalog-shaping files, the workflow POSTs `{ "sync": "docs" }`, telling the receiver to diff the live docs catalog against its indexed pages, add what is missing and drop what is gone. Markdown changes in the same push still map to explicit `pages` entries alongside the flag.

The catalog-shaping files:

| File | Why it shapes the catalog |
|---|---|
| `src/constants/content.js` | route-to-source mapping and excluded directories |
| `src/scripts/llms-index-config.js` | collapsed routes, excluded paths, additional resources |
| `src/scripts/generate-llms-index.js` | index generation itself |
| `scripts/generate-api-ref.mjs`, `scripts/lib/api-ref-output.mjs`, `scripts/lib/openapi-spec-source.mjs` | which generated API reference pages exist |

These six paths appear twice: in the workflow's `on.push.paths` filter, so the workflow runs at all, and in `CATALOG_SYNC_PATHS` in `src/scripts/docs-reindex-map.js`, so the mapper sets the flag. A rename away from one of these paths also triggers sync, since the old file's absence changes what the generators produce.

## Interface

Payload shapes, by what changed in the push:

Markdown only (unchanged from before):

```json
{ "pages": [{ "url": "https://neon.com/docs/reference/api.md", "deleted": false }] }
```

Catalog-shaping file only:

```json
{ "sync": "docs" }
```

Both:

```json
{ "pages": [{ "url": "https://neon.com/docs/reference/api.md", "deleted": false }], "sync": "docs" }
```

`workflow_dispatch` gains a `sync` boolean and `urls` becomes optional. At least one of the two is required; a dispatch with neither fails with `workflow_dispatch requires https://neon.com/**.md URLs and/or sync`.

```bash
gh workflow run docs-reindex.yml -f sync=true
gh workflow run docs-reindex.yml -f urls="https://neon.com/docs/reference/api.md" -f sync=true
```

A push touching only markdown produces the same payload as before, with no `sync` key. Nothing changes for the receiver on those runs.

## Also in here

Catalog-shaping files are no longer counted in the skipped summary. Before, a mixed push would have reported `content.js` as a "not markdown" skip, which reads as "ignored" when the file is what queued the sync. The step summary now says `Catalog sync queued.` instead.

## Verification

`npx vitest run src/scripts/docs-reindex-map.test.js` on this branch: 15 tests pass. The new cases cover:

- each class of catalog-shaping file (routes, index config, API-ref generator) sets `sync` and produces `{ "sync": "docs" }`
- a catalog-shaping change is not counted as skipped
- a push mixing a docs page edit with an index-config edit produces both `pages` and `sync: "docs"`
- a rename away from a catalog-shaping path still triggers sync

Not verified from this branch: a live POST to the reindex webhook. The receiver's handling of `sync: "docs"` lives outside this repo and needs one real run after merge.

## For your attention

- **Renaming a catalog-shaping file needs two edits**: the `on.push.paths` filter in the workflow and `CATALOG_SYNC_PATHS` in the mapper. The commit doing the rename still fires a sync, so the index heals, but later edits at the new name go silent until both lists carry it.
- **Every edit to a generator script queues a full catalog diff on the receiver**, even a comment-only change. The paths list trades occasional unnecessary syncs for never missing a membership change.
