### PR TITLE
docs: refresh CLI reference for Neon CLI 4.17.3

### DIFF
--- a/scripts/docs-checks/neonctl/schema.json
+++ b/scripts/docs-checks/neonctl/schema.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "neonctlVersion": "4.17.1",
+  "neonctlVersion": "4.17.3",
   "binaries": [
     "neonctl",
     "neon"


### PR DESCRIPTION
Bumps the committed neonctl schema from 4.17.1 to 4.17.3. No command or option surface changes.

This pull request and its description were written by Isaac.