### PR TITLE
Drop unverified reasoning effort values from glm-5-3-flash and grok-4-6

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -1972,11 +1972,8 @@
           {
             "type": "effort",
             "values": [
-              "minimal",
               "low",
-              "medium",
               "high",
-              "xhigh",
               "max"
             ]
           }
@@ -2115,8 +2112,6 @@
           {
             "type": "effort",
             "values": [
-              "none",
-              "minimal",
               "low",
               "medium",
               "high",


### PR DESCRIPTION
## Problem

neon.com/models.json advertised reasoning effort values on `glm-5-3-flash` and `grok-4-6` that the gateway accepts with HTTP 200 but that do not select a distinct, verifiable reasoning tier. A consumer reading the catalog treats every listed value as a real tier: an agent framework that offers `medium` on GLM or `none` on Grok is offering a knob that does nothing observable.

This PR narrows both lists to the values the model labs and their peers publish.

## What the catalog publishes now

```json
"glm-5-3-flash": { "reasoning_options": [{ "type": "effort", "values": ["low", "high", "max"] }] }
"grok-4-6":      { "reasoning_options": [{ "type": "effort", "values": ["low", "medium", "high", "xhigh"] }] }
```

Both lists match the first-party and peer sources:

| Model | Published values | Sources |
|---|---|---|
| `glm-5-3-flash` | `low`, `high`, `max` | [models.dev](https://github.com/anomalyco/models.dev/blob/dev/providers/zhipuai/models/glm-5.3-flash.toml), [Zhipu docs](https://docs.bigmodel.cn/cn/guide/models/vlm/glm-5.3-flash), Vercel AI Gateway live `/v1/models` for `zai/glm-5.3-flash` |
| `grok-4-6` | `low`, `medium`, `high`, `xhigh` | [models.dev](https://github.com/anomalyco/models.dev/blob/dev/providers/xai/models/grok-4.6.toml), [xAI docs](https://docs.x.ai/developers/model-capabilities/text/reasoning) |

Removed: `minimal`, `medium` and `xhigh` from GLM; `none` and `minimal` from Grok.

## Evidence from the live gateway

Every removed value was probed against the live Neon AI Gateway on 2026-09-04.

GLM, chat `reasoning_effort`:

- `none` returned 400. The model is thinking-only.
- `minimal`, `medium` and `xhigh` returned 200, but `reasoning_content` lengths were not monotonic across the tiers. A 200 with no ordered output is not evidence of a distinct tier, so these are unpublished.
- `low`, `high` and `max` returned 200 and match the lab/peer set, so they stay.

Grok, chat `reasoning_effort` and Responses `reasoning.effort`:

- `max` returned 400.
- `none`, `minimal`, `low`, `medium`, `high` and `xhigh` returned 200.
- Neither API ever returned a reasoning item or `reasoning_content`, so there is no way to show `none` turns reasoning off or that `minimal` differs from `low`. Both are unpublished. The four remaining values stay on the strength of the xAI and models.dev listings.

## Nothing else changes

The catalog shape is unchanged; only two `values` arrays got shorter. Consumers behave as before: `/models` spreads the catalog entries, the docs table reads only the `reasoning` boolean, the console hydrates from neon.com/models and `validateCatalog` checks structure without enumerating effort tokens.

## Verification

- `validateCatalog`: 45 models pass, 0 fail
- vitest: 68 tests pass
- `check:models-sync`: exit 0

## For your attention

- `grok-4-6` still has no `cost` entry in the catalog. Pre-existing and unchanged here.