### PR TITLE
docs: unify the Discord, Telegram, and WhatsApp bot guides

### DIFF
--- a/content/docs/compute/functions/discord-bot.md
+++ b/content/docs/compute/functions/discord-bot.md
@@ -8,7 +8,7 @@ summary: >-
   public function URL, verify Discord's Ed25519 request signatures, and store data in Postgres
   on the same branch.
 enableTableOfContents: true
-updatedOn: '2026-09-02T23:13:13.838Z'
+updatedOn: '2026-09-07T18:56:07.527Z'
 isDraft: false
 ---
 
@@ -115,9 +115,10 @@ This walkthrough is deploy-only. Discord needs a public HTTPS URL, so we don't u
 
 ## Add Discord secrets
 
-Template scripts read `.env.local` (for example `neon deploy --env .env.local` and `node --env-file=.env.local`), the same convention as Next.js and `vercel env pull`. Bootstrap scaffolds a `.env.example` but no `.env.local` yet. Copy the example first, then link so Neon merges the branch's variables into it:
+Template scripts read `.env.local` (for example `neon deploy --env .env.local` and `node --env-file=.env.local`), the same convention as Next.js and `vercel env pull`. Bootstrap scaffolds a `.env.example` but no `.env.local` yet. Install dependencies, copy the example, then link. `neon link` loads `neon.ts` to pull the branch's variables, so the packages must be installed first:
 
 ```bash
+npm install
 cp .env.example .env.local
 neon link
 ```
@@ -148,8 +149,6 @@ If you omit `DISCORD_GUILD_ID`, the register script creates global commands, whi
 
 ## Deploy the function
 
-If you used `neon bootstrap` and let it install dependencies, skip that step. If you cloned by hand, run `npm install` first.
-
 `npm run deploy` runs `neon deploy --env .env.local`, which evaluates `neon.ts` with your Discord secrets in `process.env`:
 
 ```bash
@@ -159,6 +158,14 @@ npm run deploy
 The CLI applies the `neon.ts` policy, bundles the function and waits until that apply finishes. You'll see `Applied changes` and a **Function URLs** list. If the command fails, check [function logs](/docs/compute/functions/logs). Flags are in [Deploy and manage functions](/docs/compute/functions/deploy).
 
 Deployed env is a snapshot of `.env.local` at apply time. Run `npm run deploy` again after any change to `.env.local`.
+
+## Apply the database schema
+
+```bash
+npm run db:push
+```
+
+`db:push` reads `neon.ts` (the same config `deploy` uses), so it needs the function secrets you set above, plus the `DATABASE_URL` that `neon link` wrote. `/ping` works without the tables; `/name` and `/profile` need them.
 
 ## Set the Interactions Endpoint URL
 
@@ -232,33 +239,9 @@ If nothing appears, or Discord says "The application did not respond":
 Call `request.text()` and verify **before** `JSON.parse`. Discord signs `timestamp + body` as the exact bytes it sent. Parsing JSON first can change whitespace and fail verification. See [Interactions Overview](https://discord.com/developers/docs/interactions/overview).
 </Admonition>
 
-The GET and POST `PING` path looks like this. ApplicationCommand and MessageComponent dispatch is in the source.
+The POST path reads the raw body and verifies the signature before parsing:
 
 ```ts filename="functions/discord.ts"
-import { InteractionResponseType, InteractionType } from "discord-api-types/v10";
-import { DISCORD_INTERACTIONS_PATH } from "../src/constants/discord.js";
-import { getDiscordEnv } from "../src/env.js";
-import { discordInteractionSchema } from "../src/schemas/discord.js";
-import { jsonResponse } from "../src/utils/jsonResponse.js";
-import { verifyDiscordRequest } from "../src/utils/verifyDiscordRequest.js";
-
-export default async function handler(request: Request): Promise<Response> {
-  const url = new URL(request.url);
-
-  switch (request.method) {
-    case "GET":
-      return jsonResponse({
-        ok: true,
-        service: "discord-interactions",
-        interactionsPath: DISCORD_INTERACTIONS_PATH,
-        interactionsUrl: `${url.origin}${DISCORD_INTERACTIONS_PATH}`,
-      });
-    case "POST":
-      break;
-    default:
-      return jsonResponse({ error: "method not allowed" }, { status: 405 });
-  }
-
   const body = await request.text();
   const env = getDiscordEnv();
   const isVerified = verifyDiscordRequest({
@@ -279,34 +262,29 @@ export default async function handler(request: Request): Promise<Response> {
   } catch {
     return jsonResponse({ error: "invalid json" }, { status: 400 });
   }
-
-  const parsedPayload = discordInteractionSchema.safeParse(payloadBody);
-
-  if (!parsedPayload.success) {
-    return jsonResponse({ error: "invalid interaction payload" }, { status: 400 });
-  }
-
-  const payload = parsedPayload.data;
-
-  if (payload.type === InteractionType.Ping) {
-    return jsonResponse({ type: InteractionResponseType.Pong });
-  }
-
-  // ApplicationCommand and MessageComponent dispatch is in the source.
-}
 ```
 
-## Next steps
+<details>
+<summary>View full code: `functions/discord.ts`</summary>
 
-The template already implements more than `/ping`:
+<ExternalCode url="https://raw.githubusercontent.com/neondatabase/examples/main/bots/discord-bot-http/functions/discord.ts" />
 
+</details>
+
+View it on [GitHub](https://github.com/neondatabase/examples/blob/main/bots/discord-bot-http/functions/discord.ts).
+
+## Commands
+
+- `/ping`: Pong embed with estimated interaction latency.
 - `/info` and `/help`: [Components v2](https://discord.com/developers/docs/components/overview) panels (Discord's newer message layout) with runtime details and slash-command mentions.
 - `/buttons`: Components v2 buttons (primary, secondary, success and danger).
-- `/name` and `/profile`: Postgres via Drizzle (`profiles` and `command_usage` tables). After the project is linked and deployed so `DATABASE_URL` exists, run `npm run db:push` once. If you skip that, those commands reply that they could not reach the Neon database. On a cold branch they can also fall back to a warming-up reply; run the command again once the branch is warm.
+- `/name` and `/profile`: Postgres via Drizzle (`profiles` and `command_usage` tables). If the database misses a 2.5-second deadline, the bot replies "Warming up"; run the command again once the branch is warm.
 
-To add LLM chat and image generation, see the [Community Guide](/guides/discord-bot-on-neon-functions). That's a separate from-scratch walkthrough.
+## Related templates
 
-Sibling HTTP bot templates: [Telegram](https://github.com/neondatabase/examples/tree/main/bots/telegram-bot-http) and [WhatsApp](https://github.com/neondatabase/examples/tree/main/bots/whatsapp-bot-http).
+- [Community guide: Discord bot on Neon Functions](/guides/discord-bot-on-neon-functions): adds LLM chat and image generation, built from scratch.
+- [Telegram HTTP bot](https://github.com/neondatabase/examples/tree/main/bots/telegram-bot-http)
+- [WhatsApp HTTP bot](https://github.com/neondatabase/examples/tree/main/bots/whatsapp-bot-http)
 
 ## Example
 

--- a/content/docs/compute/functions/telegram-bot.md
+++ b/content/docs/compute/functions/telegram-bot.md
@@ -7,7 +7,7 @@ summary: >-
   Host a Telegram bot on Neon Functions. Receive webhook updates, run bot commands, verify the
   webhook secret token, and store data in Postgres on the same branch.
 enableTableOfContents: true
-updatedOn: '2026-09-02T23:13:13.838Z'
+updatedOn: '2026-09-07T18:56:07.527Z'
 isDraft: false
 ---
 
@@ -85,9 +85,10 @@ This walkthrough deploys the function before connecting Telegram. Telegram requi
 
 ## Add Telegram secrets
 
-Bootstrap scaffolds a `.env.example` but no `.env.local`. Copy the example first, then link so Neon merges the branch's variables into it:
+Bootstrap scaffolds a `.env.example` but no `.env.local`. Install dependencies, copy the example, then link. `neon link` loads `neon.ts` to pull the branch's variables, so the packages must be installed first:
 
 ```bash
+npm install
 cp .env.example .env.local
 neon link
 ```
@@ -125,8 +126,6 @@ Only the local webhook setup script reads `TELEGRAM_WEBHOOK_URL`. Neon doesn't p
 
 ## Deploy the function
 
-If `neon bootstrap` installed dependencies, you can deploy now. If you copied the source by hand, run `npm install` first.
-
 The `deploy` script runs `neon deploy --env .env.local`, which evaluates `neon.ts` with your Telegram secrets in `process.env`:
 
 ```bash
@@ -134,6 +133,14 @@ npm run deploy
 ```
 
 The CLI applies the `neon.ts` policy, bundles the function and waits for the deployment to finish. You'll see `Applied changes` and a **Function URLs** list. If the deployment fails, check [function logs](/docs/compute/functions/logs) and [Deploy and manage functions](/docs/compute/functions/deploy).
+
+## Apply the database schema
+
+```bash
+npm run db:push
+```
+
+`db:push` reads `neon.ts` (the same config `deploy` uses), so it needs the function secrets you set above, plus the `DATABASE_URL` that `neon link` wrote. `/ping` works without the tables; `/name` and `/profile` need them.
 
 ## Set the webhook
 
@@ -180,7 +187,7 @@ The script calls Telegram's `setMyCommands` method with `/ping`, `/info`, `/help
 
 Run this command again after you change the command list.
 
-## Try `/ping`
+## Try /ping
 
 Open the bot link that BotFather gave you. If Telegram shows a **Start** button, click it. Then send `/ping`. The bot replies with `Pong` and an estimated webhook latency.
 
@@ -206,31 +213,53 @@ The template doesn't deduplicate Telegram `update_id` values. If you add a comma
 Check `X-Telegram-Bot-Api-Secret-Token` before processing an update. The template compares it with `TELEGRAM_WEBHOOK_SECRET` using Node.js `timingSafeEqual`.
 </Admonition>
 
-The handler verifies the secret before parsing an update. It handles callback queries, tracks recognized commands without delaying replies and sends `Unknown command. Try /help.` for unsupported commands. See the complete handler:
+The POST path verifies the secret before parsing the update:
+
+```ts filename="functions/telegram.ts"
+  const isVerified = verifyTelegramRequest(
+    getTelegramWebhookSecret(),
+    request.headers.get("x-telegram-bot-api-secret-token"),
+  );
+
+  if (!isVerified) {
+    return jsonResponse({ error: "invalid webhook secret" }, { status: 401 });
+  }
+
+  let payloadBody: unknown;
+
+  try {
+    payloadBody = await request.json();
+  } catch {
+    return jsonResponse({ error: "invalid json" }, { status: 400 });
+  }
+```
+
+It handles callback queries, tracks recognized commands without delaying replies and sends `Unknown command. Try /help.` for unsupported commands.
+
+<details>
+<summary>View full code: `functions/telegram.ts`</summary>
 
 <ExternalCode url="https://raw.githubusercontent.com/neondatabase/examples/main/bots/telegram-bot-http/functions/telegram.ts" />
 
-## Next steps
+</details>
 
-The template includes more than `/ping`:
+View it on [GitHub](https://github.com/neondatabase/examples/blob/main/bots/telegram-bot-http/functions/telegram.ts).
 
-- `/info`: shows the Node.js version, platform, request method, function URL and Neon branch.
-- `/help`: lists the commands defined by the template's shared command list.
-- `/buttons`: shows an inline keyboard with refresh, echo, time and confirm callbacks.
+## Commands
+
+- `/ping`: replies with Pong and an estimated webhook latency.
+- `/info`: Node.js version, platform, request method, function URL and Neon branch.
+- `/help`: lists the template's commands.
+- `/buttons`: inline keyboard with refresh, echo, time and confirm callbacks.
 - `/name <your name>`: stores a display name. `/name` without an argument shows the stored name.
-- `/profile`: shows the stored name, total command count and per-command usage.
+- `/profile`: stored name, total command count and per-command usage.
 
-The template stores Telegram user IDs, display names and usage counts in the `profiles` and `command_usage` tables. Usage tracking is best-effort and doesn't block replies.
+The template stores Telegram user IDs, display names and usage counts in the `profiles` and `command_usage` tables. Usage tracking is best-effort and doesn't block replies. If the database misses a 2.5-second deadline, the bot replies "Warming up"; run the command again once the branch is warm.
 
-`neon link` wrote `DATABASE_URL` into `.env.local`, so create the tables any time after that:
+## Related templates
 
-```bash
-npm run db:push
-```
-
-The template gives `/name` and `/profile` 2.5 seconds for a database response. If a cold Postgres compute misses that deadline, the bot returns **Warming up**. Wait a moment, then run the command again.
-
-Sibling bot templates: [Discord](https://github.com/neondatabase/examples/tree/main/bots/discord-bot-http) and [WhatsApp](https://github.com/neondatabase/examples/tree/main/bots/whatsapp-bot-http).
+- [Discord HTTP bot](https://github.com/neondatabase/examples/tree/main/bots/discord-bot-http)
+- [WhatsApp HTTP bot](https://github.com/neondatabase/examples/tree/main/bots/whatsapp-bot-http)
 
 ## Example
 

--- a/content/docs/compute/functions/whatsapp-bot.md
+++ b/content/docs/compute/functions/whatsapp-bot.md
@@ -7,7 +7,7 @@ summary: >-
   Host a WhatsApp bot on Neon Functions. Receive WhatsApp Cloud API webhooks, verify Meta's
   request signatures, reply through the Graph API, and store data in Postgres on the same branch.
 enableTableOfContents: true
-updatedOn: '2026-09-02T23:13:13.838Z'
+updatedOn: '2026-09-07T18:56:07.527Z'
 isDraft: false
 ---
 
@@ -108,9 +108,10 @@ Deploy the function before connecting Meta. Meta needs a public HTTPS callback U
 
 ## Add WhatsApp secrets
 
-The deploy script runs `neon deploy --env .env.local`, the same convention as Next.js and `vercel env pull`. Bootstrap scaffolds a `.env.example` but no `.env.local`. Copy the example first, then link so Neon merges the branch's variables into it:
+The deploy script runs `neon deploy --env .env.local`, the same convention as Next.js and `vercel env pull`. Bootstrap scaffolds a `.env.example` but no `.env.local`. Install dependencies, copy the example, then link. `neon link` loads `neon.ts` to pull the branch's variables, so the packages must be installed first:
 
 ```bash
+npm install
 cp .env.example .env.local
 neon link
 ```
@@ -145,6 +146,18 @@ npm run deploy
 
 The script runs `neon deploy --env .env.local`. The CLI evaluates `neon.ts`, bundles the handler and waits for the deployment to finish. If the deployment fails, check [function logs](/docs/compute/functions/logs) and [Deploy and manage functions](/docs/compute/functions/deploy).
 
+Deployed environment variables are a snapshot of `.env.local` at deployment time. Run `npm run deploy` again after changing any WhatsApp value.
+
+## Apply the database schema
+
+```bash
+npm run db:push
+```
+
+`db:push` reads `neon.ts` (the same config `deploy` uses), so it needs the function secrets you set above, plus the `DATABASE_URL` that `neon link` wrote. `/ping` works without the tables; `/name` and `/profile` need them.
+
+## Set the webhook
+
 Your callback URL is `NEON_FUNCTION_WHATSAPP_BASE_URL` (from `.env.local`) with `/api/webhook` appended:
 
 ```text shouldWrap
@@ -152,20 +165,6 @@ https://br-cool-darkness-123456-whatsapp.compute.us-east-2.aws.neon.tech/api/web
 ```
 
 Your URL will differ. Use the exact `NEON_FUNCTION_WHATSAPP_BASE_URL` value from `.env.local`, with `/api/webhook` appended; the host is specific to your branch.
-
-Deployed environment variables are a snapshot of `.env.local` at deployment time. Run `npm run deploy` again after changing any WhatsApp value.
-
-## Apply the database schema
-
-The `/name` and `/profile` commands use the `profiles` and `command_usage` tables. `neon link` wrote `DATABASE_URL` into `.env.local`, so apply the included Drizzle schema to the linked Neon database:
-
-```bash
-npm run db:push
-```
-
-You can test `/ping` without these tables, but the database-backed commands return an error until you apply the schema.
-
-## Configure the webhook
 
 In the Meta App Dashboard, open **WhatsApp** > **Configuration**. Enter:
 
@@ -203,31 +202,11 @@ If the bot doesn't reply:
 
 ## How it works
 
-`functions/whatsapp.ts` handles GET verification requests and POST webhook deliveries at `/api/webhook`. The GET path compares Meta's verify token with your configured token:
+`functions/whatsapp.ts` handles GET verification requests and POST webhook deliveries at `/api/webhook`. The GET path checks the mode and verify token, then returns the challenge value as plain text.
 
-```ts filename="functions/whatsapp.ts"
-export default async function handler(request: Request): Promise<Response> {
-  const url = new URL(request.url);
-
-  if (request.method === "GET") {
-    const isVerified = verifyWhatsAppWebhookChallenge({
-      mode: url.searchParams.get("hub.mode"),
-      token: url.searchParams.get("hub.verify_token"),
-      verifyToken: getWhatsAppVerifyToken(),
-    });
-
-    if (!isVerified) {
-      return new Response("invalid verify token", { status: 403 });
-    }
-
-    return new Response(url.searchParams.get("hub.challenge") ?? "", {
-      headers: { "content-type": "text/plain" },
-    });
-  }
-
-  // POST signature verification and message dispatch follow.
-}
-```
+<Admonition type="important" title="Verify the raw body">
+Call `request.text()` and verify the signature before `JSON.parse`. Meta computes `X-Hub-Signature-256` from the exact request body with your app secret. Parsing and serializing the payload first can change its bytes and invalidate the signature.
+</Admonition>
 
 For a POST, the handler reads the raw body, verifies its HMAC signature with the app secret and only then parses the JSON:
 
@@ -258,10 +237,6 @@ if (!parsedPayload.success) {
 }
 ```
 
-<Admonition type="important" title="Verify the raw body">
-Call `request.text()` and verify the signature before `JSON.parse`. Meta computes `X-Hub-Signature-256` from the exact request body with your app secret. Parsing and serializing the payload first can change its bytes and invalidate the signature.
-</Admonition>
-
 The handler extracts entries that contain a `messages` array. For each incoming message, it:
 
 1. Tries to mark the message as read.
@@ -272,7 +247,16 @@ The handler extracts entries that contain a `messages` array. For each incoming 
 
 Read status updates and command usage tracking are best effort. A failure in either task doesn't block the command reply. Valid status webhooks don't contain an incoming `messages` array, so the handler acknowledges them without running a command.
 
-## Commands and callbacks
+<details>
+<summary>View full code: `functions/whatsapp.ts`</summary>
+
+<ExternalCode url="https://raw.githubusercontent.com/neondatabase/examples/main/bots/whatsapp-bot-http/functions/whatsapp.ts" />
+
+</details>
+
+View it on [GitHub](https://github.com/neondatabase/examples/blob/main/bots/whatsapp-bot-http/functions/whatsapp.ts).
+
+## Commands
 
 The template supports:
 
@@ -293,7 +277,12 @@ The `/buttons` callbacks use the IDs `button-test:refresh`, `button-test:echo` a
 
 Text responses and button panels are sent through the same Graph API `messages` endpoint. When Meta includes an incoming message ID, the bot adds it as reply context.
 
-The `/name` and `/profile` handlers use a 2.5-second database deadline. If a scaled-to-zero branch is still waking up, the bot returns a warming-up message. Run the command again after the branch is warm.
+The `/name` and `/profile` commands use Postgres via Drizzle. If the database misses a 2.5-second deadline, the bot replies "Warming up"; run the command again once the branch is warm.
+
+## Related templates
+
+- [Discord HTTP bot](https://github.com/neondatabase/examples/tree/main/bots/discord-bot-http)
+- [Telegram HTTP bot](https://github.com/neondatabase/examples/tree/main/bots/telegram-bot-http)
 
 ## Example
 


### PR DESCRIPTION
## Overview

The three "host a bot on Neon Functions" guides (Discord, Telegram, WhatsApp) had drifted
into different shapes. This gives them one shared skeleton and section names, promotes the
database schema step to its own step in each, and standardizes How it works to a single
focused snippet with the full handler collapsed and linked to GitHub. Prose and environment
setup are aligned across the three.

Verified end to end against a live Neon project: scaffolding, `neon link` env pull, the
deploy-time env requirement, and `db:push` all behave as the guides now describe.

This pull request and its description were written by Isaac.
