### PR TITLE
fix: shorten markdown cache TTL so agent reads stay tracked

### DIFF
--- a/src/middleware.test.js
+++ b/src/middleware.test.js
@@ -599,7 +599,8 @@ describe('Middleware - AI Agent Integration Tests', () => {
 
       const response = await middleware(req);
 
-      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600, s-maxage=86400');
+      // Short TTL so a cached hit re-enters the proxy and re-fires the LLM read beacon.
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=60, s-maxage=300');
       expect(response.headers.get('X-Robots-Tag')).toBe('noindex');
     });
 

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -212,7 +212,10 @@ export async function proxy(req) {
             status: 200,
             headers: {
               'Content-Type': 'text/markdown; charset=utf-8',
-              'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+              // Short TTL so a cached hit still re-enters the proxy and fires the
+              // LLM read beacon (which runs only here). A long s-maxage lets the
+              // CDN replay hits for a day, silently zeroing agent pageview tracking.
+              'Cache-Control': 'public, max-age=60, s-maxage=300',
               'X-Content-Source': 'markdown',
               'X-Robots-Tag': 'noindex',
               'X-LLMs-Txt': '/blog/llms.txt',
@@ -282,7 +285,10 @@ export async function proxy(req) {
                 status: 200,
                 headers: {
                   'Content-Type': 'text/markdown; charset=utf-8',
-                  'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+                  // Short TTL so a cached hit still re-enters the proxy and fires the
+                  // LLM read beacon (which runs only here). A long s-maxage lets the
+                  // CDN replay hits for a day, silently zeroing agent pageview tracking.
+                  'Cache-Control': 'public, max-age=60, s-maxage=300',
                   'X-Content-Source': 'markdown',
                   'X-Robots-Tag': 'noindex',
                 },
@@ -351,7 +357,10 @@ export async function proxy(req) {
                   status: 200,
                   headers: {
                     'Content-Type': 'text/markdown; charset=utf-8',
-                    'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+                    // Short TTL so a cached hit still re-enters the proxy and fires the
+                    // LLM read beacon (which runs only here). A long s-maxage lets the
+                    // CDN replay hits for a day, silently zeroing agent pageview tracking.
+                    'Cache-Control': 'public, max-age=60, s-maxage=300',
                     'X-Content-Source': 'markdown',
                     'X-Robots-Tag': 'noindex',
                   },


### PR DESCRIPTION
## Overview

Agent pageview tracking runs server-side in the edge middleware (the LLM read beacon in
src/proxy.js). A response served from a shared cache skips the middleware, so a long
s-maxage on the markdown responses can silently drop agent reads from the analytics.

This lowers the three 200 markdown success paths (agent, content-route .md, and blog .md)
from a one-day shared TTL to the five-minute TTL already used for the .md redirect and 404
responses, so cached hits re-enter the proxy and stay counted. It trades a little cache
efficiency on hot pages for accurate tracking, matching the earlier redirect change.

Verified with the middleware unit suite (`npx vitest run src/middleware.test.js`, 92 pass).

This pull request and its description were written by Isaac.
