### PR TITLE
docs: refresh Neon CLI reference for 4.14.6

### DIFF
--- a/content/docs/cli/env.md
+++ b/content/docs/cli/env.md
@@ -46,3 +46,9 @@ Pull only the variables for the services you name, ignoring `neon.ts`. Repeat `-
 ```bash
 neon env pull --service ai-gateway --service postgres
 ```
+
+Use a specific `neon.ts` policy instead of the one found by walking up from the current directory:
+
+```bash
+neon env pull --config ./config/neon.ts
+```

--- a/content/docs/cli/inspect.md
+++ b/content/docs/cli/inspect.md
@@ -23,7 +23,7 @@ Run a single diagnostic query against a branch's Postgres. Pick the query with a
 
 <CliOptions command="inspect db" />
 
-By default the command resolves the project, branch, database, and role from your [context](/docs/cli/set-context) and connects through the Neon API. Pass `--db-url` to inspect any Postgres directly from a connection string, which bypasses API resolution and lets you point `inspect` at a database outside Neon.
+By default the command resolves the project, branch, database, and role from your [context](/docs/cli/set-context) and connects through the Neon API. Pass `--db-url` to inspect any Postgres directly from a connection string, which bypasses API resolution and lets you point `inspect` at a database outside Neon without being logged in to Neon.
 
 When you omit `--database-name`, `inspect` covers every database on the branch and adds a `database` column so you can tell the rows apart. Pass `--database-name` to inspect a single database, which also scopes `locks` and `long-running-queries` to that database so lock and relation names resolve correctly. Database-scoped checks such as `table-sizes`, `locks`, and `outliers` run against each database, while compute-wide checks (`lfc-hit-rate`, `working-set`, and `replication-slots`) run once. If any database fails, the whole run fails, so pass `--database-name` to narrow to one when that happens. `--db-url` always inspects the single database in the connection string and never adds the `database` column.
 

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.14.2",
+  "neonctlVersion": "4.14.6",
   "binaries": [
     "neonctl",
     "neon"
@@ -976,11 +976,11 @@
           "options": {
             "config": {
               "type": "string",
-              "describe": "Path to neon.ts. Defaults to walking up from the current directory"
+              "describe": "Path to neon.ts for registration and the bundled env pull. Defaults to walking up from the current directory"
             },
             "env-pull": {
               "type": "boolean",
-              "describe": "Write the provisioned DATABASE_URL and service URLs to a dotenv file",
+              "describe": "Write the same Neon env vars `env pull` would",
               "default": true
             },
             "file": {
@@ -1615,6 +1615,10 @@
           "aliases": [],
           "positionals": [],
           "options": {
+            "config": {
+              "type": "string",
+              "describe": "Path to a neon.ts policy (defaults to walking up from cwd)"
+            },
             "env": {
               "type": "array",
               "alias": "e"


### PR DESCRIPTION
Refresh the Neon CLI reference for the 4.14.6 release.

- schema.json: bump 4.14.2 to 4.14.6; adds `env pull --config`
- env.md: add `neon env pull --config` example
- inspect.md: note `--db-url` skips API resolution and login

This pull request and its description were written by Isaac.