### PR TITLE
docs: point WebSocket references to upgradeWebSocket

### DIFF
--- a/content/blog/posts/neon-functions-backend-logic-next-to-your-data.md
+++ b/content/blog/posts/neon-functions-backend-logic-next-to-your-data.md
@@ -53,7 +53,7 @@ We recommend you keep the UI on Vercel, Netlify, or wherever you already host fr
 
 This is one thing we were sure about when designing Functions: they had to be long-running. Lambda-style caps are fine for CRUD, but [longer runtimes are needed in the age of agents](https://neon.com/docs/compute/functions/agents), since one agent request can stream for minutes while the agent calls models and tools.
 
-This is also relevant for [WebSockets and SSE](https://neon.com/docs/compute/functions/websockets). You can use functions to export an upgrade handler for WebSockets, or return text/event-stream for SSE, and fan out across isolates with Postgres LISTEN/NOTIFY instead of standing up Redis.
+This is also relevant for [WebSockets and SSE](https://neon.com/docs/compute/functions/websockets). You can use functions to accept a WebSocket with `upgradeWebSocket`, or return text/event-stream for SSE, and fan out across isolates with Postgres LISTEN/NOTIFY instead of standing up Redis.
 
 <Admonition type="note" title="Another important note">
 A function isn't a background job runner: it's always requested and always returns a web response (JSON, a stream, SSE, or a WebSocket upgrade). For queued work with its own lifecycle, [pair a function with something like Inngest today.](https://neon.com/guides/durable-workflow-on-neon-functions)

--- a/content/faqs/best-backend-real-time-chat-presence-live-updates.md
+++ b/content/faqs/best-backend-real-time-chat-presence-live-updates.md
@@ -17,20 +17,20 @@ Neon, with the real-time server on a Neon Function. A chat room or presence indi
 
 ## Two transports
 
-- **WebSockets** for two-way traffic: chat, presence, collaborative editing. Export an `upgrade` method next to `fetch`, and the runtime hands WebSocket upgrades to it. The `ws` package works with `noServer: true`.
+- **WebSockets** for two-way traffic: chat, presence, collaborative editing. Call `upgradeWebSocket` from `@neon/functions` in your `fetch` handler and return the `response` it gives you. No extra export and no `ws` dependency.
 - **Server-sent events** for one-way streams: live counters, notifications, progress, token streams. Plain HTTP, no library, and the browser's `EventSource` reconnects on its own ([WebSockets and SSE](/docs/compute/functions/websockets)).
 
 ```ts
-import type { IncomingMessage } from 'node:http';
-import type { Duplex } from 'node:stream';
+import { upgradeWebSocket } from '@neon/functions';
 
 export default {
   fetch(request: Request) {
-    return new Response('...');
-  },
-
-  upgrade(req: IncomingMessage, socket: Duplex, head: Buffer) {
-    // handle the WebSocket upgrade
+    if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+      return new Response('This endpoint speaks WebSocket. Send an Upgrade request.', { status: 426 });
+    }
+    const { socket, response } = upgradeWebSocket(request);
+    socket.addEventListener('message', (event) => socket.send(`echo: ${event.data}`));
+    return response;
   },
 };
 ```
@@ -44,7 +44,7 @@ Under load the platform runs several isolates, and a message posted through one 
 Two templates show the whole pattern: `neon bootstrap --template realtime-chat` (Next.js, Hono, Postgres, Managed Better Auth) and `--template realtime-sse` (TanStack Router, Hono) ([starter templates](/docs/compute/functions/overview#starter-templates)).
 
 <Admonition type="note" title="Beta scope">
-Functions are in beta, available in `aws-us-east-2` and `aws-eu-central-1` (with support expanding toward all regions), free during the beta on every plan, and JavaScript and TypeScript only. `neon dev` returns `200 OK` for WebSocket upgrades locally during the beta, so test WebSocket behavior against a deployed function ([WebSockets and SSE](/docs/compute/functions/websockets)).
+Functions are in beta, available in `aws-us-east-2` and `aws-eu-central-1` (with support expanding toward all regions), free during the beta on every plan, and JavaScript and TypeScript only. With a current `neon` CLI, `neon dev` serves WebSocket upgrades locally, so you can test before deploying ([WebSockets and SSE](/docs/compute/functions/websockets)).
 </Admonition>
 
 ## Keep the front end where it is


### PR DESCRIPTION
## Overview

Follow-up to #5484. Two pages outside that PR still referenced the old `upgrade`-export
WebSocket path: the real-time FAQ and the Functions launch blog post. Update both to
`upgradeWebSocket` from `@neon/functions` so they match the WebSockets and SSE guide.

The FAQ also claimed `neon dev` returns `200 OK` for local upgrades; a current `neon`
CLI serves them, so that note now points readers to test locally. Version floors stay
on the canonical guide rather than being repeated here.

This pull request and its description were written by Isaac.
