### PR TITLE
Add WorkOS case study link to Claimable Neon post

### DIFF
--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -93,8 +93,8 @@ The protocol supports three registration methods:
 
 Claimable Neon uses the Anonymous method.
 
-<Admonition type="note" title="From WorkOS">
-WorkOS published a [case study](https://workos.com/blog/neon-claimable-postgres-auth-md-case-study) on how Claimable Neon implements auth.md.
+<Admonition type="note" title="Read the WorkOS story">
+[Get the full story by WorkOS](https://workos.com/blog/neon-claimable-postgres-auth-md-case-study) on how Claimable Neon implements auth.md.
 </Admonition>
 
 ## Why we chose anonymous registration

--- a/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
+++ b/content/blog/posts/an-agent-provisions-a-neon-backend-a-human-claims-it-later.md
@@ -93,6 +93,10 @@ The protocol supports three registration methods:
 
 Claimable Neon uses the Anonymous method.
 
+<Admonition type="note" title="From WorkOS">
+WorkOS published a [case study](https://workos.com/blog/neon-claimable-postgres-auth-md-case-study) on how Claimable Neon implements auth.md.
+</Admonition>
+
 ## Why we chose anonymous registration
 
 An allowlist of known agent products would have been the more predictable launch: we could recognize requests from a handful of providers and reject everything else. But we actually want to see what happens when the instructions are public and the first interaction does not require a human identity. Which agents discover the file? What do they request? How far do they get? Do they ask for a database, Auth, or the Data API? Which projects do humans decide to keep?


### PR DESCRIPTION
## Summary
- Adds a note in the auth.md section linking to WorkOS's [Claimable Neon case study](https://workos.com/blog/neon-claimable-postgres-auth-md-case-study)

## Test plan
- [ ] Preview the post and confirm the admonition renders under **Powered by auth.md**
- [ ] Confirm the WorkOS link opens the case study