### PR TITLE
Add verified knowledge cutoffs and lab release dates to three AI Gateway models

### DIFF
--- a/src/app/models.json/data.json
+++ b/src/app/models.json/data.json
@@ -80,6 +80,7 @@
         "temperature": false,
         "structured_output": false,
         "open_weights": false,
+        "knowledge": "2026-06",
         "release_date": "2026-09-01",
         "last_updated": "2026-09-01",
         "modalities": {
@@ -2049,8 +2050,8 @@
         "temperature": true,
         "structured_output": true,
         "open_weights": true,
-        "release_date": "2026-08-28",
-        "last_updated": "2026-08-28",
+        "release_date": "2026-08-26",
+        "last_updated": "2026-08-26",
         "modalities": {
           "input": [
             "text",
@@ -2190,8 +2191,9 @@
         "temperature": true,
         "structured_output": true,
         "open_weights": false,
-        "release_date": "2026-08-24",
-        "last_updated": "2026-08-24",
+        "knowledge": "2026-02-01",
+        "release_date": "2026-08-12",
+        "last_updated": "2026-08-12",
         "modalities": {
           "input": [
             "text",


### PR DESCRIPTION
## Problem

`src/app/models.json/data.json` is the authored catalog behind `neon.com/models.json`, and the `neon` provider on models.dev mirrors it. Three entries carried lab facts that do not match what the labs publish, so the mirror and the catalog disagreed on fields the catalog is supposed to own.

`npm run check:models-sync` on `origin/main`, trimmed to the fields this PR touches:

```
  claude-fable-5-1:
    knowledge:
      here:       undefined
      models.dev: "2026-06"
  glm-5-3-flash:
    release_date / last_updated:
      here:       "2026-08-28"
      models.dev: "2026-08-26"
  grok-4-6:
    knowledge:
      here:       undefined
      models.dev: "2026-02-01"
    release_date / last_updated:
      here:       "2026-08-24"
      models.dev: "2026-08-12"
```

The mirror had the right values. The catalog is the source of truth, so the fix goes here.

## Change

One file, `src/app/models.json/data.json`. Each value is checked against the lab's own page.

```json
"claude-fable-5-1": {
  "knowledge": "2026-06"
}
```

Anthropic, [How up-to-date is Claude's training data](https://support.claude.com/en/articles/8114494-how-up-to-date-is-claude-s-training-data): "Claude Fable 5.1 was trained on data up until June 2026."

```json
"grok-4-6": {
  "knowledge": "2026-02-01",
  "release_date": "2026-08-12",
  "last_updated": "2026-08-12"
}
```

xAI, [Grok 4.6 model page](https://docs.x.ai/developers/grok-4-6): "Knowledge cutoff February 1, 2026". xAI, [release notes](https://docs.x.ai/developers/release-notes): "August 12 Grok 4.6 ... is now available on the xAI API".

```json
"glm-5-3-flash": {
  "release_date": "2026-08-26",
  "last_updated": "2026-08-26"
}
```

Z.ai, [GLM-5.3 Flash announcement](https://z.ai/blog/glm-5.3-flash), dated 2026-08-26. The page renders client-side; the date is in the page's JS bundle, so a plain `curl` of the HTML does not show it.

`last_updated` equals `release_date` on both models because each lab publishes one date and models.dev's lab files carry the same value in both fields.

Everything else on the three entries is unchanged, including `open_weights`, `modalities`, `limit` and `cost`.

## Verification

Run at `5f2acbdb8`:

- `npx vitest run scripts/lib/models-catalog.test.js src/scripts/import-models-from-models-dev.test.js src/app/models/route.test.js`: 64 passed. This includes `validateCatalog`, which checks `knowledge`, `release_date` and `last_updated` are ISO dates.
- `node src/scripts/check-models-endpoint-sync.js`: 46 models in sync between `/models` and `/models.json` on 14 shared fields.
- `npm run check:models-sync`: exit 0. The three models above no longer differ from the mirror on `knowledge`, `release_date` or `last_updated`.
- Each source URL above fetched and the quoted text located on the page.

## For your attention

- `glm-5-3-flash.modalities.input` is still `["text", "image"]` here and `["text", "image", "video", "pdf"]` on models.dev. Out of this PR. `open_weights` now matches live `api.json` (`true`) after [anomalyco/models.dev#6509](https://github.com/anomalyco/models.dev/pull/6509).

