### PR TITLE
docs: note expanded shared_buffers cache on large fixed-size computes

### DIFF
--- a/content/docs/extensions/neon.md
+++ b/content/docs/extensions/neon.md
@@ -12,7 +12,7 @@ summary: >-
   ANALYZE` with the `FILECACHE` and `PREFETCH` options provides per-query cache
   and prefetch metrics without requiring the extension.
 enableTableOfContents: true
-updatedOn: '2026-08-07T13:46:01.605Z'
+updatedOn: '2026-09-10T13:38:23.543Z'
 ---
 
 The `neon` extension provides functions and views designed to gather Neon-specific metrics.
@@ -26,7 +26,11 @@ The `neon_stat_file_cache` view provides insights into how effectively your Neon
 
 ## What is the compute cache?
 
-Neon uses up to 75% of your compute's RAM for data caching. This cache stores frequently accessed data in the local memory of the Neon compute, which reduces latency and improves query performance by minimizing the need to fetch data from database storage. Like Postgres [shared buffers](/docs/reference/glossary#shared-buffers), it caches your most recently accessed data. To view the compute cache size for each Neon compute size, see [How to size your compute](/docs/manage/computes#how-to-size-your-compute).
+Neon caches frequently accessed data on the compute, which reduces latency and improves query performance by minimizing reads from database storage. This compute cache provides up to 75% of your compute's RAM in capacity and can span two tiers: Postgres [shared buffers](/docs/reference/glossary#shared-buffers), which are held in memory and are the fastest to read, and a larger secondary file cache on the compute's local disk that holds more data but requires disk I/O. A read checks shared buffers first, then the file cache, and only then falls through to database storage. The `neon_stat_file_cache` view reports the file-cache tier. To view the compute cache size for each Neon compute size, see [How to size your compute](/docs/manage/computes#how-to-size-your-compute).
+
+<Admonition type="note" title="Large fixed-size computes">
+On large fixed-size computes (18 CU and above), Neon sets `shared_buffers` to 75% of RAM (backed by huge pages) and disables the secondary file cache, so the entire compute cache is held in memory as shared buffers. The capacity is unchanged; what differs is that hot pages stay in the fastest tier instead of falling through to disk, and how you measure the cache. Because the file cache is off, `neon_stat_file_cache`, [`neon inspect db lfc-hit-rate`](/docs/cli/inspect#db-lfc-hit-rate), and [`neon inspect db working-set`](/docs/cli/inspect#db-working-set) no longer report it on these computes. Run `SHOW shared_buffers` and `SHOW huge_pages` to confirm the configuration, and use the [Compute cache hit rate](/docs/introduction/monitoring-page#compute-cache-hit-rate) graph, which works on every compute size. For background, see [Improving Postgres compute cache on Neon](https://neon.com/blog/improving-lakebase-compute-cache-part-1).
+</Admonition>
 
 ## Monitoring compute cache usage
 

--- a/content/docs/manage/computes.md
+++ b/content/docs/manage/computes.md
@@ -8,7 +8,7 @@ summary: >-
   compute endpoints via the Neon Console or API.
 enableTableOfContents: true
 isDraft: false
-updatedOn: '2026-08-26T13:16:52.511Z'
+updatedOn: '2026-09-10T13:38:23.543Z'
 ---
 
 A compute is a virtualized service that runs applications. In Neon, a compute runs Postgres.
@@ -438,6 +438,10 @@ The following table outlines the RAM, compute cache size (75% of RAM), and the `
 
 <Admonition type="note">
 Compute size support differs by [Neon plan](/docs/introduction/plans). Autoscaling is supported up to 16 CU. Neon supports fixed compute sizes (no autoscaling) for computes sizes larger than 16 CU.
+</Admonition>
+
+<Admonition type="note" title="Caching on large fixed-size computes">
+On fixed-size computes of 18 CU and above, Neon delivers this cache as Postgres `shared_buffers` set to 75% of RAM and backed by huge pages, and disables the secondary file cache that smaller and autoscaling computes rely on. This keeps hot data in memory rather than on the compute's local disk. Confirm the configuration with `SHOW shared_buffers` and `SHOW huge_pages`, and measure cache efficiency with the [Compute cache hit rate](/docs/introduction/monitoring-page#compute-cache-hit-rate) graph. See [What is the compute cache?](/docs/extensions/neon#what-is-the-compute-cache) for details.
 </Admonition>
 
 | Compute Size (CU) | RAM (GB) | Compute cache size (GB) | max_connections |

--- a/content/docs/postgresql/query-performance.md
+++ b/content/docs/postgresql/query-performance.md
@@ -14,7 +14,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/postgres/query-performance
-updatedOn: '2026-08-07T13:46:01.605Z'
+updatedOn: '2026-09-10T13:38:23.543Z'
 ---
 
 Many factors can impact query performance in Postgres, ranging from insufficient indexing and database maintenance to poorly optimized queries or inadequate system resources. With such a wide range of factors, it can be difficult to know where to start. In this topic, we'll look at several strategies you can use to optimize query performance in Postgres.
@@ -363,7 +363,11 @@ For information about right-sizing your compute in Neon, see [How to size your c
 
 A cache hit ratio tells you the percentage of queries served from memory. Queries not served from memory retrieve data from disk, which is more costly and can result in slower query performance.
 
-In a standalone Postgres instance, you can query the cache hit ratio with an SQL statement that looks for `shared buffers` block hits. In Neon, it’s a little different. Neon caches data in your compute's memory (up to 75% of your compute's RAM). To query your cache hit ratio in Neon, you need to look at compute cache hits instead of shared buffer hits.
+In a standalone Postgres instance, you can query the cache hit ratio with an SQL statement that looks for `shared buffers` block hits. In Neon, it’s a little different. Neon caches data on your compute (up to 75% of your compute's RAM). To query your cache hit ratio in Neon, you need to look at compute cache hits instead of shared buffer hits.
+
+<Admonition type="note">
+This applies to autoscaling computes and fixed-size computes below 18 CU. On fixed-size computes of 18 CU and above, Neon caches data in Postgres `shared_buffers` rather than the file cache, so the `neon_stat_file_cache` view below does not reflect the working cache there. On those computes, check the [Compute cache hit rate](/docs/introduction/monitoring-page#compute-cache-hit-rate) graph or `SHOW shared_buffers` instead. See [What is the compute cache?](/docs/extensions/neon#what-is-the-compute-cache) for details.
+</Admonition>
 
 To enable querying compute cache statistics, Neon provides a [neon_stat_file_cache](/docs/extensions/neon#the-neonstatfilecache-view) view. To access this view, you need to install the [neon](/docs/extensions/neon) extension:
 

--- a/content/docs/reference/compatibility.md
+++ b/content/docs/reference/compatibility.md
@@ -13,7 +13,7 @@ summary: >-
 enableTableOfContents: true
 redirectFrom:
   - /docs/conceptual-guides/compatibility
-updatedOn: '2026-09-02T21:07:43.155Z'
+updatedOn: '2026-09-10T13:38:23.543Z'
 ---
 
 **Neon is Postgres**. However, as a managed Postgres service, there are some differences you should be aware of.
@@ -58,37 +58,37 @@ Because Neon is a managed Postgres service, Postgres parameters are not user-con
 If you are a Neon [Scale plan](/docs/introduction/plans) user and require a different Postgres instance-level setting, you can contact [Neon Support](/docs/introduction/support) to see if the desired setting can be supported. Please keep in mind that it may not be possible to support some parameters due to platform limitations and constraints.
 </Admonition>
 
-| Parameter                             | Value         | Note                                                                                                                                                                |
-| ------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client_connection_check_interval`    | 60000         |                                                                                                                                                                     |
-| `dynamic_shared_memory_type`          | mmap          |                                                                                                                                                                     |
-| `effective_io_concurrency`            | 20            |                                                                                                                                                                     |
-| `effective_cache_size`                |               | Set based on the [compute cache](/docs/reference/glossary#compute-cache) size of your maximum Neon compute size                                                     |
-| `fsync`                               | off           | Neon syncs data to the Neon database storage engine to store your data safely and reliably                                                                          |
-| `hot_standby`                         | off           |                                                                                                                                                                     |
-| `idle_in_transaction_session_timeout` | 300000        |                                                                                                                                                                     |
-| `listen_addresses`                    | '\*'          |                                                                                                                                                                     |
-| `log_connections`                     | on            |                                                                                                                                                                     |
-| `log_disconnections`                  | on            |                                                                                                                                                                     |
-| `log_min_error_statement`             | panic         |                                                                                                                                                                     |
-| `log_temp_files`                      | 1048576       |                                                                                                                                                                     |
-| `maintenance_work_mem`                | 65536         | The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size).                                                                    |
-| `max_connections`                     | 112           | The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size).                                                                    |
-| `max_parallel_workers`                | 8             |                                                                                                                                                                     |
-| `max_replication_flush_lag`           | 10240         |                                                                                                                                                                     |
-| `max_replication_slots`               | 10            |                                                                                                                                                                     |
-| `max_replication_write_lag`           | 500           |                                                                                                                                                                     |
-| `max_wal_senders`                     | 10            |                                                                                                                                                                     |
-| `max_wal_size`                        | 1024          |                                                                                                                                                                     |
-| `max_worker_processes`                | 26            | The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size).                                                                    |
-| `password_encryption`                 | scram-sha-256 |                                                                                                                                                                     |
-| `restart_after_crash`                 | off           |                                                                                                                                                                     |
-| `shared_buffers`                      | 128MB         | In Neon, up to 75% of your compute's RAM is used for data caching. The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size). |
-| `superuser_reserved_connections`      | 7             |                                                                                                                                                                     |
-| `synchronous_standby_names`           | 'walproposer' |                                                                                                                                                                     |
-| `wal_level`                           | replica       | Defaults to `replica`. When you [enable logical replication](/docs/guides/logical-replication-neon#enable-logical-replication), Neon changes it to `logical`.       |
-| `wal_log_hints`                       | off           |                                                                                                                                                                     |
-| `wal_sender_timeout`                  | 10000         |                                                                                                                                                                     |
+| Parameter                             | Value         | Note                                                                                                                                                                                                                    |
+| ------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client_connection_check_interval`    | 60000         |                                                                                                                                                                                                                         |
+| `dynamic_shared_memory_type`          | mmap          |                                                                                                                                                                                                                         |
+| `effective_io_concurrency`            | 20            |                                                                                                                                                                                                                         |
+| `effective_cache_size`                |               | Set based on the [compute cache](/docs/reference/glossary#compute-cache) size of your maximum Neon compute size                                                                                                         |
+| `fsync`                               | off           | Neon syncs data to the Neon database storage engine to store your data safely and reliably                                                                                                                              |
+| `hot_standby`                         | off           |                                                                                                                                                                                                                         |
+| `idle_in_transaction_session_timeout` | 300000        |                                                                                                                                                                                                                         |
+| `listen_addresses`                    | '\*'          |                                                                                                                                                                                                                         |
+| `log_connections`                     | on            |                                                                                                                                                                                                                         |
+| `log_disconnections`                  | on            |                                                                                                                                                                                                                         |
+| `log_min_error_statement`             | panic         |                                                                                                                                                                                                                         |
+| `log_temp_files`                      | 1048576       |                                                                                                                                                                                                                         |
+| `maintenance_work_mem`                | 65536         | The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size).                                                                                                                        |
+| `max_connections`                     | 112           | The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size).                                                                                                                        |
+| `max_parallel_workers`                | 8             |                                                                                                                                                                                                                         |
+| `max_replication_flush_lag`           | 10240         |                                                                                                                                                                                                                         |
+| `max_replication_slots`               | 10            |                                                                                                                                                                                                                         |
+| `max_replication_write_lag`           | 500           |                                                                                                                                                                                                                         |
+| `max_wal_senders`                     | 10            |                                                                                                                                                                                                                         |
+| `max_wal_size`                        | 1024          |                                                                                                                                                                                                                         |
+| `max_worker_processes`                | 26            | The value differs by compute size. See [below](#parameter-settings-that-differ-by-compute-size).                                                                                                                        |
+| `password_encryption`                 | scram-sha-256 |                                                                                                                                                                                                                         |
+| `restart_after_crash`                 | off           |                                                                                                                                                                                                                         |
+| `shared_buffers`                      | 128MB         | The `shared_buffers` value differs by compute size; the [compute cache](/docs/reference/glossary#compute-cache) provides up to 75% of your compute's RAM. See [below](#parameter-settings-that-differ-by-compute-size). |
+| `superuser_reserved_connections`      | 7             |                                                                                                                                                                                                                         |
+| `synchronous_standby_names`           | 'walproposer' |                                                                                                                                                                                                                         |
+| `wal_level`                           | replica       | Defaults to `replica`. When you [enable logical replication](/docs/guides/logical-replication-neon#enable-logical-replication), Neon changes it to `logical`.                                                           |
+| `wal_log_hints`                       | off           |                                                                                                                                                                                                                         |
+| `wal_sender_timeout`                  | 10000         |                                                                                                                                                                                                                         |
 
 ### Parameter settings that differ by compute size
 
@@ -196,6 +196,8 @@ _For most applications, we recommend using connection pooling, which supports up
   backends = 1 + max_connections + max_worker_processes
   shared_buffers_mb = max(128, (1023 + backends * 256) / 1024)
   ```
+
+  On large fixed-size computes (18 CU and above), `shared_buffers` is instead set to 75% of your compute's RAM (backed by huge pages) and the secondary file cache is disabled, so this formula does not apply. See [What is the compute cache?](/docs/extensions/neon#what-is-the-compute-cache).
 
 - The `effective_cache_size` parameter is set based on the [compute cache](/docs/reference/glossary#compute-cache) size of your maximum Neon compute size. This helps the Postgres query planner make smarter decisions, which can improve query performance. For details on compute cache size by compute size, see the table in [How to size your compute](/docs/manage/computes#how-to-size-your-compute).
 

--- a/content/docs/reference/glossary.md
+++ b/content/docs/reference/glossary.md
@@ -12,7 +12,7 @@ enableTableOfContents: true
 redirectFrom:
   - /docs/conceptual-guides/glossary
   - /docs/cloud/concepts/
-updatedOn: '2026-09-02T18:59:27.831Z'
+updatedOn: '2026-09-10T13:38:23.543Z'
 ---
 
 ## access token
@@ -130,7 +130,7 @@ Neon creates a primary read-write compute for the project's default branch. Neon
 
 ## compute cache
 
-The compute cache is a layer of caching that stores frequently accessed data from the storage layer in the local memory of the compute. This cache helps to reduce latency and improve query performance by minimizing the need to fetch data from the storage layer repeatedly. Like Postgres [shared buffers](#shared-buffers), it caches your most recently accessed data. In Neon, up to 75% of your compute's RAM is used for data caching.
+The compute cache is a layer of caching on the compute that stores frequently accessed data from the storage layer, reducing latency and improving query performance by avoiding repeated fetches from storage. Exposed as a single cache, it can span two tiers: Postgres [shared buffers](#shared-buffers), which are held in memory, and a larger secondary file cache on the compute's local disk. It provides up to 75% of your compute's RAM in capacity. For details, see [What is the compute cache?](/docs/extensions/neon#what-is-the-compute-cache).
 
 ## compute endpoint
 
@@ -570,7 +570,7 @@ A cloud-based development model that enables developing and running applications
 
 ## shared buffers
 
-A memory area in Postgres for caching blocks of data from storage (disk on standalone Postgres or Pageservers in Neon). This cache enhances the performance of database operations by reducing the need to access the slower storage for frequently accessed data. In Neon, the `shared_buffers` parameter [scales with compute size](/docs/reference/compatibility#parameter-settings-that-differ-by-compute-size), and up to 75% of your compute's RAM is used for data caching. For additional information about shared buffers in Postgres, see [Resource Consumption](https://www.postgresql.org/docs/current/runtime-config-resource.html), in the Postgres documentation.
+A memory area in Postgres for caching blocks of data from storage (disk on standalone Postgres or Pageservers in Neon). This cache enhances the performance of database operations by reducing the need to access the slower storage for frequently accessed data. In Neon, `shared_buffers` is the in-memory tier of the [compute cache](#compute-cache), and its value [differs by compute size](/docs/reference/compatibility#parameter-settings-that-differ-by-compute-size). For additional information about shared buffers in Postgres, see [Resource Consumption](https://www.postgresql.org/docs/current/runtime-config-resource.html), in the Postgres documentation.
 
 ## Snapshot
 


### PR DESCRIPTION
Documents the compute-cache change in [Improving Postgres compute cache on Neon, Part 1](https://neon.com/blog/improving-lakebase-compute-cache-part-1): on fixed-size computes of 18 CU and above, Neon sets Postgres `shared_buffers` to 75% of RAM (backed by huge pages) and disables the secondary file cache, so the whole compute cache stays in memory.

Along the way it corrects how the docs describe the compute cache, to match the architecture: a single cache exposed to users, spanning up to two tiers (in-memory `shared_buffers` plus a larger secondary file cache on the compute's local disk). The previous "local memory" description of the file cache was inaccurate.

Changes:

- `content/docs/extensions/neon.md` — rewrite the "What is the compute cache?" intro as a two-tier cache; correct the file cache from "local memory" to a secondary tier on local disk; add a note that large fixed computes (18 CU+) use `shared_buffers` only, where `neon_stat_file_cache` / `neon inspect db lfc-hit-rate` / `working-set` no longer apply. Verify with `SHOW shared_buffers` / `SHOW huge_pages`; measure with the Compute cache hit rate graph.
- `content/docs/manage/computes.md` — matching note near the compute-size table.
- `content/docs/postgresql/query-performance.md` — scope the file-cache hit-ratio guidance to autoscaling and sub-18 CU computes; point large computes to the graph or `SHOW shared_buffers`.
- `content/docs/reference/glossary.md` — rewrite the **compute cache** definition as two tiers and drop the local-memory claim; clarify that **shared buffers** is the in-memory tier of the compute cache, not the whole 75%.
- `content/docs/reference/compatibility.md` — distinguish the `shared_buffers` value from the 75% compute cache; note that the `shared_buffers` formula does not apply on 18 CU+ fixed computes.

Autoscaling computes are unchanged (deferred to the blog's Part 2); a fuller rewrite can follow when that ships.

This pull request and its description were written by Isaac.

## NEON PREVIEW

- https://neon-next-git-docs-large-compute-shared-buffers-neondatabase.vercel.app/docs/extensions/neon
- https://neon-next-git-docs-large-compute-shared-buffers-neondatabase.vercel.app/docs/manage/computes
- https://neon-next-git-docs-large-compute-shared-buffers-neondatabase.vercel.app/docs/postgresql/query-performance
- https://neon-next-git-docs-large-compute-shared-buffers-neondatabase.vercel.app/docs/reference/glossary
- https://neon-next-git-docs-large-compute-shared-buffers-neondatabase.vercel.app/docs/reference/compatibility
