### PR TITLE
docs: mark neon set-context as deprecated in favor of neon link

### DIFF
--- a/content/docs/cli/quickstart.md
+++ b/content/docs/cli/quickstart.md
@@ -6,12 +6,12 @@ summary: >-
   Homebrew, npm, or bun, then authenticates using browser-based `neon auth` or
   a personal API key. Use this page when setting up terminal access to Neon for
   the first time, before working through the full CLI reference. It also covers
-  the `.neon` context file (`neon set-context`) to avoid repeating
+  the `.neon` context file (`neon link`) to avoid repeating
   `--project-id` and `--org-id` flags, shell tab completion, and first commands
   like `neon projects list`, `neon branches create`, and
   `neon connection-string`.
 enableTableOfContents: true
-updatedOn: '2026-07-01T13:41:48.668Z'
+updatedOn: '2026-09-08T10:51:23.316Z'
 redirectFrom:
   - /docs/reference/cli-quickstart
 ---
@@ -142,17 +142,11 @@ If you run a CLI command without an organization context, the CLI prompts you to
 Once linked, you can run CLI commands from any subdirectory of your project; the CLI walks up parent folders to find the `.neon` file. The file is also automatically added to `.gitignore` so it's not committed by accident.
 </Admonition>
 
-Alternatively, set context manually with [`neon set-context`](/docs/cli/set-context):
-
-```bash
-neon set-context --org-id <your-org-id> --project-id <your-project-id>
-```
-
 <Admonition type="info">
 You can find your organization ID in the Neon Console by selecting your organization and navigating to **Settings**. You can find your Neon project ID by opening your project in the Neon Console and navigating to **Settings** > **General**.
 </Admonition>
 
-The `set-context` command creates a `.neon` file in your current directory with your project context.
+Either form of `neon link` creates a `.neon` file in your current directory with your project context.
 
 ```bash
 cat .neon
@@ -165,19 +159,9 @@ cat .neon
 }
 ```
 
-You can also create named context files for different organization and project contexts:
-
-```bash
-neon set-context --org-id <your-org-id> --project-id <your-project-id> --context-file dev_project
-```
-
-To switch contexts, add the `--context-file` option to any command:
-
-```bash
-neon branches list --context-file Documents/dev_project
-```
-
-For more about the `set-context` command, see [Neon CLI commands: set-context](/docs/cli/set-context).
+<Admonition type="important" title="Deprecated">
+Earlier versions of the CLI used [`neon set-context`](/docs/cli/set-context) to write the `.neon` file directly. That command is deprecated in favor of `neon link` and prints a deprecation warning when you run it. Use `neon link` for new workflows.
+</Admonition>
 
 ## Enable shell completion
 

--- a/content/docs/cli/set-context.md
+++ b/content/docs/cli/set-context.md
@@ -11,7 +11,7 @@ summary: >-
   tree to the project root, supports multiple independent named files, and
   persists until reset with `neon set-context` or deleted manually.
 enableTableOfContents: true
-updatedOn: '2026-09-08T10:51:23.316Z'
+updatedOn: '2026-09-08T11:08:55.450Z'
 redirectFrom:
   - /docs/reference/cli-set-context
 ---
@@ -19,7 +19,7 @@ redirectFrom:
 The `set-context` command sets a background context for your CLI sessions, so you don't have to specify the project ID in every command. The context is saved to a default `.neon` file in the current directory, or to a [named context file](#using-a-named-context-file) of your choice, and stays in place until you reset it or remove the file.
 
 <Admonition type="important" title="Deprecated">
-`set-context` is deprecated in favor of [`neon link`](/docs/cli/link), which binds a directory to a project interactively or non-interactively and writes the same `.neon` context file. The command still works but prints a deprecation warning when you run it, and may be removed in a future release. Use `neon link` to set project context and [`neon checkout`](/docs/cli/checkout) to switch branches.
+`set-context` is deprecated in favor of [`neon link`](/docs/cli/link), which writes the same `.neon` context file. It still works but prints a deprecation warning when you run it, and may be removed in a future release. Use `neon link` to set project context; it verifies your inputs and infers your organization. For the same write-without-checks behavior `set-context` had (for example, in scripts), use `neon link --no-checks`. To switch branches, use [`neon checkout`](/docs/cli/checkout).
 </Admonition>
 
 <Admonition type="tip" title="How the CLI finds your `.neon` file">

--- a/content/docs/cli/set-context.md
+++ b/content/docs/cli/set-context.md
@@ -11,15 +11,15 @@ summary: >-
   tree to the project root, supports multiple independent named files, and
   persists until reset with `neon set-context` or deleted manually.
 enableTableOfContents: true
-updatedOn: '2026-07-01T13:41:48.668Z'
+updatedOn: '2026-09-08T10:51:23.316Z'
 redirectFrom:
   - /docs/reference/cli-set-context
 ---
 
 The `set-context` command sets a background context for your CLI sessions, so you don't have to specify the project ID in every command. The context is saved to a default `.neon` file in the current directory, or to a [named context file](#using-a-named-context-file) of your choice, and stays in place until you reset it or remove the file.
 
-<Admonition type="tip" title="Prefer link or checkout">
-For most workflows, use [`neon link`](/docs/cli/link) to bind a directory to a project or [`neon checkout`](/docs/cli/checkout) to switch branches. Use `set-context` when you need to set context values directly (for example, in scripts).
+<Admonition type="important" title="Deprecated">
+`set-context` is deprecated in favor of [`neon link`](/docs/cli/link), which binds a directory to a project interactively or non-interactively and writes the same `.neon` context file. The command still works but prints a deprecation warning when you run it, and may be removed in a future release. Use `neon link` to set project context and [`neon checkout`](/docs/cli/checkout) to switch branches.
 </Admonition>
 
 <Admonition type="tip" title="How the CLI finds your `.neon` file">


### PR DESCRIPTION
## What

Marks the `neon set-context` CLI command as deprecated in the docs, in favor of `neon link`.

The 4.14.0 CLI schema the docs build against describes `set-context` as `"Deprecated: use \`neon link\`"`, and the command prints a deprecation warning when run, but the docs still presented it as a first-class way to set context.

## Changes

- **`content/docs/cli/set-context.md`**: replaced the "Prefer link or checkout" tip with a `Deprecated` admonition pointing to `neon link` (and `neon checkout` for branches). The rest of the reference is unchanged since the command still works.
- **`content/docs/cli/quickstart.md`**: `neon link` is now the sole recommended way to write the `.neon` context file. Replaced the standalone `set-context` walkthrough with a short deprecation note, and updated the summary frontmatter.

Incidental cross-links to the set-context page elsewhere are intentionally left in place.

Resolves LKB-15147.

This pull request and its description were written by Isaac.

## NEON PREVIEW

- https://neon-next-git-docs-lkb-15147-deprecate-set-context-neondatabase.vercel.app/docs/cli/set-context
- https://neon-next-git-docs-lkb-15147-deprecate-set-context-neondatabase.vercel.app/docs/cli/quickstart
