### PR TITLE
Add blog: Claimable Neon: Backends provisioned by agents & claimed by humans

### DIFF
--- a/content/blog/authors/data.json
+++ b/content/blog/authors/data.json
@@ -845,5 +845,12 @@
     "url": "https://www.linkedin.com/in/pan-angel/",
     "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/angel-pan.jpg",
     "photoAlt": "Angel Pan"
+  },
+  "zachary-proser": {
+    "name": "Zachary Proser",
+    "role": "AI Engineer, WorkOS",
+    "url": null,
+    "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/zachary-proser.jpg",
+    "photoAlt": "Zachary Proser"
   }
 }

--- a/content/blog/posts/an-agent-can-provision-a-neon-backend-a-human-can-claim-it-later.md
+++ b/content/blog/posts/an-agent-can-provision-a-neon-backend-a-human-can-claim-it-later.md
@@ -1,0 +1,114 @@
+---
+title: An agent can provision a Neon backend, a human can claim it later
+description: Who'll come through the door?
+excerpt: >-
+  We're launching Claimable Neon to give the agent another path. This flow
+  implements the anonymous registration method in auth.md, the open agent
+  registration protocol authored by WorkOS, to give agents a way to provision a
+  temporary Neon project without creating an account or collecting payment
+  details.
+date: '2026-09-10T12:00:00'
+updatedOn: '2026-09-08T21:47:00'
+category: product
+categories:
+  - product
+  - community
+authors:
+  - andre-landgraf
+cover:
+  image: null
+  alt: null
+isFeatured: false
+seo:
+  title: An agent can provision a Neon backend, a human can claim it later - Neon
+  description: Who'll come through the door?
+  keywords: []
+  noindex: false
+  ogTitle: An agent can provision a Neon backend, a human can claim it later - Neon
+  ogDescription: Who'll come through the door?
+  image: null
+---
+
+## Who'll come through the door?
+
+Everyone has experienced this:
+
+- Your agent is halfway through building an app
+- It needs a database, but you (the human who started the task) are no longer at the keyboard
+- The next step would be a signup form, an email verification, or an API key the agent does not have - it needs you, so the work stops.
+
+**We're launching** [Claimable Neon](https://neon.com/claimable-neon) **to give the agent another path. This flow implements the anonymous registration method in** [auth.md](https://workos.com/auth-md)**, the open agent registration protocol authored by WorkOS, to give agents a way to provision a temporary Neon project without creating an account or collecting payment details. The agent gets credentials scoped to that project and keeps building. If the result is worth keeping, a human can later sign in and claim the project into a Neon organization.**
+
+Today, agents can deploy Neon databases ([Lakebase Postgres](https://neon.com/docs/postgres/overview)), the [Data API,](https://neon.com/docs/data-api/overview) and [Managed Better Auth](https://neon.com/docs/auth/overview) via Claimable Neon, with the rest of the Neon backend services ([Object Storage](https://neon.com/docs/storage/overview), [Functions](https://neon.com/docs/compute/functions/overview), and [AI Gateway](https://neon.com/docs/ai-gateway/overview)) coming soon.
+
+## The idea behind Claimable Neon is simple: deploy a project before an account
+
+Claimable Neon separates provisioning from ownership:
+
+1. **The agent discovers the path.** It starts with `llms.txt`, then reads `neon.com/auth.md` to learn how Claimable Neon works.
+2. **The agent provisions a project.** `neon claim create` registers anonymously, creates one temporary project, and returns credentials scoped to that project.
+3. **The agent builds.** It can connect with standard Postgres clients, run SQL, create branches, and configure the Data API or Managed Better Auth if the app needs them.
+4. **A human claims it.** The agent generates a short-lived claim link. The human signs in to Neon, selects an organization, and accepts the transfer.
+
+An unclaimed project will expire after 72 hours, and it is capped at 100 MB of storage and 1 GB of transfer. Those limits keep the anonymous path useful for prototypes while keeping resource usage contained. As soon as a claim begins, Neon revokes the pre-claim access tokens and rotates `DATABASE_URL`. Managed Better Auth and the Data API also transfer with the project if the agent enabled them.
+
+## auth.md is the sign on the door
+
+To build something like Claimable Neon, you need to tell agents more than where an API lives: they need to know how to register, which flows a service accepts, which capabilities they can request, and how to obtain credentials without pretending to be a human. [auth.md](https://workos.com/auth-md) solves all of this.
+
+WorkOS authored auth.md, but the protocol is not tied to WorkOS infrastructure - any service can publish it, and any agent can read it. It composes existing OAuth standards with a registration layer designed for agents.
+
+How it works:
+
+- A service publishes a Markdown file, usually at `https://service.example.com/auth.md`, with instructions an agent can follow
+- The file points the agent to structured OAuth metadata that defines the actual endpoints and supported flows
+- The agent uses that metadata to register, receives a service-signed identity assertion, and exchanges the assertion for a short-lived, scoped access token. It can exchange the same assertion again when the access token expires. No long-lived API key needs to pass from a human to an agent.
+
+The protocol supports three registration methods:
+
+- **Agent verified:** an agent provider vouches for a signed-in user.
+- **User claimed:** the agent waits while a human signs in and confirms a code.
+- **Anonymous:** the agent starts with limited access, then offers a claim flow if the human wants to keep the result.
+
+Claimable Neon uses the anonymous method.
+
+## Why we chose anonymous registration
+
+An allowlist of known agent products would have been the more predictable launch: we could recognize requests from a handful of providers and reject everything else. But we actually want to see what happens when the instructions are public and the first interaction does not require a human identity. Which agents discover the file? What do they request? How far do they get? Do they ask for a database, Auth, or the Data API? Which projects do humans decide to keep?
+
+And anonymous registration does not mean unrestricted access. The agent receives credentials for one temporary project, capabilities have explicit grant decisions, access tokens are short-lived and revocable. As we've mentioned, we've also set things up so the project has a fixed lifetime and small quotas before claim. The project-scoped Neon API key stays inside Claimable Neon and is never returned to the agent.
+
+## From neon.new to Claimable Neon
+
+If you've been following Neon for a while, you might recognize the predecessors of Claimable Neon: we've been experimenting with this claimable workflows for a while, with projects like [neon.new](https://neon.new) or Instagres. This was built for developers: for example, they used it in workshops and demos to create an ephemeral Postgres database without stopping for signup.
+
+Claimable Neon keeps that useful split between creation and ownership, but changes who the first user is. If neon.new was an unauthenticated endpoint for developers, claimable Neon is a service for agents. It is also more closely integrated with Neon than its predecessors - it is built on the Neon Open API and `@neon/sdk`.
+
+Since agents are the main access point now, Claimable Neon will eventually replace neon.new.
+
+## Ask your agent to try it
+
+To try it, point your agent at `neon.com/docs/llms.txt` or ask it to create a Neon project for an app when you do not yet have a Neon account.
+
+Under the hood, the CLI path looks like this:
+
+```
+npm i -g neon@latest
+neon skills -s neon -s neon-postgres
+neon claim create --service data-api --service auth --env-pull
+```
+
+The agent can then use existing Neon commands:
+
+```
+neon branches list
+neon claim accept --no-open
+```
+
+If the agent already has access to a Neon account, it should use that account. Claimable Neon is the path for the moment before an account exists and the human is not around to create one.
+
+---
+
+Most signup flows begin by proving who a person is. Claimable Neon begins by limiting what an unknown agent can do. That inversion makes this launch super interesting - now we get to watch who arrives.
+
+**We loved collaborating with WorkOS to build Claimable Neon. If you're building something similar,  make sure to check out** [auth.md](https://workos.com/auth-md)**.**

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -19,7 +19,7 @@ authors:
 cover:
   image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/cover.jpg
   alt: Claimable Neon
-isFeatured: false
+isFeatured: true
 seo:
   title: 'Claimable Neon: Provisioned by agents, claimed by humans - Neon'
   description: >-
@@ -39,6 +39,8 @@ seo:
     details.
   image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/social.jpg
 ---
+
+![Claimable Neon](https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/cover.jpg)
 
 When building with agents, surely you have experienced this:
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -1,6 +1,11 @@
 ---
-title: An agent can provision a Neon backend, a human can claim it later
-description: Who'll come through the door?
+title: An agent provisions a Neon backend, a human claims it later
+description: >-
+  We're launching Claimable Neon to give the agent another path. This flow
+  implements the anonymous registration method in auth.md, the open agent
+  registration protocol authored by WorkOS, to give agents a way to provision a
+  temporary Neon project without creating an account or collecting payment
+  details.
 excerpt: >-
   We're launching Claimable Neon to give the agent another path. This flow
   implements the anonymous registration method in auth.md, the open agent
@@ -20,16 +25,24 @@ cover:
   alt: null
 isFeatured: false
 seo:
-  title: An agent can provision a Neon backend, a human can claim it later - Neon
-  description: Who'll come through the door?
+  title: An agent provisions a Neon backend, a human claims it later - Neon
+  description: >-
+    We're launching Claimable Neon to give the agent another path. This flow
+    implements the anonymous registration method in auth.md, the open agent
+    registration protocol authored by WorkOS, to give agents a way to provision a
+    temporary Neon project without creating an account or collecting payment
+    details.
   keywords: []
   noindex: false
-  ogTitle: An agent can provision a Neon backend, a human can claim it later - Neon
-  ogDescription: Who'll come through the door?
+  ogTitle: An agent provisions a Neon backend, a human claims it later - Neon
+  ogDescription: >-
+    We're launching Claimable Neon to give the agent another path. This flow
+    implements the anonymous registration method in auth.md, the open agent
+    registration protocol authored by WorkOS, to give agents a way to provision a
+    temporary Neon project without creating an account or collecting payment
+    details.
   image: null
 ---
-
-## Who'll come through the door?
 
 Everyone has experienced this:
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -41,7 +41,10 @@ seo:
   image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/social.jpg
 ---
 
-While building with agents, you've probably run into a situation where an agent needs a database, but by then you've stepped away from the keyboard. The next step is something like a signup form, an email verification, or an API key the agent doesn't have. It needs you to complete that step manually, and until then it can't proceed with the implementation.
+When building with agents, surely you have experienced this: 
+- Your agent is halfway through building an app
+- It needs a database, but you (the human who started the task) are no longer at the keyboard
+- The next step would be a signup form, an email verification, or an API key the agent does not have - it needs you, so the work stops
 
 We're launching **[Claimable Neon](https://neon.com/claimable-neon)** to give the agent another path. This flow implements the anonymous registration method in [auth.md](https://workos.com/auth-md), the open agent registration protocol authored by WorkOS, to give agents a way to provision a temporary Neon project without creating an account or collecting payment details. The agent gets credentials scoped to that project and keeps building. If you like the result, you can sign in later and claim the project into a Neon organization.
 
@@ -80,7 +83,7 @@ The protocol supports three registration methods:
 - User claimed: the agent waits while a human signs in and confirms a code.
 - Anonymous: the agent starts with limited access, then offers a claim flow if the human wants to keep the result.
 
-Claimable Neon uses the **Anonymous** method.
+Claimable Neon uses the Anonymous method.
 
 ## Why we chose anonymous registration
 
@@ -115,8 +118,8 @@ neon branches list
 neon claim accept --no-open
 ```
 
-If the agent already has access to a Neon account, it should use that account. Claimable Neon is the path for the moment before an account exists and the human is not around to create one.
+PS: If the agent already has access to a Neon account, it should use that account. Claimable Neon is the path for the moment before an account exists and the human is not around to create one.
 
 ---
 
-We loved collaborating with WorkOS to build Claimable Neon. If you're building something similar, make sure to check out [auth.md](https://workos.com/auth-md).
+**We loved collaborating with WorkOS to build Claimable Neon. If you're building something similar, make sure to check out [auth.md](https://workos.com/auth-md).**

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -3,8 +3,7 @@ title: 'Claimable Neon: Provisioned by agents, claimed by humans'
 description: >-
   Who'll come through the door?
 excerpt: >-
-  We're launching Claimable Neon to give the agent another path. This flow
-  implements the anonymous registration method in auth.md, the open agent
+  Claimable Neon implements the anonymous registration method in auth.md, the open agent
   registration protocol authored by WorkOS, to give agents a way to provision a
   temporary Neon project without creating an account or collecting payment
   details.

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -1,7 +1,7 @@
 ---
 title: Claimable Neon: An agent provisions a backend, a human claims it later
 description: >-
-Who'll come through the door?
+  Who'll come through the door?
 excerpt: >-
   We're launching Claimable Neon to give the agent another path. This flow
   implements the anonymous registration method in auth.md, the open agent

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -57,7 +57,7 @@ Claimable Neon separates provisioning from ownership:
 
 An unclaimed project will expire after 72 hours, and it is capped at 100 MB of storage and 1 GB of transfer. Those limits keep the anonymous path useful for prototypes while keeping resource usage contained. As soon as a claim begins, Neon revokes the pre-claim access tokens and rotates the database credentials. Managed Better Auth and the Data API also transfer with the project if the agent enabled them.
 
-## auth.md is the sign on the door
+## Powered by auth.md
 
 To build something like Claimable Neon, you need to guide agents beyond the API docs. They need to know how to register, which flows a service accepts, which capabilities they can request, and how to obtain credentials without pretending to be a human. [auth.md](https://workos.com/auth-md) provides that guide.
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -94,7 +94,7 @@ And anonymous registration does not mean unrestricted access. The agent receives
 
 If you've been following Neon for a while, you might recognize the predecessors of Claimable Neon: we've been experimenting with this claimable workflows for a while, with projects like [neon.new](https://neon.new) or Instagres. This was built for developers: for example, they used it in workshops and demos to create an ephemeral Postgres database without stopping for signup.
 
-Claimable Neon keeps that useful split between creation and ownership, but changes who the first user is. If neon.new was an unauthenticated endpoint for developers, claimable Neon is a service for agents. It is also more closely integrated with Neon than its predecessors - it is built on the Neon Open API and `@neon/sdk`.
+Claimable Neon keeps that useful split between creation and ownership, but changes who the first user is. If neon.new was an unauthenticated endpoint for developers, claimable Neon is a service for agents. Just like its predecessors - it is built on the Neon Open API. This time using the [new `@neon/sdk`](/blog/neon-sdk).
 
 Since agents are the main access point now, Claimable Neon will eventually replace neon.new.
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -16,9 +16,10 @@ categories:
   - community
 authors:
   - andre-landgraf
+  - zachary-proser
 cover:
-  image: null
-  alt: null
+  image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/cover.jpg
+  alt: Claimable Neon
 isFeatured: false
 seo:
   title: 'Claimable Neon: Provisioned by agents, claimed by humans - Neon'
@@ -37,7 +38,7 @@ seo:
     registration protocol authored by WorkOS, to give agents a way to provision a
     temporary Neon project without creating an account or collecting payment
     details.
-  image: null
+  image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/social.jpg
 ---
 
 While building with agents, you've probably run into a situation where an agent needs a database, but by then you've stepped away from the keyboard. The next step is something like a signup form, an email verification, or an API key the agent doesn't have. It needs you to complete that step manually, and until then it can't proceed with the implementation.

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -40,7 +40,8 @@ seo:
   image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/social.jpg
 ---
 
-When building with agents, surely you have experienced this: 
+When building with agents, surely you have experienced this:
+
 - Your agent is halfway through building an app
 - It needs a database, but you (the human who started the task) are no longer at the keyboard
 - The next step would be a signup form, an email verification, or an API key the agent does not have - it needs you, so the work stops
@@ -51,7 +52,10 @@ Today, agents can deploy Neon databases ([Lakebase Postgres](https://neon.com/do
 
 ## Deploy a Neon backend before an account
 
-**[add clip 1]**
+<video autoPlay muted loop playsInline width="708" height="398" aria-label="Claimable Neon: an agent provisions a backend and a human claims it">
+<source src="https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/clip-1.webm" type="video/webm" />
+<source src="https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/clip-1.mp4" type="video/mp4" />
+</video>
 
 Claimable Neon separates provisioning from ownership:
 
@@ -66,7 +70,10 @@ An unclaimed project will expire after 72 hours, and it is capped at 100 MB of s
 
 To build something like Claimable Neon, you need to guide agents beyond the API docs. They need to know how to register, which flows a service accepts, which capabilities they can request, and how to obtain credentials without pretending to be a human. [auth.md](https://workos.com/auth-md) provides that guide.
 
-**[add clip 2]**
+<video autoPlay muted loop playsInline width="708" height="631" aria-label="WorkOS auth.md agent registration protocol walkthrough">
+<source src="https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/clip-2.webm" type="video/webm" />
+<source src="https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/clip-2.mp4" type="video/mp4" />
+</video>
 
 WorkOS authored auth.md, but the protocol is not tied to WorkOS infrastructure - any service can publish it, and any agent can read it. It composes existing OAuth standards with a registration layer designed for agents.
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -1,11 +1,7 @@
 ---
-title: An agent provisions a Neon backend, a human claims it later
+title: Claimable Neon: An agent provisions a backend, a human claims it later
 description: >-
-  We're launching Claimable Neon to give the agent another path. This flow
-  implements the anonymous registration method in auth.md, the open agent
-  registration protocol authored by WorkOS, to give agents a way to provision a
-  temporary Neon project without creating an account or collecting payment
-  details.
+Who'll come through the door?
 excerpt: >-
   We're launching Claimable Neon to give the agent another path. This flow
   implements the anonymous registration method in auth.md, the open agent

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -48,6 +48,8 @@ Today, agents can deploy Neon databases ([Lakebase Postgres](https://neon.com/do
 
 ## How Claimable Neon works
 
+**[add clip 1]**
+
 Claimable Neon separates provisioning from ownership:
 
 1. **The agent discovers the path:** It starts with `llms.txt`, then reads `neon.com/auth.md` to learn how Claimable Neon works.
@@ -61,6 +63,8 @@ An unclaimed project will expire after 72 hours, and it is capped at 100 MB of s
 
 To build something like Claimable Neon, you need to guide agents beyond the API docs. They need to know how to register, which flows a service accepts, which capabilities they can request, and how to obtain credentials without pretending to be a human. [auth.md](https://workos.com/auth-md) provides that guide.
 
+**[add clip 2]**
+
 WorkOS authored auth.md, but the protocol is not tied to WorkOS infrastructure - any service can publish it, and any agent can read it. It composes existing OAuth standards with a registration layer designed for agents.
 
 How it works:
@@ -71,9 +75,9 @@ How it works:
 
 The protocol supports three registration methods:
 
-- **Agent verified:** an agent provider vouches for a signed-in user.
-- **User claimed:** the agent waits while a human signs in and confirms a code.
-- **Anonymous:** the agent starts with limited access, then offers a claim flow if the human wants to keep the result.
+- Agent verified: an agent provider vouches for a signed-in user.
+- User claimed: the agent waits while a human signs in and confirms a code.
+- Anonymous: the agent starts with limited access, then offers a claim flow if the human wants to keep the result.
 
 Claimable Neon uses the **Anonymous** method.
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -1,5 +1,5 @@
 ---
-title: 'Claimable Neon: An agent provisions a backend, a human claims it later'
+title: 'Claimable Neon: Backends provisioned by agents & claimed by humans'
 description: >-
   Who'll come through the door?
 excerpt: >-
@@ -21,7 +21,7 @@ cover:
   alt: null
 isFeatured: false
 seo:
-  title: An agent provisions a Neon backend, a human claims it later - Neon
+  title: 'Claimable Neon: Backends provisioned by agents & claimed by humans - Neon'
   description: >-
     We're launching Claimable Neon to give the agent another path. This flow
     implements the anonymous registration method in auth.md, the open agent
@@ -30,7 +30,7 @@ seo:
     details.
   keywords: []
   noindex: false
-  ogTitle: An agent provisions a Neon backend, a human claims it later - Neon
+  ogTitle: 'Claimable Neon: Backends provisioned by agents & claimed by humans - Neon'
   ogDescription: >-
     We're launching Claimable Neon to give the agent another path. This flow
     implements the anonymous registration method in auth.md, the open agent
@@ -40,38 +40,34 @@ seo:
   image: null
 ---
 
-Everyone has experienced this:
+While building with agents, you've probably run into a situation where an agent needs a database, but by then you've stepped away from the keyboard. The next step is something like a signup form, an email verification, or an API key the agent doesn't have. It needs you to complete that step manually, and until then it can't proceed with the implementation.
 
-- Your agent is halfway through building an app
-- It needs a database, but you (the human who started the task) are no longer at the keyboard
-- The next step would be a signup form, an email verification, or an API key the agent does not have - it needs you, so the work stops.
+We're launching **[Claimable Neon](https://neon.com/claimable-neon)** to give the agent another path. This flow implements the anonymous registration method in [auth.md](https://workos.com/auth-md), the open agent registration protocol authored by WorkOS, to give agents a way to provision a temporary Neon project without creating an account or collecting payment details. The agent gets credentials scoped to that project and keeps building. If you like the result, you can sign in later and claim the project into a Neon organization.
 
-**We're launching** [Claimable Neon](https://neon.com/claimable-neon) **to give the agent another path. This flow implements the anonymous registration method in** [auth.md](https://workos.com/auth-md)**, the open agent registration protocol authored by WorkOS, to give agents a way to provision a temporary Neon project without creating an account or collecting payment details. The agent gets credentials scoped to that project and keeps building. If the result is worth keeping, a human can later sign in and claim the project into a Neon organization.**
+Today, agents can deploy Neon databases ([Lakebase Postgres](https://neon.com/docs/postgres/overview)), the [Data API](https://neon.com/docs/data-api/overview), and [Managed Better Auth](https://neon.com/docs/auth/overview) via Claimable Neon, with the rest of the Neon backend services ([Object Storage](https://neon.com/docs/storage/overview), [Functions](https://neon.com/docs/compute/functions/overview), and [AI Gateway](https://neon.com/docs/ai-gateway/overview)) coming soon.
 
-Today, agents can deploy Neon databases ([Lakebase Postgres](https://neon.com/docs/postgres/overview)), the [Data API,](https://neon.com/docs/data-api/overview) and [Managed Better Auth](https://neon.com/docs/auth/overview) via Claimable Neon, with the rest of the Neon backend services ([Object Storage](https://neon.com/docs/storage/overview), [Functions](https://neon.com/docs/compute/functions/overview), and [AI Gateway](https://neon.com/docs/ai-gateway/overview)) coming soon.
-
-## The idea behind Claimable Neon is simple: deploy a project before an account
+## How Claimable Neon works
 
 Claimable Neon separates provisioning from ownership:
 
-1. **The agent discovers the path.** It starts with `llms.txt`, then reads `neon.com/auth.md` to learn how Claimable Neon works.
-2. **The agent provisions a project.** `neon claim create` registers anonymously, creates one temporary project, and returns credentials scoped to that project.
-3. **The agent builds.** It can connect with standard Postgres clients, run SQL, create branches, and configure the Data API or Managed Better Auth if the app needs them.
-4. **A human claims it.** The agent generates a short-lived claim link. The human signs in to Neon, selects an organization, and accepts the transfer.
+1. **The agent discovers the path:** It starts with `llms.txt`, then reads `neon.com/auth.md` to learn how Claimable Neon works.
+2. **The agent provisions a project:** `neon claim create` registers anonymously, creates one temporary project, and returns credentials scoped to that project.
+3. **The agent builds:** It can connect with standard Postgres clients, run SQL, create branches, and configure the Data API or Managed Better Auth if the app needs them.
+4. **A human claims it:** The agent generates a short-lived claim link. The human signs in to Neon, selects an organization, and accepts the transfer.
 
-An unclaimed project will expire after 72 hours, and it is capped at 100 MB of storage and 1 GB of transfer. Those limits keep the anonymous path useful for prototypes while keeping resource usage contained. As soon as a claim begins, Neon revokes the pre-claim access tokens and rotates `DATABASE_URL`. Managed Better Auth and the Data API also transfer with the project if the agent enabled them.
+An unclaimed project will expire after 72 hours, and it is capped at 100 MB of storage and 1 GB of transfer. Those limits keep the anonymous path useful for prototypes while keeping resource usage contained. As soon as a claim begins, Neon revokes the pre-claim access tokens and rotates the database credentials. Managed Better Auth and the Data API also transfer with the project if the agent enabled them.
 
 ## auth.md is the sign on the door
 
-To build something like Claimable Neon, you need to tell agents more than where an API lives: they need to know how to register, which flows a service accepts, which capabilities they can request, and how to obtain credentials without pretending to be a human. [auth.md](https://workos.com/auth-md) solves all of this.
+To build something like Claimable Neon, you need to guide agents beyond the API docs. They need to know how to register, which flows a service accepts, which capabilities they can request, and how to obtain credentials without pretending to be a human. [auth.md](https://workos.com/auth-md) provides that guide.
 
 WorkOS authored auth.md, but the protocol is not tied to WorkOS infrastructure - any service can publish it, and any agent can read it. It composes existing OAuth standards with a registration layer designed for agents.
 
 How it works:
 
-- A service publishes a Markdown file, usually at `https://service.example.com/auth.md`, with instructions an agent can follow
-- The file points the agent to structured OAuth metadata that defines the actual endpoints and supported flows
-- The agent uses that metadata to register, receives a service-signed identity assertion, and exchanges the assertion for a short-lived, scoped access token. It can exchange the same assertion again when the access token expires. No long-lived API key needs to pass from a human to an agent.
+- A service publishes a Markdown file, usually at `https://service.example.com/auth.md`, with instructions for agents to follow.
+- The file points the agent to structured OAuth metadata that defines the actual endpoints and supported flows.
+- The agent uses that metadata to register, receives a service-signed identity assertion, and exchanges the assertion for a short-lived, scoped access token. It can exchange the same assertion again when the access token expires, with no long-lived API key required.
 
 The protocol supports three registration methods:
 
@@ -79,7 +75,7 @@ The protocol supports three registration methods:
 - **User claimed:** the agent waits while a human signs in and confirms a code.
 - **Anonymous:** the agent starts with limited access, then offers a claim flow if the human wants to keep the result.
 
-Claimable Neon uses the anonymous method.
+Claimable Neon uses the **Anonymous** method.
 
 ## Why we chose anonymous registration
 
@@ -118,6 +114,4 @@ If the agent already has access to a Neon account, it should use that account. C
 
 ---
 
-Most signup flows begin by proving who a person is. Claimable Neon begins by limiting what an unknown agent can do. That inversion makes this launch super interesting - now we get to watch who arrives.
-
-**We loved collaborating with WorkOS to build Claimable Neon. If you're building something similar,  make sure to check out** [auth.md](https://workos.com/auth-md)**.**
+We loved collaborating with WorkOS to build Claimable Neon. If you're building something similar, make sure to check out [auth.md](https://workos.com/auth-md).

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -114,6 +114,8 @@ The agent can then use existing Neon commands:
 
 ```
 neon branches list
+neon checkout dev
+neon env pull
 neon claim accept --no-open
 ```
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -1,5 +1,5 @@
 ---
-title: 'Claimable Neon: Backends provisioned by agents & claimed by humans'
+title: 'Claimable Neon: Provisioned by agents, claimed by humans'
 description: >-
   Who'll come through the door?
 excerpt: >-
@@ -21,7 +21,7 @@ cover:
   alt: null
 isFeatured: false
 seo:
-  title: 'Claimable Neon: Backends provisioned by agents & claimed by humans - Neon'
+  title: 'Claimable Neon: Provisioned by agents, claimed by humans - Neon'
   description: >-
     We're launching Claimable Neon to give the agent another path. This flow
     implements the anonymous registration method in auth.md, the open agent

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -47,7 +47,7 @@ We're launching **[Claimable Neon](https://neon.com/claimable-neon)** to give th
 
 Today, agents can deploy Neon databases ([Lakebase Postgres](https://neon.com/docs/postgres/overview)), the [Data API](https://neon.com/docs/data-api/overview), and [Managed Better Auth](https://neon.com/docs/auth/overview) via Claimable Neon, with the rest of the Neon backend services ([Object Storage](https://neon.com/docs/storage/overview), [Functions](https://neon.com/docs/compute/functions/overview), and [AI Gateway](https://neon.com/docs/ai-gateway/overview)) coming soon.
 
-## How Claimable Neon works
+## The idea is simple: deploy a Neon backend before an account
 
 **[add clip 1]**
 

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -1,5 +1,5 @@
 ---
-title: Claimable Neon: An agent provisions a backend, a human claims it later
+title: 'Claimable Neon: An agent provisions a backend, a human claims it later'
 description: >-
   Who'll come through the door?
 excerpt: >-

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -50,7 +50,7 @@ We're launching **[Claimable Neon](https://neon.com/claimable-neon)** to give th
 
 Today, agents can deploy Neon databases ([Lakebase Postgres](https://neon.com/docs/postgres/overview)), the [Data API](https://neon.com/docs/data-api/overview), and [Managed Better Auth](https://neon.com/docs/auth/overview) via Claimable Neon, with the rest of the Neon backend services ([Object Storage](https://neon.com/docs/storage/overview), [Functions](https://neon.com/docs/compute/functions/overview), and [AI Gateway](https://neon.com/docs/ai-gateway/overview)) coming soon.
 
-## The idea is simple: deploy a Neon backend before an account
+## Deploy a Neon backend before an account
 
 **[add clip 1]**
 

--- a/src/utils/api-blog.js
+++ b/src/utils/api-blog.js
@@ -281,6 +281,8 @@ export const getBlogPostBySlug = async (slug, options = {}) => {
     return { post: null, relatedPosts: [] };
   }
 
+  const socialImage = postEntry.data.seo?.image || postEntry.data.cover?.image;
+
   const post = {
     ...mapPostToListShape(postEntry, snapshot.authorsData, snapshot.categoriesData),
     content: postEntry.content,
@@ -296,9 +298,7 @@ export const getBlogPostBySlug = async (slug, options = {}) => {
         postEntry.data.seo?.ogDescription ||
         postEntry.data.seo?.description ||
         postEntry.data.description,
-      twitterImage: postEntry.data.cover?.image
-        ? { mediaItemUrl: postEntry.data.cover.image }
-        : null,
+      twitterImage: socialImage ? { mediaItemUrl: socialImage } : null,
     },
   };
 


### PR DESCRIPTION

- Adds the product + community blog post on Claimable Neon
