### PR TITLE
docs: refresh the CLI reference schema (Neon CLI 4.14.1)

### DIFF
--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.14.0",
+  "neonctlVersion": "4.14.1",
   "binaries": [
     "neonctl",
     "neon"


### PR DESCRIPTION
Regenerate the CLI reference schema for the Neon CLI 4.14.1 release.

4.14.1 is a dependency-only patch (@neon/config 1.3.0). The one user-visible change
it ships — neon.ts now accepts every compute size Neon offers (0.25, 0.5, integers 1–16,
even integers 18–56) with new autoscaling range rules — is already documented on the
neon.ts reference page (#5745), so no doc pages need editing.

- Regenerate schema.json: neonctlVersion 4.14.0 → 4.14.1 (no command or option changes)
- No page, nav, group, or meta.js changes

This pull request and its description were written by Isaac.