### PR TITLE
docs: summarize compliance certs in the llms.txt

### DIFF
--- a/src/scripts/llms-index-config.js
+++ b/src/scripts/llms-index-config.js
@@ -226,7 +226,7 @@ module.exports = {
     {
       name: 'Security',
       description:
-        'Compliance certifications, acceptable use policies, HIPAA, and security reporting.',
+        'Compliance certifications (SOC 2 Type 1 and Type 2, SOC 3, ISO 27001, ISO 27701, GDPR, CCPA), acceptable use policies, HIPAA, and security reporting.',
     },
     {
       name: 'Extensions',


### PR DESCRIPTION
Brief: /dashboard/neon/actions/neon-compliance-in-llms-and-mcp

names the specific certs (SOC 2 Type 1/Type 2, SOC 3, ISO 27001, ISO 27701, GDPR, CCPA) in the llms.txt `Security` section description so agents route there on keyword match & avoids a hop