### PR TITLE
docs: correct NEON_FUNCTION_<SLUG>_BASE_URL scope to local-only

### DIFF
--- a/content/changelog/2026-09-04.md
+++ b/content/changelog/2026-09-04.md
@@ -39,7 +39,7 @@ Two updates to the Neon CLI for setting up and connecting your projects:
   npx neon@latest init
   ```
 
-- **`neon env pull` writes [Neon Function](/docs/compute/functions/overview) invocation URLs**: each function's public URL is written as `NEON_FUNCTION_<SLUG>_BASE_URL`, so one function can reach another from the environment. See [Environment variables](/docs/compute/functions/environment-variables).
+- **`neon env pull` writes [Neon Function](/docs/compute/functions/overview) invocation URLs**: each function's public URL is written to your local `.env` as `NEON_FUNCTION_<SLUG>_BASE_URL`, so your local app or frontend can call your deployed functions. See [Environment variables](/docs/compute/functions/environment-variables).
 
   ```bash
   neon env pull

--- a/content/docs/compute/functions/environment-variables.md
+++ b/content/docs/compute/functions/environment-variables.md
@@ -6,7 +6,7 @@ summary: >-
   functions automatically. Set your own variables with --env at deploy time or
   in neon.ts, and pull branch variables locally with neon env pull.
 enableTableOfContents: true
-updatedOn: '2026-09-04T11:30:15.813Z'
+updatedOn: '2026-09-09T11:24:52.979Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Functions" />
@@ -121,7 +121,7 @@ neon env pull --file .env.preview
 
 To pull from a different branch, switch with `neon checkout`; it pulls the new branch's variables as part of the switch.
 
-`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's the core variables `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and `NEON_BRANCH`, plus the variables for any service you **declare in `neon.ts`**: the Managed Better Auth URLs, the Neon Data API URL, the AI Gateway credentials (`NEON_AI_GATEWAY_TOKEN`, `NEON_AI_GATEWAY_BASE_URL`), and the Object Storage credentials (`AWS_*`). It also writes a public invocation URL for each Neon Function as `NEON_FUNCTION_<SLUG>_BASE_URL` (origin only, matching `NEON_AUTH_BASE_URL` and `NEON_AI_GATEWAY_BASE_URL`), so one function can call another by reading its URL from the environment.
+`env pull` writes only the Neon-managed variables and preserves every other line in the file. That's the core variables `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and `NEON_BRANCH`, plus the variables for any service you **declare in `neon.ts`**: the Managed Better Auth URLs, the Neon Data API URL, the AI Gateway credentials (`NEON_AI_GATEWAY_TOKEN`, `NEON_AI_GATEWAY_BASE_URL`), and the Object Storage credentials (`AWS_*`). It also writes a public invocation URL for each Neon Function as `NEON_FUNCTION_<SLUG>_BASE_URL` (origin only, matching `NEON_AUTH_BASE_URL` and `NEON_AI_GATEWAY_BASE_URL`), so code running locally can call your deployed functions by reading their URLs from the environment. These variables are local-only: they aren't injected into a deployed function's runtime. To call one function from another at runtime, pass the target URL explicitly (for example as a `--env` variable) or read the incoming request's `Host` header.
 
 ## Constraints
 


### PR DESCRIPTION
## What this fixes

The 2026-09-04 changelog and the Neon Functions environment variables page said that `neon env pull` writes `NEON_FUNCTION_<SLUG>_BASE_URL` "so one function can reach another from the environment." That wording is misleading.

Reported symptom: after `neon env pull`, `NEON_FUNCTION_<SLUG>_BASE_URL` appears in the local `.env.local`, but it is not present in a deployed function's `process.env`, so a deployed function can't reach another function by reading that variable.

That is the intended behavior, not a bug:

- `neon env pull` writes these function base URLs into your local `.env` only. They're for code running locally (for example a frontend or app in the same repo) calling your deployed functions.
- They are not injected into a deployed function's runtime environment.
- To call one function from another at runtime, pass the target URL explicitly (for example as a `--env` variable) or read the incoming request's `Host` header, which is available in function code.

## Changes

- **`content/changelog/2026-09-04.md`**: reword the `neon env pull` entry to say the function base URLs are written to the local `.env` so a local app or frontend can call deployed functions.
- **`content/docs/compute/functions/environment-variables.md`**: state that these variables are local-only and add how to call one function from another at runtime.

This pull request and its description were written by Isaac.