### PR TITLE
Add SQL/PGQ revert admonition to PostgreSQL 19 pages

### DIFF
--- a/content/postgresql/postgresql-19-new-features.md
+++ b/content/postgresql/postgresql-19-new-features.md
@@ -31,6 +31,10 @@ The release spans six areas:
 
 ## SQL/PGQ Property Graph Queries
 
+<Admonition type="important" title="SQL/PGQ has been reverted from PostgreSQL 19">
+On September 7, 2026, the SQL/PGQ property graph query feature was [reverted from PostgreSQL 19](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b1f106c80cbeb18d3a0219994d98a51a6eca8ede) ahead of the final release. `CREATE PROPERTY GRAPH` and `GRAPH_TABLE` will not ship in PostgreSQL 19. The earliest the feature could return is PostgreSQL 20, expected in September 2027. The examples below reflect the implementation that was in the PostgreSQL 19 beta and may change if the feature lands in a future release.
+</Admonition>
+
 PostgreSQL 19 brings native graph query capabilities into core via the SQL:2023 SQL/PGQ standard. Existing relational tables can be exposed as property graphs and traversed with pattern matching syntax, removing the need for a separate graph database for most workloads.
 
 ### [SQL/PGQ: Graph Queries on Existing Tables](/postgresql/postgresql-19/sql-pgq-graph-queries)

--- a/content/postgresql/postgresql-19/sql-pgq-graph-queries.md
+++ b/content/postgresql/postgresql-19/sql-pgq-graph-queries.md
@@ -13,8 +13,8 @@ nextLink:
   slug: 'postgresql-19/on-conflict-do-select'
 ---
 
-<Admonition type="note" title="PostgreSQL 19 Beta 1 is here">
-[PostgreSQL 19 Beta 1 was released on June 4, 2026](https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/), so you can try SQL/PGQ property graph queries for yourself ahead of the final release expected later in 2026. Beta 1 adds support for property graph queries using SQL standard syntax over your existing relational tables, with no new storage engine or extensions.
+<Admonition type="important" title="SQL/PGQ has been reverted from PostgreSQL 19">
+On September 7, 2026, the SQL/PGQ property graph query feature was [reverted from PostgreSQL 19](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b1f106c80cbeb18d3a0219994d98a51a6eca8ede) ahead of the final release. `CREATE PROPERTY GRAPH` and `GRAPH_TABLE` will not ship in PostgreSQL 19. The earliest the feature could return is PostgreSQL 20, expected in September 2027. The examples below reflect the implementation that was in the PostgreSQL 19 beta and may change if the feature lands in a future release.
 </Admonition>
 
 **Summary**: PostgreSQL 19 adds SQL/PGQ (Property Graph Queries) based on the SQL:2023 standard. You can define graph structures over your existing relational tables and query them with pattern matching syntax - no new storage engine, no extensions, no data migration.


### PR DESCRIPTION
## Summary

SQL/PGQ property graph queries were [reverted from PostgreSQL 19](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b1f106c80cbeb18d3a0219994d98a51a6eca8ede) on September 7, 2026, ahead of the final release.

This PR adds an `important` admonition to every PostgreSQL 19 page or section that covers graph queries, stating that the feature won't ship in PostgreSQL 19 and can't return before PostgreSQL 20 (expected September 2027).

## Changes

- `content/postgresql/postgresql-19/sql-pgq-graph-queries.md`: replaces the "Beta 1 is here" note (which invited readers to try the feature) with the revert admonition.
- `content/postgresql/postgresql-19-new-features.md`: adds the revert admonition at the top of the "SQL/PGQ Property Graph Queries" section.

The example content is left intact as a reference for the beta implementation. The `on-conflict-do-select` page only references SQL/PGQ in its prev/next link metadata, so it wasn't changed.

This pull request and its description were written by Isaac.