### PR TITLE
docs: add 2026-09-11 changelog

### DIFF
--- a/content/changelog/2026-09-11.md
+++ b/content/changelog/2026-09-11.md
@@ -4,7 +4,7 @@ title: Claimable Neon, @neon/tools, and more
 
 ## Claimable Neon: provisioned by agents, claimed by humans
 
-Claimable Neon is for developers building with agents. When your agent is mid-build and needs a database, the signup, email verification, or API key that is typically required brings work to a halt. [Claimable Neon](https://neon.com/claimable-neon) solves this problem. It lets your agent provision a temporary project with scoped credentials, without an account or payment details, and keep building. If you like the result, you can sign in later and claim the project.
+Claimable Neon is for developers building with agents. When your agent is mid-build, the signup, email verification, or API key it needs to provision a database brings everything to a halt. [Claimable Neon](https://neon.com/claimable-neon) solves this problem. It lets your agent provision a temporary project with scoped credentials, without an account or payment details, and keep building. If you like the result, you can sign in later and claim the project.
 
 ```bash
 # Agent: provision a claimable project (writes DATABASE_URL to .env)
@@ -37,9 +37,7 @@ const created = await tools['projects.createAndConnect'].execute({
 });
 ```
 
-The same `@neon/tools` catalog now powers the hosted [Neon MCP server](/docs/ai/neon-mcp-server), which connects a coding assistant like Cursor or Claude to Neon. This expands the capabilities of the Neon MCP server with over 70 new tools.
-
-Read more about `@neon/tools` and our expanded Neon MCP server in [Give your agent Neon tools](https://neon.com/blog/give-your-agent-neon-tools).
+The same `@neon/tools` catalog now powers the hosted [Neon MCP server](/docs/ai/neon-mcp-server) for coding assistants like Cursor and Claude, adding over 70 new tools. Read more in [Give your agent Neon tools](https://neon.com/blog/give-your-agent-neon-tools).
 
 ## Faster queries on large computes
 

--- a/content/changelog/2026-09-11.md
+++ b/content/changelog/2026-09-11.md
@@ -4,7 +4,7 @@ title: Claimable Neon, @neon/tools, and more
 
 ## Claimable Neon: provisioned by agents, claimed by humans
 
-Claimable Neon is for developers building with agents. When your agent is mid-build, needing a database, a signup, an email verification, or an API key it doesn't have would normally bring work to a halt. [Claimable Neon](https://neon.com/claimable-neon) solves this problem. It lets the agent provision a temporary project with scoped credentials, without an account or payment details, and keep building. If you like the result, you can sign in later and claim it into a Neon organization.
+Claimable Neon is for developers building with agents. When your agent is mid-build and needs a database, the signup, email verification, or API key that is typically required brings work to a halt. [Claimable Neon](https://neon.com/claimable-neon) solves this problem. It lets your agent provision a temporary project with scoped credentials, without an account or payment details, and keep building. If you like the result, you can sign in later and claim the project.
 
 ```bash
 # Agent: provision a claimable project (writes DATABASE_URL to .env)
@@ -16,7 +16,7 @@ neon claim accept
 
 Today you can provision [Lakebase Postgres](/docs/get-started/why-neon), [the Data API](/docs/data-api/overview), and [Managed Better Auth](/docs/auth/overview) this way, with support for [Object Storage](/docs/storage/overview), [Functions](/docs/compute/functions/overview), and [AI Gateway](/docs/ai-gateway/overview) coming soon.
 
-For how it works, including credential rotation and the [`auth.md`](https://workos.com/auth-md) open agent registration protocol from WorkOS, see the [Claimable Neon docs](/docs/reference/claimable-neon) and the [launch blog post](https://neon.com/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later).
+For how it works, see the [Claimable Neon docs](/docs/reference/claimable-neon) and the [launch blog post](https://neon.com/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later).
 
 ## Give your agent Neon tools with `@neon/tools`
 

--- a/content/changelog/2026-09-11.md
+++ b/content/changelog/2026-09-11.md
@@ -20,7 +20,7 @@ For how it works, see the [Claimable Neon docs](/docs/reference/claimable-neon) 
 
 ## Give your agent Neon tools with `@neon/tools`
 
-If you're building an AI agent or app that manages Neon itself, such as one that spins up a project per user or a branch per task, [`@neon/tools`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/tools) gives it typed, function-calling tools instead of hand-written API wrappers. It turns the [`@neon/sdk`](/docs/reference/typescript-sdk) client into tools you hand to a model. Pick the Neon operations you want to expose, and they stay in sync with Neon's API. It also ships adapters for MCP, Mastra, and Eve.
+If you're building an AI agent or app that manages Neon itself, such as one that spins up a project or a branch, [`@neon/tools`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/tools) gives it typed, function-calling tools instead of hand-written API wrappers. It turns the [`@neon/sdk`](/docs/reference/typescript-sdk) client into tools you hand to a model. Pick the Neon operations you want to expose, and they stay in sync with Neon's API. It also ships adapters for MCP, Mastra, and Eve.
 
 ```ts
 import { createNeonTools } from '@neon/tools';
@@ -36,8 +36,6 @@ const created = await tools['projects.createAndConnect'].execute({
   region_id: 'aws-us-east-1',
 });
 ```
-
-Use it when the agent you're building needs to manage Neon.
 
 The same `@neon/tools` catalog now powers the hosted [Neon MCP server](/docs/ai/neon-mcp-server), which connects a coding assistant like Cursor or Claude to Neon. This expands the capabilities of the Neon MCP server with over 70 new tools.
 

--- a/content/changelog/2026-09-11.md
+++ b/content/changelog/2026-09-11.md
@@ -1,0 +1,61 @@
+---
+title: Claimable Neon, @neon/tools, and more
+---
+
+## Claimable Neon: provisioned by agents, claimed by humans
+
+Claimable Neon is for developers building with agents. When your agent is mid-build, needing a database, a signup, an email verification, or an API key it doesn't have would normally bring work to a halt. [Claimable Neon](https://neon.com/claimable-neon) solves this problem. It lets the agent provision a temporary project with scoped credentials, without an account or payment details, and keep building. If you like the result, you can sign in later and claim it into a Neon organization.
+
+```bash
+# Agent: provision a claimable project (writes DATABASE_URL to .env)
+neon claim create --env-pull
+
+# Human: sign in and take ownership
+neon claim accept
+```
+
+Today you can provision [Lakebase Postgres](/docs/get-started/why-neon), [the Data API](/docs/data-api/overview), and [Managed Better Auth](/docs/auth/overview) this way, with support for [Object Storage](/docs/storage/overview), [Functions](/docs/compute/functions/overview), and [AI Gateway](/docs/ai-gateway/overview) coming soon.
+
+For how it works, including credential rotation and the [`auth.md`](https://workos.com/auth-md) open agent registration protocol from WorkOS, see the [Claimable Neon docs](/docs/reference/claimable-neon) and the [launch blog post](https://neon.com/blog/an-agent-provisions-a-neon-backend-a-human-claims-it-later).
+
+## Give your agent Neon tools with `@neon/tools`
+
+If you're building an AI agent or app that manages Neon itself, such as one that spins up a project per user or a branch per task, [`@neon/tools`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/tools) gives it typed, function-calling tools instead of hand-written API wrappers. It turns the [`@neon/sdk`](/docs/reference/typescript-sdk) client into tools you hand to a model. Pick the Neon operations you want to expose, and they stay in sync with Neon's API. It also ships adapters for MCP, Mastra, and Eve.
+
+```ts
+import { createNeonTools } from '@neon/tools';
+
+const tools = createNeonTools({
+  apiKey: process.env.NEON_API_KEY,
+  tools: ['projects.list', 'projects.createAndConnect', 'branches.createAndConnect'],
+});
+
+// createAndConnect provisions a project, attaches compute, and returns a connection string
+const created = await tools['projects.createAndConnect'].execute({
+  name: 'agent-project',
+  region_id: 'aws-us-east-1',
+});
+```
+
+Use it when the agent you're building needs to manage Neon.
+
+The same `@neon/tools` catalog now powers the hosted [Neon MCP server](/docs/ai/neon-mcp-server), which connects a coding assistant like Cursor or Claude to Neon. This expands the capabilities of the Neon MCP server with over 70 new tools.
+
+Read more about `@neon/tools` and our expanded Neon MCP server in [Give your agent Neon tools](https://neon.com/blog/give-your-agent-neon-tools).
+
+## Faster queries on large computes
+
+Lakebase Postgres now puts much more of a large compute's memory to work as cache. On fixed-size computes of 18 CU and above, shared buffers expand to use up to 75% of available memory, backed by huge pages, so more of your working set stays resident and fewer reads fall through to storage. Cache-heavy workloads can see up to 2x throughput, with no configuration change or restart required.
+
+On an affected compute you can confirm the larger cache with `SHOW shared_buffers` and `SHOW huge_pages`.
+
+For the engineering deep dive, see [Improving Lakebase Postgres compute cache on Neon, Part 1](https://neon.com/blog/improving-lakebase-compute-cache-part-1).
+
+## Fixes & improvements
+
+<details>
+<summary>**Scheduled snapshots**</summary>
+
+The most recent scheduled snapshot on a branch is now kept for as long as the branch has an active snapshot schedule, instead of being deleted when it reaches its retention deadline. A branch with a schedule always keeps at least one snapshot to restore from, even before its next scheduled snapshot is created. Older scheduled snapshots and manual snapshots still expire on their normal schedule.
+
+</details>


### PR DESCRIPTION
Adds the 2026-09-11 changelog:

- **Claimable Neon**: agents provision a temporary project, humans claim it later
- **@neon/tools**: the Neon SDK as typed agent tools
- **Faster queries on large computes**: larger cache on 18 CU+ computes
- **Fixes & improvements**: scheduled snapshots keep the latest scheduled snapshot while a schedule is active

**Preview:** 
https://neon-next-git-changelog-2026-09-11-neondatabase.vercel.app/docs/changelog/2026-09-11


