### PR TITLE
chore: update topbar to promote Claimable Neon post

### DIFF
--- a/content/config/topbar.yaml
+++ b/content/config/topbar.yaml
@@ -1,4 +1,4 @@
-text: 'Large Postgres compute nodes now run up to 2× faster and with lower latency. Read the engineering writeup'
+text: 'Just shipped: Claimable Neon - agents provision backends without signup, humans claim them later'
 link:
-  url: 'https://neon.com/blog/improving-lakebase-compute-cache-part-1'
+  url: 'https://neon.com/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later'
   target: '_blank'


### PR DESCRIPTION
## Summary

- Updates the site topbar announcement to: "Just shipped: Claimable Neon - agents provision backends without signup, humans claim them later"
- Links to https://neon.com/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later

## Test plan

- [ ] Verify topbar displays the new message on the homepage
- [ ] Confirm the link opens https://neon.com/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later