### PR TITLE
docs: refresh CLI reference for Neon CLI 4.17.1

### DIFF
--- a/content/docs/cli/init.md
+++ b/content/docs/cli/init.md
@@ -9,7 +9,7 @@ summary: >-
   MCP server), links a Neon project, and optionally writes a neon.ts config. It runs
   interactively by default; pass -y and --agent for an unattended agent setup.
 enableTableOfContents: true
-updatedOn: '2026-09-11T02:29:56.410Z'
+updatedOn: '2026-09-11T17:10:38.159Z'
 redirectFrom:
   - /docs/reference/cli-init
 ---
@@ -55,7 +55,7 @@ The plugin and the skills-plus-MCP option are mutually exclusive. Installing ski
 
 ### Link a project and write neon.ts
 
-After agent setup, `init` runs [`neon link`](/docs/cli/link) (unless the directory is already linked). Linking writes a `.neon` file with your org, project, and branch, and pulls the branch's environment variables (including `DATABASE_URL`) into `.env` if one exists, otherwise `.env.local`.
+After agent setup, `init` runs [`neon link`](/docs/cli/link) (unless the directory is already linked). Linking writes a `.neon` file with your org, project, and branch, and pulls the branch's environment variables (including `DATABASE_URL`) into `.env` if one exists, otherwise `.env.local`. Pass `--no-link` to set up agent tooling and `neon.ts` without linking a project; you can link later with `neon link`.
 
 It can also write a [`neon.ts` config](/docs/cli/config) you can edit and apply with `neon config apply`. In a terminal, `init` asks whether to create it. Pass `--config` to create it without asking, `--no-config` to skip it, or `--services` to create it with specific services declared (which implies `--config`). When you scaffold a template, `init` keeps the `neon.ts` that template ships and ignores these flags.
 

--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.16.0",
+  "neonctlVersion": "4.17.1",
   "binaries": [
     "neonctl",
     "neon"
@@ -267,7 +267,7 @@
         },
         "default": {
           "type": "boolean",
-          "describe": "Quick start: scaffold the default template (or --template), then install, git, agent tooling (project folders, else the host CLI agent; if none, pass --agent or omit --default in a terminal), and link --yes. Skips those pickers; link --yes still asks for a project unless one is already linked",
+          "describe": "Quick start: scaffold the default template (or --template), then install, git, agent tooling (project folders, else the host CLI agent; if none, pass --agent or omit --default in a terminal), and link with defaults. Project selection may still be required",
           "default": false,
           "alias": "y"
         },
@@ -288,7 +288,7 @@
         },
         "link": {
           "type": "boolean",
-          "describe": "Run `neon link` after scaffolding. Templates with neon.ts link after install so env pull works; otherwise link runs before install. In interactive mode this is offered as a prompt; use --no-link to skip without being asked.",
+          "describe": "Link a Neon project after scaffolding. Templates with neon.ts link after install so env pull works; otherwise linking happens before install. In interactive mode this is offered as a prompt; use --no-link to skip without being asked.",
           "default": true
         },
         "list-templates": {
@@ -319,7 +319,7 @@
         },
         {
           "command": "$0 bootstrap my-app --default",
-          "description": "Skip the pickers; link --yes still asks for a project unless one is already linked"
+          "description": "Skip the pickers; project selection may still be required"
         },
         {
           "command": "$0 bootstrap --list-templates --output json",
@@ -1971,6 +1971,11 @@
           "type": "string",
           "hidden": true
         },
+        "link": {
+          "type": "boolean",
+          "describe": "Link a Neon project during setup. Use --no-link to skip without being asked",
+          "default": true
+        },
         "org-id": {
           "type": "string",
           "describe": "Forwarded to link: organization ID to link to"
@@ -2004,7 +2009,7 @@
         },
         "yes": {
           "type": "boolean",
-          "describe": "Empty dir: scaffold the default template. --skip-template: plugin, or skills and MCP, for project folders, else the host CLI agent. Exits if none. Then link --yes and config init --services none. link --yes still asks for a project unless one is already linked",
+          "describe": "Empty dir: scaffold the default template. --skip-template: plugin, or skills and MCP, for project folders, else the host CLI agent. Exits if none. Then link with defaults and create the bare neon.ts policy. Project selection may still be required",
           "default": false,
           "alias": "y"
         }


### PR DESCRIPTION
Refresh the CLI schema to Neon CLI 4.17.1 (adds init --link, reworded init/bootstrap describes) and note --no-link on the init page.

This pull request and its description were written by Isaac.
