### PR TITLE
chore: regenerate the API reference from the OpenAPI spec

### DIFF
--- a/content/docs/api-navigation.yaml
+++ b/content/docs/api-navigation.yaml
@@ -301,15 +301,24 @@
 - title: "Functions"
   slug: reference/api/functions
   items:
+    - title: "Create a trigger"
+      slug: reference/api/functions/create-project-branch-trigger
+      method: POST
     - title: "Delete a custom domain from a branch"
       slug: reference/api/functions/delete-project-branch-custom-domain
       method: DELETE
     - title: "Delete a function on the branch"
       slug: reference/api/functions/delete-project-branch-function
       method: DELETE
+    - title: "Delete a trigger"
+      slug: reference/api/functions/delete-project-branch-trigger
+      method: DELETE
     - title: "Deploy code to a function"
       slug: reference/api/functions/create-project-branch-function-deployment
       method: POST
+    - title: "Get a trigger"
+      slug: reference/api/functions/get-project-branch-trigger
+      method: GET
     - title: "Get function details"
       slug: reference/api/functions/get-project-branch-function
       method: GET
@@ -319,11 +328,17 @@
     - title: "List the custom domains on a branch"
       slug: reference/api/functions/list-project-branch-custom-domains
       method: GET
+    - title: "List triggers on the branch"
+      slug: reference/api/functions/list-project-branch-triggers
+      method: GET
     - title: "Register a custom domain on a branch"
       slug: reference/api/functions/register-project-branch-custom-domain
       method: POST
     - title: "Update a function"
       slug: reference/api/functions/update-project-branch-function
+      method: PATCH
+    - title: "Update a trigger"
+      slug: reference/api/functions/update-project-branch-trigger
       method: PATCH
 - title: "Logs"
   slug: reference/api/logs

--- a/content/docs/api-operation-ids.json
+++ b/content/docs/api-operation-ids.json
@@ -1,6 +1,6 @@
 {
   "_generatedBy": "scripts/generate-api-ref.mjs — do not edit by hand",
-  "count": 174,
+  "count": 179,
   "operationIds": [
     "acceptProjectTransferRequest",
     "addBranchNeonAuthOauthProvider",
@@ -28,6 +28,7 @@
     "createProjectBranchDatabase",
     "createProjectBranchFunctionDeployment",
     "createProjectBranchRole",
+    "createProjectBranchTrigger",
     "createProjectEndpoint",
     "createProjectTransferRequest",
     "createSnapshot",
@@ -50,6 +51,7 @@
     "deleteProjectBranchDatabase",
     "deleteProjectBranchFunction",
     "deleteProjectBranchRole",
+    "deleteProjectBranchTrigger",
     "deleteProjectEndpoint",
     "deleteProjectJWKS",
     "deleteProjectVPCEndpoint",
@@ -94,6 +96,7 @@
     "getProjectBranchSchema",
     "getProjectBranchSchemaComparison",
     "getProjectBranchStorage",
+    "getProjectBranchTrigger",
     "getProjectEndpoint",
     "getProjectJWKS",
     "getProjectOperation",
@@ -118,6 +121,7 @@
     "listProjectBranchLogFieldValues",
     "listProjectBranchLogFields",
     "listProjectBranchRoles",
+    "listProjectBranchTriggers",
     "listProjectBranches",
     "listProjectEndpoints",
     "listProjectMembers",
@@ -174,6 +178,7 @@
     "updateProjectBranchDataAPI",
     "updateProjectBranchDatabase",
     "updateProjectBranchFunction",
+    "updateProjectBranchTrigger",
     "updateProjectEndpoint",
     "updateSnapshot"
   ]


### PR DESCRIPTION
Regenerate the API reference from the OpenAPI spec at neon.com/api_spec/release/v2.json.

- Add 5 branch-trigger operations under the Functions tag (174 -> 179 operations):
  create, get, list, update, and delete a branch trigger.
- Only the two committed index files change (api-navigation.yaml, api-operation-ids.json);
  the per-operation JSON/Markdown and llms.txt files are gitignored build outputs.

This pull request and its description were written by Isaac.