### PR TITLE
Correct MCP tool counts on the @neon/tools launch post

### DIFF
--- a/content/blog/posts/give-your-agent-neon-tools.md
+++ b/content/blog/posts/give-your-agent-neon-tools.md
@@ -36,7 +36,7 @@ seo:
     https://cdn.neonapi.io/public/images/pages/blog/give-your-agent-neon-tools/cover.jpg
 ---
 
-**Today we're launching** `@neon/tools`**, a package that turns the** `@neon/sdk` **ergonomic client into typed agent tools with adapters for MCP, Mastra, and Eve. We're also using it to expand the hosted** [Neon MCP Server](https://neon.com/docs/ai/neon-mcp-server)**, which now exposes 82 new tools, bringing the total to 101 tools: 82 Management API tools alongside 19 hand-written tools for SQL, migrations, diagnostics, docs, and search.**
+**Today we're launching** `@neon/tools`**, a package that turns the** `@neon/sdk` **ergonomic client into typed agent tools with adapters for MCP, Mastra, and Eve. We're also using it to expand the hosted** [Neon MCP Server](https://neon.com/docs/ai/neon-mcp-server)**, which now exposes 69 new tools, bringing the total to 104 tools: 85 Management API tools alongside 19 hand-written tools for SQL, migrations, diagnostics, docs, and search.**
 
 If you build agent platforms or your own agents, you can now select the Neon operations you need and hand them to a model as tools, without writing the schemas, retries, and workflows by hand:
 
@@ -141,7 +141,7 @@ const created = await tools["projects.createAndConnect"].execute({
 
 ## @neon/tools now powers Neon MCP
 
-With `@neon/tools`, we grew the [Neon MCP Server](https://neon.com/docs/ai/neon-mcp-server) to over 101 tools. The expanded surface includes:
+With `@neon/tools`, we grew the [Neon MCP Server](https://neon.com/docs/ai/neon-mcp-server) to 104 tools. The expanded surface includes:
 
 - project updates, recovery, members, permissions, regions, and operations
 - branch, Postgres role, and database management

--- a/content/blog/posts/give-your-agent-neon-tools.md
+++ b/content/blog/posts/give-your-agent-neon-tools.md
@@ -8,7 +8,7 @@ excerpt: >-
   ergonomic client into typed agent tools with adapters for MCP, Mastra, and
   Eve. We're also using it to expand the hosted Neon MCP Server.
 date: '2026-09-03T12:00:00'
-updatedOn: '2026-09-03T15:00:00'
+updatedOn: '2026-09-08T21:00:00'
 category: product
 categories:
   - product
@@ -36,7 +36,7 @@ seo:
     https://cdn.neonapi.io/public/images/pages/blog/give-your-agent-neon-tools/cover.jpg
 ---
 
-**Today we're launching** `@neon/tools`**, a package that turns the** `@neon/sdk` **ergonomic client into typed agent tools with adapters for MCP, Mastra, and Eve. We're also using it to expand the hosted** [Neon MCP Server](https://neon.com/docs/ai/neon-mcp-server)**, which now exposes 69 new tools, bringing the total to 104 tools: 85 Management API tools alongside 19 hand-written tools for SQL, migrations, diagnostics, docs, and search.**
+**Today we're launching** `@neon/tools`**, a package that turns the** `@neon/sdk` **ergonomic client into typed agent tools with adapters for MCP, Mastra, and Eve. We're also using it to expand the hosted** [Neon MCP Server](https://neon.com/docs/ai/neon-mcp-server)**, which now exposes 71 new tools, bringing the total to 104 tools: 85 Management API tools alongside 19 hand-written tools for SQL, migrations, diagnostics, docs, and search.**
 
 If you build agent platforms or your own agents, you can now select the Neon operations you need and hand them to a model as tools, without writing the schemas, retries, and workflows by hand:
 


### PR DESCRIPTION
## Problem

The published post [Give your agent Neon tools](https://neon.com/blog/give-your-agent-neon-tools) states counts for the hosted Neon MCP Server that do not match what the server serves:

| Claim in the post | Published | Actual |
| --- | --- | --- |
| Total tools | 101 (and "over 101" further down) | 104 |
| Management API tools | 82 | 85 |
| Hand-written tools | 19 | 19 |
| New tools | 82 | 71 |

The 82 and 101 figures were the catalog size at draft time. The server shipped with three more generated tools than the draft counted, and the "new" number was taken as the full generated count rather than the number of tool names that did not exist before.

## Diagnosis

Live catalog, `GET https://mcp.neon.tech/api/list-tools`:

```
$ curl -s https://mcp.neon.tech/api/list-tools | python3 -c 'import sys,json; print(len(json.load(sys.stdin)["tools"]))'
104
```

The hosted-tools catalog snapshot on `mcp-server-neon` `origin/main` lists 85 generated Management API tools and 19 host tools. 85 + 19 = 104.

"New" is smaller than "generated" because some generated tools replaced existing hand-written tools under the same name. Before Management API tools were generated from `@neon/tools` ([mcp-server-neon#324](https://github.com/neondatabase/mcp-server-neon/pull/324)) the server exposed 35 tool names. Diffed against the live 104:

| | Count |
| --- | --- |
| Kept (19 host + 14 generated with a pre-existing name) | 33 |
| Removed (`configure_neon_auth`, `list_shared_projects`) | 2 |
| Added | 71 |

71 is the count a reader would get by comparing the old and new tool lists, so that is what the post now says.

## Change

`content/blog/posts/give-your-agent-neon-tools.md`, three lines:

- Intro paragraph: `82 new tools, bringing the total to 101 tools: 82 Management API tools` becomes `71 new tools, bringing the total to 104 tools: 85 Management API tools`. The 19 hand-written tools are unchanged.
- "@neon/tools now powers Neon MCP" section: `over 101 tools` becomes `104 tools`. "Over" is dropped because the number is now the exact catalog size.
- `updatedOn` moves from `2026-09-03T15:00:00` to `2026-09-08T21:00:00`, so the correction shows as an update to readers and crawlers.

No other content, code sample or link in the post changes.

## Verification

- `curl https://mcp.neon.tech/api/list-tools` returns 104 tools, matching the new total.
- 85 generated + 19 host in the `mcp-server-neon` catalog snapshot matches the new breakdown.
- 33 kept + 71 added = 104, and 33 + 2 removed = 35, the pre-#324 tool count.

Not verified: the site build and preview deployment. The change is limited to prose and one frontmatter timestamp in an existing post, so the Vercel preview on this PR is the check.

## For your attention

- The 71 figure counts tool names, so a generated tool that replaced a hand-written tool of the same name is not counted as new even though its schema and implementation changed. Counting those 14 as new would give 85, which is the total generated count and would restate the error the post had.