### PR TITLE
docs: simplify the bot guides' schema step

### DIFF
--- a/content/docs/compute/functions/discord-bot.md
+++ b/content/docs/compute/functions/discord-bot.md
@@ -8,7 +8,7 @@ summary: >-
   public function URL, verify Discord's Ed25519 request signatures, and store data in Postgres
   on the same branch.
 enableTableOfContents: true
-updatedOn: '2026-09-07T18:56:07.527Z'
+updatedOn: '2026-09-07T20:03:10.807Z'
 isDraft: false
 ---
 
@@ -165,7 +165,7 @@ Deployed env is a snapshot of `.env.local` at apply time. Run `npm run deploy` a
 npm run db:push
 ```
 
-`db:push` reads `neon.ts` (the same config `deploy` uses), so it needs the function secrets you set above, plus the `DATABASE_URL` that `neon link` wrote. `/ping` works without the tables; `/name` and `/profile` need them.
+`neon link` wrote `DATABASE_URL` into `.env.local`, so you can apply the schema any time after linking. `/ping` works without the tables; `/name` and `/profile` need them.
 
 ## Set the Interactions Endpoint URL
 

--- a/content/docs/compute/functions/telegram-bot.md
+++ b/content/docs/compute/functions/telegram-bot.md
@@ -7,7 +7,7 @@ summary: >-
   Host a Telegram bot on Neon Functions. Receive webhook updates, run bot commands, verify the
   webhook secret token, and store data in Postgres on the same branch.
 enableTableOfContents: true
-updatedOn: '2026-09-07T18:56:07.527Z'
+updatedOn: '2026-09-07T20:03:10.807Z'
 isDraft: false
 ---
 
@@ -140,7 +140,7 @@ The CLI applies the `neon.ts` policy, bundles the function and waits for the dep
 npm run db:push
 ```
 
-`db:push` reads `neon.ts` (the same config `deploy` uses), so it needs the function secrets you set above, plus the `DATABASE_URL` that `neon link` wrote. `/ping` works without the tables; `/name` and `/profile` need them.
+`neon link` wrote `DATABASE_URL` into `.env.local`, so you can apply the schema any time after linking. `/ping` works without the tables; `/name` and `/profile` need them.
 
 ## Set the webhook
 

--- a/content/docs/compute/functions/whatsapp-bot.md
+++ b/content/docs/compute/functions/whatsapp-bot.md
@@ -7,7 +7,7 @@ summary: >-
   Host a WhatsApp bot on Neon Functions. Receive WhatsApp Cloud API webhooks, verify Meta's
   request signatures, reply through the Graph API, and store data in Postgres on the same branch.
 enableTableOfContents: true
-updatedOn: '2026-09-07T18:56:07.527Z'
+updatedOn: '2026-09-07T20:03:10.807Z'
 isDraft: false
 ---
 
@@ -154,7 +154,7 @@ Deployed environment variables are a snapshot of `.env.local` at deployment time
 npm run db:push
 ```
 
-`db:push` reads `neon.ts` (the same config `deploy` uses), so it needs the function secrets you set above, plus the `DATABASE_URL` that `neon link` wrote. `/ping` works without the tables; `/name` and `/profile` need them.
+`neon link` wrote `DATABASE_URL` into `.env.local`, so you can apply the schema any time after linking. `/ping` works without the tables; `/name` and `/profile` need them.
 
 ## Set the webhook
 


### PR DESCRIPTION
## Overview

With the bot templates now reading `DATABASE_URL` directly
(neondatabase/examples#258), `npm run db:push` no longer needs the
Discord/Telegram/WhatsApp secrets. This updates the three guides' schema step to
say the schema applies right after `neon link`.

Merge after neondatabase/examples#258: `neon bootstrap` serves the template from
that repo, so until #258 lands the shipped templates still need the secrets for
`db:push`.

This pull request and its description were written by Isaac.
