### PR TITLE
feat: add Claimable Neon blog assets and co-author

### DIFF
--- a/content/blog/authors/data.json
+++ b/content/blog/authors/data.json
@@ -845,5 +845,12 @@
     "url": "https://www.linkedin.com/in/pan-angel/",
     "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/angel-pan.jpg",
     "photoAlt": "Angel Pan"
+  },
+  "zachary-proser": {
+    "name": "Zachary Proser",
+    "role": "AI Engineer, WorkOS",
+    "url": null,
+    "photo": "https://cdn.neonapi.io/public/images/pages/blog/authors/zachary-proser.jpg",
+    "photoAlt": "Zachary Proser"
   }
 }

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -16,9 +16,10 @@ categories:
   - community
 authors:
   - andre-landgraf
+  - zachary-proser
 cover:
-  image: null
-  alt: null
+  image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/cover.jpg
+  alt: Claimable Neon
 isFeatured: false
 seo:
   title: An agent provisions a Neon backend, a human claims it later - Neon
@@ -37,7 +38,7 @@ seo:
     registration protocol authored by WorkOS, to give agents a way to provision a
     temporary Neon project without creating an account or collecting payment
     details.
-  image: null
+  image: https://cdn.neonapi.io/public/images/pages/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later/social.jpg
 ---
 
 Everyone has experienced this:

--- a/src/utils/api-blog.js
+++ b/src/utils/api-blog.js
@@ -281,6 +281,8 @@ export const getBlogPostBySlug = async (slug, options = {}) => {
     return { post: null, relatedPosts: [] };
   }
 
+  const socialImage = postEntry.data.seo?.image || postEntry.data.cover?.image;
+
   const post = {
     ...mapPostToListShape(postEntry, snapshot.authorsData, snapshot.categoriesData),
     content: postEntry.content,
@@ -296,9 +298,7 @@ export const getBlogPostBySlug = async (slug, options = {}) => {
         postEntry.data.seo?.ogDescription ||
         postEntry.data.seo?.description ||
         postEntry.data.description,
-      twitterImage: postEntry.data.cover?.image
-        ? { mediaItemUrl: postEntry.data.cover.image }
-        : null,
+      twitterImage: socialImage ? { mediaItemUrl: socialImage } : null,
     },
   };
 


### PR DESCRIPTION
Add the CDN-hosted cover and social images to the Claimable Neon post and list Zachary Proser (AI Engineer, WorkOS) as a co-author with his profile photo. Make blog sharing metadata prefer seo.image, falling back to the cover when no social image is set, and fix the post description indentation.

Validation: all 866 existing unit tests, ESLint and git diff --check pass.
