### PR TITLE
docs: document GA/billing behavior for beta services

### DIFF
--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   Use short model IDs like gpt-5-mini or gemini-3-flash. The databricks- prefix
   is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:18:16.922Z'
+updatedOn: '2026-09-09T18:39:19.826Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -48,7 +48,9 @@ If you hit the limit, you'll receive a `429 Too Many Requests` response with a m
 
 The TPM limit is counted against total tokens (input and output combined), not input alone. Upstream output token limits (20,000 OTPM for most models) apply independently, so you can hit a `429` on output tokens without reaching the gateway's TPM limit. See [Databricks Foundation Model API limits](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits) for details.
 
-Once billing begins, usage will also be capped by your prepaid credit balance. See [Pricing](#pricing) below.
+The 200,000 TPM ceiling is a soft limit. If you need a higher limit, [contact Support](/docs/introduction/support).
+
+Once billing begins, a default daily spend limit of $20 per account also applies, alongside your prepaid credit balance. It's a soft limit too, so [contact Support](/docs/introduction/support) if you need it raised. When you reach either limit, requests are blocked with a `429 Too Many Requests` response and error code `REQUEST_LIMIT_EXCEEDED`; see [Troubleshooting](/docs/ai-gateway/troubleshooting#429-account-quota-exceeded). See [Pricing](#pricing) below.
 
 ## Pricing
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   Use short model IDs like gpt-5-mini or gemini-3-flash. The databricks- prefix
   is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-09-09T18:39:19.826Z'
+updatedOn: '2026-09-10T10:23:31.223Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -50,7 +50,7 @@ The TPM limit is counted against total tokens (input and output combined), not i
 
 The 200,000 TPM ceiling is a soft limit. If you need a higher limit, [contact Support](/docs/introduction/support).
 
-Once billing begins, a default daily spend limit of $20 per account also applies, alongside your prepaid credit balance. It's a soft limit too, so [contact Support](/docs/introduction/support) if you need it raised. When you reach either limit, requests are blocked with a `429 Too Many Requests` response and error code `REQUEST_LIMIT_EXCEEDED`; see [Troubleshooting](/docs/ai-gateway/troubleshooting#429-account-quota-exceeded). See [Pricing](#pricing) below.
+Independent of billing, Neon enforces an account-level daily spend cap on AI Gateway usage, separate from the per-minute rate limit above. If your account exceeds it, every AI Gateway endpoint returns `429 Too Many Requests` with error code `REQUEST_LIMIT_EXCEEDED` (message `ai gateway daily token limit exceeded`) until the cap resets or the block is lifted. This can happen even though inference itself isn't billed yet during the beta. Neon hasn't published a fixed cap value; it isn't a flat number and can vary by account. See [Troubleshooting](/docs/ai-gateway/troubleshooting#429-account-quota-exceeded) if you hit this, or [contact Support](/docs/introduction/support) if you need it raised. See [Pricing](#pricing) below.
 
 ## Pricing
 

--- a/content/docs/ai-gateway/models.md
+++ b/content/docs/ai-gateway/models.md
@@ -7,7 +7,7 @@ summary: >-
   Use short model IDs like gpt-5-mini or gemini-3-flash. The databricks- prefix
   is also accepted.
 enableTableOfContents: true
-updatedOn: '2026-09-10T10:23:31.223Z'
+updatedOn: '2026-09-10T10:25:32.615Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -50,7 +50,7 @@ The TPM limit is counted against total tokens (input and output combined), not i
 
 The 200,000 TPM ceiling is a soft limit. If you need a higher limit, [contact Support](/docs/introduction/support).
 
-Independent of billing, Neon enforces an account-level daily spend cap on AI Gateway usage, separate from the per-minute rate limit above. If your account exceeds it, every AI Gateway endpoint returns `429 Too Many Requests` with error code `REQUEST_LIMIT_EXCEEDED` (message `ai gateway daily token limit exceeded`) until the cap resets or the block is lifted. This can happen even though inference itself isn't billed yet during the beta. Neon hasn't published a fixed cap value; it isn't a flat number and can vary by account. See [Troubleshooting](/docs/ai-gateway/troubleshooting#429-account-quota-exceeded) if you hit this, or [contact Support](/docs/introduction/support) if you need it raised. See [Pricing](#pricing) below.
+A separate account-level daily spend cap also applies and can block AI Gateway requests with a `429` / `REQUEST_LIMIT_EXCEEDED` even during the free beta. It isn't a fixed published number and can vary by account. See [Pricing](#pricing) for details, or [Troubleshooting](/docs/ai-gateway/troubleshooting#429-account-quota-exceeded) if you hit it.
 
 ## Pricing
 

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-09-09T19:36:33.907Z'
+updatedOn: '2026-09-10T10:23:31.223Z'
 ---
 
 ## Foundation model access
@@ -102,7 +102,7 @@ Your credits will stay on your account, but you won't be able to use AI Gateway 
 </FaqItem>
 
 <FaqItem question="What are the default usage limits?">
-By default, each account has a soft limit of 200,000 tokens per minute, plus a $20 daily spend limit once billing begins. These soft limits guard against runaway costs and platform abuse. If you need higher limits, [contact Support](/docs/introduction/support). See [Rate limits](/docs/ai-gateway/models#rate-limits) for details.
+By default, each account has a soft limit of 200,000 tokens per minute. Separately, Neon enforces an account-level daily spend cap on total usage. It applies even during the free beta, isn't a fixed published number, and can vary by account. Both guard against runaway costs and platform abuse. If you're blocked and need a limit raised, [contact Support](/docs/introduction/support). See [Rate limits](/docs/ai-gateway/models#rate-limits) for details.
 </FaqItem>
 
 <FaqItem question="What happens if I hit a usage limit?">

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-09-02T15:10:53.712Z'
+updatedOn: '2026-09-09T18:39:19.826Z'
 ---
 
 ## Foundation model access
@@ -16,6 +16,8 @@ Neon AI Gateway serves frontier models like GPT (`gpt-5`) and Gemini (`gemini-3-
 **See every supported model in the [model catalog](/docs/ai-gateway/models#available-models).**
 
 Open-weight models are available to every project right away. Frontier models from OpenAI and Google are rolling out gradually. Don't see them in your project yet? Request early access below.
+
+When AI Gateway reaches GA, all available models will be open to any paid Neon customer with prepaid credits, with no early-access step.
 
 <RequestForm type="backend-platform" title="Request early access to additional foundation models" description="Drop your email and we'll reach out as access opens up." buttonText="Request Early Access" confirmation="You're on the list. We'll be in touch as access opens up." />
 
@@ -43,7 +45,7 @@ Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets 
 Participation in this Beta is subject to our Terms of Service. Access is not available to users, organizations, or entities located in or operating from regions restricted by Anthropic's [Supported Regions Policy](https://www.anthropic.com/supported-countries). This restriction also applies to entities that are majority owned, directly or indirectly, by companies headquartered in unsupported regions.
 </Admonition>
 
-- **One credential for all providers.** A single Neon credential gives you access to models from OpenAI, Google, Meta, Databricks, and Alibaba. No separate provider accounts needed.
+- **One credential for all providers.** A single Neon credential gives you access to models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba. No separate provider accounts needed.
 - **Standard SDKs, one URL change.** OpenAI SDK and google-genai both work out of the box.
 - **AI follows your branches.** Each branch has its own gateway endpoint. If you use Neon branches for preview deployments, AI requests from a feature branch are scoped to that branch. It's the same isolation your database already gets.
 - **Streaming support.** Server-sent events work on all endpoints with no extra configuration.
@@ -51,11 +53,11 @@ Participation in this Beta is subject to our Terms of Service. Access is not ava
 
 ## Pricing
 
-AI Gateway pricing isn't finalized. Here's what to expect once it moves out of beta:
+Inference is free during the beta. Billing begins when AI Gateway reaches GA. Here's what to expect once it does:
 
-- **Paid plans only.** AI Gateway will be available on Neon's Launch and Scale plans. There's no difference in AI Gateway pricing or model access between the two plans.
-- **No markup.** Neon charges the same per-token rate as the model provider. Published provider prices are passed on to users with no additional markup.
-- **Free during beta.** Inference remains free through the end of the beta. Billing begins when AI Gateway reaches GA.
+- **Paid plans only.** AI Gateway will be available on Neon's Launch and Scale plans. Any paid customer with prepaid credits will be able to access all available models. There's no difference in AI Gateway pricing or model access between the two plans.
+- **No markup.** Neon will charge the same per-token rate as the model provider. Published provider prices are passed on to users with no additional markup.
+- **Prepaid credits.** Inference will draw down a prepaid credit balance. 1 credit will equal $1 USD, with a $5 minimum purchase, and credits will be valid for 12 months from purchase. You'll buy credits from the **Billing** page in the [Neon Console](https://console.neon.tech/app/billing).
 
 We'll publish exact per-model rates on the [Neon pricing page](https://neon.com/pricing) and update this page before billing begins.
 
@@ -74,5 +76,48 @@ neon bootstrap --template ai-sdk
 ```bash
 neon bootstrap --template mastra
 ```
+
+## Frequently asked questions
+
+<Faq>
+
+<FaqItem question="Who can use AI Gateway?">
+During the beta, AI Gateway is available on Neon's paid plans (Launch and Scale). When it reaches GA, any paid Neon customer with prepaid credits will be able to access all available models.
+</FaqItem>
+
+<FaqItem question="How much will AI Gateway credits cost?">
+When billing begins, 1 credit will equal $1 USD, with a $5 minimum purchase. You'll buy credits from the **Billing** page in the [Neon Console](https://console.neon.tech/app/billing). Inference is free during the beta.
+</FaqItem>
+
+<FaqItem question="Will my credit balance be able to go negative?">
+Yes, by a small amount. Usage can exceed your remaining balance before it's detected, so a minimum balance of $2 will apply to account for this.
+</FaqItem>
+
+<FaqItem question="Will credits expire?">
+Credits will be valid for 12 months from the date of purchase.
+</FaqItem>
+
+<FaqItem question="What happens to my credits if I downgrade to Free?">
+Your credits will stay on your account, but you won't be able to use AI Gateway while on the Free plan. They become available again if you upgrade to a paid plan.
+</FaqItem>
+
+<FaqItem question="What are the default usage limits?">
+By default, each account has a soft limit of 200,000 tokens per minute, plus a $20 daily spend limit once billing begins. These soft limits guard against runaway costs and platform abuse. If you need higher limits, [contact Support](/docs/introduction/support). See [Rate limits](/docs/ai-gateway/models#rate-limits) for details.
+</FaqItem>
+
+<FaqItem question="What happens if I hit a usage limit?">
+Requests are blocked once you reach your per-minute token limit or daily spend limit, and the gateway returns an `HTTP 429` response:
+
+```json
+{
+  "error_code": "REQUEST_LIMIT_EXCEEDED",
+  "message": "ai gateway daily token limit exceeded"
+}
+```
+
+See [Troubleshooting](/docs/ai-gateway/troubleshooting#429-account-quota-exceeded).
+</FaqItem>
+
+</Faq>
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-09-09T18:39:19.826Z'
+updatedOn: '2026-09-09T19:36:33.907Z'
 ---
 
 ## Foundation model access
@@ -45,7 +45,7 @@ Neon AI Gateway is the LLM inference layer built into the Neon backend. It lets 
 Participation in this Beta is subject to our Terms of Service. Access is not available to users, organizations, or entities located in or operating from regions restricted by Anthropic's [Supported Regions Policy](https://www.anthropic.com/supported-countries). This restriction also applies to entities that are majority owned, directly or indirectly, by companies headquartered in unsupported regions.
 </Admonition>
 
-- **One credential for all providers.** A single Neon credential gives you access to models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba. No separate provider accounts needed.
+- **One credential for all providers.** A single Neon credential gives you access to models from OpenAI, Google, Meta, Databricks, and Alibaba. No separate provider accounts needed.
 - **Standard SDKs, one URL change.** OpenAI SDK and google-genai both work out of the box.
 - **AI follows your branches.** Each branch has its own gateway endpoint. If you use Neon branches for preview deployments, AI requests from a feature branch are scoped to that branch. It's the same isolation your database already gets.
 - **Streaming support.** Server-sent events work on all endpoints with no extra configuration.

--- a/content/docs/ai-gateway/overview.md
+++ b/content/docs/ai-gateway/overview.md
@@ -6,7 +6,7 @@ summary: >-
   Neon credential gives you access to models across multiple providers. Standard AI
   SDKs work without code changes. Each branch gets its own gateway endpoint.
 enableTableOfContents: true
-updatedOn: '2026-09-10T10:23:31.223Z'
+updatedOn: '2026-09-10T10:25:32.615Z'
 ---
 
 ## Foundation model access
@@ -102,7 +102,7 @@ Your credits will stay on your account, but you won't be able to use AI Gateway 
 </FaqItem>
 
 <FaqItem question="What are the default usage limits?">
-By default, each account has a soft limit of 200,000 tokens per minute. Separately, Neon enforces an account-level daily spend cap on total usage. It applies even during the free beta, isn't a fixed published number, and can vary by account. Both guard against runaway costs and platform abuse. If you're blocked and need a limit raised, [contact Support](/docs/introduction/support). See [Rate limits](/docs/ai-gateway/models#rate-limits) for details.
+By default, each account has a soft limit of 200,000 tokens per minute. Separately, Neon enforces an account-level daily spend cap on total usage. It applies even during the free beta, isn't a fixed published number, and can vary by account. Both guard against runaway costs. If you're blocked and need a limit raised, [contact Support](/docs/introduction/support). See [Rate limits](/docs/ai-gateway/models#rate-limits) for details.
 </FaqItem>
 
 <FaqItem question="What happens if I hit a usage limit?">

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -25,7 +25,7 @@ redirectFrom:
   - /docs/reference/billing-sample
   - /docs/introduction/legacy-plans
   - /docs/introduction/extra-usage
-updatedOn: '2026-09-02T21:17:48.434Z'
+updatedOn: '2026-09-09T18:39:19.826Z'
 ---
 
 Neon offers plans to support you at every stage, from your first prototype to production at scale.
@@ -372,15 +372,17 @@ There's no charge for Functions during the beta, but [usage limits](/docs/comput
 
 On the **Free** plan, you get 10 active Capacity-Hours, 400 waiting Capacity-Hours, and 1 million invocations per month.
 
+When billing begins, these Free allowances will be enforced at two levels: an account-wide total across all your projects, and an independent per-project limit.
+
 When billing begins, egress (data a function sends out) will count toward your [public network transfer](#public-network-transfer) allowance, which is shared across all products.
 
 See [Neon Functions](/docs/compute/functions/overview) for what's included and current limitations.
 
 ### AI Gateway
 
-Neon AI Gateway provides access to foundation models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba through a single Neon credential. It is available on paid plans (Launch and Scale) during the beta.
+Neon AI Gateway provides access to foundation models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba through a single Neon credential. It is available on paid plans (Launch and Scale) during the beta. When AI Gateway reaches GA, any paid customer with prepaid credits will be able to access all available models.
 
-Inference is free during the beta. When billing begins, prices will match each provider's published list prices, with no additional markup.
+Inference is free during the beta. When billing begins, prices will match each provider's published list prices, with no additional markup, drawing down a prepaid credit balance you buy from the Billing page in the Neon Console.
 
 See [AI Gateway pricing](/docs/ai-gateway/overview#pricing) for details.
 

--- a/content/docs/introduction/plans.md
+++ b/content/docs/introduction/plans.md
@@ -25,7 +25,7 @@ redirectFrom:
   - /docs/reference/billing-sample
   - /docs/introduction/legacy-plans
   - /docs/introduction/extra-usage
-updatedOn: '2026-09-09T18:39:19.826Z'
+updatedOn: '2026-09-10T10:25:32.615Z'
 ---
 
 Neon offers plans to support you at every stage, from your first prototype to production at scale.
@@ -380,7 +380,7 @@ See [Neon Functions](/docs/compute/functions/overview) for what's included and c
 
 ### AI Gateway
 
-Neon AI Gateway provides access to foundation models from Anthropic, OpenAI, Google, Meta, Databricks, and Alibaba through a single Neon credential. It is available on paid plans (Launch and Scale) during the beta. When AI Gateway reaches GA, any paid customer with prepaid credits will be able to access all available models.
+Neon AI Gateway provides access to foundation models from OpenAI, Google, Meta, Databricks, and Alibaba through a single Neon credential. It is available on paid plans (Launch and Scale) during the beta. When AI Gateway reaches GA, any paid customer with prepaid credits will be able to access all available models.
 
 Inference is free during the beta. When billing begins, prices will match each provider's published list prices, with no additional markup, drawing down a prepaid credit balance you buy from the Billing page in the Neon Console.
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   or the AWS CLI. Supports single-part and multipart uploads, range requests,
   batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-08-21T15:53:18.662Z'
+updatedOn: '2026-09-09T18:39:19.826Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -72,7 +72,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 
 ## Multipart upload
 
-During beta, the maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. This is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects. For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload makes large uploads more reliable because each part is retried independently, though it doesn't raise the per-object limit during beta.
+During beta, the maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. This is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects. When billing begins, paid plans follow standard [S3 limits](https://aws.amazon.com/s3/faqs/): objects up to 50 TB, with a 5 GB maximum for a single-request upload, so multipart upload is required for larger objects (AWS recommends it above 100 MB). For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload makes large uploads more reliable because each part is retried independently, though it doesn't raise the per-object limit during beta.
 
 <CodeTabs labels={["TypeScript", "Python"]}>
 

--- a/content/docs/storage/objects.md
+++ b/content/docs/storage/objects.md
@@ -6,7 +6,7 @@ summary: >-
   or the AWS CLI. Supports single-part and multipart uploads, range requests,
   batch deletes, and presigned URLs for browser-side access.
 enableTableOfContents: true
-updatedOn: '2026-09-09T18:39:19.826Z'
+updatedOn: '2026-09-10T09:15:52.922Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -72,7 +72,7 @@ aws s3 cp ./photo.jpg s3://my-bucket/images/photo.jpg \
 
 ## Multipart upload
 
-During beta, the maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. This is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects. When billing begins, paid plans follow standard [S3 limits](https://aws.amazon.com/s3/faqs/): objects up to 50 TB, with a 5 GB maximum for a single-request upload, so multipart upload is required for larger objects (AWS recommends it above 100 MB). For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload makes large uploads more reliable because each part is retried independently, though it doesn't raise the per-object limit during beta.
+During beta, the maximum object size is 5 GiB, whether you upload it in a single request or as a multipart upload. This is a beta limit, not a permanent cap; [contact support](/docs/introduction/support) if you need to store larger objects. When billing begins, paid plans follow standard [S3 limits](https://aws.amazon.com/s3/faqs/): objects up to 5 TB, with a 5 GB maximum for a single-request upload, so multipart upload is required for larger objects (AWS recommends it above 100 MB). For large files, the AWS SDK automatically uses multipart upload above a configurable threshold. You can also initiate multipart upload manually for fine-grained control. Multipart upload makes large uploads more reliable because each part is retried independently, though it doesn't raise the per-object limit during beta.
 
 <CodeTabs labels={["TypeScript", "Python"]}>
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-09-02T20:41:07.968Z'
+updatedOn: '2026-09-09T18:39:19.826Z'
 ---
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
@@ -57,8 +57,10 @@ During the beta, the following usage limits apply:
 
 - **Region**: object storage is available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
 - **Free object storage**: the Free plan includes 5 GB of object storage per project. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
-- **Object size**: objects can be up to 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload). [Contact support](/docs/introduction/support) if you need to store larger objects.
+- **Object size**: during the beta, objects can be up to 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload). [Contact support](/docs/introduction/support) if you need to store larger objects. When billing begins, paid plans follow standard [S3 limits](https://aws.amazon.com/s3/faqs/): individual objects up to 50 TB, with a 5 GB maximum for a single-request upload. Use [multipart upload](/docs/storage/objects#multipart-upload) for larger objects; AWS recommends it for anything over 100 MB.
 - **Rate limiting**: requests may be throttled during heavy use, returning a `503 SlowDown` response. Back off and retry. See [Connection and performance errors](/docs/storage/troubleshooting#connection-and-performance-errors).
+
+When billing begins, storage-volume limits apply to the Free plan only. Paid plans have no fixed limit on total storage or number of objects; storage is metered per GB (see [plans and pricing](/docs/introduction/plans#object-storage)).
 
 For S3 API and feature limitations (as opposed to usage limits), see [Known limitations](/docs/storage/s3-compatibility#known-limitations).
 

--- a/content/docs/storage/overview.md
+++ b/content/docs/storage/overview.md
@@ -7,7 +7,7 @@ summary: >-
   or tool. Point it at your branch endpoint and authenticate with your Neon
   credential.
 enableTableOfContents: true
-updatedOn: '2026-09-09T18:39:19.826Z'
+updatedOn: '2026-09-10T09:15:52.922Z'
 ---
 
 Neon Object Storage is S3-compatible object storage built into the Neon backend for apps and agents. Every branch gets its own isolated storage namespace. Use any AWS S3-compatible SDK or tool. Point it at your branch endpoint and authenticate with your Neon credential. No separate storage account or cloud credentials required.
@@ -57,7 +57,7 @@ During the beta, the following usage limits apply:
 
 - **Region**: object storage is available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`). Support is expanding toward all regions.
 - **Free object storage**: the Free plan includes 5 GB of object storage per project. See [plans and pricing](/docs/introduction/plans#object-storage) for storage and egress rates.
-- **Object size**: during the beta, objects can be up to 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload). [Contact support](/docs/introduction/support) if you need to store larger objects. When billing begins, paid plans follow standard [S3 limits](https://aws.amazon.com/s3/faqs/): individual objects up to 50 TB, with a 5 GB maximum for a single-request upload. Use [multipart upload](/docs/storage/objects#multipart-upload) for larger objects; AWS recommends it for anything over 100 MB.
+- **Object size**: during the beta, objects can be up to 5 GiB, whether uploaded in a single request or with [multipart upload](/docs/storage/objects#multipart-upload). [Contact support](/docs/introduction/support) if you need to store larger objects. When billing begins, paid plans follow standard [S3 limits](https://aws.amazon.com/s3/faqs/): individual objects up to 5 TB, with a 5 GB maximum for a single-request upload. Use [multipart upload](/docs/storage/objects#multipart-upload) for larger objects; AWS recommends it for anything over 100 MB.
 - **Rate limiting**: requests may be throttled during heavy use, returning a `503 SlowDown` response. Back off and retry. See [Connection and performance errors](/docs/storage/troubleshooting#connection-and-performance-errors).
 
 When billing begins, storage-volume limits apply to the Free plan only. Paid plans have no fixed limit on total storage or number of objects; storage is metered per GB (see [plans and pricing](/docs/introduction/plans#object-storage)).


### PR DESCRIPTION
Documents GA and billing behavior for three beta services, cast as future ("when GA" / "when billing begins"). Beta scaffolding is left intact so the pages remain accurate today.

## NEON PREVIEW

- https://neon-next-git-docs-ai-gateway-ga-access-neondatabase.vercel.app/docs/ai-gateway/overview
- https://neon-next-git-docs-ai-gateway-ga-access-neondatabase.vercel.app/docs/ai-gateway/models
- https://neon-next-git-docs-ai-gateway-ga-access-neondatabase.vercel.app/docs/introduction/plans
- https://neon-next-git-docs-ai-gateway-ga-access-neondatabase.vercel.app/docs/storage/overview
- https://neon-next-git-docs-ai-gateway-ga-access-neondatabase.vercel.app/docs/storage/objects

This pull request and its description were written by Isaac.