### PR TITLE
docs: add lakebase_vector index build guidance

### DIFF
--- a/content/docs/extensions/lakebase-vector.md
+++ b/content/docs/extensions/lakebase-vector.md
@@ -10,7 +10,7 @@ summary: >-
   lakebase_ann.epsilon, and lakebase_ann.prefilter GUCs, and reference all
   operator classes and index options.
 enableTableOfContents: true
-updatedOn: '2026-09-03T16:16:10.689Z'
+updatedOn: '2026-09-09T10:20:49.000Z'
 ---
 
 The `lakebase_vector` extension adds the `lakebase_ann` index type to Postgres for approximate nearest-neighbor (ANN) vector search. It is a drop-in companion to `pgvector`: the same `vector` types, distance operators, and query syntax work unchanged; only the index type changes.
@@ -128,6 +128,31 @@ LIMIT 10;
 Prefiltering works best when the filter is cheap to evaluate and removes most rows. Leave it off for filters that match many rows or require expensive calculations, since evaluating the filter inside the index can add overhead.
 
 When you set these GUCs from application code, the `SET` and the query must run on the same session. With a connection pool or the [Neon serverless driver](/docs/serverless/serverless-driver), where each statement can use a different connection, issue both in a single transaction so the `SET` applies to the query.
+
+### Index build time
+
+Larger `shared_buffers` can significantly reduce index build time. Neon enables this optimization only on [larger computes](/docs/manage/computes#how-to-size-your-compute). Check the current value before optimizing an index build:
+
+```sql title="PostgreSQL"
+SHOW shared_buffers;
+```
+
+If `shared_buffers` is 1 GB or less, consider temporarily resizing to a larger compute before starting the index build.
+
+You can also speed up index creation by increasing the number of parallel workers.
+
+The `max_parallel_maintenance_workers` configuration parameter sets the maximum number of parallel workers that can be started by a single utility command such as `CREATE INDEX`.
+
+The `max_parallel_workers` configuration parameter sets the maximum number of workers that the compute can support for parallel operations. Values of `max_parallel_maintenance_workers` above this limit have no effect.
+
+The `max_worker_processes` configuration parameter sets the maximum number of background processes that the compute can support. Neon [manages this setting](/docs/reference/compatibility#parameter-settings-that-differ-by-compute-size) based on compute size. Values of `max_parallel_workers` above this limit have no effect.
+
+```sql title="PostgreSQL"
+SHOW max_worker_processes;
+-- Set both values to the desired parallelism minus one.
+SET max_parallel_workers = 15;
+SET max_parallel_maintenance_workers = 15;
+```
 
 ### Concurrent index updates
 


### PR DESCRIPTION
Add new guidance for improving lakebase_vector index build time by:

- Checking `shared_buffers`
- Using a larger compute when appropriate
- Increasing parallel-worker limits

Align the changes to the Lakebase docs from https://github.com/databricks-eng/universe/pull/2568948