### PR TITLE
docs: update docs to neon cli 4.16.0

### DIFF
--- a/content/docs/ai-gateway/authentication.md
+++ b/content/docs/ai-gateway/authentication.md
@@ -7,7 +7,7 @@ summary: >-
   created on your main branch works in all preview branches. No provider
   API keys are required.
 enableTableOfContents: true
-updatedOn: '2026-08-17T23:18:55.558Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -18,7 +18,18 @@ AI Gateway uses Neon bearer credentials, the same scoped-credential system as [O
 
 A credential must include the `ai_gateway:invoke` scope.
 
-<Tabs labels={["Console", "API"]}>
+<Tabs labels={["CLI", "Console", "API"]}>
+<TabItem>
+
+Create a credential with the [Neon CLI](/docs/cli/credentials):
+
+```bash
+neon credentials create --scope ai_gateway:invoke --name my-app-credential
+```
+
+The `api_token` is printed once; set it as `NEON_AI_GATEWAY_TOKEN`. Run it in a directory [linked](/docs/cli/link) to your project, or pass `--project-id` and `--branch`.
+
+</TabItem>
 <TabItem>
 
 In the Neon Console, select your branch and click **Credentials** under **Branch** in the sidebar. Click **Create credential**, give it a name, and check **ai_gateway:invoke**.
@@ -188,13 +199,19 @@ This design lets you use a single credential across your entire development work
 
 ## Rotating credentials
 
-To rotate a credential: create a new one, update your environment variables, then revoke the old one.
+To rotate a credential in place with the [Neon CLI](/docs/cli/credentials), run `neon credentials rotate <token_id>` (find the id with `neon credentials list`). The `token_id` stays the same and a new `api_token` is minted, so update `NEON_AI_GATEWAY_TOKEN` with it. Otherwise, create a new credential, update your environment variables, then revoke the old one.
 
 To revoke from the Console, open the **Credentials** page and use the action menu (⋮) next to the credential. To revoke via the API:
 
 ```bash shouldWrap
 curl -X DELETE "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials/{token_id}" \
   -H "Authorization: Bearer $NEON_API_KEY"
+```
+
+Or with the [Neon CLI](/docs/cli/credentials):
+
+```bash
+neon credentials revoke <token_id>
 ```
 
 <NeedHelp/>

--- a/content/docs/ai-gateway/get-started.md
+++ b/content/docs/ai-gateway/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   host, and making your first request to the Neon AI Gateway using the OpenAI
   SDK. No provider API keys required. Authenticate with your Neon credential.
 enableTableOfContents: true
-updatedOn: '2026-09-02T15:10:53.712Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 ---
 
 <FeatureBetaProps feature_name="Neon AI Gateway" />
@@ -27,7 +27,13 @@ You need a project in AWS US East (Ohio) (`aws-us-east-2`) or AWS Europe (Frankf
 
 ## Create a credential
 
-In the Neon Console, select your branch, click **Credentials** under **Branch**, then click **Create credential** and check **ai_gateway:invoke**. Copy the credential before closing, it's shown only once.
+With the [Neon CLI](/docs/cli/credentials), run:
+
+```bash
+neon credentials create --scope ai_gateway:invoke
+```
+
+Or, in the Neon Console, select your branch, click **Credentials** under **Branch**, then click **Create credential** and check **ai_gateway:invoke**. Copy the credential before closing, it's shown only once.
 
 Or use the API:
 

--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -10,7 +10,7 @@ summary: >-
   with `neon skills`, `npx skills add neondatabase/agent-skills -y`, `neon init`,
   or editor plugins at project level or globally.
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 redirectFrom:
   - /docs/ai/ai-rules
   - /docs/ai/ai-rules-neon-toolkit
@@ -125,7 +125,7 @@ Pi reads the `skills/` directory directly, so there's no separate sync step. Thi
 
 ### neon init
 
-The `neon init` command sets up the current directory to use Neon with your AI coding assistant. Run it in a terminal: it installs agent tooling (either a plugin, or skills and the MCP server), links a Neon project, and writes a `neon.ts` config. In an empty directory, it scaffolds a starter template first.
+The `neon init` command sets up the current directory to use Neon with your AI coding assistant. Run it in a terminal: it installs agent tooling (either a plugin, or skills and the MCP server), links a Neon project, and optionally writes a `neon.ts` config. In an empty directory, it lets you pick a starter template, name one with `--template`, or skip scaffolding with `--skip-template`.
 
 ```bash
 npx neon@latest init

--- a/content/docs/ai/connect-mcp-clients-to-neon.md
+++ b/content/docs/ai/connect-mcp-clients-to-neon.md
@@ -10,7 +10,7 @@ summary: >-
 redirectFrom:
   - /guides/neon-mcp-server-github-copilot-vs-code
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 ---
 
 Connect MCP clients to the Neon MCP Server to interact with your Lakebase Postgres databases in natural language.
@@ -27,7 +27,7 @@ The fastest way to get started:
 npx neon@latest init
 ```
 
-**`neon init`** (see [`neon init` reference](/docs/cli/init)) sets up the current directory for Neon. Run it in a terminal: it installs agent tooling (either the Neon plugin, or [agent skills](https://github.com/neondatabase/agent-skills) and the MCP server), links a Neon project, and writes a `neon.ts` config. Then restart your editor and ask your AI assistant **"Get started with Neon"**.
+**`neon init`** (see [`neon init` reference](/docs/cli/init)) sets up the current directory for Neon. Run it in a terminal: it installs agent tooling (either the Neon plugin, or [agent skills](https://github.com/neondatabase/agent-skills) and the MCP server), links a Neon project, and optionally writes a `neon.ts` config. Then restart your editor and ask your AI assistant **"Get started with Neon"**.
 
 If you only want the MCP server and nothing else, run [`neon mcp`](/docs/cli/mcp):
 

--- a/content/docs/api-navigation.yaml
+++ b/content/docs/api-navigation.yaml
@@ -301,15 +301,24 @@
 - title: "Functions"
   slug: reference/api/functions
   items:
+    - title: "Create a trigger"
+      slug: reference/api/functions/create-project-branch-trigger
+      method: POST
     - title: "Delete a custom domain from a branch"
       slug: reference/api/functions/delete-project-branch-custom-domain
       method: DELETE
     - title: "Delete a function on the branch"
       slug: reference/api/functions/delete-project-branch-function
       method: DELETE
+    - title: "Delete a trigger"
+      slug: reference/api/functions/delete-project-branch-trigger
+      method: DELETE
     - title: "Deploy code to a function"
       slug: reference/api/functions/create-project-branch-function-deployment
       method: POST
+    - title: "Get a trigger"
+      slug: reference/api/functions/get-project-branch-trigger
+      method: GET
     - title: "Get function details"
       slug: reference/api/functions/get-project-branch-function
       method: GET
@@ -319,11 +328,17 @@
     - title: "List the custom domains on a branch"
       slug: reference/api/functions/list-project-branch-custom-domains
       method: GET
+    - title: "List triggers on the branch"
+      slug: reference/api/functions/list-project-branch-triggers
+      method: GET
     - title: "Register a custom domain on a branch"
       slug: reference/api/functions/register-project-branch-custom-domain
       method: POST
     - title: "Update a function"
       slug: reference/api/functions/update-project-branch-function
+      method: PATCH
+    - title: "Update a trigger"
+      slug: reference/api/functions/update-project-branch-trigger
       method: PATCH
 - title: "Logs"
   slug: reference/api/logs

--- a/content/docs/api-operation-ids.json
+++ b/content/docs/api-operation-ids.json
@@ -1,6 +1,6 @@
 {
   "_generatedBy": "scripts/generate-api-ref.mjs — do not edit by hand",
-  "count": 174,
+  "count": 179,
   "operationIds": [
     "acceptProjectTransferRequest",
     "addBranchNeonAuthOauthProvider",
@@ -28,6 +28,7 @@
     "createProjectBranchDatabase",
     "createProjectBranchFunctionDeployment",
     "createProjectBranchRole",
+    "createProjectBranchTrigger",
     "createProjectEndpoint",
     "createProjectTransferRequest",
     "createSnapshot",
@@ -50,6 +51,7 @@
     "deleteProjectBranchDatabase",
     "deleteProjectBranchFunction",
     "deleteProjectBranchRole",
+    "deleteProjectBranchTrigger",
     "deleteProjectEndpoint",
     "deleteProjectJWKS",
     "deleteProjectVPCEndpoint",
@@ -94,6 +96,7 @@
     "getProjectBranchSchema",
     "getProjectBranchSchemaComparison",
     "getProjectBranchStorage",
+    "getProjectBranchTrigger",
     "getProjectEndpoint",
     "getProjectJWKS",
     "getProjectOperation",
@@ -118,6 +121,7 @@
     "listProjectBranchLogFieldValues",
     "listProjectBranchLogFields",
     "listProjectBranchRoles",
+    "listProjectBranchTriggers",
     "listProjectBranches",
     "listProjectEndpoints",
     "listProjectMembers",
@@ -174,6 +178,7 @@
     "updateProjectBranchDataAPI",
     "updateProjectBranchDatabase",
     "updateProjectBranchFunction",
+    "updateProjectBranchTrigger",
     "updateProjectEndpoint",
     "updateSnapshot"
   ]

--- a/content/docs/cli/config.md
+++ b/content/docs/cli/config.md
@@ -70,7 +70,7 @@ npm install @neon/config @neon/env
 Use `config init` when you want a trusted starter artifact and package list. Hand-write `neon.ts` instead when you need a different filename/module format or want to avoid modifying files in the current directory.
 
 <Admonition type="tip">
-After running an interactive [`neon link`](/docs/cli/link), the CLI offers to run `config init` as its final step, unless the project already has a `neon.ts` file.
+After running an interactive [`neon link`](/docs/cli/link), the CLI prompts you to run `config init` as its final step, unless the project already has a `neon.ts` file.
 </Admonition>
 
 ## neon config status (#status)

--- a/content/docs/cli/credentials.md
+++ b/content/docs/cli/credentials.md
@@ -1,0 +1,141 @@
+---
+title: 'Neon CLI command: credentials'
+subtitle: Issue, list, reveal, rotate, and revoke scoped credentials on a branch
+summary: >-
+  The Neon CLI `neon credentials` command manages branch-scoped credentials:
+  issue a credential with storage, AI gateway, or function-invoke scopes, list
+  the credentials on a branch, reveal a credential's secrets, rotate its secrets
+  in place, and revoke it.
+enableTableOfContents: true
+---
+
+The `credentials` command manages scoped credentials on a branch. A credential grants an application or agent direct access to a branch's surfaces without an account API key. Each credential carries one or more scopes and, when issued, a pair of secrets: an `api_token` and an `s3_secret_access_key`.
+
+The available scopes are:
+
+- `storage:read` and `storage:write` for [Neon Object Storage](/docs/storage/overview)
+- `ai_gateway:invoke` for the [Neon AI Gateway](/docs/ai-gateway/overview)
+- `functions:invoke` for invoking [Neon Functions](/docs/compute/functions/overview)
+
+Credentials are branch-scoped. Pass `--project-id` and `--branch` to target a branch, or let the CLI resolve them from your [context file](/docs/cli/set-context). A credential's `token_id` has the form `nak_live_<hex>` and is stable across a rotation.
+
+<Admonition type="important" title="Secrets are shown only once">
+The `api_token` and `s3_secret_access_key` are returned only when you create or rotate a credential, or when you explicitly run `neon credentials reveal`. Store them securely as soon as they're issued.
+</Admonition>
+
+<CliSubcommands command="credentials" />
+
+## neon credentials list (#list)
+
+Lists the credentials on the branch. Secrets are never included; use [`neon credentials reveal`](#reveal) to see them.
+
+<CliUsage command="credentials list" />
+
+<CliOptions command="credentials list" />
+
+```bash
+neon credentials list --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+Token Id                                   Name                               Principal Type  Scopes                       Created At
+nak_live_aaaa1111bbbb2222cccc3333dddd4444  Default AI gateway credential      user            ai_gateway:invoke            2026-09-10T20:02:49Z
+nak_live_eeee5555ffff6666aaaa7777bbbb8888  Default object storage credential  user            storage:read, storage:write  2026-09-10T20:02:50Z
+```
+
+## neon credentials create (#create)
+
+Issues a new credential. `--scope` is required and repeatable; pass one for each capability you want to grant. `--name` is an optional label.
+
+<CliUsage command="credentials create" />
+
+<CliOptions command="credentials create" />
+
+```bash
+neon credentials create --name uploads --scope storage:read --scope storage:write --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+Token Id  nak_live_0123456789abcdef0123456789abcdef
+Name      uploads
+Scopes    storage:read, storage:write
+api_token: <api_token>
+s3_secret_access_key: <s3_secret_access_key>
+WARNING: Store these secrets now: they are not shown again unless you run neon credentials reveal.
+```
+
+With `--output json`, the secrets stay on the object so scripts can read them:
+
+<details>
+<summary>Show output</summary>
+
+```json
+{
+  "token_id": "nak_live_0123456789abcdef0123456789abcdef",
+  "token_id_short": "0123456789ab",
+  "name": "uploads",
+  "api_token": "<api_token>",
+  "s3_secret_access_key": "<s3_secret_access_key>",
+  "scopes": ["storage:read", "storage:write"],
+  "branch_id": "br-morning-frost-a1b2c3d4",
+  "created_at": "2026-09-10T20:02:49Z"
+}
+```
+
+</details>
+
+## neon credentials reveal (#reveal)
+
+Shows a credential's `api_token` and `s3_secret_access_key` again, looked up by `token_id`.
+
+<CliUsage command="credentials reveal" />
+
+<CliOptions command="credentials reveal" />
+
+```bash
+neon credentials reveal nak_live_0123456789abcdef0123456789abcdef --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+Token Id  nak_live_0123456789abcdef0123456789abcdef
+api_token: <api_token>
+s3_secret_access_key: <s3_secret_access_key>
+WARNING: These are live secrets. Treat them like a password.
+```
+
+## neon credentials rotate (#rotate)
+
+Replaces a credential's secrets in place. The `token_id` is unchanged, so anything that references the credential by ID keeps working once you update the stored secrets.
+
+<CliUsage command="credentials rotate" />
+
+<CliOptions command="credentials rotate" />
+
+```bash
+neon credentials rotate nak_live_0123456789abcdef0123456789abcdef --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+Token Id  nak_live_0123456789abcdef0123456789abcdef
+Name      uploads
+Scopes    storage:read, storage:write
+api_token: <new api_token>
+s3_secret_access_key: <new s3_secret_access_key>
+WARNING: Store the new secrets now: a retry mints another pair and does not recover a lost response. A replica may briefly accept the previous secret.
+```
+
+## neon credentials revoke (#revoke)
+
+Revokes a credential. Its secrets stop working and the `token_id` can no longer be revealed or rotated.
+
+<CliUsage command="credentials revoke" />
+
+<CliOptions command="credentials revoke" />
+
+```bash
+neon credentials revoke nak_live_0123456789abcdef0123456789abcdef --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+INFO: Credential nak_live_0123456789abcdef0123456789abcdef revoked
+```

--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -1,20 +1,20 @@
 ---
 title: 'Neon CLI command: init'
 subtitle: Set up the current directory for Neon with agent tooling, a linked project,
-  and a neon.ts config
+  and an optional neon.ts config
 summary: >-
   The `neon init` command sets up the current directory to use Neon with your AI
-  coding assistant. In an empty directory it scaffolds a starter template first,
-  then installs agent tooling (either a plugin, or skills and the MCP server), links a
-  Neon project, and writes a neon.ts config. It runs interactively by default;
-  pass -y and --agent for an unattended agent setup.
+  coding assistant. In an empty directory it lets you pick a starter template or
+  skip scaffolding, then installs agent tooling (either a plugin, or skills and the
+  MCP server), links a Neon project, and optionally writes a neon.ts config. It runs
+  interactively by default; pass -y and --agent for an unattended agent setup.
 enableTableOfContents: true
-updatedOn: '2026-08-28T15:55:20.032Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
 
-The `init` command sets up the current directory to use Neon with your AI coding assistant. It's a thin wrapper that runs Neon's other setup commands for you: it installs agent tooling (either the [Neon plugin](/docs/cli/plugins), or [agent skills](/docs/cli/skills) and the [Neon MCP server](/docs/cli/mcp)), [links a Neon project](/docs/cli/link), and writes a [`neon.ts` config](/docs/cli/config). In an empty directory, it [scaffolds a starter template](/docs/cli/bootstrap) first.
+The `init` command sets up the current directory to use Neon with your AI coding assistant. It's a thin wrapper that runs Neon's other setup commands for you: it installs agent tooling (either the [Neon plugin](/docs/cli/plugins), or [agent skills](/docs/cli/skills) and the [Neon MCP server](/docs/cli/mcp)), [links a Neon project](/docs/cli/link), and can write a [`neon.ts` config](/docs/cli/config). In an empty directory, it also [scaffolds a starter template](/docs/cli/bootstrap): pick one interactively, name one with `--template`, or skip scaffolding with `--skip-template`.
 
 `init` is interactive, so run it from a terminal. It asks how coding agents should get Neon, and prompts you to pick a project to link. If you don't have the CLI installed, run it with `npx`:
 
@@ -32,12 +32,14 @@ For agents, CI, or scripts that can't answer prompts, see [Run it non-interactiv
 
 What `init` runs depends on whether the directory is empty:
 
-| Directory                  | What `init` does                                                                                   |
-| -------------------------- | -------------------------------------------------------------------------------------------------- |
-| Empty (nothing but `.git`) | Runs [`neon bootstrap`](/docs/cli/bootstrap): scaffolds a template, then agent tooling and linking |
-| Already has files          | Installs agent tooling, links a project, then runs [`neon config init`](/docs/cli/config)          |
+| Directory                  | What `init` does                                                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Empty (nothing but `.git`) | Scaffolds a starter template with [`neon bootstrap`](/docs/cli/bootstrap), then sets up agent tooling and links a project |
+| Already has files          | Sets up agent tooling, links a project, and optionally writes a [`neon.ts` config](/docs/cli/config)                      |
 
 A directory counts as empty only when it contains nothing but a `.git` folder. Any other entry, including a `README`, a `.env` file, or a `.gitignore`, makes it an existing app. So a directory you just ran `git init` in that already has a `.gitignore` takes the existing-app path.
+
+In an empty directory, pass `--skip-template` to skip scaffolding and take the existing-app path instead: `init` sets up agent tooling, links a project, and optionally writes `neon.ts` without adding template files.
 
 ### Choose how coding agents get Neon
 
@@ -53,7 +55,9 @@ The plugin and the skills-plus-MCP option are mutually exclusive. Installing ski
 
 ### Link a project and write neon.ts
 
-After agent setup, `init` runs [`neon link`](/docs/cli/link) (unless the directory is already linked). Linking writes a `.neon` file with your org, project, and branch, and pulls the branch's environment variables (including `DATABASE_URL`) into `.env` if one exists, otherwise `.env.local`. It then runs [`neon config init`](/docs/cli/config), which creates a `neon.ts` config you can edit and apply with `neon config apply`.
+After agent setup, `init` runs [`neon link`](/docs/cli/link) (unless the directory is already linked). Linking writes a `.neon` file with your org, project, and branch, and pulls the branch's environment variables (including `DATABASE_URL`) into `.env` if one exists, otherwise `.env.local`.
+
+It can also write a [`neon.ts` config](/docs/cli/config) you can edit and apply with `neon config apply`. In a terminal, `init` asks whether to create it. Pass `--config` to create it without asking, `--no-config` to skip it, or `--services` to create it with specific services declared (which implies `--config`). When you scaffold a template, `init` keeps the `neon.ts` that template ships and ignores these flags.
 
 ## Options
 
@@ -71,22 +75,17 @@ Combine `-y` with `--agent` to do the agent setup without prompts, for example i
 neon init -y --agent cursor
 ```
 
-For the project, `init` links to the one the directory is already linked to. When the directory isn't linked yet, `neon link` picks the project interactively. To target a specific project without prompts, run the underlying commands directly and pass the project explicitly, each taking its own flags:
+By default, `init` links to the project the directory is already linked to, and when it isn't linked yet, [`neon link`](/docs/cli/link) picks one interactively. To target a project without prompts, `init` forwards project-selection flags to `link`: pass `--project-id` (with `--org-id`) to link an existing project, or `--org-id`, `--project-name`, and `--region-id` to create and link a new one. Pass `--branch` to pin a branch.
 
 ```bash
-# Install agent tooling for a specific editor
-neon skills --agent cursor -s neon -s neon-postgres
-# or install the plugin instead:
-neon plugins --agent cursor
+# Existing project, fully non-interactive
+neon init -y --agent cursor --project-id <project-id> --org-id <org-id>
 
-# Link a specific project (no prompt)
-neon link --project-id <project-id> --org-id <org-id>
-
-# Scaffold neon.ts
-neon config init --services none
+# Create a new project and link it
+neon init -y --agent cursor --org-id <org-id> --project-name my-app --region-id aws-us-east-2
 ```
 
-Authenticate without a browser by setting `NEON_API_KEY` or passing `--api-key`. See [`neon skills`](/docs/cli/skills), [`neon plugins`](/docs/cli/plugins), [`neon link`](/docs/cli/link), and [`neon config`](/docs/cli/config) for the full options.
+Authenticate without a browser by setting `NEON_API_KEY` or passing `--api-key`. Agents can find the IDs with `neon orgs list --output json` and `neon projects list --org-id <org-id> --output json`. To control `neon.ts` in the same run, add `--config`, `--no-config`, or `--services`; in an empty directory, add `--skip-template` to skip scaffolding.
 
 ## What gets created
 

--- a/content/docs/cli/link.md
+++ b/content/docs/cli/link.md
@@ -6,7 +6,7 @@ summary: >-
   directory to a Neon project, including interactive and non-interactive
   workflows for CI, scripts, and AI agents.
 enableTableOfContents: true
-updatedOn: '2026-08-26T22:59:45.286Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 redirectFrom:
   - /docs/reference/cli-link
 ---
@@ -28,6 +28,8 @@ For most workflows, use `neon link` instead of manually running `neon set-contex
 <CliOptions command="link" />
 
 By default, linking pulls the linked branch's environment variables (such as `DATABASE_URL`) into a local `.env` file. Use `--no-env-pull` to skip this step, for example when you inject environment variables at runtime instead.
+
+After an interactive link, `link` also prompts you to create a [`neon.ts` config](/docs/cli/config) when the directory doesn't already have one, so you can manage the project's Neon setup as code. Accept the prompt to write `neon.ts`, or pass `--no-config` to skip it. This applies to interactive linking only; non-interactive runs never prompt.
 
 ## Interactive mode (default)
 

--- a/content/docs/cli/triggers.md
+++ b/content/docs/cli/triggers.md
@@ -1,0 +1,146 @@
+---
+title: 'Neon CLI command: triggers'
+subtitle: Create and manage function triggers that invoke a Neon Function on a cron schedule
+summary: >-
+  The Neon CLI `neon triggers` command manages function triggers on a branch:
+  list, get, create, update, enable, disable, and delete triggers that invoke a
+  Neon Function on a cron schedule.
+enableTableOfContents: true
+---
+
+<FeatureBetaProps feature_name="Function Triggers" />
+
+The `triggers` command manages function triggers on a branch. A trigger invokes a [Neon Function](/docs/compute/functions/overview) on a cron schedule, so you can run recurring work (a nightly report, a cleanup job, a periodic sync) without a separate scheduler. You deploy the function with [`neon functions deploy`](/docs/cli/functions), then point a trigger at it by slug.
+
+Triggers are branch-scoped. Pass `--project-id` and `--branch` to target a branch, or let the CLI resolve them from your [context file](/docs/cli/set-context). Triggers can also be inherited: a trigger created on a parent branch is visible on its child branches, where the `Inherited` column shows `true` and `source_branch_id` points to the origin branch. An inherited trigger stays disabled on the child until you enable it there with [`neon triggers enable`](#enable).
+
+<CliSubcommands command="triggers" />
+
+## neon triggers list (#list)
+
+Lists the triggers on the branch.
+
+<CliUsage command="triggers list" />
+
+<CliOptions command="triggers list" />
+
+```bash
+neon triggers list --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+Trigger Id                                    Name            Function Slug  Function Path  Schedule   Enabled  Inherited  Next Run At
+trigger-12345678-90ab-cdef-1234-567890abcdef  nightly-report  child404       /              0 6 * * *  true     false      2026-09-11T06:00:00.000000Z
+```
+
+## neon triggers get (#get)
+
+Shows a single trigger by ID.
+
+<CliUsage command="triggers get" />
+
+<CliOptions command="triggers get" />
+
+```bash
+neon triggers get trigger-12345678-90ab-cdef-1234-567890abcdef --project-id solitary-heart-93902637 --branch main --output json
+```
+
+<details>
+<summary>Show output</summary>
+
+```json
+{
+  "type": "schedule",
+  "trigger_id": "trigger-12345678-90ab-cdef-1234-567890abcdef",
+  "function_slug": "child404",
+  "name": "nightly-report",
+  "function_path": "/",
+  "schedule": {
+    "cron": "0 6 * * *"
+  },
+  "enabled": true,
+  "version": 1390408,
+  "next_run_at": "2026-09-11T06:00:00.000000Z",
+  "source_branch_id": "br-morning-frost-a1b2c3d4",
+  "inherited": false
+}
+```
+
+</details>
+
+## neon triggers create (#create)
+
+Creates a trigger that invokes a function on a cron schedule. `--function-slug`, `--name`, and `--cron` are required. `--cron` takes a five-field UTC cron expression. The trigger name must be unique on the branch.
+
+<CliUsage command="triggers create" />
+
+<CliOptions command="triggers create" />
+
+By default the invocation is sent to `/` and the trigger is enabled. Use `--function-path` to send it to another route, and `--enabled false` to create it in a disabled state.
+
+```bash
+neon triggers create --function-slug child404 --name nightly-report --cron '0 6 * * *' --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+Trigger Id     trigger-12345678-90ab-cdef-1234-567890abcdef
+Name           nightly-report
+Function Slug  child404
+Function Path  /
+Schedule       0 6 * * *
+Enabled        true
+Inherited      false
+Next Run At    2026-09-11T06:00:00.000000Z
+```
+
+## neon triggers update (#update)
+
+Updates a trigger. Pass at least one of `--function-slug`, `--name`, `--cron`, `--function-path`, or `--enabled`; with no fields to change, the command returns an error. Changing the schedule recomputes `Next Run At`.
+
+<CliUsage command="triggers update" />
+
+<CliOptions command="triggers update" />
+
+```bash
+neon triggers update trigger-12345678-90ab-cdef-1234-567890abcdef --cron '*/30 * * * *' --project-id solitary-heart-93902637 --branch main
+```
+
+## neon triggers enable (#enable)
+
+Enables a trigger so it runs on its schedule. Enabling recomputes `Next Run At`.
+
+<CliUsage command="triggers enable" />
+
+<CliOptions command="triggers enable" />
+
+```bash
+neon triggers enable trigger-12345678-90ab-cdef-1234-567890abcdef --project-id solitary-heart-93902637 --branch main
+```
+
+## neon triggers disable (#disable)
+
+Disables a trigger without deleting it. A disabled trigger keeps its definition but does not run, and its `Next Run At` is cleared. Re-enable it with [`neon triggers enable`](#enable).
+
+<CliUsage command="triggers disable" />
+
+<CliOptions command="triggers disable" />
+
+```bash
+neon triggers disable trigger-12345678-90ab-cdef-1234-567890abcdef --project-id solitary-heart-93902637 --branch main
+```
+
+## neon triggers delete (#delete)
+
+Deletes a trigger.
+
+<CliUsage command="triggers delete" />
+
+<CliOptions command="triggers delete" />
+
+```bash
+neon triggers delete trigger-12345678-90ab-cdef-1234-567890abcdef --project-id solitary-heart-93902637 --branch main
+```
+
+```text filename="Output"
+INFO: Trigger trigger-12345678-90ab-cdef-1234-567890abcdef deleted
+```

--- a/content/docs/get-started/full-backend-quickstart.md
+++ b/content/docs/get-started/full-backend-quickstart.md
@@ -99,7 +99,7 @@ A single [`neon.ts`](/docs/reference/neon-ts) file declares your backend as code
 
 Work through the commands on the right:
 
-1. `neon link` connects the directory to your project (writing a `.neon` file); `neon checkout` then pins the branch and pulls its env vars, including `DATABASE_URL`, into `.env.local`. If you haven't signed in to the CLI yet, run `neon login` first.
+1. `neon link` connects the directory to your project (writing a `.neon` file); `neon checkout` then pins the branch and pulls its env vars, including `DATABASE_URL`, into `.env.local`. If you haven't signed in to the CLI yet, run `neon login` first. Run interactively, `neon link` prompts you to create `neon.ts`; the `--no-config` flag skips that prompt so the explicit `neon config init` in step 2 stays in control.
 2. `neon config init` scaffolds `neon.ts` and installs `@neon/config` and `@neon/env`. It includes a branch policy; keep it and add the `preview` blocks shown in later steps alongside it (those snippets omit the policy for brevity).
 
 Postgres is already available on the branch, so `DATABASE_URL` is in `.env.local` and you can build the data layer before adding any beta services.
@@ -108,9 +108,9 @@ Postgres is already available on the branch, so `DATABASE_URL` is in `.env.local
 <TwoColumnLayout.Block>
 
 ```bash filename="Terminal"
-neon link            # select the my-backend project
-neon checkout main   # pin the branch, pull env vars into .env.local
-neon config init     # scaffold neon.ts, install @neon/config and @neon/env
+neon link --no-config  # select the my-backend project; skip link's neon.ts prompt
+neon checkout main     # pin the branch, pull env vars into .env.local
+neon config init       # scaffold neon.ts, install @neon/config and @neon/env
 ```
 
 </TwoColumnLayout.Block>

--- a/content/docs/get-started/with-an-agent.md
+++ b/content/docs/get-started/with-an-agent.md
@@ -6,7 +6,7 @@ summary: >-
   install the Neon tooling and connect your project, or run `neon init`
   yourself in a terminal, then ask your agent to get started.
 enableTableOfContents: true
-updatedOn: '2026-08-27T22:59:15.528Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 ---
 
 Set up Neon for your project without leaving your editor. You have two options: let your AI coding assistant install the Neon tooling and connect your project for you, or run `neon init` yourself in a terminal and then hand off to your agent. Either way, your agent ends up with the [agent skills](/docs/ai/agent-skills) and [Neon MCP server](/docs/ai/neon-mcp-server) it needs to create a Neon project, connect your app, and use Neon features as you build.
@@ -56,7 +56,7 @@ From your project root, run:
 npx neon@latest init
 ```
 
-`neon init` is interactive, so run it in a terminal. It asks how your coding agents should get Neon (either a plugin, or skills and the MCP server), links a Neon project, and writes a `neon.ts` config. In an empty directory, it scaffolds a starter template first. For the full flow, and a non-interactive setup for agents and CI, see the [`neon init` reference](/docs/cli/init).
+`neon init` is interactive, so run it in a terminal. It asks how your coding agents should get Neon (either a plugin, or skills and the MCP server), links a Neon project, and optionally writes a `neon.ts` config. In an empty directory, it lets you pick a starter template, name one with `--template`, or skip scaffolding with `--skip-template`. For the full flow, and a non-interactive setup for agents and CI, see the [`neon init` reference](/docs/cli/init).
 
 If you only want the MCP server, without the skills or plugin, run [`npx neon@latest mcp`](/docs/cli/mcp) instead. If you only want agent skills, run [`npx neon@latest skills`](/docs/cli/skills).
 

--- a/content/docs/navigation.yaml
+++ b/content/docs/navigation.yaml
@@ -1307,12 +1307,16 @@
               items:
                 - title: functions
                   slug: cli/functions
+                - title: triggers
+                  slug: cli/triggers
                 - title: buckets
                   slug: cli/buckets
                 - title: data-api
                   slug: cli/data-api
                 - title: neon-auth
                   slug: cli/neon-auth
+                - title: credentials
+                  slug: cli/credentials
             - title: Organizations and networking
               items:
                 - title: api

--- a/content/docs/storage/authentication.md
+++ b/content/docs/storage/authentication.md
@@ -6,7 +6,7 @@ summary: >-
   Each credential maps to an S3 Access Key ID and Secret Access Key. Credentials
   are scoped to a branch and valid for that branch and all its descendants.
 enableTableOfContents: true
-updatedOn: '2026-08-17T23:18:55.558Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -20,7 +20,18 @@ An object storage credential requires at minimum one of:
 - [`storage:read`](#read-vs-write-scopes): allows GetObject, HeadObject, ListObjects, and ListBuckets
 - [`storage:write`](#read-vs-write-scopes): allows all read operations plus PutObject and DeleteObject
 
-<Tabs labels={["Console", "API"]}>
+<Tabs labels={["CLI", "Console", "API"]}>
+<TabItem>
+
+Create a credential with the [Neon CLI](/docs/cli/credentials):
+
+```bash
+neon credentials create --scope storage:read --scope storage:write --name my-app-credential
+```
+
+The `api_token` and `s3_secret_access_key` are printed once, so store them right away. Map `token_id` to `AWS_ACCESS_KEY_ID` and `s3_secret_access_key` to `AWS_SECRET_ACCESS_KEY` (see [Mapping to your S3 SDK](#mapping-to-your-s3-sdk)). Run it in a directory [linked](/docs/cli/link) to your project, or pass `--project-id` and `--branch`.
+
+</TabItem>
 <TabItem>
 
 In the Neon Console, select your branch and click **Credentials** under **Branch** in the sidebar. Click **Create credential**, give it a name, and check the storage scopes you need.
@@ -217,7 +228,13 @@ curl -X DELETE "https://console.neon.tech/api/v2/projects/{project_id}/branches/
   -H "Authorization: Bearer $NEON_API_KEY"
 ```
 
-To rotate a credential, create a new one, update your environment variables, then revoke the old one.
+With the [Neon CLI](/docs/cli/credentials), run `neon credentials list` to find a credential, then revoke it by its `token_id`:
+
+```bash
+neon credentials revoke <token_id>
+```
+
+To rotate a credential in place, run `neon credentials rotate <token_id>`. This mints a new `s3_secret_access_key` while keeping the `token_id` (your `AWS_ACCESS_KEY_ID`) the same, so you only update the secret. Otherwise, create a new credential, update your environment variables, then revoke the old one.
 
 ## Common errors
 

--- a/content/docs/storage/get-started.md
+++ b/content/docs/storage/get-started.md
@@ -6,7 +6,7 @@ summary: >-
   a client, creating a bucket, and uploading and downloading your first file.
   Use the Files SDK or any AWS S3-compatible SDK. Just point it at your branch endpoint.
 enableTableOfContents: true
-updatedOn: '2026-09-02T15:10:53.712Z'
+updatedOn: '2026-09-11T02:29:56.410Z'
 ---
 
 <FeatureBetaProps feature_name="Neon Object Storage" />
@@ -97,7 +97,13 @@ A `404` response means object storage is not available for that branch. There is
 
 ## Create a credential
 
-Use the Neon API to create a credential with storage access:
+Create a credential with storage access. With the [Neon CLI](/docs/cli/credentials):
+
+```bash
+neon credentials create --scope storage:read --scope storage:write
+```
+
+Or use the Neon API:
 
 ```bash shouldWrap
 curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.15.0",
+  "neonctlVersion": "4.16.0",
   "binaries": [
     "neonctl",
     "neon"
@@ -1242,6 +1242,103 @@
         }
       ]
     },
+    "credentials": {
+      "aliases": [
+        "credential"
+      ],
+      "positionals": [],
+      "options": {
+        "branch": {
+          "type": "string",
+          "describe": "Branch ID or name"
+        },
+        "project-id": {
+          "type": "string",
+          "describe": "Project ID"
+        }
+      },
+      "commands": {
+        "create": {
+          "name": "create",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "name": {
+              "type": "string",
+              "describe": "Label for the credential"
+            },
+            "scope": {
+              "type": "string",
+              "describe": "Capability to grant. Repeatable. Values: storage:read, storage:write, ai_gateway:invoke, functions:invoke",
+              "required": true,
+              "choices": [
+                "storage:read",
+                "storage:write",
+                "ai_gateway:invoke",
+                "functions:invoke"
+              ]
+            }
+          },
+          "commands": {},
+          "describe": "Issue a scoped credential on the branch"
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {},
+          "describe": "List credentials on the branch"
+        },
+        "reveal": {
+          "name": "reveal",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "tokenId",
+              "required": true,
+              "describe": "Credential token id (nak_live_<32hex>)",
+              "type": "string"
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Show a credential's api_token and s3_secret_access_key"
+        },
+        "revoke": {
+          "name": "revoke",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "tokenId",
+              "required": true,
+              "describe": "Credential token id (nak_live_<32hex>)",
+              "type": "string"
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Revoke a credential"
+        },
+        "rotate": {
+          "name": "rotate",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "tokenId",
+              "required": true,
+              "describe": "Credential token id (nak_live_<32hex>)",
+              "type": "string"
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Replace a credential's secrets in place. The token id is unchanged."
+        }
+      },
+      "describe": "Manage branch credentials",
+      "usage": "$0 credentials <sub-command> [options]"
+    },
     "data-api": {
       "aliases": [],
       "positionals": [],
@@ -1857,6 +1954,15 @@
           "describe": "Coding agent to install into (repeatable). Forwarded to plugins, or to skills and mcp. Skips agent selection. Values listed below",
           "alias": "a"
         },
+        "branch": {
+          "type": "string",
+          "describe": "Forwarded to link: branch name or ID to pin",
+          "alias": "branch-id"
+        },
+        "config": {
+          "type": "boolean",
+          "describe": "Existing app or --skip-template: create neon.ts after linking. Use --no-config to skip. Omitted in a terminal: you will be asked. Scaffolding a template keeps that template's neon.ts"
+        },
         "context-file": {
           "type": "unknown",
           "hidden": true
@@ -1865,30 +1971,59 @@
           "type": "string",
           "hidden": true
         },
+        "org-id": {
+          "type": "string",
+          "describe": "Forwarded to link: organization ID to link to"
+        },
         "output": {
           "type": "unknown",
           "describe": "Not supported; the commands init runs print their own output",
           "alias": "o",
           "hidden": true
         },
+        "project-id": {
+          "type": "string",
+          "describe": "Forwarded to link: existing project ID to link to"
+        },
+        "project-name": {
+          "type": "string",
+          "describe": "Forwarded to link: name for a new project"
+        },
+        "region-id": {
+          "type": "string",
+          "describe": "Forwarded to link: region for a new project"
+        },
+        "skip-template": {
+          "type": "boolean",
+          "describe": "Do not scaffold a template. Set up agents, link a project, and optionally neon.ts in this directory",
+          "default": false
+        },
+        "template": {
+          "type": "string",
+          "describe": "Template to scaffold into an empty directory. Conflicts with --skip-template"
+        },
         "yes": {
           "type": "boolean",
-          "describe": "Empty dir: bootstrap --default. Otherwise plugin, or skills and MCP, for project folders, else the host CLI agent. Exits if none. Then link --yes and config init --services none. link --yes still asks for a project unless one is already linked",
+          "describe": "Empty dir: scaffold the default template. --skip-template: plugin, or skills and MCP, for project folders, else the host CLI agent. Exits if none. Then link --yes and config init --services none. link --yes still asks for a project unless one is already linked",
           "default": false,
           "alias": "y"
         }
       },
       "commands": {},
-      "describe": "Set up this directory for Neon: agent tooling, a linked project, and neon.ts. In an empty directory, scaffolds a template first. Skills needs Node.js 22.20 or newer.",
+      "describe": "Set up this directory for Neon: agent tooling, a linked project, and optionally neon.ts. In an empty directory, pick a template or skip scaffolding.",
       "usage": "$0 init [options]",
       "examples": [
         {
           "command": "$0 init",
-          "description": "Empty dir: bootstrap (scaffold, agent tooling, link). Existing app: agent tooling, link, config init"
+          "description": "Set up this directory (template picker if empty)"
+        },
+        {
+          "command": "$0 init --skip-template",
+          "description": "Empty dir: agents, link, and neon.ts — no template files"
         },
         {
           "command": "$0 init -y",
-          "description": "Same steps, using each child's defaults"
+          "description": "Default template, or existing-app defaults"
         },
         {
           "command": "$0 init --agent cursor --agent claude-code",
@@ -2139,6 +2274,11 @@
           "type": "boolean",
           "describe": "Remove the org/project/branch context (writes an empty context file) instead of linking.",
           "default": false
+        },
+        "config": {
+          "type": "boolean",
+          "describe": "Offer to create neon.ts after interactive linking. Use --no-config to skip the offer",
+          "default": true
         },
         "env-pull": {
           "type": "boolean",
@@ -3946,6 +4086,162 @@
       "commands": {},
       "describe": "Show the branch's live Neon state (alias of `config status`)",
       "usage": "$0 status [options]"
+    },
+    "triggers": {
+      "aliases": [
+        "trigger"
+      ],
+      "positionals": [],
+      "options": {
+        "branch": {
+          "type": "string",
+          "describe": "Branch ID or name"
+        },
+        "project-id": {
+          "type": "string",
+          "describe": "Project ID"
+        }
+      },
+      "commands": {
+        "create": {
+          "name": "create",
+          "aliases": [],
+          "positionals": [],
+          "options": {
+            "cron": {
+              "type": "string",
+              "describe": "Five-field UTC cron expression, e.g. '*/15 * * * *'",
+              "required": true
+            },
+            "enabled": {
+              "type": "boolean",
+              "describe": "Whether the trigger runs (default true)"
+            },
+            "function-path": {
+              "type": "string",
+              "describe": "Path the invocation is sent to (default '/')"
+            },
+            "function-slug": {
+              "type": "string",
+              "describe": "Slug of the function to invoke",
+              "required": true
+            },
+            "name": {
+              "type": "string",
+              "describe": "Trigger name (unique per branch)",
+              "required": true
+            }
+          },
+          "commands": {},
+          "describe": "Create a trigger that invokes a function on a cron schedule"
+        },
+        "delete": {
+          "name": "delete",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true,
+              "describe": "Trigger ID",
+              "type": "string"
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Delete a trigger"
+        },
+        "disable": {
+          "name": "disable",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true,
+              "describe": "Trigger ID",
+              "type": "string"
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Disable a trigger without deleting it"
+        },
+        "enable": {
+          "name": "enable",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true,
+              "describe": "Trigger ID",
+              "type": "string"
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Enable a trigger"
+        },
+        "get": {
+          "name": "get",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true,
+              "describe": "Trigger ID",
+              "type": "string"
+            }
+          ],
+          "options": {},
+          "commands": {},
+          "describe": "Show a trigger"
+        },
+        "list": {
+          "name": "list",
+          "aliases": [],
+          "positionals": [],
+          "options": {},
+          "commands": {},
+          "describe": "List triggers on the branch"
+        },
+        "update": {
+          "name": "update",
+          "aliases": [],
+          "positionals": [
+            {
+              "name": "id",
+              "required": true,
+              "describe": "Trigger ID",
+              "type": "string"
+            }
+          ],
+          "options": {
+            "cron": {
+              "type": "string",
+              "describe": "Five-field UTC cron expression"
+            },
+            "enabled": {
+              "type": "boolean",
+              "describe": "Whether the trigger runs"
+            },
+            "function-path": {
+              "type": "string",
+              "describe": "Path the invocation is sent to"
+            },
+            "function-slug": {
+              "type": "string",
+              "describe": "Slug of the function to invoke"
+            },
+            "name": {
+              "type": "string",
+              "describe": "Trigger name (unique per branch)"
+            }
+          },
+          "commands": {},
+          "describe": "Update a trigger"
+        }
+      },
+      "describe": "Manage function triggers",
+      "usage": "$0 triggers <sub-command> [options]"
     },
     "vpc": {
       "aliases": [],

--- a/scripts/lib/excluded-operations.mjs
+++ b/scripts/lib/excluded-operations.mjs
@@ -8,13 +8,11 @@
 // This override is intentionally sticky: routine "regenerate the API reference"
 // runs keep skipping these operations until an id is removed here. The spec is
 // never filtered, only the rendered output, so spec tracking stays live.
-export const EXCLUDED_OPERATION_IDS = new Set([
-  'createProjectBranchTrigger',
-  'getProjectBranchTrigger',
-  'listProjectBranchTriggers',
-  'updateProjectBranchTrigger',
-  'deleteProjectBranchTrigger',
-]);
+//
+// Currently empty: the function-trigger operations that used to live here were
+// un-hidden so the API reference documents them alongside the `neon triggers`
+// CLI command. Add operationIds here to hide them again.
+export const EXCLUDED_OPERATION_IDS = new Set([]);
 
 // Pure helper: drop excluded operationIds from an iterable of ids, preserving
 // order. Used by the strict docs<->API consistency check so intentionally

--- a/scripts/lib/excluded-operations.test.js
+++ b/scripts/lib/excluded-operations.test.js
@@ -3,30 +3,26 @@ import { describe, it, expect } from 'vitest';
 import { EXCLUDED_OPERATION_IDS, withoutExcludedOperations } from './excluded-operations.mjs';
 
 describe('EXCLUDED_OPERATION_IDS', () => {
-  it('lists exactly the five branch-trigger operations', () => {
-    expect([...EXCLUDED_OPERATION_IDS].sort()).toEqual([
-      'createProjectBranchTrigger',
-      'deleteProjectBranchTrigger',
-      'getProjectBranchTrigger',
-      'listProjectBranchTriggers',
-      'updateProjectBranchTrigger',
-    ]);
+  it('is currently empty: no operations are hidden from the API reference', () => {
+    // The branch-trigger operations that used to live here were un-hidden so
+    // the API reference documents them alongside the `neon triggers` command.
+    expect([...EXCLUDED_OPERATION_IDS]).toEqual([]);
   });
 });
 
 describe('withoutExcludedOperations', () => {
-  it('removes excluded ids and keeps the rest, preserving input order', () => {
+  it('returns the ids unchanged while the exclusion set is empty, preserving order', () => {
     const input = [
       'listProjects',
       'createProjectBranchTrigger',
       'getProject',
       'listProjectBranchTriggers',
     ];
-    expect(withoutExcludedOperations(input)).toEqual(['listProjects', 'getProject']);
+    expect(withoutExcludedOperations(input)).toEqual(input);
   });
 
   it('accepts any iterable (e.g. a Set) and returns an array', () => {
     const result = withoutExcludedOperations(new Set(['getProject', 'getProjectBranchTrigger']));
-    expect(result).toEqual(['getProject']);
+    expect(result).toEqual(['getProject', 'getProjectBranchTrigger']);
   });
 });

--- a/src/components/pages/doc/cli-reference/cli-command-index/groups.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/groups.js
@@ -53,6 +53,8 @@ const GROUP_OF = {
   plugins: 'setup',
   claim: 'setup',
   ask: 'setup',
+  credentials: 'surfaces',
+  triggers: 'surfaces',
 };
 
 // Commands documented as a section of another command's page instead of a

--- a/src/components/pages/doc/cli-reference/cli-command-index/meta.js
+++ b/src/components/pages/doc/cli-reference/cli-command-index/meta.js
@@ -14,7 +14,7 @@
 const META = {
   login: { desc: 'Browser OAuth; stores credentials locally.', examples: ['neon login'] },
   init: {
-    desc: 'Set up this directory for Neon: agent tooling, a linked project, and neon.ts.',
+    desc: 'Set up this directory for Neon: agent tooling, a linked project, and optionally neon.ts.',
     examples: ['npx neon@latest init'],
   },
   link: {
@@ -101,6 +101,14 @@ const META = {
   functions: {
     desc: 'Deploy and manage Neon Functions on a branch.',
     examples: ['neon functions deploy api --src ./api.ts'],
+  },
+  triggers: {
+    desc: 'Invoke a Neon Function on a cron schedule.',
+    examples: ["neon triggers create --function-slug api --name nightly --cron '0 6 * * *'"],
+  },
+  credentials: {
+    desc: 'Issue and manage scoped credentials on a branch.',
+    examples: ['neon credentials create --scope storage:read'],
   },
   buckets: {
     desc: 'Branch-scoped object storage and its objects.',


### PR DESCRIPTION
Updates the CLI reference for Neon CLI 4.16.0 and documents the two new commands, plus the reworked init flow.
  - schema: regenerate schema.json to 4.16.0
  - new pages: cli/triggers.md (cron function triggers, beta) and cli/credentials.md, both grouped under surfaces, with nav + meta.js entries
  - init/link: document init's optional neon.ts, template picker / --template / --skip-template, and forwarded project flags; document link's new neon.ts prompt and --config 
  - API reference: un-hide the five function-trigger operations (empty EXCLUDED_OPERATION_IDS, regenerate api-navigation.yaml + api-operation-ids.json)
  - cross-links: add neon credentials to the Object Storage and AI Gateway auth/get-started pages; fix now stale init prose on the agent/getting-started pages