### PR TITLE
docs: refresh the CLI reference schema (Neon CLI 4.14.2)

### DIFF
--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.14.1",
+  "neonctlVersion": "4.14.2",
   "binaries": [
     "neonctl",
     "neon"


### PR DESCRIPTION
Routine refresh of the CLI reference schema from Neon CLI 4.14.1 to 4.14.2. It's a patch release with no command or option changes, so the only difference is the version string.

Done on its own so the `neon auth` to `neon login` rename builds on a 4.14.2 base without folding in the version bump.

This pull request and its description were written by Isaac.
