### PR TITLE
chore: update @neon/sdk to v4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@commitlint/config-conventional": "^19.2.2",
         "@eslint/compat": "^1.2.0",
         "@eslint/js": "^9.0.0",
-        "@neon/sdk": "^3.0.0",
+        "@neon/sdk": "^4.1.0",
         "@next/eslint-plugin-next": "16.3.3",
         "@playwright/test": "1.61.1",
         "@scalar/openapi-parser": "^0.28.2",
@@ -4287,9 +4287,9 @@
       }
     },
     "node_modules/@neon/sdk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@neon/sdk/-/sdk-3.0.0.tgz",
-      "integrity": "sha512-HoWXk7t6MqTo0s5tbFinYNcuojsLAperd8I6oouibBLie2pnucIfTP10FtQZPfZVABvnU2SGm+QT9pQDmVfGeA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@neon/sdk/-/sdk-4.1.0.tgz",
+      "integrity": "sha512-4PabwlUr514P+/8zlttndHp/o5UUNQFaAq/1zTBEgUuGrvZ3ISeALgWWTxJK9rXX8Huku/v5fA6txgU6jBzhhA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@commitlint/config-conventional": "^19.2.2",
     "@eslint/compat": "^1.2.0",
     "@eslint/js": "^9.0.0",
-    "@neon/sdk": "^3.0.0",
+    "@neon/sdk": "^4.1.0",
     "@next/eslint-plugin-next": "16.3.3",
     "@playwright/test": "1.61.1",
     "@scalar/openapi-parser": "^0.28.2",

--- a/scripts/check-docs-api-consistency.mjs
+++ b/scripts/check-docs-api-consistency.mjs
@@ -61,8 +61,9 @@ import {
   sdkRawOperationNames,
 } from './lib/api-coverage.mjs';
 import { defaultSpecCachePath, loadOpenApiSpec } from './lib/openapi-spec-source.mjs';
-import { withoutExcludedOperations } from './lib/excluded-operations.mjs';
+import { EXCLUDED_OPERATION_IDS, withoutExcludedOperations } from './lib/excluded-operations.mjs';
 import { findMissingSpecTags, readTagConfig } from './lib/tag-config.mjs';
+import { toSdkMethodName } from '../src/utils/api-ref.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -313,14 +314,17 @@ async function main() {
     }
   }
 
-  // rawOps is intentionally NOT filtered by EXCLUDED_OPERATION_IDS: the SDK
-  // really does expose the excluded ops, so offline PR mode may list them as
-  // "raw layer exposes operations the docs do not cover" (true, non-blocking,
-  // self-clearing when the override is lifted). TODO: if that advisory noise
-  // outlives its welcome, filter rawOps too via toSdkMethodName(excludedId).
+  // Ops in EXCLUDED_OPERATION_IDS are dropped from the rendered docs, so don't
+  // report them as raw-layer coverage drift either — mirror the spec-side
+  // withoutExcludedOperations filter. Without this, any SDK that exposes an
+  // excluded op shows up as "raw layer exposes operations the docs do not cover"
+  // noise on every PR run. The exclusion set is operationIds; project it into
+  // SDK-method space to subtract from rawOperations.
+  const excludedMethods = new Set([...EXCLUDED_OPERATION_IDS].map(toSdkMethodName));
+  const rawForCoverage = new Set([...rawOperations].filter((m) => !excludedMethods.has(m)));
   const coverage = computeCoverage({
     documentedOps,
-    rawOps: rawOperations,
+    rawOps: rawForCoverage,
     specOps,
   });
 


### PR DESCRIPTION
## Overview

Bump @neon/sdk from v3 to v4.1.0, the current latest, so the docs-API
consistency check stays in sync with the published SDK surface.

Also apply the EXCLUDED_OPERATION_IDS filter to the SDK raw side of the
coverage check, matching the existing spec-side filter. Without it, an
excluded operation that the SDK exposes shows up as a raw-layer coverage
notice even though it is intentionally hidden from the API reference.

This pull request and its description were written by Isaac.