### PR TITLE
feat: hide branch-trigger endpoints from the API reference

### DIFF
--- a/content/docs/api-navigation.yaml
+++ b/content/docs/api-navigation.yaml
@@ -301,24 +301,15 @@
 - title: "Functions"
   slug: reference/api/functions
   items:
-    - title: "Create a trigger"
-      slug: reference/api/functions/create-project-branch-trigger
-      method: POST
     - title: "Delete a custom domain from a branch"
       slug: reference/api/functions/delete-project-branch-custom-domain
       method: DELETE
     - title: "Delete a function on the branch"
       slug: reference/api/functions/delete-project-branch-function
       method: DELETE
-    - title: "Delete a trigger"
-      slug: reference/api/functions/delete-project-branch-trigger
-      method: DELETE
     - title: "Deploy code to a function"
       slug: reference/api/functions/create-project-branch-function-deployment
       method: POST
-    - title: "Get a trigger"
-      slug: reference/api/functions/get-project-branch-trigger
-      method: GET
     - title: "Get function details"
       slug: reference/api/functions/get-project-branch-function
       method: GET
@@ -328,17 +319,11 @@
     - title: "List the custom domains on a branch"
       slug: reference/api/functions/list-project-branch-custom-domains
       method: GET
-    - title: "List triggers on the branch"
-      slug: reference/api/functions/list-project-branch-triggers
-      method: GET
     - title: "Register a custom domain on a branch"
       slug: reference/api/functions/register-project-branch-custom-domain
       method: POST
     - title: "Update a function"
       slug: reference/api/functions/update-project-branch-function
-      method: PATCH
-    - title: "Update a trigger"
-      slug: reference/api/functions/update-project-branch-trigger
       method: PATCH
 - title: "Logs"
   slug: reference/api/logs

--- a/content/docs/api-operation-ids.json
+++ b/content/docs/api-operation-ids.json
@@ -1,6 +1,6 @@
 {
   "_generatedBy": "scripts/generate-api-ref.mjs — do not edit by hand",
-  "count": 179,
+  "count": 174,
   "operationIds": [
     "acceptProjectTransferRequest",
     "addBranchNeonAuthOauthProvider",
@@ -28,7 +28,6 @@
     "createProjectBranchDatabase",
     "createProjectBranchFunctionDeployment",
     "createProjectBranchRole",
-    "createProjectBranchTrigger",
     "createProjectEndpoint",
     "createProjectTransferRequest",
     "createSnapshot",
@@ -51,7 +50,6 @@
     "deleteProjectBranchDatabase",
     "deleteProjectBranchFunction",
     "deleteProjectBranchRole",
-    "deleteProjectBranchTrigger",
     "deleteProjectEndpoint",
     "deleteProjectJWKS",
     "deleteProjectVPCEndpoint",
@@ -96,7 +94,6 @@
     "getProjectBranchSchema",
     "getProjectBranchSchemaComparison",
     "getProjectBranchStorage",
-    "getProjectBranchTrigger",
     "getProjectEndpoint",
     "getProjectJWKS",
     "getProjectOperation",
@@ -121,7 +118,6 @@
     "listProjectBranchLogFieldValues",
     "listProjectBranchLogFields",
     "listProjectBranchRoles",
-    "listProjectBranchTriggers",
     "listProjectBranches",
     "listProjectEndpoints",
     "listProjectMembers",
@@ -178,7 +174,6 @@
     "updateProjectBranchDataAPI",
     "updateProjectBranchDatabase",
     "updateProjectBranchFunction",
-    "updateProjectBranchTrigger",
     "updateProjectEndpoint",
     "updateSnapshot"
   ]

--- a/scripts/check-docs-api-consistency.mjs
+++ b/scripts/check-docs-api-consistency.mjs
@@ -61,6 +61,7 @@ import {
   sdkRawOperationNames,
 } from './lib/api-coverage.mjs';
 import { defaultSpecCachePath, loadOpenApiSpec } from './lib/openapi-spec-source.mjs';
+import { withoutExcludedOperations } from './lib/excluded-operations.mjs';
 import { findMissingSpecTags, readTagConfig } from './lib/tag-config.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -300,7 +301,9 @@ async function main() {
         cachePath: defaultSpecCachePath(ROOT),
         log: () => {},
       });
-      specOps = [...operationIdsFromSpec(spec)];
+      // Drop intentionally-hidden ops (scripts/lib/excluded-operations.mjs) so
+      // they are not reported as `specNotDocumented` drift by the weekly job.
+      specOps = withoutExcludedOperations(operationIdsFromSpec(spec));
       // Spec tags with no entry in tag-config.json render with auto-generated
       // display/order in the API reference (the [tag-config] build warning). The
       // build only logs it; surface it here so the weekly issue flags it too.
@@ -310,6 +313,11 @@ async function main() {
     }
   }
 
+  // rawOps is intentionally NOT filtered by EXCLUDED_OPERATION_IDS: the SDK
+  // really does expose the excluded ops, so offline PR mode may list them as
+  // "raw layer exposes operations the docs do not cover" (true, non-blocking,
+  // self-clearing when the override is lifted). TODO: if that advisory noise
+  // outlives its welcome, filter rawOps too via toSdkMethodName(excludedId).
   const coverage = computeCoverage({
     documentedOps,
     rawOps: rawOperations,

--- a/scripts/generate-api-ref.mjs
+++ b/scripts/generate-api-ref.mjs
@@ -46,6 +46,7 @@ import {
   getRawSchemaAt,
 } from './lib/spec-utils.mjs';
 import { loadTagConfig } from './lib/tag-config.mjs';
+import { EXCLUDED_OPERATION_IDS } from './lib/excluded-operations.mjs';
 import { buildTs, toSdkMethodName, compareOpsForDisplay } from '../src/utils/api-ref.mjs';
 
 // Single source of truth for neonctl global flags that should not count as
@@ -1312,6 +1313,9 @@ async function main() {
     for (const method of METHODS) {
       const op = pathItem[method];
       if (!op?.operationId) continue;
+      // Temporary manual override (scripts/lib/excluded-operations.mjs): hide
+      // these ops from every generated output. Spec tracking is unaffected.
+      if (EXCLUDED_OPERATION_IDS.has(op.operationId)) continue;
 
       const opData = buildOperationData(
         pathStr,

--- a/scripts/lib/excluded-operations.mjs
+++ b/scripts/lib/excluded-operations.mjs
@@ -1,0 +1,24 @@
+// TEMPORARY manual override: operationIds present in the public OpenAPI spec
+// that we intentionally hide from the generated API reference.
+//
+// To un-hide: remove the id from EXCLUDED_OPERATION_IDS (or empty the set),
+// run `npm run generate:api-ref`, and commit the regenerated
+// content/docs/api-navigation.yaml and content/docs/api-operation-ids.json.
+//
+// This override is intentionally sticky: routine "regenerate the API reference"
+// runs keep skipping these operations until an id is removed here. The spec is
+// never filtered, only the rendered output, so spec tracking stays live.
+export const EXCLUDED_OPERATION_IDS = new Set([
+  'createProjectBranchTrigger',
+  'getProjectBranchTrigger',
+  'listProjectBranchTriggers',
+  'updateProjectBranchTrigger',
+  'deleteProjectBranchTrigger',
+]);
+
+// Pure helper: drop excluded operationIds from an iterable of ids, preserving
+// order. Used by the strict docs<->API consistency check so intentionally
+// excluded operations are not reported as `specNotDocumented` drift.
+export function withoutExcludedOperations(operationIds) {
+  return [...operationIds].filter((id) => !EXCLUDED_OPERATION_IDS.has(id));
+}

--- a/scripts/lib/excluded-operations.test.js
+++ b/scripts/lib/excluded-operations.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+import { EXCLUDED_OPERATION_IDS, withoutExcludedOperations } from './excluded-operations.mjs';
+
+describe('EXCLUDED_OPERATION_IDS', () => {
+  it('lists exactly the five branch-trigger operations', () => {
+    expect([...EXCLUDED_OPERATION_IDS].sort()).toEqual([
+      'createProjectBranchTrigger',
+      'deleteProjectBranchTrigger',
+      'getProjectBranchTrigger',
+      'listProjectBranchTriggers',
+      'updateProjectBranchTrigger',
+    ]);
+  });
+});
+
+describe('withoutExcludedOperations', () => {
+  it('removes excluded ids and keeps the rest, preserving input order', () => {
+    const input = [
+      'listProjects',
+      'createProjectBranchTrigger',
+      'getProject',
+      'listProjectBranchTriggers',
+    ];
+    expect(withoutExcludedOperations(input)).toEqual(['listProjects', 'getProject']);
+  });
+
+  it('accepts any iterable (e.g. a Set) and returns an array', () => {
+    const result = withoutExcludedOperations(new Set(['getProject', 'getProjectBranchTrigger']));
+    expect(result).toEqual(['getProject']);
+  });
+});


### PR DESCRIPTION
## Overview

The branch-trigger operations (create, get, list, update, and delete a trigger on a
branch) exist in the public API spec but aren't ready to document yet. This hides
them from the generated API reference through a reversible manual override, without
changing how every other endpoint tracks the spec.

scripts/lib/excluded-operations.mjs lists the excluded operation ids. The generator
skips them, so they produce no page, nav entry, or llms.txt/sitemap entry, and the
strict docs-vs-API check filters them so the weekly job files no false drift. The
override is sticky: routine "regenerate the API reference" runs keep them hidden
until an id is removed.

To reverse: delete the id from the override and run `npm run generate:api-ref`.

Related: #5736

This pull request and its description were written by Isaac.
