### PR TITLE
docs: note lfc-hit-rate and working-set don't apply on large fixed computes

### DIFF
--- a/content/docs/cli/inspect.md
+++ b/content/docs/cli/inspect.md
@@ -29,6 +29,10 @@ When you omit `--database-name`, `inspect` covers every database on the branch a
 
 Some queries read from Postgres statistics extensions. `outliers` and `calls` need [`pg_stat_statements`](/docs/extensions/pg_stat_statements), and `lfc-hit-rate` and `working-set` need the [`neon`](/docs/extensions/neon) extension. If a required extension is not installed, the command reports it instead of returning rows.
 
+<Admonition type="note">
+On large fixed-size computes (18 CU and above), Neon disables the file cache and serves the [compute cache](/docs/extensions/neon#what-is-the-compute-cache) from Postgres `shared_buffers`, so `lfc-hit-rate` and `working-set` return empty or misleading results on those computes. Use the [Compute cache hit rate](/docs/introduction/monitoring-page#compute-cache-hit-rate) graph or run `SHOW shared_buffers` instead.
+</Admonition>
+
 From an AI assistant, the same checks are available through the Neon MCP server's `inspect_database` tool. See [Database diagnostics](/docs/ai/neon-mcp-server#database-diagnostics).
 
 <CliSubcommands command="inspect db" anchorParts="db" />


### PR DESCRIPTION
Follow-up to #5812. On fixed-size computes of 18 CU and above, Neon disables the file cache and serves the compute cache from Postgres `shared_buffers`, so the `neon inspect db lfc-hit-rate` and `working-set` checks return empty or misleading results there.

Adds a note to the CLI `inspect` reference pointing users to the Compute cache hit rate graph or `SHOW shared_buffers` on those computes.

Note: the CLI tool itself (in `neondatabase/neon-pkgs`) still emits empty rows for these checks on LFC-disabled computes; tracked separately for the CLI team.

This pull request and its description were written by Isaac.

## NEON PREVIEW

- https://neon-next-git-docs-inspect-db-lfc-note-neondatabase.vercel.app/docs/cli/inspect