### PR TITLE
docs: document the neon functions domains commands

### DIFF
--- a/content/docs/cli/functions.md
+++ b/content/docs/cli/functions.md
@@ -1,12 +1,10 @@
 ---
 title: 'Neon CLI command: functions'
-subtitle: 'Deploy, list, inspect, and delete Neon Functions'
+subtitle: 'Deploy, list, inspect, and delete Neon Functions, and manage their custom domains'
 summary: >-
-  The Neon CLI `neon functions` command manages Neon Functions on a branch:
-  `neon functions deploy <slug>` bundles and deploys a function from a local
-  directory or entry file (with --src, --runtime, --env, and --wait), and the list,
-  get, and delete subcommands manage deployed functions. The slug is the
-  permanent function identifier: 1 to 20 lowercase letters and digits.
+  The Neon CLI `neon functions` command manages Neon Functions on a branch: deploy,
+  list, get, and delete functions, and register and manage their custom domains with
+  the `domains` subcommands.
 enableTableOfContents: true
 redirectFrom:
   - /docs/cli/function
@@ -151,3 +149,70 @@ neon functions delete hello
 ```text filename="Output"
 INFO: Function hello deleted from branch br-cool-darkness-123456
 ```
+
+## neon functions domains (#domains)
+
+Manage custom domains for functions on the branch. Custom domains are in beta.
+
+<CliSubcommands command="functions domains" anchorParts="domains" />
+
+### neon functions domains list (#domains-list)
+
+Lists the custom domains registered on the branch.
+
+<CliUsage command="functions domains list" />
+
+<CliOptions command="functions domains list" />
+
+```bash
+neon functions domains list
+```
+
+The default table shows the domain, target function, and CNAME target. To inspect DNS and routing status, use JSON output:
+
+```bash
+neon functions domains list --output json
+```
+
+```json filename="Output"
+[
+  {
+    "domain": "docs.example.com",
+    "entity_type": "function",
+    "entity_id": "hello",
+    "cname_target": "fn-custom-domains.us-east-2.aws.neon.build",
+    "status": "active",
+    "dns_status": "ok",
+    "binding_status": "present",
+    "status_reason": ""
+  }
+]
+```
+
+An `active` status confirms that DNS, CAA authorization, and routing are ready. Verify the domain with an HTTPS request because certificate issuance isn't included in this status.
+
+### neon functions domains register (#domains-register)
+
+Points a domain you already own at a function on the branch. Both `--slug` and the domain are required. The command prints a CNAME target; create a CNAME record for the domain at your DNS provider pointing at that target.
+
+<CliUsage command="functions domains register" />
+
+<CliOptions command="functions domains register" />
+
+```bash
+neon functions domains register docs.example.com --slug hello
+```
+
+### neon functions domains delete (#domains-delete)
+
+Deletes a custom domain from the branch.
+
+<CliUsage command="functions domains delete" />
+
+<CliOptions command="functions domains delete" />
+
+```bash
+neon functions domains delete docs.example.com
+```
+
+Routing changes are eventually consistent, so the custom URL can continue reaching the function briefly after deletion. Deleting a function doesn't delete its custom-domain registration; delete the domain separately.

--- a/scripts/docs-checks/neonctl/generate-schema.js
+++ b/scripts/docs-checks/neonctl/generate-schema.js
@@ -466,6 +466,17 @@ function parseCommandCall(callArgs, consts) {
     // Second arg is the description; third is the builder function.
     describe = resolveStringValue(callArgs[1], consts);
     builderNode = callArgs[2];
+  } else if (ts.isArrayLiteralExpression(first)) {
+    // Array form: `.command([name, ...aliases], desc, builder, handler)`.
+    // The first element is the command (may carry positionals, e.g.
+    // `'register <domain>'`); the rest are aliases.
+    const arr = arrayLiteralStrings(first);
+    if (arr && arr.length) {
+      commandString = arr[0];
+      aliases = arr.slice(1);
+    }
+    describe = resolveStringValue(callArgs[1], consts);
+    builderNode = callArgs[2];
   } else if (ts.isObjectLiteralExpression(first)) {
     const cmdProp = getProp(first, 'command');
     if (cmdProp) commandString = stringLiteralValue(cmdProp.initializer);

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1750,6 +1750,61 @@
           "commands": {},
           "describe": "Deploy a function from a local directory"
         },
+        "domains": {
+          "name": "domains",
+          "aliases": [
+            "domain"
+          ],
+          "positionals": [],
+          "options": {},
+          "commands": {
+            "delete": {
+              "name": "delete",
+              "aliases": [],
+              "positionals": [
+                {
+                  "name": "domain",
+                  "required": true,
+                  "describe": "Custom domain",
+                  "type": "string"
+                }
+              ],
+              "options": {},
+              "commands": {},
+              "describe": "Delete a custom domain from the branch"
+            },
+            "list": {
+              "name": "list",
+              "aliases": [],
+              "positionals": [],
+              "options": {},
+              "commands": {},
+              "describe": "List custom domains on the branch"
+            },
+            "register": {
+              "name": "register",
+              "aliases": [],
+              "positionals": [
+                {
+                  "name": "domain",
+                  "required": true,
+                  "describe": "Domain you already own (for example docs.example.com)",
+                  "type": "string"
+                }
+              ],
+              "options": {
+                "slug": {
+                  "type": "string",
+                  "describe": "Function slug this domain should point at",
+                  "required": true
+                }
+              },
+              "commands": {},
+              "describe": "Point a domain you already own at a function on the branch"
+            }
+          },
+          "describe": "Manage custom domains on the branch (beta)"
+        },
         "get": {
           "name": "get",
           "aliases": [],


### PR DESCRIPTION
Fix the schema generator so it captures the functions domains commands, and document
them. These commands already shipped; the schema parser was silently dropping them.

- generate-schema.js: parse yargs array-form command names ([name, ...aliases]); the
  parser handled only string and object forms, so functions domains (the first command
  to use the array form) never reached the schema
- schema.json: regenerate, now including functions domains (list, register, delete)
- functions.md: add the neon functions domains reference section

This pull request and its description were written by Isaac.