### PR TITLE
Add blog: Improving Lakebase Compute Cache, Part 1

### DIFF
--- a/content/blog/authors/data.json
+++ b/content/blog/authors/data.json
@@ -750,7 +750,7 @@
   },
   "sunil-kamath": {
     "name": "Sunil Kamath",
-    "role": "Software Engineer, Databricks",
+    "role": "Head of Engineering, Databricks",
     "url": null,
     "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/sunil-kamath.jpg",
     "photoAlt": "Sunil Kamath"

--- a/content/blog/authors/data.json
+++ b/content/blog/authors/data.json
@@ -356,6 +356,13 @@
     "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/hans-norheim.jpg",
     "photoAlt": "Hans Norheim"
   },
+  "haoyu-huang": {
+    "name": "Haoyu Huang",
+    "role": "Software Engineer, Databricks",
+    "url": null,
+    "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/haoyu-huang.jpg",
+    "photoAlt": "Haoyu Huang"
+  },
   "hayla-westhead": {
     "name": "Hayla Westhead",
     "role": "Lead Legal Counsel",
@@ -740,6 +747,13 @@
     "url": "https://twitter.com/siegerts",
     "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/stephen-siegert.jpg",
     "photoAlt": "Stephen Siegert"
+  },
+  "sunil-kamath": {
+    "name": "Sunil Kamath",
+    "role": "Software Engineer, Databricks",
+    "url": null,
+    "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/sunil-kamath.jpg",
+    "photoAlt": "Sunil Kamath"
   },
   "taraneh-dohmer": {
     "name": "Taraneh Dohmer",

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -1,8 +1,8 @@
 ---
 title: 'Improving Lakebase Compute Cache, Part 1'
 description: >-
-  Lakebase large Postgres compute nodes now run up to 2× faster and with lower
-  latency by increasing the shared buffers size and backing with huge pages
+  Large Postgres compute nodes now run up to 2× faster and with lower
+  latency
 excerpt: >-
   On large fixed-size Lakebase Postgres computes, we now put most of the
   machine's memory into Postgres shared buffers and back that cache with huge

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -63,7 +63,7 @@ This shared buffers + page cache scheme works reasonably well but has some downs
 
 #### Technical challenges
 
-1. In a disaggregated storage system such as Lakebase, data read from storage does not travel through the OS filesystem or page cache.
+1. In a [disaggregated storage system such as Lakebase Postgres](https://neon.com/blog/wal-s3-lakebase-storage-for-the-era-of-agents), data read from storage does not travel through the OS filesystem or page cache.
 2. Shared buffers is a static parameter, meaning that it is set prior to starting Postgres and cannot be changed without rebooting the database. This is a meaningful challenge for a serverless autoscaling system such as Lakebase.
 3. Postgres uses a separate operating system process for each active connection, so the larger the shared buffers - i.e. the more memory you give Postgres - the more memory management the OS must do for each and every connection, which in turn consumes memory.
 
@@ -102,7 +102,8 @@ On larger working sets, capping shared buffers at 1 GB forced most cache hits to
 
 <Admonition type="tip" title="Fixed computes came first">
 Our first delivery of larger shared buffers targets fixed-size computes, since shared buffers are not yet dynamic. On these, we now disable the LFC and set shared buffers to 75% of DRAM. This is live today for fixed-size computes with CU >= 18 (Neon) or >= 80 (Databricks). Eliminating the ~1 GB buffer cap keeps hot pages in the fastest memory layer instead of cascading down to local file storage. 
-  To see if large shared buffers are enabled for your compute, run `show shared_buffers` within a Postgres connection.  An 80 CU Lakebase endpoint in Databricks should see a value of `20971520`
+  
+  To see if large shared buffers are enabled for your compute, run `show shared_buffers` within a Postgres connection.  An 80 CU [Lakebase endpoint in Databricks](https://www.databricks.com/product/lakebase) should see a value of `20971520`.
 </Admonition>
 
 Keeping hot data in shared buffers rather than the OS page cache also addresses the downsides described earlier. There is no double buffering, so 1 GB of cached data consumes 1 GB of RAM instead of 2 GB. And because the cache lives inside Postgres rather than the kernel, eviction decisions can be made with knowledge of database state — that positions us to pursue smarter replacement policies than the OS can offer.
@@ -132,8 +133,6 @@ We recently introduced dedicated huge-page backing across our VM infrastructure.
 <Admonition type="tip" title="Tip">
 To see if large explicit huge pages are enabled for your compute, run `show huge_pages` within a Postgres connection.  An 80 CU Lakebase endpoint should see a value of `"on"`
 </Admonition>
-
-To move beyond fixed sized computes, we've developed a protocol for autoscaling huge pages provided to the guest. Huge pages are scaled in concert with dynamic shared buffers, ensuring that we maintain efficient address translation even at high concurrency and memory sizes.
 
 ## Production results
 
@@ -175,7 +174,7 @@ On this workload, CPU use fell from 20 cores to 4 after the August 15 rollout. T
 
 We are currently working to bring larger shared buffers to autoscaling Postgres computes. Autoscaling introduces additional complexity: we must dynamically expand shared buffers when scaling up and shrink them when scaling down—all while allocating the exact required volume of huge pages.
 
-Our next post (part 2) will get into the technical details of the dynamic shared buffers implementation, including the current state of open source Postgres and the areas we've chosen to further advance the feature and contribute upstream.
+To move beyond fixed sized computes, we've developed a protocol for autoscaling huge pages provided to the guest. Huge pages are scaled in concert with dynamic shared buffers, ensuring that we maintain efficient address translation even at high concurrency and memory sizes. Our next post (part 2) will get into the technical details of this dynamic shared buffers implementation, including the current state of open source Postgres and the areas we've chosen to further advance the feature and contribute upstream.
 
 ## Related work: disabling full-page images
 

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -75,11 +75,13 @@ Now that we've provided some background, let's talk about how we are solving the
 
 **Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory.** 
 
-We need to eventually adjust our compute platform to leverage autoscaling shared buffers, but we also want to deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers. So even if autoscaling computes are the goal, we started with fixed computes, as we'll see next.  
+We need to eventually adjust our compute platform to leverage autoscaling shared buffers, but we also want to deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers. So even if autoscaling computes are the goal, we started with fixed computes, as covered in the next section.   
 
 <Admonition type="Note" title="Contributing upstream: next">
 The Postgres machinery for achieving this goal has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community. Coming soon.
 </Admonition>
+
+Here's what we implemented.
 
 ### Larger shared buffers
 
@@ -98,15 +100,16 @@ Shared buffers were tuned conservatively so that they did not consume too much m
 
 On larger working sets, capping shared buffers at 1 GB forced most cache hits to pass through the slower LFC tier. The LFC has served us well, but our intent is to retire its current form as we progress towards fully dynamic shared buffers.
 
-Our first delivery of larger shared buffers targets fixed-size computes, since shared buffers are not yet dynamic. On these, we now disable the LFC and set shared buffers to 75% of DRAM. It is live today for fixed-size computes with CU >= 18 (Neon) or >= 80 (Lakebase). Eliminating the ~1 GB buffer cap keeps hot pages in the fastest memory layer instead of cascading down to local file storage.
-
-<Admonition type="tip" title="Tip">
-To see if large shared buffers are enabled for your compute, run `show shared_buffers` within a Postgres connection.  An 80 CU Lakebase endpoint should see a value of `20971520`
+<Admonition type="tip" title="Fixed computes came first">
+Our first delivery of larger shared buffers targets fixed-size computes, since shared buffers are not yet dynamic. On these, we now disable the LFC and set shared buffers to 75% of DRAM. This is live today for fixed-size computes with CU >= 18 (Neon) or >= 80 (Databricks). Eliminating the ~1 GB buffer cap keeps hot pages in the fastest memory layer instead of cascading down to local file storage. 
+  To see if large shared buffers are enabled for your compute, run `show shared_buffers` within a Postgres connection.  An 80 CU Lakebase endpoint in Databricks should see a value of `20971520`
 </Admonition>
 
 Keeping hot data in shared buffers rather than the OS page cache also addresses the downsides described earlier. There is no double buffering, so 1 GB of cached data consumes 1 GB of RAM instead of 2 GB. And because the cache lives inside Postgres rather than the kernel, eviction decisions can be made with knowledge of database state — that positions us to pursue smarter replacement policies than the OS can offer.
 
-Sizing shared buffers at 75% of DRAM on fixed-size computes was not as simple as making a configuration change.  That is because of the third technical challenge, the process per backend architecture. We describe our solution in the next section.
+Sizing shared buffers at 75% of DRAM on fixed-size computes was not as simple as making a configuration change.  That is because of the third technical challenge, the process per backend architecture. 
+
+This next section describes our solution.
 
 ### Addressing memory and translation overhead with huge pages
 

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -119,11 +119,13 @@ Some simple numbers: each 1 GB of shared buffers corresponds to 262,144 page tab
 
 This working set also far exceeds the capacity of the Translation Lookaside Buffer (TLB), a cache in the CPU's memory management unit that speeds virtual-to-physical translation. Even a shared buffer hit then incurs a penalty from TLB misses and page table walks.
 
-To mitigate this, the Postgres community advises using an OS mechanism named huge pages (2 MB each) with large shared buffers. Switching to huge pages reduces page table sizes by a factor of 512 and significantly lowers TLB miss rates. In our benchmark tests, configuring Postgres with huge pages reduced tail read latency by up to ~40% and decreased CPU utilization by up to ~30%.
+To mitigate this, the Postgres community advises using an OS mechanism named huge pages (2 MB each) with large shared buffers. Switching to huge pages reduces page table sizes by a factor of 512 and significantly lowers TLB miss rates. 
+
+In our benchmark tests, configuring Postgres with huge pages reduced tail read latency by up to ~40% and decreased CPU utilization by up to ~30%.
 
 ### Huge page support in virtualized environments
 
-Lakebase executes within lightweight guest virtual machines on bare-metal hosts. Memory address translation involves two virtualized layers. Capitalizing on huge pages requires a consistent implementation across the entire stack: from host-level reservation, through the hypervisor backing the VM's memory, to the guest kernel. A breakdown at any tier degrades the resulting performance benefits.
+Lakebase Postgres executes within lightweight guest virtual machines on bare-metal hosts. Memory address translation involves two virtualized layers. Capitalizing on huge pages requires a consistent implementation across the entire stack: from host-level reservation, through the hypervisor backing the VM's memory, to the guest kernel. A breakdown at any tier degrades the resulting performance benefits.
 
 We recently introduced dedicated huge-page backing across our VM infrastructure. We chose to use explicit 2 MB HugeTLB pages rather than rely on best-effort transparent huge pages. Now, VMs allocated for large fixed-size computes initialize with a predetermined volume of huge pages sufficient for Postgres startup. To optimize system resources, compute startup automatically releases any surplus huge pages beyond those required by Postgres.
 
@@ -131,11 +133,11 @@ We recently introduced dedicated huge-page backing across our VM infrastructure.
 To see if large explicit huge pages are enabled for your compute, run `show huge_pages` within a Postgres connection.  An 80 CU Lakebase endpoint should see a value of `"on"`
 </Admonition>
 
-To move beyond fixed sized computes we've developed a protocol for autoscaling huge pages provided to the guest. Huge pages are scaled in concert with dynamic shared buffers, ensuring that we maintain efficient address translation even at high concurrency and memory sizes.
+To move beyond fixed sized computes, we've developed a protocol for autoscaling huge pages provided to the guest. Huge pages are scaled in concert with dynamic shared buffers, ensuring that we maintain efficient address translation even at high concurrency and memory sizes.
 
 ## Production results
 
-The rollout started region by region a few weeks ago. The examples below were measured on large production endpoints after the restart that enabled the new configuration. The hit-rate charts are the same `Compute cache hit rate` metric you see on the Metrics tab.
+The rollout started region by region a few weeks ago. The examples below were measured on large production endpoints after the restart that enabled the new configuration.
 
 <Admonition type="tip" title="Tip">
 If you're using Neon, the hit-rate charts are the same `Compute cache hit rate` metric you see on the Metrics tab.
@@ -170,19 +172,19 @@ On this workload, CPU use fell from 20 cores to 4 after the August 15 rollout. T
 
 ## Coming next: autoscaling
 
-We are currently working to bring larger shared buffers to auto-scaling Postgres computes. Auto-scaling introduces additional complexity. We must dynamically expand shared buffers when scaling up and shrink them when scaling down—all while allocating the exact required volume of huge pages.
+We are currently working to bring larger shared buffers to autoscaling Postgres computes. Autoscaling introduces additional complexity: we must dynamically expand shared buffers when scaling up and shrink them when scaling down—all while allocating the exact required volume of huge pages.
 
-Part 2 of this series  Our next post will get into the technical details of the dynamic shared buffers implementation, including the current state of open source Postgres and the areas we've chosen to further advance the feature and contribute upstream.
+Our next post (part 2) will get into the technical details of the dynamic shared buffers implementation, including the current state of open source Postgres and the areas we've chosen to further advance the feature and contribute upstream.
 
 ## Related work: disabling full-page images
 
-Our performance optimizations extend to all compute sizes, not just large instances. Earlier this year, we [disabled Postgres full-page writes and delegated image generation to the storage tier](https://neon.com/blog/turning-off-fpw-for-faster-writes). This enhancement delivers a 94% reduction in WAL volume, up to 5× higher write throughput, and an increase from 17,000 to 62,000 rows/s on production synced-table workloads.
-
-These advancements stem from the same core architectural principle that decouples compute from the distributed storage. The storage layer acts as the authoritative system of record. A compute node is stateless, and its memory serves as a caching layer.
+Worth mentioning that our performance optimization work extend to all compute sizes, not just large instances. Earlier this year, we [disabled Postgres full-page writes and delegated image generation to the storage tier](https://neon.com/blog/turning-off-fpw-for-faster-writes). This enhancement delivers a 94% reduction in WAL volume, up to 5× higher write throughput, and an increase from 17,000 to 62,000 rows/s on production synced-table workloads.
 
 ## Try it
 
-Lakebase Postgres runs in two places — same core engine, different surroundings:
+All these performance improvements stem from the [lakebase architecture](https://neon.com/docs/introduction/architecture-overview). The storage layer acts as the authoritative system of record, a compute node is stateless - and its memory serves as a caching layer.
+
+You can run Lakebase Postgres in two places — same core engine, different surroundings:
 
 - On [Neon](https://neon.com/), as backend primitives for developers, startups, and agent platforms.
 - On [Databricks](https://www.databricks.com/product/lakebase), integrated with the Data Intelligence Platform: Unity Catalog governance, lakehouse analytics, notebooks, and AI workflows.

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -1,0 +1,168 @@
+---
+title: 'Improving Lakebase Compute Cache, Part 1'
+description: >-
+  Lakebase large Postgres compute nodes now run up to 2× faster and with lower
+  latency by increasing the shared buffers size and backing with huge pages.
+excerpt: >-
+  On large fixed-size Lakebase Postgres computes, we now put most of the
+  machine's memory into Postgres shared buffers and back that cache with huge
+  pages. Hot pages stay in DRAM instead of falling through to a local disk
+  cache, so the same working set is served faster and with less CPU.
+date: '2026-09-09T12:00:00'
+updatedOn: '2026-09-09T13:23:00'
+category: engineering
+categories:
+  - engineering
+authors:
+  - sunil-kamath
+  - haoyu-huang
+  - david-wein
+  - em-sharnoff
+cover:
+  image: null
+  alt: null
+isFeatured: false
+seo:
+  title: Improving Lakebase Compute Cache, Part 1 - Neon
+  description: >-
+    Lakebase large Postgres compute nodes now run up to 2× faster and with lower
+    latency by increasing the shared buffers size and backing with huge pages.
+  keywords: []
+  noindex: false
+  ogTitle: Improving Lakebase Compute Cache, Part 1 - Neon
+  ogDescription: >-
+    Lakebase large Postgres compute nodes now run up to 2× faster and with lower
+    latency by increasing the shared buffers size and backing with huge pages.
+  image: null
+---
+
+<Admonition type="tip" title="TL;DR">
+On large fixed-size [Lakebase Postgres](https://neon.com/docs/postgres/overview) computes, we now put most of the machine's memory into Postgres shared buffers and back that cache with huge pages. Hot pages stay in DRAM instead of falling through to a local disk cache, so the same working set is served faster and with less CPU. As a result, we're measuring up to about 2× throughput, fewer reads from the storage layer, and lower latency. This improvement is already live today on fixed-size computes at CU ≥ 80 on [Databricks](https://www.databricks.com/product/lakebase) and CU ≥ 18 on [Neon](https://neon.com/). Autoscaling computes are next (it'll be part 2 of this series).
+</Admonition>
+
+The disaggregated storage model of a lakebase provides a feature rich, flexible, low cost platform for Postgres.  Efficient caching of data is critical to provide high throughput and low latency while data is backed in an object store such as S3.
+
+This caching takes place at two layers: in distributed storage, where Postgres pages are materialized for high write throughput and read serving; and on the Postgres compute itself to serve frequently accessed pages from DRAM for ultra fast access.
+
+We've been hard at work making improvements to the compute side caching, and in this blog will lay out our near term plans and delve into what has already been shipped to customers.
+
+First, some background on how we got here.
+
+## The standard Postgres cache
+
+Databases are famously hungry for DRAM (memory).  They primarily use this memory as a data cache and expect access to rows in the cache to be measured in nanoseconds - orders of magnitude faster than even the fastest NVMe drives.
+
+Postgres organizes data in rows on pages, and pages actively being accessed must be loaded into a memory area known as "shared buffers". Because Postgres traditionally stores pages using the operating system's filesystem, the OS kernel will also use its flexible page cache to provide caching between Postgres shared buffers and the disk.
+
+This shared buffers + page cache scheme works reasonably well but has some downsides and some challenges.
+
+#### Downsides
+
+1. Double buffering which reduces the amount of data you can effectively cache on the compute.  Consider a compute with 4 GB of RAM using 1 GB for shared buffers.  As you read pages from disk to populate the 1 GB of shared buffers, the reads go through the OS page cache, which also holds that data. You are now consuming 2 GB of RAM to cache 1 GB of data.
+2. The OS page cache doesn't know anything about the shared buffers or Postgres internals, so it can't make smart decisions on which pages to replace.
+
+#### Technical Challenges
+
+1. In a disaggregated storage system such as Lakebase, data read from storage does not travel through the OS filesystem or page cache.
+2. Shared buffers is a static parameter, meaning that it is set prior to starting Postgres and cannot be changed without rebooting the database.  This is a meaningful challenge for a serverless autoscaling system such as Lakebase.
+3. Postgres uses a separate operating system process for each active connection, so the larger the shared buffers - i.e. the more memory you give Postgres - the more memory management the OS must do for each and every connection, which in turn consumes memory.
+
+## The lakebase cache path
+
+Now that we've provided some background, let's talk about how we are solving them at Databricks.
+
+**Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory.** The Postgres machinery for this has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community.
+
+In parallel we need to adjust our compute platform to leverage auto scaling shared buffers as well as deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers.
+
+### Larger Shared Buffers
+
+If you recall from the technical challenges above, a disaggregated system such as Lakebase does not route its reads through the standard OS file system and its page cache.  Also recall that Postgres shared buffers are static and cannot autoscale.
+
+To solve this we created a layer we called the local file cache (LFC). The LFC acted as a stand-in, creating an autoscaling cache that worked in tandem with shared buffers and kept as much data as possible cached on the compute. This was a clever and pragmatic solution that allowed Neon and Lakebase Postgres to launch autoscaling and has been in use on all compute since launch.
+
+Although exposed as a single high-speed compute cache to users, the underlying architecture supports up to two tiers:
+
+- **Shared buffers:** Postgres's in-memory shared buffer, representing the lowest-latency access path.
+- **Local file cache:** An expanded secondary cache residing on the compute node's local NVMe, offering higher capacity than memory but requiring disk I/O to access a page.
+
+Shared buffers were tuned conservatively so that they did not consume too much memory when running at minimum configured CU, with the maximum size ever configured at 1 GB of shared buffers and LFC consuming the remainder of the total compute cache capacity (up to 75% of DRAM). Any request that results in a miss across both tiers is routed from the compute node to the distributed storage layer.
+
+On larger working sets, capping shared buffers at 1 GB forced most cache hits to pass through the slower LFC tier. The LFC has served us well, but our intent is to retire its current form as we progress towards fully dynamic shared buffers.
+
+Our first delivery of larger shared buffers targets fixed-size computes, since shared buffers are not yet dynamic. On these, we now disable the LFC and set shared buffers to 75% of DRAM. It is live today for fixed-size computes with CU >= 18 (Neon) or >= 80 (Lakebase). Eliminating the ~1 GB buffer cap keeps hot pages in the fastest memory layer instead of cascading down to local file storage.
+
+<Admonition type="tip" title="Tip">
+To see if large shared buffers are enabled for your compute, run `show shared_buffers` within a Postgres connection.  An 80 CU Lakebase endpoint should see a value of `20971520`
+</Admonition>
+
+Keeping hot data in shared buffers rather than the OS page cache also addresses the downsides described earlier. There is no double buffering, so 1 GB of cached data consumes 1 GB of RAM instead of 2 GB. And because the cache lives inside Postgres rather than the kernel, eviction decisions can be made with knowledge of database state — that positions us to pursue smarter replacement policies than the OS can offer.
+
+Sizing shared buffers at 75% of DRAM on fixed-size computes was not as simple as making a configuration change.  That is because of the third technical challenge, the process per backend architecture. We describe our solution in the next section.
+
+### Addressing Memory and Translation Overhead with Huge Pages
+
+Postgres uses a process-based structure in which each backend maps shared buffers into its own address space, requiring its own page table entries — the kernel-maintained structures the hardware walks to translate virtual addresses to physical memory. By default Linux does this mapping across 4 KB pages.
+
+Some simple numbers: each 1 GB of shared buffers corresponds to 262,144 page table entries per process. At 32 GB of shared buffers and 512 backends, that is roughly 4.3 billion entries, or about 32 GB of page tables to map 32 GB of cache.
+
+This working set also far exceeds the capacity of the Translation Lookaside Buffer (TLB), a cache in the CPU's memory management unit that speeds virtual-to-physical translation. Even a shared buffer hit then incurs a penalty from TLB misses and page table walks.
+
+To mitigate this, the Postgres community advises using an OS mechanism named huge pages (2 MB each) with large shared buffers. Switching to huge pages reduces page table sizes by a factor of 512 and significantly lowers TLB miss rates. In our benchmark tests, configuring Postgres with huge pages reduced tail read latency by up to ~40% and decreased CPU utilization by up to ~30%.
+
+### Huge Page Support in Virtualized Environments
+
+Lakebase executes within lightweight guest virtual machines on bare-metal hosts. Memory address translation involves two virtualized layers. Capitalizing on huge pages requires a consistent implementation across the entire stack: from host-level reservation, through the hypervisor backing the VM's memory, to the guest kernel. A breakdown at any tier degrades the resulting performance benefits.
+
+We recently introduced dedicated huge-page backing across our VM infrastructure. We chose to use explicit 2 MB HugeTLB pages rather than rely on best-effort transparent huge pages. Now, VMs allocated for large fixed-size computes initialize with a predetermined volume of huge pages sufficient for Postgres startup. To optimize system resources, compute startup automatically releases any surplus huge pages beyond those required by Postgres.
+
+<Admonition type="tip" title="Tip">
+To see if large explicit huge pages are enabled for your compute, run `show huge_pages` within a Postgres connection.  An 80 CU Lakebase endpoint should see a value of `"on"`
+</Admonition>
+
+To move beyond fixed sized computes we've developed a protocol for autoscaling huge pages provided to the guest. Huge pages are scaled in concert with dynamic shared buffers, ensuring that we maintain efficient address translation even at high concurrency and memory sizes.
+
+## Production results
+
+The rollout started region by region a few weeks ago. The examples below were measured on large production endpoints after the restart that enabled the new configuration. The hit-rate charts are the same `Compute cache hit rate` metric you see on the Metrics tab.
+
+<Admonition type="tip" title="Tip">
+If you're using Neon, the hit-rate charts are the same `Compute cache hit rate` metric you see on the Metrics tab.
+</Admonition>
+
+### Example 1: ~2× throughput, 5× fewer reads from storage
+
+On one large endpoint, the change became active around 06:10 UTC on August 11. Accessed Postgres blocks per second doubled, which we use here as a proxy for throughput. The customer reported lower p50 and p99 latency compared with the prior day, week, and month.
+
+This endpoint configured a large local file cache. With larger shared buffers, the storage GetPage/s dropped from about 8K per second to about 1.5K.
+
+### Example 2: 1.3× throughput
+
+On another large endpoint, the change became active around 01:30 UTC on August 14. Throughput rose about 43%.
+
+The compute cache hit rate reached nearly 100%, with requests served almost entirely from the shared buffers.
+
+### Example 3: 5× lower CPU use, 2× higher throughput
+
+On this workload, CPU use fell from 20 cores to 4 after the August 15 rollout. The compute cache hit rate rose to almost 100%, and the measured throughput doubled.
+
+## Coming next: autoscaling
+
+## What comes next?
+
+We are currently working to bring larger shared buffers to auto-scaling Postgres computes. Auto-scaling introduces additional complexity. We must dynamically expand shared buffers when scaling up and shrink them when scaling down—all while allocating the exact required volume of huge pages.
+
+Part 2 of this series  Our next post will get into the technical details of the dynamic shared buffers implementation, including the current state of open source Postgres and the areas we've chosen to further advance the feature and contribute upstream.
+
+## Related work: disabling full-page images
+
+Our performance optimizations extend to all compute sizes, not just large instances. Earlier this year, we [disabled Postgres full-page writes and delegated image generation to the storage tier](https://neon.com/blog/turning-off-fpw-for-faster-writes). This enhancement delivers a 94% reduction in WAL volume, up to 5× higher write throughput, and an increase from 17,000 to 62,000 rows/s on production synced-table workloads.
+
+These advancements stem from the same core architectural principle that decouples compute from the distributed storage. The storage layer acts as the authoritative system of record. A compute node is stateless, and its memory serves as a caching layer.
+
+## Try it
+
+Lakebase Postgres runs in two places — same core engine, different surroundings:
+
+- On [Neon](https://neon.com/), as backend primitives for developers, startups, and agent platforms.
+- On [Databricks](https://www.databricks.com/product/lakebase), integrated with the Data Intelligence Platform: Unity Catalog governance, lakehouse analytics, notebooks, and AI workflows.

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -2,7 +2,7 @@
 title: 'Improving Lakebase Compute Cache, Part 1'
 description: >-
   Lakebase large Postgres compute nodes now run up to 2× faster and with lower
-  latency by increasing the shared buffers size and backing with huge pages.
+  latency by increasing the shared buffers size and backing with huge pages
 excerpt: >-
   On large fixed-size Lakebase Postgres computes, we now put most of the
   machine's memory into Postgres shared buffers and back that cache with huge
@@ -61,7 +61,7 @@ This shared buffers + page cache scheme works reasonably well but has some downs
 1. Double buffering which reduces the amount of data you can effectively cache on the compute.  Consider a compute with 4 GB of RAM using 1 GB for shared buffers.  As you read pages from disk to populate the 1 GB of shared buffers, the reads go through the OS page cache, which also holds that data. You are now consuming 2 GB of RAM to cache 1 GB of data.
 2. The OS page cache doesn't know anything about the shared buffers or Postgres internals, so it can't make smart decisions on which pages to replace.
 
-#### Technical Challenges
+#### Technical challenges
 
 1. In a disaggregated storage system such as Lakebase, data read from storage does not travel through the OS filesystem or page cache.
 2. Shared buffers is a static parameter, meaning that it is set prior to starting Postgres and cannot be changed without rebooting the database.  This is a meaningful challenge for a serverless autoscaling system such as Lakebase.
@@ -69,13 +69,19 @@ This shared buffers + page cache scheme works reasonably well but has some downs
 
 ## The lakebase cache path
 
+**[ADD lakebase cache hierarchy DIAGRAM]**
+
 Now that we've provided some background, let's talk about how we are solving them at Databricks.
 
-**Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory.** The Postgres machinery for this has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community.
+Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory. We need to eventually adjust our compute platform to leverage autoscaling shared buffers, as well as deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers.
 
-In parallel we need to adjust our compute platform to leverage auto scaling shared buffers as well as deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers.
+**[ADD Lakebase cache path diagram]**
 
-### Larger Shared Buffers
+<Admonition type="Note" title="Contributing upstream: next">
+The Postgres machinery for this has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community.
+</Admonition>
+
+### Larger shared buffers
 
 If you recall from the technical challenges above, a disaggregated system such as Lakebase does not route its reads through the standard OS file system and its page cache.  Also recall that Postgres shared buffers are static and cannot autoscale.
 
@@ -100,7 +106,7 @@ Keeping hot data in shared buffers rather than the OS page cache also addresses 
 
 Sizing shared buffers at 75% of DRAM on fixed-size computes was not as simple as making a configuration change.  That is because of the third technical challenge, the process per backend architecture. We describe our solution in the next section.
 
-### Addressing Memory and Translation Overhead with Huge Pages
+### Addressing memory and translation overhead with huge pages
 
 Postgres uses a process-based structure in which each backend maps shared buffers into its own address space, requiring its own page table entries — the kernel-maintained structures the hardware walks to translate virtual addresses to physical memory. By default Linux does this mapping across 4 KB pages.
 
@@ -110,7 +116,7 @@ This working set also far exceeds the capacity of the Translation Lookaside Buff
 
 To mitigate this, the Postgres community advises using an OS mechanism named huge pages (2 MB each) with large shared buffers. Switching to huge pages reduces page table sizes by a factor of 512 and significantly lowers TLB miss rates. In our benchmark tests, configuring Postgres with huge pages reduced tail read latency by up to ~40% and decreased CPU utilization by up to ~30%.
 
-### Huge Page Support in Virtualized Environments
+### Huge page support in virtualized environments
 
 Lakebase executes within lightweight guest virtual machines on bare-metal hosts. Memory address translation involves two virtualized layers. Capitalizing on huge pages requires a consistent implementation across the entire stack: from host-level reservation, through the hypervisor backing the VM's memory, to the guest kernel. A breakdown at any tier degrades the resulting performance benefits.
 
@@ -134,21 +140,30 @@ If you're using Neon, the hit-rate charts are the same `Compute cache hit rate` 
 
 On one large endpoint, the change became active around 06:10 UTC on August 11. Accessed Postgres blocks per second doubled, which we use here as a proxy for throughput. The customer reported lower p50 and p99 latency compared with the prior day, week, and month.
 
+**[ADD shared buffer hits & misses DIAGRAM]**
+
 This endpoint configured a large local file cache. With larger shared buffers, the storage GetPage/s dropped from about 8K per second to about 1.5K.
+
+**[ADD GetPage DIAGRAM]**
+
 
 ### Example 2: 1.3× throughput
 
 On another large endpoint, the change became active around 01:30 UTC on August 14. Throughput rose about 43%.
 
+**[ADD shared buffer hits & misses Aug 12-13 diagram]**
+
 The compute cache hit rate reached nearly 100%, with requests served almost entirely from the shared buffers.
+
+**[ADD shared buffer hit rate DIAGRAM]**
 
 ### Example 3: 5× lower CPU use, 2× higher throughput
 
 On this workload, CPU use fell from 20 cores to 4 after the August 15 rollout. The compute cache hit rate rose to almost 100%, and the measured throughput doubled.
 
-## Coming next: autoscaling
+**[ADD CPU usage DIAGRAM]**
 
-## What comes next?
+## Coming next: autoscaling
 
 We are currently working to bring larger shared buffers to auto-scaling Postgres computes. Auto-scaling introduces additional complexity. We must dynamically expand shared buffers when scaling up and shrink them when scaling down—all while allocating the exact required volume of huge pages.
 

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -75,10 +75,10 @@ Now that we've provided some background, let's talk about how we are solving the
 
 **Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory.** 
 
-We need to eventually adjust our compute platform to leverage autoscaling shared buffers, as well as deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers.
+We need to eventually adjust our compute platform to leverage autoscaling shared buffers, but we also want to deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers. So even if autoscaling computes are the goal, we started with fixed computes, as we'll see next.  
 
 <Admonition type="Note" title="Contributing upstream: next">
-The Postgres machinery for this has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community.
+The Postgres machinery for achieving this goal has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community. Coming soon.
 </Admonition>
 
 ### Larger shared buffers

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -19,8 +19,8 @@ authors:
   - david-wein
   - em-sharnoff
 cover:
-  image: null
-  alt: null
+  image: https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/cover.jpg
+  alt: Improving Lakebase Compute Cache, Part 1
 isFeatured: false
 seo:
   title: Improving Lakebase Compute Cache, Part 1 - Neon
@@ -33,14 +33,14 @@ seo:
   ogDescription: >-
     Lakebase large Postgres compute nodes now run up to 2× faster and with lower
     latency by increasing the shared buffers size and backing with huge pages.
-  image: null
+  image: https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/social.jpg
 ---
 
 <Admonition type="tip" title="TL;DR">
 On large fixed-size [Lakebase Postgres](https://neon.com/docs/postgres/overview) computes, we now put most of the machine's memory into Postgres shared buffers and back that cache with huge pages. Hot pages stay in DRAM instead of falling through to a local disk cache, so the same working set is served faster and with less CPU. As a result, we're measuring up to about 2× throughput, fewer reads from the storage layer, and lower latency. This improvement is already live today on fixed-size computes at CU ≥ 80 on [Databricks](https://www.databricks.com/product/lakebase) and CU ≥ 18 on [Neon](https://neon.com/). Autoscaling computes are next (it'll be part 2 of this series).
 </Admonition>
 
-The disaggregated storage model of a lakebase provides a feature rich, flexible, low cost platform for Postgres.  Efficient caching of data is critical to provide high throughput and low latency while data is backed in an object store such as S3.
+The disaggregated storage model of a lakebase provides a feature rich, flexible, low cost platform for Postgres. Efficient caching of data is critical to provide high throughput and low latency while data is backed in an object store such as S3.
 
 This caching takes place at two layers: in distributed storage, where Postgres pages are materialized for high write throughput and read serving; and on the Postgres compute itself to serve frequently accessed pages from DRAM for ultra fast access.
 
@@ -50,7 +50,7 @@ First, some background on how we got here.
 
 ## The standard Postgres cache
 
-Databases are famously hungry for DRAM (memory).  They primarily use this memory as a data cache and expect access to rows in the cache to be measured in nanoseconds - orders of magnitude faster than even the fastest NVMe drives.
+Databases are famously hungry for DRAM (memory). They primarily use this memory as a data cache and expect access to rows in the cache to be measured in nanoseconds - orders of magnitude faster than even the fastest NVMe drives.
 
 Postgres organizes data in rows on pages, and pages actively being accessed must be loaded into a memory area known as "shared buffers". Because Postgres traditionally stores pages using the operating system's filesystem, the OS kernel will also use its flexible page cache to provide caching between Postgres shared buffers and the disk.
 
@@ -58,24 +58,24 @@ This shared buffers + page cache scheme works reasonably well but has some downs
 
 #### Downsides
 
-1. Double buffering which reduces the amount of data you can effectively cache on the compute.  Consider a compute with 4 GB of RAM using 1 GB for shared buffers.  As you read pages from disk to populate the 1 GB of shared buffers, the reads go through the OS page cache, which also holds that data. You are now consuming 2 GB of RAM to cache 1 GB of data.
+1. Double buffering which reduces the amount of data you can effectively cache on the compute. Consider a compute with 4 GB of RAM using 1 GB for shared buffers. As you read pages from disk to populate the 1 GB of shared buffers, the reads go through the OS page cache, which also holds that data. You are now consuming 2 GB of RAM to cache 1 GB of data.
 2. The OS page cache doesn't know anything about the shared buffers or Postgres internals, so it can't make smart decisions on which pages to replace.
 
 #### Technical challenges
 
 1. In a disaggregated storage system such as Lakebase, data read from storage does not travel through the OS filesystem or page cache.
-2. Shared buffers is a static parameter, meaning that it is set prior to starting Postgres and cannot be changed without rebooting the database.  This is a meaningful challenge for a serverless autoscaling system such as Lakebase.
+2. Shared buffers is a static parameter, meaning that it is set prior to starting Postgres and cannot be changed without rebooting the database. This is a meaningful challenge for a serverless autoscaling system such as Lakebase.
 3. Postgres uses a separate operating system process for each active connection, so the larger the shared buffers - i.e. the more memory you give Postgres - the more memory management the OS must do for each and every connection, which in turn consumes memory.
 
 ## The lakebase cache path
 
-**[ADD lakebase cache hierarchy DIAGRAM]**
+![Lakebase read cache hierarchy from object storage through the pageserver and local file cache to shared buffers](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/lakebase-read-cache-hierarchy-dark.jpg)
 
 Now that we've provided some background, let's talk about how we are solving them at Databricks.
 
-**Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory.** 
+**Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory.**
 
-We need to eventually adjust our compute platform to leverage autoscaling shared buffers, but we also want to deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers. So even if autoscaling computes are the goal, we started with fixed computes, as covered in the next section.   
+We need to eventually adjust our compute platform to leverage autoscaling shared buffers, but we also want to deliver sensible incremental improvements to our customers as they become available. Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers. So even if autoscaling computes are the goal, we started with fixed computes, as covered in the next section.
 
 <Admonition type="Note" title="Contributing upstream: next">
 The Postgres machinery for achieving this goal has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community. Coming soon.
@@ -85,9 +85,9 @@ Here's what we implemented.
 
 ### Larger shared buffers
 
-**[ADD Lakebase cache path diagram]**
+![Lakebase cache path before and after increasing Postgres shared buffers](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/lakebase-cache-path-before-after.jpg)
 
-If you recall from the technical challenges above, a disaggregated system such as Lakebase does not route its reads through the standard OS file system and its page cache.  Also recall that Postgres shared buffers are static and cannot autoscale.
+If you recall from the technical challenges above, a disaggregated system such as Lakebase does not route its reads through the standard OS file system and its page cache. Also recall that Postgres shared buffers are static and cannot autoscale.
 
 To solve this we created a layer we called the local file cache (LFC). The LFC acted as a stand-in, creating an autoscaling cache that worked in tandem with shared buffers and kept as much data as possible cached on the compute. This was a clever and pragmatic solution that allowed Neon and Lakebase Postgres to launch autoscaling and has been in use on all compute since launch.
 
@@ -107,7 +107,7 @@ Our first delivery of larger shared buffers targets fixed-size computes, since s
 
 Keeping hot data in shared buffers rather than the OS page cache also addresses the downsides described earlier. There is no double buffering, so 1 GB of cached data consumes 1 GB of RAM instead of 2 GB. And because the cache lives inside Postgres rather than the kernel, eviction decisions can be made with knowledge of database state — that positions us to pursue smarter replacement policies than the OS can offer.
 
-Sizing shared buffers at 75% of DRAM on fixed-size computes was not as simple as making a configuration change.  That is because of the third technical challenge, the process per backend architecture. 
+Sizing shared buffers at 75% of DRAM on fixed-size computes was not as simple as making a configuration change. That is because of the third technical challenge, the process per backend architecture.
 
 This next section describes our solution.
 
@@ -119,7 +119,7 @@ Some simple numbers: each 1 GB of shared buffers corresponds to 262,144 page tab
 
 This working set also far exceeds the capacity of the Translation Lookaside Buffer (TLB), a cache in the CPU's memory management unit that speeds virtual-to-physical translation. Even a shared buffer hit then incurs a penalty from TLB misses and page table walks.
 
-To mitigate this, the Postgres community advises using an OS mechanism named huge pages (2 MB each) with large shared buffers. Switching to huge pages reduces page table sizes by a factor of 512 and significantly lowers TLB miss rates. 
+To mitigate this, the Postgres community advises using an OS mechanism named huge pages (2 MB each) with large shared buffers. Switching to huge pages reduces page table sizes by a factor of 512 and significantly lowers TLB miss rates.
 
 In our benchmark tests, configuring Postgres with huge pages reduced tail read latency by up to ~40% and decreased CPU utilization by up to ~30%.
 
@@ -147,28 +147,29 @@ If you're using Neon, the hit-rate charts are the same `Compute cache hit rate` 
 
 On one large endpoint, the change became active around 06:10 UTC on August 11. Accessed Postgres blocks per second doubled, which we use here as a proxy for throughput. The customer reported lower p50 and p99 latency compared with the prior day, week, and month.
 
-**[ADD shared buffer hits & misses DIAGRAM]**
+![Shared buffer hits and misses before and after the August 11 rollout](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/shared-buffer-hits-and-misses.jpg)
 
 This endpoint configured a large local file cache. With larger shared buffers, the storage GetPage/s dropped from about 8K per second to about 1.5K.
 
-**[ADD GetPage DIAGRAM]**
-
+![Storage GetPage requests per second dropping after the August 11 rollout](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/storage-getpage-s.jpg)
 
 ### Example 2: 1.3× throughput
 
 On another large endpoint, the change became active around 01:30 UTC on August 14. Throughput rose about 43%.
 
-**[ADD shared buffer hits & misses Aug 12-13 diagram]**
+![Shared buffer hits and misses from August 12 to 15, showing the August 14 rollout](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/shared-buffer-hits-and-misses-aug-12-15.jpg)
 
 The compute cache hit rate reached nearly 100%, with requests served almost entirely from the shared buffers.
 
-**[ADD shared buffer hit rate DIAGRAM]**
+![Shared buffer hit rate approaching 100 percent after the August 14 rollout](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/shared-buffer-hit-rate.jpg)
 
 ### Example 3: 5× lower CPU use, 2× higher throughput
 
 On this workload, CPU use fell from 20 cores to 4 after the August 15 rollout. The compute cache hit rate rose to almost 100%, and the measured throughput doubled.
 
-**[ADD CPU usage DIAGRAM]**
+![CPU usage falling after the August 15 rollout](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/cpu-usage.jpg)
+
+![Shared buffer hits and misses from August 10 to 18, showing higher throughput after the August 15 rollout](https://cdn.neonapi.io/public/images/pages/blog/improving-lakebase-compute-cache-part-1/shared-buffer-hits-and-misses-aug-10-18.jpg)
 
 ## Coming next: autoscaling
 

--- a/content/blog/posts/improving-lakebase-compute-cache-part-1.md
+++ b/content/blog/posts/improving-lakebase-compute-cache-part-1.md
@@ -73,15 +73,17 @@ This shared buffers + page cache scheme works reasonably well but has some downs
 
 Now that we've provided some background, let's talk about how we are solving them at Databricks.
 
-Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory. We need to eventually adjust our compute platform to leverage autoscaling shared buffers, as well as deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers.
+**Our desired end state is to make the most efficient use of the DRAM on your compute via Postgres dynamic shared buffers that autoscale with your workload and use up to 75% of available memory.** 
 
-**[ADD Lakebase cache path diagram]**
+We need to eventually adjust our compute platform to leverage autoscaling shared buffers, as well as deliver sensible incremental improvements to our customers as they become available.  Each incremental delivery allows us to confidently ship one or more pieces of the roadmap while giving real benefit to customers.
 
 <Admonition type="Note" title="Contributing upstream: next">
 The Postgres machinery for this has been discussed in the open source community with reasonable progress.  We've decided to collaborate in the open and accelerate delivery of this technology for the broader Postgres community.
 </Admonition>
 
 ### Larger shared buffers
+
+**[ADD Lakebase cache path diagram]**
 
 If you recall from the technical challenges above, a disaggregated system such as Lakebase does not route its reads through the standard OS file system and its page cache.  Also recall that Postgres shared buffers are static and cannot autoscale.
 


### PR DESCRIPTION

- Adds the engineering blog post on larger shared buffers and huge pages for Lakebase Postgres compute cache (part 1)
